### PR TITLE
chore(ci): use codecov for minimum coverage check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,19 @@
 codecov:
+  branch: dev
+
+coverage:
+  # https://docs.codecov.com/docs/coverage-configuration
+  range: "80...90"
   # https://docs.codecov.io/docs/commit-status
   status:
+    # TODO: re-enable patch in the future
+    patch: off
     project:
       default:
         # minimum coverage ratio that the commit must meet to be considered a success
-        target: 82%
+        target: 83%
         if_ci_failed: error
         only_pulls: true
+
 github_checks:
-  annotations: false
+  annotations: true

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ tests-doctests:
 
 .PHONY: tests-lib
 tests-lib:
-	pytest --durations=10 $(pytest_flags) --doctest-modules hathor --cov-fail-under=83 $(tests_lib)
+	pytest --durations=10 $(pytest_flags) --doctest-modules hathor $(tests_lib)
 
 .PHONY: tests-genesis
 tests-genesis:
@@ -46,7 +46,7 @@ tests: tests-cli tests-lib tests-genesis
 
 .PHONY: tests-full
 tests-full:
-	pytest $(pytest_flags) --durations=10 --cov-fail-under=90 --cov-config=.coveragerc_full ./tests
+	pytest $(pytest_flags) --durations=10 --cov-config=.coveragerc_full ./tests
 
 # checking:
 


### PR DESCRIPTION
This moves the minimum coverage check to codecov. The pipeline will still fail if coverage is not reached, but the tests checks will still pass, this should make it easier to see coverage specific failures.