### PR TITLE
fix(websocket): bytes is not JSON serializable on 'first_block' field

### DIFF
--- a/tests/websocket/test_websocket.py
+++ b/tests/websocket/test_websocket.py
@@ -54,6 +54,9 @@ class TestWebsocket(_BaseResourceTest._ResourceTest):
         self.protocol.state = HathorAdminWebsocketProtocol.STATE_OPEN
 
         tx = self.genesis[1]
+        meta = tx.get_metadata()
+        meta.first_block = self.genesis[0].hash
+        self.manager.tx_storage.save_transaction(tx, only_metadata=True)
         self.manager.pubsub.publish(HathorEvents.NETWORK_NEW_TX_ACCEPTED,
                                     tx=tx)
         self.run_to_completion()


### PR DESCRIPTION
I think this is a regression from the mempool API. I made this fix quickly, I haven't added any tests, I'm open to suggestions on how to test this (and possibly any JSON serialization error on events).