### PR TITLE
fix(api): validate_address returns 500 on valid address

### DIFF
--- a/hathor/transaction/resources/validate_address.py
+++ b/hathor/transaction/resources/validate_address.py
@@ -1,9 +1,11 @@
 import base64
+from typing import Union
 
 from twisted.web import resource
 
 from hathor.api_util import set_cors
 from hathor.cli.openapi_files.register import register_resource
+from hathor.manager import HathorManager
 from hathor.transaction.scripts import create_base_script
 from hathor.util import api_catch_exceptions, json_dumpb
 
@@ -31,7 +33,7 @@ class _ValidateAddressResource(resource.Resource):
     """
     isLeaf = True
 
-    def __init__(self, manager, address):
+    def __init__(self, manager: HathorManager, address: Union[str, bytes]):
         super().__init__()
         # Important to have the manager so we can know the tx_storage
         self.manager = manager

--- a/hathor/transaction/resources/validate_address.py
+++ b/hathor/transaction/resources/validate_address.py
@@ -35,6 +35,9 @@ class _ValidateAddressResource(resource.Resource):
         super().__init__()
         # Important to have the manager so we can know the tx_storage
         self.manager = manager
+        if isinstance(address, bytes):
+            address = address.decode('ascii')
+        assert isinstance(address, str)
         self.address = address
 
     @api_catch_exceptions

--- a/tests/resources/base_resource.py
+++ b/tests/resources/base_resource.py
@@ -52,7 +52,9 @@ class RequestBody(object):
 
 class TestDummyRequest(DummyRequest):
     def __init__(self, method, url, args=None, headers=None):
-        DummyRequest.__init__(self, url.split('/'))
+        slash = b'/' if isinstance(url, bytes) else '/'
+        path = url.split(slash)
+        DummyRequest.__init__(self, path)
         self.method = method
         self.headers = headers or {}
         self.content = RequestBody()

--- a/tests/resources/transaction/test_validate_address.py
+++ b/tests/resources/transaction/test_validate_address.py
@@ -21,20 +21,20 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
 
     @inlineCallbacks
     def test_simple(self):
-        address = 'HNXsVtRUmwDCtpcCJUrH4QiHo9kUKx199A'
+        address = b'HNXsVtRUmwDCtpcCJUrH4QiHo9kUKx199A'
         response_success = yield self.web.get(address)
         data_success = response_success.json_value()
         self.assertEqual(data_success, {
            'valid': True,
            'script': 'dqkUr6YAVWv0Ps6bjgSGuqMb1GqCw6+IrA==',
-           'address': address,
+           'address': address.decode('ascii'),
            'type': 'p2pkh',
         })
 
     @inlineCallbacks
     def test_invalid_network(self):
         # this address is valid on the testnet
-        response_success = yield self.web.get('WTPcVyGjo9tSet8QAH7qudW2LwtkgubZGU')
+        response_success = yield self.web.get(b'WTPcVyGjo9tSet8QAH7qudW2LwtkgubZGU')
         data_success = response_success.json_value()
         self.assertEqual(data_success, {
            'valid': False,
@@ -44,7 +44,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
 
     @inlineCallbacks
     def test_wrong_size(self):
-        address = 'HNXsVtRUmwDCtpcCJUrH4QiHo9kUKx199Aa'
+        address = b'HNXsVtRUmwDCtpcCJUrH4QiHo9kUKx199Aa'
         response_success = yield self.web.get(address)
         data_success = response_success.json_value()
         self.assertEqual(data_success, {
@@ -56,7 +56,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
     @inlineCallbacks
     def test_gibberish(self):
         # this isn't remotely what an address looks like
-        response_success = yield self.web.get('ahl8sfyoiuh23$%!!dfads')
+        response_success = yield self.web.get(b'ahl8sfyoiuh23$%!!dfads')
         data_success = response_success.json_value()
         self.assertEqual(data_success, {
            'valid': False,


### PR DESCRIPTION
This is a regression that passes the tests but not on actual usage. I'm figuring out how to test this, it can potentially affect other endpoints that rely on a request parameter to be passed as `str`, but so far this is the only known case (maybe because it's the only usage of `getChild`).