### PR TITLE
feat(p2p): only say the peer is "blocked" when explicitly configured

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -154,6 +154,9 @@ class HathorSettings(NamedTuple):
     # that the peer is synced (in seconds).
     P2P_SYNC_THRESHOLD: int = 60
 
+    # Whether to warn the other peer of the reason for closing the connection
+    WHITELIST_WARN_BLOCKED_PEERS: bool = False
+
     # Maximum number of opened threads that are solving POW for send tokens
     MAX_POW_THREADS: int = 5
 

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -97,7 +97,10 @@ class PeerIdState(BaseState):
 
         # is it on the whitelist?
         if settings.ENABLE_PEER_WHITELIST and peer.id not in protocol.node.peers_whitelist:
-            protocol.send_error_and_close_connection('Blocked (id={}). Get in touch with Hathor team.'.format(peer.id))
+            if settings.WHITELIST_WARN_BLOCKED_PEERS:
+                protocol.send_error_and_close_connection(f'Blocked (by {peer.id}). Get in touch with Hathor team.')
+            else:
+                protocol.send_error_and_close_connection('Connection rejected.')
             return
 
         if peer.id == protocol.my_peer.id:


### PR DESCRIPTION
This change makes it so we have to explicitly enable "peer blocked" warnings. Which should make it so "internal nodes" that don't use the default whitelist don't annoy everyone.