### PR TITLE
feat(db): testnet-golf and prevent mixing networks

### DIFF
--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -18,8 +18,8 @@ from hathor.conf.settings import HathorSettings
 SETTINGS = HathorSettings(
     P2PKH_VERSION_BYTE=b'\x49',
     MULTISIG_VERSION_BYTE=b'\x87',
-    NETWORK_NAME='testnet-foxtrot',
-    BOOTSTRAP_DNS=['foxtrot.testnet.hathor.network'],
+    NETWORK_NAME='testnet-golf',
+    BOOTSTRAP_DNS=['golf.testnet.hathor.network'],
     # Genesis stuff
     GENESIS_OUTPUT_SCRIPT=bytes.fromhex('76a914a584cf48b161e4a49223ed220df30037ab740e0088ac'),
     GENESIS_TIMESTAMP=1577836800,

--- a/hathor/transaction/storage/exceptions.py
+++ b/hathor/transaction/storage/exceptions.py
@@ -29,3 +29,7 @@ class TransactionIsNotABlock(HathorError):
 
 class AttributeDoesNotExist(HathorError):
     """You are trying to get a storage attribute that does not exist"""
+
+
+class WrongNetworkError(HathorError):
+    """You are trying to use a database for a different network"""

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -108,6 +108,9 @@ class TransactionStorage(ABC):
         # Initialize cache for genesis transactions.
         self._genesis_cache: Dict[bytes, BaseTransaction] = {}
 
+        # Key storage attribute to save if the network stored is the expected network
+        self._network_attribute: str = 'network'
+
         # Key storage attribute to save if the full node is running a full verification
         self._running_full_verification_attribute: str = 'running_full_verification'
 
@@ -458,7 +461,52 @@ class TransactionStorage(ABC):
 
     def pre_init(self) -> None:
         """Storages can implement this to run code before transaction loading starts"""
-        pass
+        self._check_and_set_network()
+
+    def _check_and_set_network(self) -> None:
+        """Check the network name is as expected and try to set it when none is present"""
+        from hathor.transaction.storage.exceptions import WrongNetworkError
+
+        network = settings.NETWORK_NAME
+        stored_network = self.get_network()
+
+        if stored_network is None:
+            # no network is set, let's try to infer it
+            self._checked_set_network(network)
+        elif stored_network != network:
+            # the stored network does not match, something is wrong
+            raise WrongNetworkError(f'Databases created on {stored_network}, expected {network}')
+        else:
+            # the network is what is expected, nothing to do here
+            pass
+
+    def _checked_set_network(self, network: str) -> None:
+        """Tries to set the network name on storage, while checking if we can safely do so."""
+        from hathor.transaction.storage.exceptions import WrongNetworkError
+
+        if self.is_empty():
+            # we're fresh out of a new database, let's just make sure we don't have the wrong genesis
+            for tx in self.get_all_transactions():
+                # XXX: maybe this can happen if you start a fresh database on one network and the genesis is saved
+                #      somehow (is this even possible?) and you then start on a different network, hopefully this
+                #      can be safely removed in a few releases
+                if not tx.is_genesis:
+                    raise WrongNetworkError(f'Transaction {tx.hash_hex} is not from {network}')
+            self.set_network(network)
+        else:
+            # XXX: the database IS NOT empty, what do we do?
+            #      - for the sake of compatibility we will accept this on the mainnet, and set it as mainnet,
+            #        this is mostly so everyone running on the mainnet has a no-interaction auto-migration
+            #      - for the sake of cleaning up the mess of foxtrot->golf testnet migration, we'll refuse to use
+            #        the database when it is not the mainnet
+            #      - in a few releases we can be confident that everyone running the network has made a smooth
+            #        upgrade and we should be able to remove these workarounds and refuse older databases, and
+            #        instead indiviudally assist (like suggesting a snapshot or fresh start) to anyone that is
+            #        unable to use a very old database
+            if network == 'mainnet':
+                self.set_network(network)
+            else:
+                raise WrongNetworkError(f'This database is not suitable to be used on {network}')
 
     def get_best_block(self) -> Block:
         """The block with highest score or one of the blocks with highest scores. Can be used for mining."""
@@ -897,6 +945,16 @@ class TransactionStorage(ABC):
         """ Get value from storage
         """
         raise NotImplementedError
+
+    def get_network(self) -> Optional[str]:
+        """ Return the stored network name
+        """
+        return self.get_value(self._network_attribute)
+
+    def set_network(self, network: str) -> None:
+        """ Save the network name
+        """
+        return self.add_value(self._network_attribute, network)
 
     def start_full_verification(self) -> None:
         """ Save full verification on storage


### PR DESCRIPTION
Acceptance criteria: after this version is in use (i.e., after nodes have upgraded), a database used on the mainnet should be rejected immediately when trying to use it for the testnet, and vice-versa; additionally when upgrading mainnet should be implied, but testnet-golf must be explicit (i.e., do not try to "import" a testnet-foxtrot database).