### PR TITLE
chore(docker): fix build, broke due to recent updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,63 +29,60 @@ jobs:
         - python-impl: pypy
           python-version: 3.7
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Prepare tags
       id: prep
+      shell: python
       run: |
-        DEFAULT_PYTHON=python3.7
-        DEFAULT_PYPY=pypy3.7
-        DOCKER_IMAGE=hathornetwork/hathor-core
-        GHCR_IMAGE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')/hathor-core"
-        VERSION=noop
-        if [ "${{ github.event_name }}" = "schedule" ]; then
-          VERSION=nightly
-        elif [[ $GITHUB_REF == refs/tags/* ]]; then
-          VERSION=${GITHUB_REF#refs/tags/}
-          VERSION=${VERSION%%-r[0-9]*}
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-          if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-            VERSION=edge
-          fi
-        elif [[ $GITHUB_REF == refs/pull/* ]]; then
-          VERSION=pr-${{ github.event.number }}
-        fi
-        BASE_VERSION=$VERSION
-        DOCKERFILE=Dockerfile.github
-        SUFFIX=python${{ matrix.python-version }}
-        if [[ "${{ matrix.python-impl }}" == "pypy" ]]; then
-          DOCKERFILE=Dockerfile.github-pypy
-          SUFFIX=pypy${{ matrix.python-version }}
-        fi
-        VERSION="${VERSION}-${SUFFIX}"
-        TAGS="${DOCKER_IMAGE}:${VERSION}"
-        TAGS="${TAGS},${GHCR_IMAGE}:${VERSION}"
-        if [[ $SUFFIX == "$DEFAULT_PYTHON" ]]; then
-          TAGS="$TAGS,${DOCKER_IMAGE}:${BASE_VERSION}"
-          TAGS="$TAGS,${GHCR_IMAGE}:${BASE_VERSION}"
-        elif [[ $SUFFIX == "$DEFAULT_PYPY" ]]; then
-          TAGS="$TAGS,${DOCKER_IMAGE}:${BASE_VERSION}-pypy"
-          TAGS="$TAGS,${GHCR_IMAGE}:${BASE_VERSION}-pypy"
-        fi
-        if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-          MINOR=${BASE_VERSION%.*}-${SUFFIX}
-          TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR}"
-          TAGS="$TAGS,${GHCR_IMAGE}:${MINOR}"
-          #MAJOR=${MINOR%.*}-${SUFFIX}
-          #TAGS="$TAGS,${DOCKER_IMAGE}:${MAJOR}"
-          #TAGS="$TAGS,${GHCR_IMAGE}:${MAJOR}"
-          if [[ $SUFFIX == "$DEFAULT_PYTHON" ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
-            TAGS="$TAGS,${GHCR_IMAGE}:latest"
-          fi
-        elif [ "${{ github.event_name }}" = "push" ]; then
-          # TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}-${SUFFIX}"  # these tags are annoying on DockerHub
-          TAGS="$TAGS,${GHCR_IMAGE}:sha-${GITHUB_SHA::8}-${SUFFIX}"
-        fi
-        echo ::set-output name=version::${VERSION}
-        echo ::set-output name=tags::${TAGS}
-        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo ::set-output name=dockerfile::${DOCKERFILE}
+        import datetime
+        import itertools
+        import re
+        def extract_pyver(filename):
+            for line in open(filename).readlines():
+                if line.startswith('ARG PYTHON'):
+                    return line.split('=')[1].strip()
+        ref = '${{ github.ref }}'
+        dockerfile_cpython = 'Dockerfile.github'
+        dockerfile_pypy = 'Dockerfile.github-pypy'
+        default_python = 'python' + extract_pyver(dockerfile_cpython)
+        default_pypy = 'pypy' + extract_pyver(dockerfile_pypy)
+        if '${{ github.event_name }}' == 'schedule':
+            base_version = 'nightly'
+        elif ref.startswith('refs/tags/'):
+            base_version = ref[10:].split('-', 1)[0]
+        elif ref.startswith('refs/heads/'):
+            base_version = ref[11:].replace('/', '-')
+            if base_version == '${{ github.event.repository.default_branch }}':
+              base_version = 'stable'
+        elif ref.startswith('refs/pull/'):
+            base_version = 'pr-${{ github.event.number }}'
+        else:
+            base_version = 'noop'
+        if '${{ matrix.python-impl }}' == 'pypy':
+            dockerfile = dockerfile_pypy
+            suffix = 'pypy${{ matrix.python-version }}'
+        else:
+            dockerfile = dockerfile_cpython
+            suffix = 'python${{ matrix.python-version }}'
+        version = base_version + '-' + suffix
+        tags = {version}
+        if suffix == default_python:
+            tags.add(base_version)
+        elif suffix == default_pypy:
+            tags.add(base_version + '-pypy')
+        if re.match(r'^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$', base_version):
+            minor = base_version.rpartition('.')[0]
+            tags.add(minor + '-' + suffix)
+            if suffix == default_python:
+                tags.add('latest')
+        elif '${{ github.event_name }}' == 'push':
+            tags.add('sha-' + '${{ github.sha }}'[:8])
+        print('::set-output name=version::' + version)
+        print('::set-output name=tags::' + ','.join(itertools.chain(('${{ secrets.DOCKERHUB_IMAGE }}:' + t for t in tags),
+                                                                    ('${{ secrets.GHCR_IMAGE }}:' + t for t in tags))))
+        print('::set-output name=created::' + datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+        print('::set-output name=dockerfile::' + dockerfile)
     - name: Set up QEMU  # arm64 is not available natively
       uses: docker/setup-qemu-action@v1
       with:
@@ -107,8 +104,6 @@ jobs:
         registry: ghcr.io
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
-    - name: Checkout
-      uses: actions/checkout@v2
     - name: Set up Python 3.7 (base) # 3.7 is the fastest to setup, and the specific version doesn't matter here
       uses: actions/setup-python@v2
       with:
@@ -150,7 +145,7 @@ jobs:
       with:
         context: .
         file: ${{ steps.prep.outputs.dockerfile }}
-        build-args: PYTHON_VERSION=${{ matrix.python-version }}
+        build-args: PYTHON=${{ matrix.python-version }}
         platforms: linux/amd64,linux/arm64
         pull: true
         push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-# before changing these variables, make sure the tag $PYTHON_VERSION-alpine$ALPINE_VERSION exists first
+# before changing these variables, make sure the tag $PYTHON-alpine$ALPINE exists first
 # list of valid tags hese: https://hub.docker.com/_/python
-ARG PYTHON_VERSION=3.6
-ARG ALPINE_VERSION=3.12
+# XXX: docker.io/python images use a `ENV PYTHON_VERSION` that would shadow an ARG of same name
+ARG PYTHON=3.7
+ARG ALPINE=3.13
 
 # stage-0: copy pyproject.toml/poetry.lock and install the production set of dependencies
-FROM python:$PYTHON_VERSION-alpine$ALPINE_VERSION as stage-0
+FROM python:$PYTHON-alpine$ALPINE as stage-0
+ARG PYTHON
 WORKDIR /usr/src/app/
 RUN apk add --no-cache openssl libffi graphviz
 # XXX: adding rocksdb and rocksdb-dev separately allows reuse of the rocksdb only
@@ -14,35 +16,39 @@ RUN apk add --no-cache openssl libffi graphviz
 #      making the python binding try to load the updated lib, this pattern will prevent that)
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb-dev
-RUN apk add openssl-dev libffi-dev build-base
-RUN pip install poetry
+RUN apk add openssl-dev libffi-dev build-base rust cargo
+RUN pip --no-input --no-cache-dir install --upgrade pip poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 COPY pyproject.toml poetry.lock  ./
 RUN poetry install -n -E rocksdb --no-root --no-dev
 
 # stage-1: install all dev dependencies and build protos, reuse .venv from stage-0
-FROM python:$PYTHON_VERSION-alpine$ALPINE_VERSION as stage-1
+FROM python:$PYTHON-alpine$ALPINE as stage-1
+ARG PYTHON
 WORKDIR /usr/src/app/
 RUN apk add --no-cache openssl libffi graphviz
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb-dev
-RUN apk add openssl-dev libffi-dev build-base
-RUN pip install poetry
+RUN apk add openssl-dev libffi-dev build-base rust cargo
+RUN pip --no-input --no-cache-dir install --upgrade pip poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 COPY pyproject.toml poetry.lock  ./
-COPY --from=stage-0 /usr/src/app/.venv /usr/src/app/.venv/
+RUN poetry install -n -E rocksdb --no-root --no-dev
+# up to the line above is be the same as in stage-0, and thus all layers are re-used
 RUN poetry install -n -E rocksdb --no-root
 COPY Makefile ./
 COPY hathor/protos ./hathor/protos/
+RUN make clean-protos
 RUN poetry run make protos
 
 # finally: use production .venv (from stage-0) and compiled protos (from stage-1)
 # lean and mean: this image should be about ~110MB, would be about ~470MB if using the whole stage-1
-FROM python:$PYTHON_VERSION-alpine$ALPINE_VERSION
+FROM python:$PYTHON-alpine$ALPINE
+ARG PYTHON
 WORKDIR /usr/src/app/
 RUN apk add --no-cache openssl libffi graphviz
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
-COPY --from=stage-0 /usr/src/app/.venv/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
+COPY --from=stage-0 /usr/src/app/.venv/lib/python${PYTHON}/site-packages /usr/local/lib/python${PYTHON}/site-packages
 COPY --from=stage-1 /usr/src/app/hathor/protos/*.py /usr/src/app/hathor/protos/
 COPY hathor ./hathor
 EXPOSE 40403 8080

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -1,10 +1,11 @@
-# before changing these variables, make sure the tag $PYTHON_VERSION-alpine$ALPINE_VERSION exists first
+# before changing these variables, make sure the tag $PYTHON-alpine$ALPINE exists first
 # list of valid tags hese: https://hub.docker.com/_/python
-ARG PYTHON_VERSION=3.7
-ARG ALPINE_VERSION=3.12
+# XXX: docker.io/python images use a `ENV PYTHON` that would shadow an ARG of same name
+ARG PYTHON=3.7
+ARG ALPINE=3.13
 
 # stage-0: install all python deps, build and install package, everything will be available on .venv
-FROM python:$PYTHON_VERSION-alpine$ALPINE_VERSION as stage-0
+FROM python:$PYTHON-alpine$ALPINE as stage-0
 # install runtime first deps to speedup the dev deps and because layers will be reused on stage-1
 RUN apk add --no-cache openssl libffi graphviz
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
@@ -22,7 +23,7 @@ RUN pip --no-input --no-cache-dir install --no-deps --compile -r requirements.tx
 
 # finally: use production .venv from before
 # lean and mean: this image should be about ~50MB, would be about ~470MB if using the whole stage-1
-FROM python:$PYTHON_VERSION-alpine$ALPINE_VERSION
+FROM python:$PYTHON-alpine$ALPINE
 RUN apk add --no-cache openssl libffi graphviz
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
 COPY --from=stage-0 /app/.venv/lib/ /usr/local/lib/

--- a/Dockerfile.github-pypy
+++ b/Dockerfile.github-pypy
@@ -1,10 +1,10 @@
-# before changing these variables, make sure the tag $PYTHON_VERSION-alpine$ALPINE_VERSION exists first
+# before changing these variables, make sure the tag $PYTHON-alpine$ALPINE exists first
 # list of valid tags hese: https://hub.docker.com/_/pypy
-ARG PYTHON_VERSION=3.6
-ARG DEBIAN_VERSION=slim-buster
+ARG PYTHON=3.7
+ARG DEBIAN=slim-buster
 
 # stage-0: copy pyproject.toml/poetry.lock and install the production set of dependencies
-FROM pypy:$PYTHON_VERSION-$DEBIAN_VERSION as stage-0
+FROM pypy:$PYTHON-$DEBIAN as stage-0
 # install runtime first deps to speedup the dev deps and because layers will be reused on stage-1
 RUN apt-get -qy update
 RUN apt-get -qy install libssl1.1 graphviz librocksdb5.17
@@ -19,12 +19,11 @@ RUN pip --no-input --no-cache-dir install --upgrade "pip<21" wheel
 COPY requirements.txt ./requirements.txt
 RUN pip --no-input --no-cache-dir install --no-deps --compile -r requirements.txt
 COPY dist ./dist
-#RUN pip --no-input --no-cache-dir install --compile --no-deps dist/hathor-*.whl
 RUN pip --no-input --no-cache-dir install --compile --no-deps `ls -1 dist/hathor-*.whl`
 
 # finally: use production .venv from before
 # lean and mean: this image should be about ~50MB, would be about ~470MB if using the whole stage-1
-FROM pypy:$PYTHON_VERSION-$DEBIAN_VERSION
+FROM pypy:$PYTHON-$DEBIAN
 RUN apt-get -qy update
 RUN apt-get -qy install libssl1.1 graphviz librocksdb5.17
 COPY --from=stage-0 /app/.venv/site-packages/ /opt/pypy/site-packages/


### PR DESCRIPTION
> Recent updates on the cryptography package introduced the need for rustc
> for compiling it from source. Although the required runtime version of
> cryptography is locked in `poetry.lock`, when installing Poetry (from
> outside the controlled virtualenv) it gets pulled by some dependency and
> the latest version is installed. The bare `Dockerfile` has been updated
> to support these changes (install Rust and update alpine).
> 
> The last update to the workflow script that builds and pushes the image
> stopped adding the `latest` tag. I ported the script to Python because
> it's better to maintain than the Bash script we had. This update also
> includes some small adjustments to support easier testing of this build
> script and use the Python version on the `Dockerfile`s as the default
> (as opposed to encoding it in the script).

Because these changes will only have effect _after_ being merged to `dev` and then to `master` and then when we release a tag, I've tested those steps on separate Github and Dockerhub repos:

- workflow docker build on default branch: https://github.com/jansegre/hathor-core/actions/runs/591606097 (notice that the script under "Prepare tags" can be copied and run on python/ipython as is, this greatly helps testing and debugging that script)
- workflow docker build on a release tag: https://github.com/jansegre/hathor-core/actions/runs/591653561
- autobuild on Dockerhub: https://hub.docker.com/repository/registry-1.docker.io/jansegre/hathor-core/builds/fca75cf7-132f-4c9c-bbd6-93d17f66b1f8 (this tests the base `Dockerfile`, an important change is that the autobuild cache has been disabled, so this type of breakage will be harder to miss)
