### PR TITLE
fix(tests): retry tests/p2p/test_split_brain once if it fails

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -225,6 +225,14 @@ pycodestyle = ">=2.5.0,<2.6.0"
 pyflakes = ">=2.1.0,<2.2.0"
 
 [[package]]
+name = "flaky"
+version = "3.7.0"
+description = "Plugin for nose or pytest that automatically reruns flaky tests."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "graphviz"
 version = "0.10.1"
 description = "Simple Python interface for Graphviz"
@@ -910,7 +918,7 @@ rocksdb = ["cython", "python-rocksdb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.6"
-content-hash = "b4e71760c36fcc2f7f39f1d65de5ee5ca800058c802a357e981fd771523fde6e"
+content-hash = "06dff1e7191fa3e1e619ed31877a7014e34671670407033aa9b7396f891d9324"
 
 [metadata.files]
 aiohttp = [
@@ -1116,6 +1124,10 @@ entrypoints = [
 flake8 = [
     {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
+flaky = [
+    {file = "flaky-3.7.0-py2.py3-none-any.whl", hash = "sha256:d6eda73cab5ae7364504b7c44670f70abed9e75f77dd116352f662817592ec9c"},
+    {file = "flaky-3.7.0.tar.gz", hash = "sha256:3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d"},
 ]
 graphviz = [
     {file = "graphviz-0.10.1-py2.py3-none-any.whl", hash = "sha256:0e1744a45b0d707bc44f99c7b8e5f25dc22cf96b6aaf2432ac308ed9822a9cb6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pytest = "<4.6"
 pytest-cov = "<2.8"
 mypy-protobuf = "<1.11"
 grpcio-tools = "<1.22"
+flaky = "<3.8"
 
 [tool.poetry.dependencies]
 python = "~3.6"

--- a/tests/p2p/test_split_brain.py
+++ b/tests/p2p/test_split_brain.py
@@ -1,5 +1,6 @@
 import random
 
+import pytest
 from mnemonic import Mnemonic
 
 from hathor.graphviz import GraphvizVisualizer
@@ -46,6 +47,8 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         wallet.unlock(words=words, tx_storage=manager.tx_storage)
         return manager
 
+    # retry the test once if it fails, see: https://github.com/box/flaky
+    @pytest.mark.flaky
     def test_split_brain(self):
         debug_pdf = False
 


### PR DESCRIPTION
That test is known to randomly fail. We will always re-run it manually when that happens. This PR adds the [flaky](https://github.com/box/flaky) plugin that will do just that automatically for tests marked as flaky (`@pytest.mark.flaky` like this one is now) with the following strategy: out of 2 runs it has to pass one.

This is what it looks like when it passes the first time:

```
===Flaky Test Report===

test_split_brain passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
```

And this is what it looks like when it fails once and has to run again (which took several tries):

```
===Flaky Test Report===

test_split_brain failed (1 runs remaining out of 2).
	<class 'twisted.trial.unittest.FailTest'>
	Items in the first set but not the second:
Interval(3177661205, inf, b'\x07B\x96\x9dx\x01Av\x80\xf0\xb4E\xd3\x8d\xc2\xc5\xc1\x14uDsl\xe7\x80\xd4\x82\x95\xbdZm\xdd;')
	[<TracebackEntry /Users/jan/Projects/hathor-core/tests/p2p/test_split_brain.py:116>, <TracebackEntry /Users/jan/Projects/hathor-core/tests/unittest.py:85>, <TracebackEntry /Users/jan/Library/Caches/pypoetry/virtualenvs/hathor-JIQwCn9w-py3.6/lib/python3.6/site-packages/twisted/trial/_synctest.py:432>, <TracebackEntry /Users/jan/Library/Caches/pypoetry/virtualenvs/hathor-JIQwCn9w-py3.6/lib/python3.6/site-packages/twisted/trial/_synctest.py:375>]
test_split_brain passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
```

I did not have the patience to run try and make it fail twice in a row.