### PR TITLE
feat(cli): option to log in plain JSON

### DIFF
--- a/hathor/cli/main.py
+++ b/hathor/cli/main.py
@@ -135,7 +135,11 @@ class CliManager:
             pudb.set_trace(paused=False)
             capture_stdout = False
 
-        setup_logging(debug, capture_stdout)
+        json_logs = '--json-logs' in sys.argv
+        if json_logs:
+            sys.argv.remove('--json-logs')
+
+        setup_logging(debug, capture_stdout, json_logs)
         module.main()
 
 


### PR DESCRIPTION
This is what a regular log looks like:

```
2021-06-15 21:56:36 [info     ] [hathor.cli.run_node] hathor-core v0.39.1            genesis=3fdff62 hathor=0.39.1 my_peer_id=c68251cd14fb3d02eb743f39c5663f291f17d40f466fc0207eae28a82cd4e0ba pid=20658 platform=Darwin-20.5.0-x86_64-i386-64bit python=3.7.10-CPython
2021-06-15 21:56:36 [info     ] [hathor.cli.run_node] with storage                   path=/Users/jan/Projects/hathor-core4/datamain storage_class=TransactionRocksDBStorage
2021-06-15 21:56:36 [info     ] [hathor.cli.run_node] with cache                     capacity=100000 interval=5
2021-06-15 21:56:36 [info     ] [hathor.manager] start manager                  network=mainnet
2021-06-15 21:56:36 [info     ] [hathor.p2p.manager] update whitelist
2021-06-15 21:56:36 [info     ] [hathor.manager] initialize
^C2021-06-15 21:56:38 [warning  ] [hathor.cli.main] Aborting and exiting...
```

But when using `--json-logs` it looks like this:

```
{"hathor": "0.39.1", "pid": 20734, "genesis": "3fdff62", "my_peer_id": "c68251cd14fb3d02eb743f39c5663f291f17d40f466fc0207eae28a82cd4e0ba", "python": "3.7.10-CPython", "platform": "Darwin-20.5.0-x86_64-i386-64bit", "event": "hathor-core v0.39.1", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 21:57:17"}
{"storage_class": "TransactionRocksDBStorage", "path": "/Users/jan/Projects/hathor-core4/datamain", "event": "with storage", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 21:57:17"}
{"capacity": 100000, "interval": 5, "event": "with cache", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 21:57:17"}
{"network": "mainnet", "event": "start manager", "logger": "hathor.manager", "level": "info", "timestamp": "2021-06-15 21:57:17"}
{"event": "update whitelist", "logger": "hathor.p2p.manager", "level": "info", "timestamp": "2021-06-15 21:57:17"}
{"event": "initialize", "logger": "hathor.manager", "level": "info", "timestamp": "2021-06-15 21:57:18"}
^C{"event": "Aborting and exiting...", "logger": "hathor.cli.main", "level": "warning", "timestamp": "2021-06-15 21:57:19"}
```

It still logs to `stderr` and does not mess with `stdout`, but will correctly capture unhandled exceptions:

```
{"hathor": "0.39.1", "pid": 21091, "genesis": "3fdff62", "my_peer_id": "c68251cd14fb3d02eb743f39c5663f291f17d40f466fc0207eae28a82cd4e0ba", "python": "3.7.10-CPython", "platform": "Darwin-20.5.0-x86_64-i386-64bit", "event": "hathor-core v0.39.1", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 21:59:16"}
{"storage_class": "TransactionRocksDBStorage", "path": "/Users/jan/Projects/hathor-core4/datamain", "event": "with storage", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 21:59:16"}
{"capacity": 100000, "interval": 5, "event": "with cache", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 21:59:16"}
{"network": "mainnet", "event": "start manager", "logger": "hathor.manager", "level": "info", "timestamp": "2021-06-15 21:59:16"}
{"event": "update whitelist", "logger": "hathor.p2p.manager", "level": "info", "timestamp": "2021-06-15 21:59:16"}
{"event": "initialize", "logger": "hathor.manager", "level": "info", "timestamp": "2021-06-15 21:59:16"}
{"event": "Uncaught exception:", "logger": "hathor.cli.main", "level": "error", "timestamp": "2021-06-15 21:59:16", "exception": "Traceback (most recent call last):\n  File \"/Users/jan/Projects/hathor-core4/hathor/cli/main.py\", line 148, in main\n    sys.exit(CliManager().execute_from_command_line())\n  File \"/Users/jan/Projects/hathor-core4/hathor/cli/main.py\", line 143, in execute_from_command_line\n    module.main()\n  File \"/Users/jan/Projects/hathor-core4/hathor/cli/run_node.py\", line 439, in main\n    RunNode().run()\n  File \"/Users/jan/Projects/hathor-core4/hathor/cli/run_node.py\", line 428, in __init__\n    self.prepare(args)\n  File \"/Users/jan/Projects/hathor-core4/hathor/cli/run_node.py\", line 235, in prepare\n    self.start_manager()\n  File \"/Users/jan/Projects/hathor-core4/hathor/cli/run_node.py\", line 239, in start_manager\n    self.manager.start()\n  File \"/Users/jan/Projects/hathor-core4/hathor/manager.py\", line 237, in start\n    self._initialize_components()\n  File \"/Users/jan/Projects/hathor-core4/hathor/manager.py\", line 337, in _initialize_components\n    raise Exception('foobar')\nException: foobar"}
```

And unhandled error in deferred:

```
{"hathor": "0.39.1", "pid": 22218, "genesis": "3fdff62", "my_peer_id": "c68251cd14fb3d02eb743f39c5663f291f17d40f466fc0207eae28a82cd4e0ba", "python": "3.7.10-CPython", "platform": "Darwin-20.5.0-x86_64-i386-64bit", "event": "hathor-core v0.39.1", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 22:02:30"}
{"storage_class": "TransactionRocksDBStorage", "path": "/Users/jan/Projects/hathor-core4/datamain", "event": "with storage", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 22:02:30"}
{"capacity": 100000, "interval": 5, "event": "with cache", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 22:02:30"}
{"network": "mainnet", "event": "start manager", "logger": "hathor.manager", "level": "info", "timestamp": "2021-06-15 22:02:30"}
{"event": "update whitelist", "logger": "hathor.p2p.manager", "level": "info", "timestamp": "2021-06-15 22:02:30"}
{"event": "Unhandled error in Deferred:", "logger": "twisted", "level": "critical", "timestamp": "2021-06-15 22:02:30"}
{"event": "", "logger": "twisted", "level": "critical", "timestamp": "2021-06-15 22:02:30", "exception": "Exception: foobar"}
{"listen": 9080, "with_wallet_api": false, "event": "with status", "logger": "hathor.cli.run_node", "level": "info", "timestamp": "2021-06-15 22:02:30"}
...
```