### PR TITLE
fix(sync-v2): wrongly included sync-v2 capability

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -307,7 +307,7 @@ class HathorSettings(NamedTuple):
 
     # Capabilities
     CAPABILITY_WHITELIST: str = 'whitelist'
-    CAPABILITY_SYNC_V2: str = 'node-sync-v2'
+    CAPABILITY_SYNC_V2: str = 'sync-v2'
 
     # Where to download whitelist from
     WHITELIST_URL: Optional[str] = None

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -189,7 +189,7 @@ class HathorManager:
         if capabilities is not None:
             self.capabilities = capabilities
         else:
-            self.capabilities = [settings.CAPABILITY_WHITELIST, settings.CAPABILITY_SYNC_V2]
+            self.capabilities = [settings.CAPABILITY_WHITELIST]
 
     def start(self) -> None:
         """ A factory must be started only once. And it is usually automatically started.


### PR DESCRIPTION
The sync-v2 capability was wrongly added to the broadcasted capabilities, which would lead to nodes currently not having sync-v2 implemented to appear as having it enabled and new nodes would try to use sync-v2 and fail

Since the capability name is now tainted, I've renamed it.