### PR TITLE
fix(metrics): protocol_state=None case not accounted for

### DIFF
--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -216,7 +216,8 @@ class Metrics:
             self.peers += 1
         elif key == HathorEvents.NETWORK_PEER_DISCONNECTED:
             # Check if peer was ready before disconnecting
-            if data['protocol'].state.state_name == HathorProtocol.PeerState.READY.name:
+            protocol_state = data['protocol'].state
+            if protocol_state is not None and protocol_state.state_name == HathorProtocol.PeerState.READY.name:
                 self.peers -= 1
         else:
             raise ValueError('Invalid key')


### PR DESCRIPTION
I recently got a traceback like this:

```
Traceback (most recent call last):
  File ".../python3.7/site-packages/twisted/internet/defer.py", line 311, in addCallbacks
    self._runCallbacks()
  File ".../python3.7/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File ".../python3.7/site-packages/twisted/internet/base.py", line 447, in _continueFiring
    callable(*args, **kwargs)
  File ".../python3.7/site-packages/twisted/internet/base.py", line 706, in disconnectAll
    failure.Failure(main.CONNECTION_LOST))
--- <exception caught here> ---
  File ".../python3.7/site-packages/twisted/python/log.py", line 103, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File ".../python3.7/site-packages/twisted/python/log.py", line 86, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File ".../python3.7/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File ".../python3.7/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
  File ".../python3.7/site-packages/twisted/internet/tcp.py", line 519, in connectionLost
    self._commonConnection.connectionLost(self, reason)
  File ".../python3.7/site-packages/twisted/internet/tcp.py", line 327, in connectionLost
    protocol.connectionLost(reason)
  File ".../python3.7/site-packages/twisted/internet/endpoints.py", line 146, in connectionLost
    return self._wrappedProtocol.connectionLost(reason)
  File ".../python3.7/site-packages/twisted/protocols/tls.py", line 403, in connectionLost
    ProtocolWrapper.connectionLost(self, reason)
  File ".../python3.7/site-packages/twisted/protocols/policies.py", line 125, in connectionLost
    self.wrappedProtocol.connectionLost(reason)
  File ".../hathor-core/hathor/p2p/protocol.py", line 357, in connectionLost
    self.on_disconnect(reason)
  File ".../hathor-core/hathor/p2p/protocol.py", line 275, in on_disconnect
    self.connections.on_peer_disconnect(self)
  File ".../hathor-core/hathor/p2p/manager.py", line 220, in on_peer_disconnect
    self.pubsub.publish(HathorEvents.NETWORK_PEER_DISCONNECTED, protocol=protocol)
  File ".../hathor-core/hathor/pubsub.py", line 166, in publish
    fn(key, args)
  File ".../hathor-core/hathor/metrics.py", line 219, in handle_publish
    if data['protocol'].state.state_name == HathorProtocol.PeerState.READY.name:
builtins.AttributeError: 'NoneType' object has no attribute 'state_name'
```

It might not be too important because that happened when exiting `hathor-core`, but it's still an error. In the future we should consider a better typing strategy on the `data` variable that metric events receive because currently it erases the types of its values (by effectively being a `Dict[str, Any]`), so mypy can't see these kind of errors.