### PR TITLE
refactor(indexes): Move all indexes to MemoryIndexesManager

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -486,8 +486,9 @@ class RunNode:
                     parent.putChild(url_path, resource)
 
             # Websocket resource
+            assert self.manager.tx_storage.indexes is not None
             ws_factory = HathorAdminWebsocketFactory(metrics=self.manager.metrics,
-                                                     wallet_index=self.manager.tx_storage.wallet_index)
+                                                     addresses_index=self.manager.tx_storage.indexes.addresses)
             ws_factory.start()
             root.putChild(b'ws', WebSocketResource(ws_factory))
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -29,7 +29,6 @@ from hathor.checkpoint import Checkpoint
 from hathor.conf import HathorSettings
 from hathor.consensus import ConsensusAlgorithm
 from hathor.exception import HathorError, InvalidNewTransaction
-from hathor.indexes import TokensIndex, WalletIndex
 from hathor.mining import BlockTemplate, BlockTemplates
 from hathor.p2p.peer_discovery import PeerDiscovery
 from hathor.p2p.peer_id import PeerId
@@ -149,8 +148,9 @@ class HathorManager:
         self.tx_storage = tx_storage
         self.tx_storage.pubsub = self.pubsub
         if wallet_index and self.tx_storage.with_index:
-            self.tx_storage.wallet_index = WalletIndex(self.pubsub)
-            self.tx_storage.tokens_index = TokensIndex()
+            assert self.tx_storage.indexes is not None
+            self.tx_storage.indexes.enable_addresses_index(self.pubsub)
+            self.tx_storage.indexes.enable_tokens_index()
 
         self.metrics = Metrics(
             pubsub=self.pubsub,

--- a/hathor/transaction/resources/transaction.py
+++ b/hathor/transaction/resources/transaction.py
@@ -110,7 +110,8 @@ def get_tx_extra_data(tx: BaseTransaction) -> Dict[str, Any]:
     detailed_tokens = []
     for token_uid_hex in serialized['tokens']:
         assert tx.storage is not None
-        tokens_index = tx.storage.tokens_index
+        assert tx.storage.indexes is not None
+        tokens_index = tx.storage.indexes.tokens
         assert tokens_index is not None
         token_info = tokens_index.get_token_info(bytes.fromhex(token_uid_hex))
         detailed_tokens.append({'uid': token_uid_hex, 'name': token_info.name, 'symbol': token_info.symbol})
@@ -166,7 +167,7 @@ class TransactionResource(resource.Resource):
         """ Get 'id' (hash) from request.args
             Returns the tx with this hash or {'success': False} if hash is invalid or tx does not exist
         """
-        if not self.manager.tx_storage.tokens_index:
+        if not self.manager.tx_storage.indexes.tokens:
             request.setResponseCode(503)
             return json.dumps({'success': False}).encode('utf-8')
 

--- a/hathor/wallet/resources/thin_wallet/address_balance.py
+++ b/hathor/wallet/resources/thin_wallet/address_balance.py
@@ -79,10 +79,10 @@ class AddressBalanceResource(resource.Resource):
         request.setHeader(b'content-type', b'application/json; charset=utf-8')
         set_cors(request, 'GET')
 
-        wallet_index = self.manager.tx_storage.wallet_index
-        tokens_index = self.manager.tx_storage.tokens_index
+        addresses_index = self.manager.tx_storage.indexes.addresses
+        tokens_index = self.manager.tx_storage.indexes.tokens
 
-        if not wallet_index or not tokens_index:
+        if not addresses_index or not tokens_index:
             request.setResponseCode(503)
             return json.dumps({'success': False}, indent=4).encode('utf-8')
 
@@ -101,7 +101,7 @@ class AddressBalanceResource(resource.Resource):
             }).encode('utf-8')
 
         tokens_data: Dict[bytes, TokenData] = defaultdict(TokenData)
-        tx_hashes = wallet_index.get_from_address(requested_address)
+        tx_hashes = addresses_index.get_from_address(requested_address)
         for tx_hash in tx_hashes:
             tx = self.manager.tx_storage.get_transaction(tx_hash)
             meta = tx.get_metadata(force_reload=True)

--- a/hathor/wallet/resources/thin_wallet/address_search.py
+++ b/hathor/wallet/resources/thin_wallet/address_search.py
@@ -85,9 +85,9 @@ class AddressSearchResource(resource.Resource):
         request.setHeader(b'content-type', b'application/json; charset=utf-8')
         set_cors(request, 'GET')
 
-        wallet_index = self.manager.tx_storage.wallet_index
+        addresses_index = self.manager.tx_storage.indexes.addresses
 
-        if not wallet_index:
+        if not addresses_index:
             request.setResponseCode(503)
             return json.dumps({'success': False}, indent=4).encode('utf-8')
 
@@ -128,7 +128,7 @@ class AddressSearchResource(resource.Resource):
                     'message': 'Token uid is not a valid hexadecimal value.'
                 }).encode('utf-8')
 
-        hashes = wallet_index.get_from_address(address)
+        hashes = addresses_index.get_from_address(address)
         # XXX To do a timestamp sorting, so the pagination works better
         # we must get all transactions and sort them
         # This is not optimal for performance

--- a/hathor/wallet/resources/thin_wallet/token_history.py
+++ b/hathor/wallet/resources/thin_wallet/token_history.py
@@ -52,7 +52,8 @@ class TokenHistoryResource(resource.Resource):
         request.setHeader(b'content-type', b'application/json; charset=utf-8')
         set_cors(request, 'GET')
 
-        if not self.manager.tx_storage.tokens_index:
+        tokens_index = self.manager.tx_storage.indexes.tokens
+        if not tokens_index:
             request.setResponseCode(503)
             return json.dumps({'success': False}).encode('utf-8')
 
@@ -105,13 +106,13 @@ class TokenHistoryResource(resource.Resource):
                 }).encode('utf-8')
 
             if page == 'previous':
-                elements, has_more = self.manager.tx_storage.tokens_index.get_newer_transactions(
+                elements, has_more = tokens_index.get_newer_transactions(
                         token_uid, ref_timestamp, hash_bytes, count)
             else:
-                elements, has_more = self.manager.tx_storage.tokens_index.get_older_transactions(
+                elements, has_more = tokens_index.get_older_transactions(
                         token_uid, ref_timestamp, hash_bytes, count)
         else:
-            elements, has_more = self.manager.tx_storage.tokens_index.get_newest_transactions(token_uid, count)
+            elements, has_more = tokens_index.get_newest_transactions(token_uid, count)
 
         transactions = [self.manager.tx_storage.get_transaction(element) for element in elements]
         serialized = [tx.to_json_extended() for tx in transactions]

--- a/hathor/wallet/resources/thin_wallet/tokens.py
+++ b/hathor/wallet/resources/thin_wallet/tokens.py
@@ -38,15 +38,16 @@ class TokenResource(resource.Resource):
 
     def get_one_token_data(self, token_uid: bytes) -> Dict[str, Any]:
         # Get one token data specified in id
+        tokens_index = self.manager.tx_storage.indexes.tokens
         try:
-            token_info = self.manager.tx_storage.tokens_index.get_token_info(token_uid)
+            token_info = tokens_index.get_token_info(token_uid)
         except KeyError:
             return {'success': False, 'message': 'Unknown token'}
 
         mint = []
         melt = []
 
-        transactions_count = self.manager.tx_storage.tokens_index.get_transactions_count(token_uid)
+        transactions_count = tokens_index.get_transactions_count(token_uid)
 
         for tx_hash, index in token_info.mint:
             mint.append({
@@ -78,7 +79,7 @@ class TokenResource(resource.Resource):
         # XXX For now we only set a fixed limit of 200 tokens to return
 
         # Get all tokens
-        all_tokens = self.manager.tx_storage.tokens_index.tokens
+        all_tokens = self.manager.tx_storage.indexes.tokens.tokens
 
         tokens = []
         count = 0
@@ -119,7 +120,7 @@ class TokenResource(resource.Resource):
         request.setHeader(b'content-type', b'application/json; charset=utf-8')
         set_cors(request, 'GET')
 
-        if not self.manager.tx_storage.tokens_index:
+        if not self.manager.tx_storage.indexes.tokens:
             request.setResponseCode(503)
             return json.dumps({'success': False}).encode('utf-8')
 

--- a/tests/resources/transaction/test_tx.py
+++ b/tests/resources/transaction/test_tx.py
@@ -120,12 +120,12 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
         self.manager.tx_storage.save_transaction(tx_input)
 
         token_bytes1 = bytes.fromhex('001c382847d8440d05da95420bee2ebeb32bc437f82a9ae47b0745c8a29a7b0d')
-        status = self.manager.tx_storage.tokens_index.tokens[token_bytes1]
+        status = self.manager.tx_storage.indexes.tokens.tokens[token_bytes1]
         status.name = 'Test Coin'
         status.symbol = 'TSC'
 
         token_bytes2 = bytes.fromhex('007231eee3cb6160d95172a409d634d0866eafc8775f5729fff6a61e7850aba5')
-        status2 = self.manager.tx_storage.tokens_index.tokens[token_bytes2]
+        status2 = self.manager.tx_storage.indexes.tokens.tokens[token_bytes2]
         status2.name = 'NewCoin'
         status2.symbol = 'NCN'
 
@@ -209,7 +209,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
         # Both inputs are the same as the last parent, so no need to manually add them
 
         token_bytes1 = bytes.fromhex('000023b318c91dcfd4b967b205dc938f9f5e2fd5114256caacfb8f6dd13db330')
-        status = self.manager.tx_storage.tokens_index.tokens[token_bytes1]
+        status = self.manager.tx_storage.indexes.tokens.tokens[token_bytes1]
         status.name = 'Wat wat'
         status.symbol = 'WAT'
 

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -495,6 +495,22 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         self.assertFalse(response_data['success'])
 
     @inlineCallbacks
+    def test_address_history_invalid_params_post(self):
+        # missing param
+        response_history = yield self.web_address_history.post('thin_wallet/address_history')
+        response_data = response_history.json_value()
+        self.assertFalse(response_data['success'])
+
+        # invalid address
+        response_history = yield self.web_address_history.post(
+            'thin_wallet/address_history', {
+                'addresses[]': 'aaa'
+            }
+        )
+        response_data = response_history.json_value()
+        self.assertFalse(response_data['success'])
+
+    @inlineCallbacks
     def test_send_tokens_invalid_params(self):
         # missing body
         response = yield self.web.post('thin_wallet/send_tokens')

--- a/tests/tx/test_tokens.py
+++ b/tests/tx/test_tokens.py
@@ -159,7 +159,7 @@ class BaseTokenTest(unittest.TestCase):
         self.run_to_completion()
 
         # check tokens index
-        tokens_index = self.manager.tx_storage.tokens_index.tokens[token_uid]
+        tokens_index = self.manager.tx_storage.indexes.tokens.tokens[token_uid]
         self.assertIn((tx2.hash, 1), tokens_index.mint)
         self.assertIn((tx.hash, 2), tokens_index.melt)
         # there should only be one element on the indexes for the token
@@ -264,7 +264,7 @@ class BaseTokenTest(unittest.TestCase):
         self.run_to_completion()
 
         # check tokens index
-        tokens_index = self.manager.tx_storage.tokens_index.tokens[token_uid]
+        tokens_index = self.manager.tx_storage.indexes.tokens.tokens[token_uid]
         self.assertIn((tx.hash, 1), tokens_index.mint)
         self.assertIn((tx2.hash, 1), tokens_index.melt)
         # there should only be one element on the indexes for the token
@@ -354,7 +354,7 @@ class BaseTokenTest(unittest.TestCase):
         # 3. HTR deposit change
         tx = create_tokens(self.manager, self.address_b58, mint_amount=100)
         token_uid = tx.tokens[0]
-        tokens_index = self.manager.tx_storage.tokens_index.tokens[tx.tokens[0]]
+        tokens_index = self.manager.tx_storage.indexes.tokens.tokens[tx.tokens[0]]
         self.assertIn((tx.hash, 1), tokens_index.mint)
         self.assertIn((tx.hash, 2), tokens_index.melt)
         # there should only be one element on the indexes for the token

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -843,7 +843,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         address_b58 = parse_address_script(script).address
         # Get how many transactions wallet index already has for this address
-        wallet_index_count = len(self.tx_storage.wallet_index.index[address_b58])
+        wallet_index_count = len(self.tx_storage.indexes.addresses.index[address_b58])
 
         _input = TxInput(genesis_block.hash, 0, b'')
         tx = Transaction(weight=1, inputs=[_input], outputs=[output], parents=parents,
@@ -857,7 +857,7 @@ class BaseTransactionTest(unittest.TestCase):
         self.manager.propagate_tx(tx)
 
         # This transaction has an output to address_b58, so we need one more element on the index
-        self.assertEqual(len(self.tx_storage.wallet_index.index[address_b58]), wallet_index_count + 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.index[address_b58]), wallet_index_count + 1)
 
         # Second transaction: spend tokens from output with address=address_b58 and
         # send tokens to 2 outputs, one with address=address_b58 and another one
@@ -882,8 +882,8 @@ class BaseTransactionTest(unittest.TestCase):
 
         # tx2 has two outputs, for address_b58 and new_address_b58
         # So we must have one more element on address_b58 index and only one on new_address_b58
-        self.assertEqual(len(self.tx_storage.wallet_index.index[address_b58]), wallet_index_count + 2)
-        self.assertEqual(len(self.tx_storage.wallet_index.index[new_address_b58]), 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.index[address_b58]), wallet_index_count + 2)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.index[new_address_b58]), 1)
 
         # Third transaction: spend tokens from output with address=address_b58 and send
         # tokens to a new address = output3_address_b58, which is from a random wallet
@@ -906,9 +906,9 @@ class BaseTransactionTest(unittest.TestCase):
         # tx3 has one output, for another new address (output3_address_b58) and it's spending an output of address_b58
         # So address_b58 index must have one more element and output3_address_b58 should have one element also
         # new_address_b58 was not spent neither received tokens, so didn't change
-        self.assertEqual(len(self.tx_storage.wallet_index.index[address_b58]), wallet_index_count + 3)
-        self.assertEqual(len(self.tx_storage.wallet_index.index[output3_address_b58]), 1)
-        self.assertEqual(len(self.tx_storage.wallet_index.index[new_address_b58]), 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.index[address_b58]), wallet_index_count + 3)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.index[output3_address_b58]), 1)
+        self.assertEqual(len(self.tx_storage.indexes.addresses.index[new_address_b58]), 1)
 
     def test_sighash_cache(self):
         from unittest import mock

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -12,7 +12,6 @@ from twisted.trial import unittest
 
 from hathor.conf import HathorSettings
 from hathor.daa import TestMode, _set_test_mode
-from hathor.indexes import TokensIndex, WalletIndex
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH
 from hathor.transaction.storage import (
@@ -69,8 +68,8 @@ class BaseTransactionStorageTest(unittest.TestCase):
         wallet.unlock(b'teste')
         self.manager = HathorManager(self.reactor, tx_storage=self.tx_storage, wallet=wallet)
 
-        self.tx_storage.wallet_index = WalletIndex(self.manager.pubsub)
-        self.tx_storage.tokens_index = TokensIndex()
+        self.tx_storage.indexes.enable_addresses_index(self.manager.pubsub)
+        self.tx_storage.indexes.enable_tokens_index()
 
         block_parents = [tx.hash for tx in chain(self.genesis_blocks, self.genesis_txs)]
         output = TxOutput(200, P2PKH.create_output_script(BURN_ADDRESS))
@@ -183,24 +182,24 @@ class BaseTransactionStorageTest(unittest.TestCase):
         # Testing add and remove from cache
         if self.tx_storage.with_index:
             if obj.is_block:
-                self.assertTrue(obj.hash in self.tx_storage.block_index.tips_index.tx_last_interval)
+                self.assertTrue(obj.hash in self.tx_storage.indexes.block_tips.tx_last_interval)
             else:
-                self.assertTrue(obj.hash in self.tx_storage.tx_index.tips_index.tx_last_interval)
+                self.assertTrue(obj.hash in self.tx_storage.indexes.tx_tips.tx_last_interval)
 
         self.tx_storage.del_from_indexes(obj)
 
         if self.tx_storage.with_index:
             if obj.is_block:
-                self.assertFalse(obj.hash in self.tx_storage.block_index.tips_index.tx_last_interval)
+                self.assertFalse(obj.hash in self.tx_storage.indexes.block_tips.tx_last_interval)
             else:
-                self.assertFalse(obj.hash in self.tx_storage.tx_index.tips_index.tx_last_interval)
+                self.assertFalse(obj.hash in self.tx_storage.indexes.tx_tips.tx_last_interval)
 
         self.tx_storage.add_to_indexes(obj)
         if self.tx_storage.with_index:
             if obj.is_block:
-                self.assertTrue(obj.hash in self.tx_storage.block_index.tips_index.tx_last_interval)
+                self.assertTrue(obj.hash in self.tx_storage.indexes.block_tips.tx_last_interval)
             else:
-                self.assertTrue(obj.hash in self.tx_storage.tx_index.tips_index.tx_last_interval)
+                self.assertTrue(obj.hash in self.tx_storage.indexes.tx_tips.tx_last_interval)
 
     def test_save_block(self):
         self.validate_save(self.block)
@@ -238,10 +237,10 @@ class BaseTransactionStorageTest(unittest.TestCase):
                 self._validate_not_in_index(tx, self.tx_storage.tx_index)
 
         # Check wallet index.
-        wallet_index = self.tx_storage.wallet_index
-        addresses = wallet_index._get_addresses(tx)
+        addresses_index = self.tx_storage.indexes.addresses
+        addresses = addresses_index._get_addresses(tx)
         for address in addresses:
-            self.assertNotIn(tx.hash, wallet_index.index[address])
+            self.assertNotIn(tx.hash, addresses_index.index[address])
 
         # TODO Check self.tx_storage.tokens_index
 

--- a/tests/wallet/test_index.py
+++ b/tests/wallet/test_index.py
@@ -42,7 +42,7 @@ class BaseWalletIndexTest(unittest.TestCase):
         self.manager.propagate_tx(tx1)
         self.run_to_completion()
 
-        wallet_data = self.manager.tx_storage.wallet_index.get_from_address(address)
+        wallet_data = self.manager.tx_storage.indexes.addresses.get_from_address(address)
         self.assertEqual(len(wallet_data), 1)
         self.assertEqual(wallet_data, [tx1.hash])
 
@@ -50,7 +50,7 @@ class BaseWalletIndexTest(unittest.TestCase):
         self.manager.propagate_tx(tx2)
         self.run_to_completion()
 
-        wallet_data = self.manager.tx_storage.wallet_index.get_from_address(address)
+        wallet_data = self.manager.tx_storage.indexes.addresses.get_from_address(address)
         self.assertEqual(len(wallet_data), 2)
         self.assertEqual(set(wallet_data), set([tx1.hash, tx2.hash]))
 


### PR DESCRIPTION
## Acceptance Criteria

1. Move current indexes to `MemoryIndexesManager`.
2. Remove direct access to internal parts of the indexes (because it will have a different implementation soon).
3. Turn `IndexesManager` into an interface that will be implemented by `DiskIndexesManager` in the near future.