### PR TITLE
chore(ci): remove poetry cache, which was causing tests to crash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,23 +51,11 @@ jobs:
       run: brew install -q graphviz rocksdb
     - name: Install Poetry
       run: pip -q --no-input install poetry
-    - name: Get Poetry cache-dir
-      id: poetry-install
-      shell: bash
-      run: echo ::set-output name=cache-dir::$(poetry config cache-dir)
-    - name: Cache Poetry dependencies
-      uses: actions/cache@v2
-      id: poetry-cache
-      # skip on Windows because `Compile protos` hangs
-      if: matrix.os != 'windows-latest'
-      with:
-        path: ${{ steps.poetry-install.outputs.cache-dir }}
-        key: ${{ runner.os }}-py${{ matrix.python }}-pypoetry-${{ hashFiles('poetry.lock') }}
     - name: Install Poetry dependencies (with rocksdb)
-      if: steps.poetry-cache.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-latest'
       run: poetry install -n -E rocksdb --no-root
     - name: Install Poetry dependencies (without rocksdb)
-      if: steps.poetry-cache.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest'
       run: poetry install -n --no-root
     - name: Compile protos
       run: poetry run make protos


### PR DESCRIPTION
I thought about just disabling the caches or just hijacking the cache key to force it to be rebuilt (since there isn't a way to force cache invalidation for Github Actions), but after reviewing all builds, not using this cache will add about 3min to build time, which is not much (it usually takes about 30min for the whole matrix to finish).

Given that we don't really know what caused the cache to become a problem, and thus we don't know how to incorporate that into the key to make it "imcompatible" (for instance we already incorporate the OS and Python version, so one cache can't be used on a different os or Python version), we don't know when something like this will happen again. And given that we can't "quickly" solve this by force-invalidating a cache (I think it takes 7 days of no use for a cache to be dropped), it seems to me that just not using the cache is the best current approach.

What do you think?