### PR TITLE
chore(ci): dropping pypy-3.6 because image is no longe provided

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,6 @@ jobs:
         - 3.9
         include:
         - python-impl: pypy
-          python-version: 3.6
-        - python-impl: pypy
           python-version: 3.7
     steps:
     - name: Checkout


### PR DESCRIPTION
We're using official PyPy docker images from https://hub.docker.com/_/pypy and they are no longer providing images for `pypy-3.6-*` which were being used as the base for the build that is failing. Since we're slowly moving away from Python 3.6, and since we also don't officially support PyPy, I think it's best to just drop that build.