### PR TITLE
feat: skipping block difficulty validation while initializing the node

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -248,5 +248,6 @@ class HathorSettings(NamedTuple):
     # Amount in which tx min weight reaches the middle point between the minimum and maximum weight
     MIN_TX_WEIGHT_K: int = 100
 
-    # Quantity of blocks without a weight verification when doing a full verification
-    QUANTITY_BLOCKS_SKIP_WEIGHT_VERIFICATION: int = 1000
+    # When the node is being initialized (with a full verification) we don't verify
+    # the difficulty of all blocks, we execute the validation every N blocks only
+    VERIFY_WEIGHT_EVERY_N_BLOCKS: int = 1000

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -247,3 +247,6 @@ class HathorSettings(NamedTuple):
 
     # Amount in which tx min weight reaches the middle point between the minimum and maximum weight
     MIN_TX_WEIGHT_K: int = 100
+
+    # Quantity of blocks without a weight verification when doing a full verification
+    QUANTITY_BLOCKS_SKIP_WEIGHT_VERIFICATION: int = 1000

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -279,12 +279,19 @@ class HathorManager:
                 cnt2 = cnt
             cnt += 1
 
+            # It's safe to skip block weight verification during initialization because
+            # we trust the difficulty stored in metadata
             skip_block_weight_verification = True
             if block_count % settings.QUANTITY_BLOCKS_SKIP_WEIGHT_VERIFICATION == 0:
                 skip_block_weight_verification = False
 
             try:
-                assert self.on_new_tx(tx, quiet=True, fails_silently=False, skip_block_weight_verification=skip_block_weight_verification)
+                assert self.on_new_tx(
+                    tx,
+                    quiet=True,
+                    fails_silently=False,
+                    skip_block_weight_verification=skip_block_weight_verification
+                )
             except (InvalidNewTransaction, TxValidationError):
                 pretty_json = json.dumps(tx.to_json(), indent=4)
                 self.log.error('An unexpected error occurred when initializing {tx.hash_hex}\n'

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -282,7 +282,7 @@ class HathorManager:
             # It's safe to skip block weight verification during initialization because
             # we trust the difficulty stored in metadata
             skip_block_weight_verification = True
-            if block_count % settings.QUANTITY_BLOCKS_SKIP_WEIGHT_VERIFICATION == 0:
+            if block_count % settings.VERIFY_WEIGHT_EVERY_N_BLOCKS == 0:
                 skip_block_weight_verification = False
 
             try:

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -423,14 +423,15 @@ class HathorManager:
             tx = cast(Block, tx)
             assert tx.hash is not None  # XXX: it appears that after casting this assert "casting" is lost
 
-            # Validate minimum block difficulty
-            block_weight = self.calculate_block_difficulty(tx)
-            if tx.weight < block_weight - settings.WEIGHT_TOL:
-                raise InvalidNewTransaction(
-                    'Invalid new block {}: weight ({}) is smaller than the minimum weight ({})'.format(
-                        tx.hash.hex(), tx.weight, block_weight
+            if self.state != self.NodeState.INITIALIZING:
+                # Validate minimum block difficulty
+                block_weight = self.calculate_block_difficulty(tx)
+                if tx.weight < block_weight - settings.WEIGHT_TOL:
+                    raise InvalidNewTransaction(
+                        'Invalid new block {}: weight ({}) is smaller than the minimum weight ({})'.format(
+                            tx.hash.hex(), tx.weight, block_weight
+                        )
                     )
-                )
 
             parent_block = tx.get_block_parent()
             tokens_issued_per_block = self.get_tokens_issued_per_block(parent_block.get_metadata().height + 1)


### PR DESCRIPTION
In my notebook:

`dev`: between 19 - 24 tx/s
`feat/skip-block-weight-validation`: between 80 - 120 tx/s