### PR TITLE
feat(indexes): add RocksDBAddressIndex stored in disk

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
+    - name: Prepare vars
+      shell: python
+      run: |
+        import os
+        with open(os.environ['GITHUB_ENV'], 'a') as f:
+            if '${{ matrix.os }}'.startswith('windows'):
+                print('HATHOR_TEST_MEMORY_STORAGE=true', file=f)
     - name: Install Ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y -q install graphviz librocksdb-dev libsnappy-dev liblz4-dev

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -488,7 +488,7 @@ class RunNode:
             # Websocket resource
             assert self.manager.tx_storage.indexes is not None
             ws_factory = HathorAdminWebsocketFactory(metrics=self.manager.metrics,
-                                                     addresses_index=self.manager.tx_storage.indexes.addresses)
+                                                     address_index=self.manager.tx_storage.indexes.addresses)
             ws_factory.start()
             root.putChild(b'ws', WebSocketResource(ws_factory))
 

--- a/hathor/indexes/__init__.py
+++ b/hathor/indexes/__init__.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.indexes.addresses_index import AddressesIndex
-from hathor.indexes.manager import IndexesManager, MemoryIndexesManager
+from hathor.indexes.address_index import AddressIndex
+from hathor.indexes.manager import IndexesManager, MemoryIndexesManager, RocksDBIndexesManager
 from hathor.indexes.timestamp_index import TimestampIndex
 
 __all__ = [
     'IndexesManager',
     'MemoryIndexesManager',
-    'AddressesIndex',
+    'RocksDBIndexesManager',
+    'AddressIndex',
     'TimestampIndex',
 ]

--- a/hathor/indexes/address_index.py
+++ b/hathor/indexes/address_index.py
@@ -1,0 +1,72 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Iterable, List, Optional
+
+from structlog import get_logger
+
+from hathor.transaction import BaseTransaction
+
+if TYPE_CHECKING:  # pragma: no cover
+    from hathor.pubsub import PubSubManager
+
+logger = get_logger()
+
+
+class AddressIndex(ABC):
+    """ Index of inputs/outputs by address
+    """
+    pubsub: Optional['PubSubManager']
+
+    def publish_tx(self, tx: BaseTransaction, *, addresses: Optional[Iterable[str]] = None) -> None:
+        """ Publish WALLET_ADDRESS_HISTORY for all addresses of a transaction.
+        """
+        from hathor.pubsub import HathorEvents
+        if not self.pubsub:
+            return
+        if addresses is None:
+            addresses = tx.get_related_addresses()
+        data = tx.to_json_extended()
+        for address in addresses:
+            self.pubsub.publish(HathorEvents.WALLET_ADDRESS_HISTORY, address=address, history=data)
+
+    @abstractmethod
+    def add_tx(self, tx: BaseTransaction) -> None:
+        """ Add tx inputs and outputs to the wallet index (indexed by its addresses).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove_tx(self, tx: BaseTransaction) -> None:
+        """ Remove tx inputs and outputs from the wallet index (indexed by its addresses).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_from_address(self, address: str) -> List[bytes]:
+        """ Get list of transaction hashes of an address
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_sorted_from_address(self, address: str) -> List[bytes]:
+        """ Get a sorted list of transaction hashes of an address
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_address_empty(self, address: str) -> bool:
+        """Check whether address has no transactions at all."""
+        raise NotImplementedError

--- a/hathor/indexes/rocksdb_address_index.py
+++ b/hathor/indexes/rocksdb_address_index.py
@@ -1,0 +1,175 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
+
+from structlog import get_logger
+
+from hathor.indexes.address_index import AddressIndex
+from hathor.pubsub import HathorEvents
+from hathor.transaction import BaseTransaction
+
+if TYPE_CHECKING:  # pragma: no cover
+    import rocksdb
+
+    from hathor.pubsub import EventArguments, PubSubManager
+
+logger = get_logger()
+
+_CF_NAME_ADDRESS_INDEX = b'address-index'
+
+
+class RocksDBAddressIndex(AddressIndex):
+    """ Index of inputs/outputs by address.
+
+    This index uses rocksdb and the following key format:
+
+        key = [address][tx.timestamp][tx.hash]
+              |--34b--||--4 bytes---||--32b--|
+
+    It works nicely because rocksdb uses a tree sorted by key under the hoods.
+
+    The timestamp must be serialized in big-endian, so ts1 > ts2 implies that bytes(ts1) > bytes(ts2),
+    hence the transactions are sorted by timestamp.
+    """
+    def __init__(self, db: 'rocksdb.DB', *, cf_name: Optional[bytes] = None,
+                 pubsub: Optional['PubSubManager'] = None) -> None:
+        self.log = logger.new()
+        self._db = db
+
+        # column family stuff
+        self._cf_name = cf_name or _CF_NAME_ADDRESS_INDEX
+        self._reset_cf()
+
+        self.pubsub = pubsub
+        if self.pubsub:
+            self.subscribe_pubsub_events()
+
+    def _reset_cf(self) -> None:
+        """Ensure we have a working and fresh column family"""
+        import rocksdb
+
+        log_cf = self.log.new(cf=self._cf_name.decode('ascii'))
+        _cf = self._db.get_column_family(self._cf_name)
+        # XXX: dropping column because initialization currently expects a fresh index
+        if _cf is not None:
+            old_id = _cf.id
+            log_cf.debug('drop existing column family')
+            self._db.drop_column_family(_cf)
+        else:
+            old_id = None
+            log_cf.debug('no need to drop column family')
+        del _cf
+        log_cf.debug('create fresh column family')
+        _cf = self._db.create_column_family(self._cf_name, rocksdb.ColumnFamilyOptions())
+        new_id = _cf.id
+        assert _cf is not None
+        assert _cf.is_valid
+        assert new_id != old_id
+        self._cf = _cf
+        log_cf.debug('got column family', is_valid=_cf.is_valid, id=_cf.id, old_id=old_id)
+
+    def _to_key(self, address: str, tx: Optional[BaseTransaction] = None) -> bytes:
+        import struct
+        assert len(address) == 34
+        key = address.encode('ascii')
+        if tx:
+            assert tx.hash is not None
+            assert len(tx.hash) == 32
+            key += struct.pack('>I', tx.timestamp) + tx.hash
+            assert len(key) == 34 + 4 + 32
+        return key
+
+    def _from_key(self, key: bytes) -> Tuple[str, int, bytes]:
+        import struct
+        assert len(key) == 34 + 4 + 32
+        address = key[:34].decode('ascii')
+        timestamp: int
+        (timestamp,) = struct.unpack('>I', key[34:38])
+        tx_hash = key[38:]
+        assert len(address) == 34
+        assert len(tx_hash) == 32
+        return address, timestamp, tx_hash
+
+    def subscribe_pubsub_events(self) -> None:
+        """ Subscribe wallet index to receive voided/winner tx pubsub events
+        """
+        assert self.pubsub is not None
+        # Subscribe to voided/winner events
+        events = [HathorEvents.STORAGE_TX_VOIDED, HathorEvents.STORAGE_TX_WINNER]
+        for event in events:
+            self.pubsub.subscribe(event, self.handle_tx_event)
+
+    def add_tx(self, tx: BaseTransaction) -> None:
+        """ Add tx inputs and outputs to the wallet index (indexed by its addresses).
+        """
+        assert tx.hash is not None
+
+        addresses = tx.get_related_addresses()
+        for address in addresses:
+            self.log.debug('put address', address=address)
+            self._db.put((self._cf, self._to_key(address, tx)), b'')
+
+        self.publish_tx(tx, addresses=addresses)
+
+    def remove_tx(self, tx: BaseTransaction) -> None:
+        """ Remove tx inputs and outputs from the wallet index (indexed by its addresses).
+        """
+        assert tx.hash is not None
+
+        addresses = tx.get_related_addresses()
+        for address in addresses:
+            self.log.debug('delete address', address=address)
+            self._db.delete((self._cf, self._to_key(address, tx)))
+
+    def handle_tx_event(self, key: HathorEvents, args: 'EventArguments') -> None:
+        """ This method is called when pubsub publishes an event that we subscribed
+        """
+        data = args.__dict__
+        tx = data['tx']
+        meta = tx.get_metadata()
+        if meta.has_voided_by_changed_since_last_call() or meta.has_spent_by_changed_since_last_call():
+            self.publish_tx(tx)
+
+    def _get_from_address_iter(self, address: str) -> Iterable[bytes]:
+        self.log.debug('seek to', address=address)
+        it = self._db.iterkeys(self._cf)
+        it.seek(self._to_key(address))
+        for _cf, key in it:
+            addr, _, tx_hash = self._from_key(key)
+            if addr != address:
+                break
+            self.log.debug('seek found', tx=tx_hash.hex())
+            yield tx_hash
+        self.log.debug('seek end')
+
+    def get_from_address(self, address: str) -> List[bytes]:
+        """ Get list of transaction hashes of an address
+        """
+        return list(self._get_from_address_iter(address))
+
+    def get_sorted_from_address(self, address: str) -> List[bytes]:
+        """ Get a sorted list of transaction hashes of an address
+        """
+        return list(self._get_from_address_iter(address))
+
+    def is_address_empty(self, address: str) -> bool:
+        self.log.debug('seek to', address=address)
+        it = self._db.iterkeys(self._cf)
+        it.seek(self._to_key(address))
+        key = it.get()
+        addr, _, _ = self._from_key(key)
+        is_empty = addr == address
+        self.log.debug('seek empty', is_empty=is_empty)
+        return is_empty

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -149,7 +149,8 @@ class HathorManager:
         self.tx_storage.pubsub = self.pubsub
         if wallet_index and self.tx_storage.with_index:
             assert self.tx_storage.indexes is not None
-            self.tx_storage.indexes.enable_addresses_index(self.pubsub)
+            self.log.debug('enable wallet indexes')
+            self.tx_storage.indexes.enable_address_index(self.pubsub)
             self.tx_storage.indexes.enable_tokens_index()
 
         self.metrics = Metrics(
@@ -300,7 +301,6 @@ class HathorManager:
             wait_stratum = self.stratum_factory.stop()
             if wait_stratum:
                 waits.append(wait_stratum)
-
         return defer.DeferredList(waits)
 
     def do_discovery(self) -> None:

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Optional, Set
 
 from twisted.internet import threads
 
+from hathor.indexes import IndexesManager
 from hathor.transaction import BaseTransaction
 from hathor.transaction.storage.transaction_storage import BaseTransactionStorage
 
@@ -130,6 +131,9 @@ class TransactionCacheStorage(BaseTransactionStorage):
 
     def get_all_genesis(self) -> Set[BaseTransaction]:
         return self.store.get_all_genesis()
+
+    def _build_indexes_manager(self) -> IndexesManager:
+        return self.store._build_indexes_manager()
 
     def _save_transaction(self, tx: BaseTransaction, *, only_metadata: bool = False) -> None:
         """Saves the transaction without modifying TimestampIndex entries (in superclass)."""

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -1015,13 +1015,16 @@ class BaseTransactionStorage(TransactionStorage):
     def _save_transaction(self, tx: BaseTransaction, *, only_metadata: bool = False) -> None:
         raise NotImplementedError
 
+    def _build_indexes_manager(self) -> IndexesManager:
+        return MemoryIndexesManager()
+
     def _reset_cache(self) -> None:
         """Reset all caches. This function should not be called unless you know what you are doing."""
         assert self.with_index, 'Cannot reset cache because it has not been enabled.'
         self._cache_block_count = 0
         self._cache_tx_count = 0
 
-        self.indexes = MemoryIndexesManager()
+        self.indexes = self._build_indexes_manager()
 
         genesis = self.get_all_genesis()
         if genesis:

--- a/hathor/websocket/factory.py
+++ b/hathor/websocket/factory.py
@@ -23,7 +23,7 @@ from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 
 from hathor.conf import HathorSettings
-from hathor.indexes import AddressesIndex
+from hathor.indexes import AddressIndex
 from hathor.metrics import Metrics
 from hathor.p2p.rate_limiter import RateLimiter
 from hathor.pubsub import HathorEvents
@@ -82,7 +82,7 @@ class HathorAdminWebsocketFactory(WebSocketServerFactory):
     def buildProtocol(self, addr):
         return self.protocol(self)
 
-    def __init__(self, metrics: Optional[Metrics] = None, addresses_index: Optional[AddressesIndex] = None):
+    def __init__(self, metrics: Optional[Metrics] = None, address_index: Optional[AddressIndex] = None):
         """
         :param metrics: If not given, a new one is created.
         :type metrics: :py:class:`hathor.metrics.Metrics`
@@ -101,7 +101,7 @@ class HathorAdminWebsocketFactory(WebSocketServerFactory):
         self.buffer_deques: Dict[str, Deque[Dict[str, Any]]] = {}
 
         self.metrics = metrics
-        self.addresses_index = addresses_index
+        self.address_index = address_index
 
         self.is_running = False
 
@@ -320,7 +320,7 @@ class HathorAdminWebsocketFactory(WebSocketServerFactory):
             payload = json.dumps({'message': 'Reached maximum number of subscribed '
                                              f'addresses ({settings.WS_MAX_SUBS_ADDRS_CONN}).',
                                   'type': 'subscribe_address', 'success': False}).encode('utf-8')
-        elif self.addresses_index and _count_empty(subs, self.addresses_index) >= settings.WS_MAX_SUBS_ADDRS_EMPTY:
+        elif self.address_index and _count_empty(subs, self.address_index) >= settings.WS_MAX_SUBS_ADDRS_EMPTY:
             payload = json.dumps({'message': 'Reached maximum number of subscribed '
                                              f'addresses without output ({settings.WS_MAX_SUBS_ADDRS_EMPTY}).',
                                   'type': 'subscribe_address', 'success': False}).encode('utf-8')
@@ -361,6 +361,6 @@ class HathorAdminWebsocketFactory(WebSocketServerFactory):
             self._remove_connection_from_address_dict(connection, address)
 
 
-def _count_empty(addresses: Set[str], addresses_index: AddressesIndex) -> int:
+def _count_empty(addresses: Set[str], address_index: AddressIndex) -> int:
     """ Count how many of the addresses given are empty (have no outputs)."""
-    return sum(1 for addr in addresses if addresses_index.is_address_empty(addr))
+    return sum(1 for addr in addresses if address_index.is_address_empty(addr))

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -843,7 +843,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         address_b58 = parse_address_script(script).address
         # Get how many transactions wallet index already has for this address
-        wallet_index_count = len(self.tx_storage.indexes.addresses.index[address_b58])
+        wallet_index_count = len(self.tx_storage.indexes.addresses.get_from_address(address_b58))
 
         _input = TxInput(genesis_block.hash, 0, b'')
         tx = Transaction(weight=1, inputs=[_input], outputs=[output], parents=parents,
@@ -857,7 +857,7 @@ class BaseTransactionTest(unittest.TestCase):
         self.manager.propagate_tx(tx)
 
         # This transaction has an output to address_b58, so we need one more element on the index
-        self.assertEqual(len(self.tx_storage.indexes.addresses.index[address_b58]), wallet_index_count + 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(address_b58)), wallet_index_count + 1)
 
         # Second transaction: spend tokens from output with address=address_b58 and
         # send tokens to 2 outputs, one with address=address_b58 and another one
@@ -882,8 +882,8 @@ class BaseTransactionTest(unittest.TestCase):
 
         # tx2 has two outputs, for address_b58 and new_address_b58
         # So we must have one more element on address_b58 index and only one on new_address_b58
-        self.assertEqual(len(self.tx_storage.indexes.addresses.index[address_b58]), wallet_index_count + 2)
-        self.assertEqual(len(self.tx_storage.indexes.addresses.index[new_address_b58]), 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(address_b58)), wallet_index_count + 2)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(new_address_b58)), 1)
 
         # Third transaction: spend tokens from output with address=address_b58 and send
         # tokens to a new address = output3_address_b58, which is from a random wallet
@@ -906,9 +906,9 @@ class BaseTransactionTest(unittest.TestCase):
         # tx3 has one output, for another new address (output3_address_b58) and it's spending an output of address_b58
         # So address_b58 index must have one more element and output3_address_b58 should have one element also
         # new_address_b58 was not spent neither received tokens, so didn't change
-        self.assertEqual(len(self.tx_storage.indexes.addresses.index[address_b58]), wallet_index_count + 3)
-        self.assertEqual(len(self.tx_storage.indexes.addresses.index[output3_address_b58]), 1)
-        self.assertEqual(len(self.tx_storage.indexes.addresses.index[new_address_b58]), 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(address_b58)), wallet_index_count + 3)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(output3_address_b58)), 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(new_address_b58)), 1)
 
     def test_sighash_cache(self):
         from unittest import mock

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -68,7 +68,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         wallet.unlock(b'teste')
         self.manager = HathorManager(self.reactor, tx_storage=self.tx_storage, wallet=wallet)
 
-        self.tx_storage.indexes.enable_addresses_index(self.manager.pubsub)
+        self.tx_storage.indexes.enable_address_index(self.manager.pubsub)
         self.tx_storage.indexes.enable_tokens_index()
 
         block_parents = [tx.hash for tx in chain(self.genesis_blocks, self.genesis_txs)]
@@ -238,9 +238,9 @@ class BaseTransactionStorageTest(unittest.TestCase):
 
         # Check wallet index.
         addresses_index = self.tx_storage.indexes.addresses
-        addresses = addresses_index._get_addresses(tx)
+        addresses = tx.get_related_addresses()
         for address in addresses:
-            self.assertNotIn(tx.hash, addresses_index.index[address])
+            self.assertNotIn(tx.hash, addresses_index.get_from_address(address))
 
         # TODO Check self.tx_storage.tokens_index
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import tempfile
 import time
@@ -15,13 +16,13 @@ from hathor.daa import TestMode, _set_test_mode
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.sync_version import SyncVersion
-from hathor.transaction.storage.memory_storage import TransactionMemoryStorage
 from hathor.util import Random
 from hathor.wallet import Wallet
 
 logger = get_logger()
 main = ut_main
 settings = HathorSettings()
+USE_MEMORY_STORAGE = os.environ.get('HATHOR_TEST_MEMORY_STORAGE', 'false').lower() == 'true'
 
 
 def shorten_hash(container):
@@ -123,7 +124,14 @@ class TestCase(unittest.TestCase):
             if unlock_wallet:
                 wallet.unlock(b'MYPASS')
         if tx_storage is None:
-            tx_storage = TransactionMemoryStorage()
+            if USE_MEMORY_STORAGE:
+                from hathor.transaction.storage.memory_storage import TransactionMemoryStorage
+                tx_storage = TransactionMemoryStorage()
+            else:
+                from hathor.transaction.storage.rocksdb_storage import TransactionRocksDBStorage
+                directory = tempfile.mkdtemp()
+                self.tmpdirs.append(directory)
+                tx_storage = TransactionRocksDBStorage(directory)
         manager = HathorManager(
             self.clock,
             peer_id=peer_id,


### PR DESCRIPTION
## Acceptance criteria

1. Create `AddressesIndex` interface.
2. Implement `AddressesRocksDBIndex`.
3. Implement `RocksDBIndexesManager`.
4. Test `RocksDBIndexesManager`.
5. Skip add/del from `AddressesRocksDBIndex` during initialization.
6. Use `RocksDBIndexesManager` when using `TransactionRocksDBStorage`.