### PR TITLE
fix(p2p): re-run discovery when no peers are connected

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -245,8 +245,7 @@ class HathorManager:
         for description in self.listen_addresses:
             self.listen(description, ssl=self.ssl)
 
-        for peer_discovery in self.peer_discoveries:
-            peer_discovery.discover_and_connect(self.connections.connect_to)
+        self.do_discovery()
 
         self.start_time = time.time()
 
@@ -281,6 +280,10 @@ class HathorManager:
                 waits.append(wait_stratum)
 
         return defer.DeferredList(waits)
+
+    def do_discovery(self) -> None:
+        for peer_discovery in self.peer_discoveries:
+            peer_discovery.discover_and_connect(self.connections.connect_to)
 
     def start_profiler(self) -> None:
         """

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -282,6 +282,9 @@ class HathorManager:
         return defer.DeferredList(waits)
 
     def do_discovery(self) -> None:
+        """
+        Do a discovery and connect on all discovery strategies.
+        """
         for peer_discovery in self.peer_discoveries:
             peer_discovery.discover_and_connect(self.connections.connect_to)
 

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -227,6 +227,7 @@ class ConnectionsManager:
 
         TODO(epnichols): Should we always connect to *all*? Should there be a max #?
         """
+        # when we have no connected peers left, run the discovery process again
         if len(self.connected_peers) < 1:
             # XXX: accessing manager through downloader because there is no other reference
             self.downloader.manager.do_discovery()

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -225,8 +225,11 @@ class ConnectionsManager:
         """ It is called by the `lc_reconnect` timer and tries to connect to all known
         peers.
 
-        TODO(epnichols): Should we always conect to *all*? Should there be a max #?
+        TODO(epnichols): Should we always connect to *all*? Should there be a max #?
         """
+        if len(self.connected_peers) < 1:
+            # XXX: accessing manager through downloader because there is no other reference
+            self.downloader.manager.do_discovery()
         now = int(self.reactor.seconds())
         for peer in self.peer_storage.values():
             self.connect_to_if_not_connected(peer, now)


### PR DESCRIPTION
This PR was created to fix an issue, but it's actually a feature.

To fix the problem of rejecting every peer before getting the whitelist I added the feature of re-running the discovery process periodically if there are no connected peers.