### PR TITLE
chore(docker): disable poetry cache on docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,14 +110,7 @@ jobs:
         python-version: 3.7
     - name: Install Poetry
       run: pip -q --no-input install poetry
-    - name: Cache Poetry dependencies
-      uses: actions/cache@v2
-      id: poetry-cache
-      with:
-        path: ~/.cache/pypoetry
-        key: ${{ runner.os }}-py3.7-pypoetry-${{ hashFiles('poetry.lock') }}
     - name: Install Poetry dependencies
-      if: steps.poetry-cache.outputs.cache-hit != 'true'
       run: poetry install -n --no-root
     - name: Generate protobuf files
       run: poetry run make protos


### PR DESCRIPTION
After the last docker build fix I noticed scheduled builds broke on my fork. I realized we removed the poetry log cache for the tests but not for the docker build, and this was causing the failures.

Scheduled build history:

- hadn't failed yet but problem was there: https://github.com/jansegre/hathor-core/actions/runs/594827023
- failed: https://github.com/jansegre/hathor-core/actions/runs/598270493
- ...
- last one that failed: https://github.com/jansegre/hathor-core/actions/runs/606957181
- fix pushed: https://github.com/jansegre/hathor-core/actions/runs/608344826
- first scheduled build, no problem: https://github.com/jansegre/hathor-core/actions/runs/609282150