### PR TITLE
refactor(logging): structlog where missing, shorter/cleaner messages

### DIFF
--- a/hathor/cli/util.py
+++ b/hathor/cli/util.py
@@ -1,4 +1,6 @@
 from argparse import ArgumentParser
+from collections import OrderedDict
+from datetime import datetime
 from enum import Flag
 from functools import reduce
 from operator import or_
@@ -11,14 +13,23 @@ def create_parser() -> ArgumentParser:
     return configargparse.ArgumentParser(auto_env_var_prefix='hathor_')
 
 
-def setup_logging(debug: bool = False, capture_stdout: bool = True, *, _test_logging: bool = False) -> None:
+def setup_logging(debug: bool = False, capture_stdout: bool = False, *, _test_logging: bool = False) -> None:
+    import logging
     import logging.config
 
     import colorama
     import structlog
     import twisted
+    from twisted.logger import LogLevel
 
-    logger = structlog.get_logger()
+    # Mappings to Python's logging module
+    twisted_to_logging_level = {
+        LogLevel.debug: logging.DEBUG,
+        LogLevel.info: logging.INFO,
+        LogLevel.warn: logging.WARNING,
+        LogLevel.error: logging.ERROR,
+        LogLevel.critical: logging.CRITICAL,
+    }
 
     # common timestamper for structlog loggers and foreign (stdlib and twisted) loggers
     timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
@@ -110,6 +121,13 @@ def setup_logging(debug: bool = False, capture_stdout: bool = True, *, _test_log
 
             return sio.getvalue()
 
+        def _repr(self, val):
+            if isinstance(val, datetime):
+                return str(val)
+            else:
+                return super()._repr(val)
+
+    # See: https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
     logging.config.dictConfig({
             'version': 1,
             'disable_existing_loggers': False,
@@ -139,11 +157,15 @@ def setup_logging(debug: bool = False, capture_stdout: bool = True, *, _test_log
                 # },
             },
             'loggers': {
+                # set twisted verbosity one level lower than hathor's
+                'twisted': {
+                    'handlers': ['default'],
+                    'level': 'INFO' if debug else 'WARN',
+                    'propagate': False,
+                },
                 '': {
-                    # 'handlers': ['default', 'file'],
                     'handlers': ['default'],
                     'level': 'DEBUG' if debug else 'INFO',
-                    'propagate': True,
                 },
             }
     })
@@ -164,17 +186,36 @@ def setup_logging(debug: bool = False, capture_stdout: bool = True, *, _test_log
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-            # structlog.twisted.JSONRenderer(),
         ],
-        context_class=dict,
+        context_class=OrderedDict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
 
-    twisted.python.log.startLoggingWithObserver(twisted.logger.STDLibLogObserver(), setStdout=capture_stdout)
+    twisted_logger = structlog.get_logger('twisted')
+
+    def twisted_structlog_observer(event):
+        try:
+            level = twisted_to_logging_level.get(event.get('log_level'), logging.INFO)
+            kwargs = {}
+            msg = ''
+            if not msg and 'log_format' in event:
+                msg = event['log_format'].format(**event)
+            if not msg and 'format' in event:
+                msg = event['format'] % event
+            failure = event.get('log_failure')
+            if failure is not None:
+                kwargs['exc_info'] = (failure.type, failure.value, failure.getTracebackObject())
+            twisted_logger.log(level, msg, **kwargs)
+        except Exception as e:
+            print('error when logging event', e)
+
+    # start logging to std logger so structlog can catch it
+    twisted.python.log.startLoggingWithObserver(twisted_structlog_observer, setStdout=capture_stdout)
 
     if _test_logging:
+        logger = structlog.get_logger()
         logger.debug('Test: debug.')
         logger.info('Test: info.')
         logger.warning('Test: warning.')

--- a/hathor/indexes.py
+++ b/hathor/indexes.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, DefaultDict, Dict, Iterable, List, NamedTuple,
 
 from intervaltree import Interval, IntervalTree
 from sortedcontainers import SortedKeyList
-from twisted.logger import Logger
+from structlog import get_logger
 
 from hathor.pubsub import HathorEvents
 from hathor.transaction import BaseTransaction, Transaction
@@ -30,6 +30,8 @@ from hathor.transaction.scripts import parse_address_script
 if TYPE_CHECKING:  # pragma: no cover
     from hathor.pubsub import PubSubManager, EventArguments  # noqa: F401
     from hathor.transaction import TxOutput  # noqa: F401
+
+logger = get_logger()
 
 
 class TransactionIndexElement(NamedTuple):
@@ -109,8 +111,6 @@ class TipsIndex:
     TODO Use an interval tree stored in disk, possibly using a B-tree.
     """
 
-    log = Logger()
-
     # An interval tree used to know the tips at any timestamp.
     # The intervals are in the form (begin, end), where begin is the timestamp
     # of the transaction, and end is the smallest timestamp of the tx's children.
@@ -121,6 +121,7 @@ class TipsIndex:
     tx_last_interval: Dict[bytes, Interval]
 
     def __init__(self) -> None:
+        self.log = logger.new()
         self.tree = IntervalTree()
         self.tx_last_interval = {}  # Dict[bytes(hash), Interval]
 

--- a/hathor/p2p/node_sync.py
+++ b/hathor/p2p/node_sync.py
@@ -184,7 +184,6 @@ class NodeSyncTimestamp(Plugin):
         :param reactor: Reactor to schedule later calls. (default=twisted.internet.reactor)
         :type reactor: Reactor
         """
-        self.log = logger.new()
         self.protocol = protocol
         self.manager = protocol.node
 
@@ -218,6 +217,9 @@ class NodeSyncTimestamp(Plugin):
         # Indicate whether the synchronization is running.
         self.is_running: bool = False
 
+        # Create logger with context
+        self.log = logger.new(peer_id_short=self.short_peer_id)
+
     def get_status(self):
         """ Return the status of the sync.
         """
@@ -230,8 +232,8 @@ class NodeSyncTimestamp(Plugin):
     def short_peer_id(self) -> str:
         """ Returns the id of the peer (only 7 first chars)
         """
-        assert self.protocol.peer is not None
-        assert self.protocol.peer.id is not None
+        if self.protocol.peer is None or self.protocol.peer.id is None:
+            return ''
         return self.protocol.peer.id[:7]
 
     def get_cmd_dict(self) -> Dict[ProtocolMessages, Callable[[str], None]]:
@@ -355,23 +357,20 @@ class NodeSyncTimestamp(Plugin):
 
         :param next_timestamp: Timestamp to start the sync
         """
-        self.log.debug('sync-{p} Sync starting at {next_timestamp}', p=self.short_peer_id,
-                       next_timestamp=next_timestamp)
+        self.log.debug('sync start', ts=next_timestamp)
         assert next_timestamp < inf
         pending: WeakSet[Deferred] = WeakSet()
         next_offset = 0
         while True:
             payload = cast(NextPayload, (yield self.get_peer_next(next_timestamp, offset=next_offset)))
-            self.log.debug('sync-{p} NextPayload ts={ts} next_ts={nts} next_offset={noff} hashes={hs}',
-                           p=self.short_peer_id, ts=payload.timestamp, nts=payload.next_timestamp,
-                           noff=payload.next_offset, hs=len(payload.hashes))
+            self.log.debug('next payload', ts=payload.timestamp, next_ts=payload.next_timestamp,
+                           next_offset=payload.next_offset, hashes=len(payload.hashes))
             count = 0
             for h in payload.hashes:
                 if not self.manager.tx_storage.transaction_exists(h):
                     pending.add(self.get_data(h))
                     count += 1
-            self.log.debug('sync-{p} next_ts={ts} count={c} pending={pen}', p=self.short_peer_id,
-                           ts=next_timestamp, c=count, pen=len(pending))
+            self.log.debug('...', next_ts=next_timestamp, count=count, pending=len(pending))
             if next_timestamp != payload.next_timestamp and count == 0:
                 break
             next_timestamp = payload.next_timestamp
@@ -389,7 +388,7 @@ class NodeSyncTimestamp(Plugin):
 
         It uses an exponential search followed by a binary search.
         """
-        # self.log.debug('Running find_synced_timestamp...')
+        self.log.debug('find synced timestamp')
         tips = cast(TipsPayload, (yield self.get_peer_tips()))
         if self.peer_timestamp:
             # Peer's timestamp cannot go backwards.
@@ -443,8 +442,7 @@ class NodeSyncTimestamp(Plugin):
             return None
 
         assert low + 1 == high
-        self.log.debug('sync-{log_source.short_peer_id} Synced at {log_source.synced_timestamp} \
-                       (latest timestamp {log_source.peer_timestamp})', log_source=self)
+        self.log.debug('synced', latest_ts=self.peer_timestamp, synced_at=self.synced_timestamp)
         return self.synced_timestamp + 1
 
     @inlineCallbacks
@@ -452,7 +450,7 @@ class NodeSyncTimestamp(Plugin):
         """ Run the next step to keep nodes synced.
         """
         next_timestamp = yield self.find_synced_timestamp()
-        self.log.debug('sync-{p} _next_step next_timestamp={ts}', p=self.short_peer_id, ts=next_timestamp)
+        self.log.debug('_next_step', next_timestamp=next_timestamp)
         if next_timestamp is None:
             return
 
@@ -464,14 +462,14 @@ class NodeSyncTimestamp(Plugin):
         """
         if self.is_running:
             # Already running...
-            # self.log.debug('Already running: {log_source.is_running}')
+            self.log.debug('already running')
             return
 
         try:
             self.is_running = True
             yield self._next_step()
-        except Exception as e:
-            self.log.warn('Exception: {e!r}', e=e)
+        except Exception:
+            self.log.warn('_next_step error', exc_info=True)
             raise
         else:
             if self.call_later_id and self.call_later_id.active():
@@ -622,7 +620,7 @@ class NodeSyncTimestamp(Plugin):
         """ Handle a received GET-DATA message.
         """
         hash_hex = payload
-        # self.log.debug('handle_get_data {hash_hex}', hash_hex=hash_hex)
+        # self.log.debug('handle_get_data', payload=hash_hex)
         try:
             tx = self.protocol.node.tx_storage.get_transaction(bytes.fromhex(hash_hex))
             self.send_data(tx)
@@ -641,7 +639,7 @@ class NodeSyncTimestamp(Plugin):
     def send_data(self, tx: BaseTransaction) -> None:
         """ Send a DATA message.
         """
-        # self.log.debug('Sending {tx.hash_hex}...', tx=tx)
+        self.log.debug('send tx', tx=tx.hash_hex)
         payload = base64.b64encode(tx.get_struct()).decode('ascii')
         self.send_message(ProtocolMessages.DATA, payload)
 
@@ -732,5 +730,4 @@ class NodeSyncTimestamp(Plugin):
             We need this errback because otherwise the sync crashes when the deferred is canceled.
             We should just log a warning because it will continue the sync and will try to get this tx again.
         """
-        self.log.warn('sync-{p} failed to download tx hash={h}, reason={reason}',
-                      p=self.short_peer_id, h=hash_bytes.hex(), reason=reason)
+        self.log.warn('failed to download tx', tx=hash_bytes.hex(), reason=reason)

--- a/hathor/p2p/states/base.py
+++ b/hathor/p2p/states/base.py
@@ -1,21 +1,22 @@
 from typing import TYPE_CHECKING, Callable, Dict, Optional
 
-from twisted.logger import Logger
+from structlog import get_logger
 
 from hathor.p2p.messages import ProtocolMessages
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol  # noqa: F401
 
+logger = get_logger()
+
 
 class BaseState:
-    log = Logger()
-
     protocol: 'HathorProtocol'
     base_cmd_map: Dict[ProtocolMessages, Callable[[str], None]]
     cmd_map: Dict[ProtocolMessages, Callable[[str], None]]
 
     def __init__(self, protocol: 'HathorProtocol'):
+        self.log = logger.new()
         self.protocol = protocol
         self.base_cmd_map = {
             ProtocolMessages.ERROR: self.handle_error,
@@ -30,7 +31,7 @@ class BaseState:
         self.protocol.handle_error(payload)
 
     def handle_throttle(self, payload: str) -> None:
-        self.log.info('Got throttled: {payload}', payload=payload)
+        self.log.info('throttled', payload=payload)
 
     def send_message(self, cmd: ProtocolMessages, payload: Optional[str] = None) -> None:
         self.protocol.send_message(cmd, payload)

--- a/hathor/p2p/states/hello.py
+++ b/hathor/p2p/states/hello.py
@@ -69,7 +69,7 @@ class HelloState(BaseState):
             return
 
         if data['app'] != self._app():
-            self.log.warn('Different app versions: {data[app]}', data=data)
+            self.log.warn('different versions', theirs=data['app'], ours=self._app())
 
         if data['network'] != protocol.network:
             protocol.send_error_and_close_connection('Wrong network.')

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -2,7 +2,6 @@ import json
 from typing import TYPE_CHECKING, Dict, Iterable
 
 from twisted.internet.task import LoopingCall
-from twisted.logger import Logger
 
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.node_sync import NodeSyncTimestamp
@@ -16,8 +15,6 @@ if TYPE_CHECKING:
 
 
 class ReadyState(BaseState):
-    log = Logger()
-
     SYNC_PLUGIN_NAME = 'node-sync-timestamp'
 
     plugins: Dict[str, Plugin]
@@ -101,7 +98,7 @@ class ReadyState(BaseState):
                 'last_message': conn.last_message,
             })
         self.send_message(ProtocolMessages.PEERS, json.dumps(peers))
-        self.log.debug('Peers: {peers}', peers=peers)
+        self.log.debug('send peers', peers=peers)
 
     def handle_peers(self, payload: str) -> None:
         """ Executed when a PEERS command is received. It updates the list
@@ -114,7 +111,7 @@ class ReadyState(BaseState):
             if self.protocol.connections:
                 self.protocol.connections.on_receive_peer(peer, origin=self)
         remote = self.protocol.transport.getPeer()
-        self.log.info('{remote} PEERS {payload}', remote=remote, payload=payload)
+        self.log.debug('received peers', remote=remote, payload=payload)
 
     def send_ping_if_necessary(self) -> None:
         """ Send a PING command if the connection has been idle for 3 seconds or more.

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -451,9 +451,9 @@ class BaseTransaction(ABC):
                 assert parent.hash is not None
                 if self.timestamp <= parent.timestamp:
                     raise TimestampError('tx={} timestamp={}, parent={} timestamp={}'.format(
-                        self.hash.hex(),
+                        self.hash_hex,
                         self.timestamp,
-                        parent.hash.hex(),
+                        parent.hash_hex,
                         parent.timestamp,
                     ))
 
@@ -475,15 +475,15 @@ class BaseTransaction(ABC):
                 else:
                     if min_timestamp and parent.timestamp < min_timestamp:
                         raise TimestampError('tx={} timestamp={}, parent={} timestamp={}, min_timestamp={}'.format(
-                            self.hash.hex(),
+                            self.hash_hex,
                             self.timestamp,
-                            parent.hash.hex(),
+                            parent.hash_hex,
                             parent.timestamp,
                             min_timestamp
                         ))
                     my_parents_txs += 1
             except TransactionDoesNotExist:
-                raise ParentDoesNotExist('tx={} parent={}'.format(self.hash.hex(), parent_hash.hex()))
+                raise ParentDoesNotExist('tx={} parent={}'.format(self.hash_hex, parent_hash.hex()))
 
         # check for correct number of parents
         if self.is_block:
@@ -505,7 +505,7 @@ class BaseTransaction(ABC):
         :raises PowError: when the hash is equal or greater than the target
         """
         assert self.hash is not None
-        numeric_hash = int(self.hash.hex(), self.HEX_BASE)
+        numeric_hash = int(self.hash_hex, self.HEX_BASE)
         minimum_target = self.get_target(override_weight)
         if numeric_hash >= minimum_target:
             raise PowError(f'Transaction has invalid data ({numeric_hash} < {minimum_target})')
@@ -763,7 +763,7 @@ class BaseTransaction(ABC):
         """ Creates a json serializable Dict object from self
         """
         data: Dict[str, Any] = {}
-        data['hash'] = self.hash and self.hash.hex()
+        data['hash'] = self.hash_hex or None
         data['nonce'] = self.nonce
         data['timestamp'] = self.timestamp
         data['version'] = int(self.version)
@@ -803,7 +803,7 @@ class BaseTransaction(ABC):
 
         meta = self.get_metadata()
         ret: Dict[str, Any] = {
-            'tx_id': self.hash.hex(),
+            'tx_id': self.hash_hex,
             'version': int(self.version),
             'weight': self.weight,
             'timestamp': self.timestamp,
@@ -824,7 +824,7 @@ class BaseTransaction(ABC):
             tx2_out = tx2.outputs[tx_in.index]
             output = serialize_output(tx2, tx2_out)
             assert tx2.hash is not None
-            output['tx_id'] = tx2.hash.hex()
+            output['tx_id'] = tx2.hash_hex
             output['index'] = tx_in.index
             ret['inputs'].append(output)
 

--- a/hathor/transaction/resources/transaction.py
+++ b/hathor/transaction/resources/transaction.py
@@ -62,7 +62,7 @@ def get_tx_extra_data(tx: BaseTransaction) -> Dict[str, Any]:
             tx2_out = tx2.outputs[tx_in.index]
             output = tx2_out.to_json(decode_script=True)
             assert tx2.hash is not None
-            output['tx_id'] = tx2.hash.hex()
+            output['tx_id'] = tx2.hash_hex
             output['index'] = tx_in.index
 
             # We need to get the token_data from the current tx, and not the tx being spent

--- a/hathor/transaction/scripts.py
+++ b/hathor/transaction/scripts.py
@@ -25,7 +25,6 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Pattern, Typ
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
-from twisted.logger import Logger
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import (
@@ -164,8 +163,6 @@ class HathorScript:
 
     pushData abstracts this differences and presents an unique interface.
     """
-    log = Logger()
-
     def __init__(self) -> None:
         self.data = b''
 

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Generator, Iterator, Optional, Set
 
 from twisted.internet import threads
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
-from twisted.logger import Logger
 
 from hathor.transaction import BaseTransaction
 from hathor.transaction.storage.transaction_storage import BaseTransactionStorage
@@ -15,7 +14,6 @@ if TYPE_CHECKING:
 class TransactionCacheStorage(BaseTransactionStorage):
     """Caching storage to be used 'on top' of other storages.
     """
-    log = Logger()
 
     cache: 'OrderedDict[bytes, BaseTransaction]'
     dirty_txs: Set[bytes]
@@ -85,7 +83,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
         self.flush_deferred = None
 
     def _err_flush_thread(self, reason: Any) -> None:
-        self.log.error('Error flushing transactions: {reason}', reason=reason)
+        self.log.error('error flushing transactions', reason=reason)
         self.reactor.callLater(self.interval, self._start_flush_thread)
         self.flush_deferred = None
 

--- a/hathor/transaction/storage/remote_storage.py
+++ b/hathor/transaction/storage/remote_storage.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List
 import grpc
 from grpc._server import _Context
 from intervaltree import Interval
+from structlog import get_logger
 from twisted.internet.defer import Deferred, inlineCallbacks
-from twisted.logger import Logger
 
 from hathor import protos
 from hathor.exception import HathorError
@@ -16,6 +16,8 @@ from hathor.transaction.storage.transaction_storage import AllTipsCache, Transac
 
 if TYPE_CHECKING:
     from hathor.transaction import BaseTransaction  # noqa: F401
+
+logger = get_logger()
 
 
 class RemoteCommunicationError(HathorError):
@@ -95,7 +97,6 @@ def convert_hathor_exceptions_generator(func: Callable) -> Callable:
 class TransactionRemoteStorage(TransactionStorage):
     """Connects to a Storage API Server at given port and exposes standard storage interface.
     """
-    log = Logger()
 
     def __init__(self, with_index=None):
         super().__init__()
@@ -630,9 +631,9 @@ class TransactionRemoteStorage(TransactionStorage):
 
 
 class TransactionStorageServicer(protos.TransactionStorageServicer):
-    log = Logger()
 
     def __init__(self, tx_storage):
+        self.log = logger.new()
         self.storage = tx_storage
         # We must always disable weakref because it will run remotely, which means
         # each call will create a new instance of the block/transaction during the

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Generator, Iterator, List, NamedTuple, Optional, S
 from weakref import WeakValueDictionary
 
 from intervaltree.interval import Interval
+from structlog import get_logger
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 
 from hathor.conf import HathorSettings
@@ -37,6 +38,7 @@ class TransactionStorage(ABC):
     block_index: Optional[IndexesManager]
     tx_index: Optional[IndexesManager]
     all_index: Optional[IndexesManager]
+    log = get_logger()
 
     def __init__(self):
         # Weakref is used to guarantee that there is only one instance of each transaction in memory.
@@ -59,6 +61,9 @@ class TransactionStorage(ABC):
 
         # If should create lock when getting a transaction
         self._should_lock = False
+
+        # Provide local logger
+        self.log = self.log.new()
 
         # Cache for the latest timestamp of all tips with merkle tree precalculated to be used on the sync algorithm
         # This cache is invalidated every time a new tx or block is added to the cache and

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -17,8 +17,6 @@ limitations under the License.
 from struct import error as StructError, pack
 from typing import Any, Dict, List, Optional, Tuple
 
-from twisted.logger import Logger
-
 from hathor import protos
 from hathor.conf import HathorSettings
 from hathor.transaction import Transaction, TxInput, TxOutput, TxVersion
@@ -41,8 +39,6 @@ TOKEN_INFO_VERSION = 1
 
 
 class TokenCreationTransaction(Transaction):
-    log = Logger()
-
     def __init__(self,
                  nonce: int = 0,
                  timestamp: Optional[int] = None,

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -18,8 +18,6 @@ from collections import namedtuple
 from struct import pack
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
-from twisted.logger import Logger
-
 from hathor import protos
 from hathor.conf import HathorSettings
 from hathor.transaction import MAX_NUM_INPUTS, BaseTransaction, Block, TxInput, TxOutput, TxVersion
@@ -54,7 +52,6 @@ TokenInfo = namedtuple('TokenInfo', 'amount can_mint can_melt')
 
 
 class Transaction(BaseTransaction):
-    log = Logger()
 
     SERIALIZATION_NONCE_SIZE = 4
 

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import math
 import warnings
 from collections import OrderedDict
 from enum import Enum
@@ -286,3 +287,14 @@ def api_catch_exceptions(func: Callable[..., bytes]) -> Callable[..., bytes]:
             request.setResponseCode(getattr(e, 'status_code', 500))
             return json_dumpb({'error': str(e)})
     return wrapper
+
+
+class LogDuration(float):
+    def __str__(x):
+        if x >= 1:
+            return f'~{math.trunc(x)}s'
+        elif x >= 0.001:
+            return f'~{math.trunc(x * 1000)}ms'
+        else:
+            return '<1ms'
+    __repr__ = __str__

--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -5,9 +5,9 @@ from itertools import chain
 from math import inf
 from typing import TYPE_CHECKING, Any, DefaultDict, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
+from structlog import get_logger
 from twisted.internet.interfaces import IDelayedCall, IReactorCore
 from twisted.internet.task import Clock
-from twisted.logger import Logger
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from pycoin.key.Key import Key
 
 settings = HathorSettings()
+logger = get_logger()
 
 # check interval for maybe_spent_txs
 UTXO_CHECK_INTERVAL = 10
@@ -55,8 +56,6 @@ class WalletBalanceUpdate(NamedTuple):
 
 
 class BaseWallet:
-    log = Logger()
-
     reactor: IReactorCore
     keys: Dict[str, Any]
 
@@ -83,6 +82,8 @@ class BaseWallet:
         :param reactor: Twisted reactor that handles the time now
         :type reactor: :py:class:`twisted.internet.Reactor`
         """
+        self.log = logger.new()
+
         # Dict[token_id, Dict[Tuple[tx_id, index], UnspentTx]]
         self.unspent_txs: DefaultDict[bytes, Dict[Tuple[bytes, int], UnspentTx]] = defaultdict(dict)
 

--- a/hathor/wallet/wallet.py
+++ b/hathor/wallet/wallet.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional, Tuple
 from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePrivateKey
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
-from twisted.logger import Logger
 
 from hathor.crypto.util import get_public_key_bytes_compressed
 from hathor.pubsub import HathorEvents
@@ -16,8 +15,6 @@ from hathor.wallet.keypair import KeyPair
 
 
 class Wallet(BaseWallet):
-    log = Logger()
-
     def __init__(self, keys: Optional[Any] = None, directory: str = './', filename: str = 'keys.json',
                  pubsub: Optional[Any] = None, reactor: Optional[Any] = None) -> None:
         """ A wallet will hold key pair objects and the unspent and
@@ -59,7 +56,7 @@ class Wallet(BaseWallet):
 
     def _manually_initialize(self) -> None:
         if os.path.isfile(self.filepath):
-            self.log.info('Loading keys...')
+            self.log.info('load keys')
             self.read_keys_from_file()
 
     def read_keys_from_file(self):
@@ -88,7 +85,7 @@ class Wallet(BaseWallet):
         else:
             if self.flush_schedule is None:
                 remaining = self.flush_to_disk_interval - dt
-                self.log.info('Wallet: Flush delayed {remaining} seconds...', remaining=remaining)
+                self.log.info('flush delayed', remaining_secs=remaining)
                 assert remaining >= 0
                 self.flush_schedule = self.reactor.callLater(remaining, self._write_keys_to_file)
 
@@ -98,7 +95,7 @@ class Wallet(BaseWallet):
         data = [keypair.to_json() for keypair in self.keys.values()]
         with open(self.filepath, 'w') as json_file:
             json_file.write(json.dumps(data, indent=4))
-        self.log.info('Wallet: Keys successfully written to disk.')
+        self.log.info('keys successfully written to disk')
 
     def unlock(self, password: bytes) -> None:
         """ Validates if the password is valid

--- a/tests/cli/test_multisig_address.py
+++ b/tests/cli/test_multisig_address.py
@@ -22,16 +22,16 @@ class MultisigAddressTest(unittest.TestCase):
         # Last element is always empty string
         output.pop()
 
-        self.assertEqual(len(output), pubkey_count * 10 + 11)
+        self.assertEqual(len(output), pubkey_count * 11 + 11)
 
         def get_data(output, index):
             return output[index].split(':')[1].strip()
 
-        pubkey1 = get_data(output, 6)
-        pubkey2 = get_data(output, 16)
-        pubkey3 = get_data(output, 26)
-        redeem_script = get_data(output, 32)
-        address = get_data(output, 37)
+        pubkey1 = get_data(output, 7)
+        pubkey2 = get_data(output, 18)
+        pubkey3 = get_data(output, 29)
+        redeem_script = get_data(output, 35)
+        address = get_data(output, 40)
 
         # Generate address from given pubkeys
         args = self.parser.parse_args(['2', '--public_keys', '{},{},{}'.format(pubkey1, pubkey2, pubkey3)])

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -2,6 +2,7 @@ import json
 
 import twisted.names.client
 from twisted.internet.defer import inlineCallbacks
+from twisted.python.failure import Failure
 
 from hathor.conf import HathorSettings
 from hathor.p2p.peer_id import PeerId
@@ -81,7 +82,7 @@ class HathorProtocolTestCase(unittest.TestCase):
         # Test empty disconnect
         self.conn1.proto1.state = None
         self.conn1.proto1.connections = None
-        self.conn1.proto1.on_disconnect('')
+        self.conn1.proto1.on_disconnect(Failure(Exception()))
 
     def test_invalid_size(self):
         self.conn1.tr1.clear()
@@ -249,13 +250,13 @@ class HathorProtocolTestCase(unittest.TestCase):
 
     def test_on_disconnect(self):
         self.assertIn(self.conn1.proto1, self.manager1.connections.handshaking_peers)
-        self.conn1.disconnect('Testing')
+        self.conn1.disconnect(Failure(Exception('testing')))
         self.assertNotIn(self.conn1.proto1, self.manager1.connections.handshaking_peers)
 
     def test_on_disconnect_after_hello(self):
         self.conn1.run_one_step()
         self.assertIn(self.conn1.proto1, self.manager1.connections.handshaking_peers)
-        self.conn1.disconnect('Testing')
+        self.conn1.disconnect(Failure(Exception('testing')))
         self.assertNotIn(self.conn1.proto1, self.manager1.connections.handshaking_peers)
 
     def test_on_disconnect_after_peer_id(self):
@@ -266,7 +267,7 @@ class HathorProtocolTestCase(unittest.TestCase):
         self.conn1.run_one_step()
         self.assertIn(self.conn1.proto1, self.manager1.connections.connected_peers.values())
         self.assertNotIn(self.conn1.proto1, self.manager1.connections.handshaking_peers)
-        self.conn1.disconnect('Testing')
+        self.conn1.disconnect(Failure(Exception('testing')))
         self.assertNotIn(self.conn1.proto1, self.manager1.connections.connected_peers.values())
 
     def test_two_connections(self):


### PR DESCRIPTION
TODO:

- [x] change base to `dev` after `refactor/speed-initialization` is merged

This is what it looks like with this PR:

[![asciicast](https://asciinema.org/a/HlJwgYFzbStVRINIj0CWHFHtj.svg)](https://asciinema.org/a/HlJwgYFzbStVRINIj0CWHFHtj?speed=30&theme=tango)

And this is what it looked like before (thumbnail isn't great):

[![asciicast](https://asciinema.org/a/kURqhQBfLuGoZPf4PWJ76uN80.svg)](https://asciinema.org/a/kURqhQBfLuGoZPf4PWJ76uN80?speed=30&theme=tango)