### PR TITLE
fix(cli): Don't load HathorSettings before entering command main method

### DIFF
--- a/hathor/cli/grafana_dashboard.py
+++ b/hathor/cli/grafana_dashboard.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser, Namespace
 from enum import Flag, auto
 from typing import Any, Callable, Dict, List, Optional
 
-from hathor.util import enum_flag_all_none
+from hathor.cli.util import enum_flag_all_none
 
 # Path of this file
 dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/hathor/cli/util.py
+++ b/hathor/cli/util.py
@@ -1,4 +1,8 @@
 from argparse import ArgumentParser
+from enum import Flag
+from functools import reduce
+from operator import or_
+from typing import Type
 
 import configargparse
 
@@ -176,3 +180,13 @@ def setup_logging(debug: bool = False, capture_stdout: bool = True, *, _test_log
         logger.warning('Test: warning.')
         logger.error('Test error.')
         logger.critical('Test: critical.')
+
+
+# adapted from https://stackoverflow.com/a/42253518/947511
+def enum_flag_all_none(enumeration: Type[Flag]) -> Type[Flag]:
+    """Add NONE and ALL pseudo-members to enum.Flag classes"""
+    none_mbr = enumeration(0)
+    all_mbr = enumeration(reduce(or_, enumeration))
+    enumeration._member_map_['NONE'] = none_mbr  # type: ignore
+    enumeration._member_map_['ALL'] = all_mbr  # type: ignore
+    return enumeration

--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -4,7 +4,7 @@ SETTINGS = HathorSettings(
     P2PKH_VERSION_BYTE=b'\x49',
     MULTISIG_VERSION_BYTE=b'\x87',
     NETWORK_NAME='testnet-echo',
-    # BOOTSTRAP_DNS=['echo.testnet.hathor.network'],
+    BOOTSTRAP_DNS=['echo.testnet.hathor.network'],
     # Genesis stuff
     GENESIS_OUTPUT_SCRIPT=bytes.fromhex('76a914a584cf48b161e4a49223ed220df30037ab740e0088ac'),
     GENESIS_TIMESTAMP=1577836800,

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -16,10 +16,9 @@ limitations under the License.
 
 import warnings
 from collections import OrderedDict
-from enum import Enum, Flag
-from functools import partial, reduce, wraps
-from operator import or_
-from typing import Any, Callable, Deque, Dict, Iterable, Iterator, Tuple, Type, TypeVar, cast
+from enum import Enum
+from functools import partial, wraps
+from typing import Any, Callable, Deque, Dict, Iterable, Iterator, Tuple, TypeVar, cast
 
 from structlog import get_logger
 from twisted.internet.interfaces import IReactorCore
@@ -286,13 +285,3 @@ def api_catch_exceptions(func: Callable[..., bytes]) -> Callable[..., bytes]:
             request.setResponseCode(getattr(e, 'status_code', 500))
             return json_dumpb({'error': str(e)})
     return wrapper
-
-
-# adapted from https://stackoverflow.com/a/42253518/947511
-def enum_flag_all_none(enumeration: Type[Flag]) -> Type[Flag]:
-    """Add NONE and ALL pseudo-members to enum.Flag classes"""
-    none_mbr = enumeration(0)
-    all_mbr = enumeration(reduce(or_, enumeration))
-    enumeration._member_map_['NONE'] = none_mbr  # type: ignore
-    enumeration._member_map_['ALL'] = all_mbr  # type: ignore
-    return enumeration


### PR DESCRIPTION
We cannot top-level import from `hathor.util` in command files  because `hathor.util` loads `HathorSettings`.

Closes #108 