### PR TITLE
chore: bump version

### DIFF
--- a/hathor/cli/openapi_files/openapi_base.json
+++ b/hathor/cli/openapi_files/openapi_base.json
@@ -7,7 +7,7 @@
         ],
 	"info": {
             "title": "Hathor API",
-            "version": "0.40.2"
+            "version": "0.41.0"
 	},
 	"consumes": [
             "application/json"

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.40.2'
+__version__ = '0.41.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathor"
-version = "0.40.2"
+version = "0.41.0"
 description = "Hathor Network full-node"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bumping to `v0.41.0`, because although there is only one minor feature there are significant refactors.