### PR TITLE
chore(ci): use docker cache from master instead of dev

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -146,9 +146,7 @@ jobs:
         # this key is setup such that every branch has its cache and new branches can reuse dev's cache, but not the other way around
         key: ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-${{ github.head_ref || github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-${{ github.head_ref || github.ref }}-
-          ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-refs/heads/dev-
-          ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-
+          ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-refs/heads/master-
     - name: Build and push
       uses: docker/build-push-action@v2
       id: docker_build


### PR DESCRIPTION
Docker build will prefer a cache from dev when there isn't one for the current branch. This can be a problem because the `dev` branch isn't always built as often as the `master` branch (which is built daily from a scheduled task). And an outdated cache can have some problems. This might be the cause of the recent docker build fails on the `dev` branch, even though the scheduled `master` builds are fine. I'm not sure if this will fix those builds though, because the `dev` builds might still try to load the cache from the `dev` branch.