### PR TITLE
fix(api): regression when calling get_block_template without address

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -532,7 +532,7 @@ class HathorManager:
         assert address is not None
         block = self.get_block_templates(parent_block_hash, timestamp).generate_mining_block(
             merge_mined=merge_mined,
-            address=address,
+            address=address or None,  # XXX: because we allow b'' for explicit empty output script
             data=data,
         )
         return block

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -19,7 +19,7 @@ import warnings
 from collections import OrderedDict
 from enum import Enum
 from functools import partial, wraps
-from typing import Any, Callable, Deque, Dict, Iterable, Iterator, Tuple, TypeVar, cast
+from typing import Any, Callable, Deque, Dict, Iterable, Iterator, Optional, Tuple, TypeVar, cast
 
 from structlog import get_logger
 from twisted.internet.interfaces import IReactorCore
@@ -286,9 +286,9 @@ def api_catch_exceptions(func: Callable[..., bytes]) -> Callable[..., bytes]:
         except HathorError as e:
             self = args[0] if len(args) > 0 else None
             if isinstance(self, Resource):
-                request = args[1] if len(args) > 1 else None
-                assert isinstance(request, Request)
-                request.setResponseCode(getattr(e, 'status_code', 500))
+                request = cast(Optional[Request], args[1] if len(args) > 1 else None)
+                if request is not None:
+                    request.setResponseCode(getattr(e, 'status_code', 500))
                 return json_dumpb({'error': str(e)})
             elif isinstance(self, WebSocketAdapterProtocol):
                 self.sendClose(reason=json_dumpb({'error': str(e)}))

--- a/tests/resources/transaction/test_mining.py
+++ b/tests/resources/transaction/test_mining.py
@@ -1,0 +1,88 @@
+from twisted.internet.defer import inlineCallbacks
+
+from hathor.transaction.resources import mining
+from tests.resources.base_resource import StubSite, _BaseResourceTest
+
+
+class MiningApiTest(_BaseResourceTest._ResourceTest):
+    def setUp(self):
+        super().setUp()
+        self.get_block_template = StubSite(mining.GetBlockTemplateResource(self.manager))
+        self.submit_block = StubSite(mining.SubmitBlockResource(self.manager))
+
+    @inlineCallbacks
+    def test_get_block_template_with_address(self):
+        resp = yield self.get_block_template.get('', {b'address': b'HC7w4j7mPet49BBN5a2An3XUiPvK6C1TL7'})
+        data = resp.json_value()
+
+        self.assertEqual(len(data['parents']), 3)
+        del data['parents']
+        del data['timestamp']
+        self.assertEqual(data, {
+            'version': 0,
+            'weight': 1.0,
+            'outputs': [{'value': 6400, 'token_data': 0, 'script': 'dqkUPW28v25nssvMMiWZR1alal4tOieIrA=='}],
+            'metadata': {
+                'hash': None,
+                'spent_outputs': [],
+                'received_by': [],
+                'children': [],
+                'conflict_with': [],
+                'voided_by': [],
+                'twins': [],
+                'accumulated_weight': 1.0,
+                'score': 0,
+                'height': 1,
+                'first_block': None,
+            },
+            'tokens': [],
+            'data': '',
+        })
+
+    @inlineCallbacks
+    def test_get_block_template_without_address(self):
+        resp = yield self.get_block_template.get('')
+        data = resp.json_value()
+
+        self.assertEqual(len(data['parents']), 3)
+        del data['parents']
+        del data['timestamp']
+        self.assertEqual(data, {
+            'version': 0,
+            'weight': 1.0,
+            'outputs': [{'value': 6400, 'token_data': 0, 'script': ''}],
+            'metadata': {
+                'hash': None,
+                'spent_outputs': [],
+                'received_by': [],
+                'children': [],
+                'conflict_with': [],
+                'voided_by': [],
+                'twins': [],
+                'accumulated_weight': 1.0,
+                'score': 0,
+                'height': 1,
+                'first_block': None,
+            },
+            'tokens': [],
+            'data': '',
+        })
+
+    @inlineCallbacks
+    def test_get_block_template_while_node_syncing(self):
+        self.manager._allow_mining_without_peers = False
+        resp = yield self.get_block_template.get('')
+        data = resp.json_value()
+
+        self.assertEqual(data, {
+            'error': 'Node syncing',
+        })
+
+    @inlineCallbacks
+    def test_get_block_template_and_submit_block(self):
+        from hathor.client import create_tx_from_dict
+        resp = yield self.get_block_template.get('', {b'address': b'HC7w4j7mPet49BBN5a2An3XUiPvK6C1TL7'})
+        data = resp.json_value()
+        block = create_tx_from_dict(data)
+        block.resolve(False)
+        self.assertTrue(self.manager.propagate_tx(block))


### PR DESCRIPTION
This regression was caught because of an error on the tx-mining-service after yesterdays v0.37.3 deploy.