### PR TITLE
chore(ci): dynamic matrix for reduced private fork build time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,28 +10,57 @@ on:
     branches:
     - dev
 jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - id: set-matrix
+      shell: python
+      run: |
+        import os
+        import json
+        full_matrix = {
+          'python': ['3.7', '3.8', '3.9'],
+          'os': ['ubuntu-latest', 'macos-latest'],
+          'include': [
+            {'os': 'windows-latest', 'python': '3.7'},
+            # these still have some errors:
+            # {'os': 'windows-latest', 'python': '3.8'},
+            # {'os': 'windows-latest', 'python': '3.9'},
+          ],
+        }
+        reduced_matrix = {
+          'python': ['3.7'],
+          'os': ['ubuntu-latest'],
+        }
+        github_repository = os.environ['GITHUB_REPOSITORY']
+        if github_repository.lower() == 'hathornetwork/hathor-core':
+            matrix = full_matrix
+        else:
+            matrix = reduced_matrix
+        print('::set-output name=matrix::' + json.dumps(matrix))
+  check-matrix:
+    runs-on: ubuntu-latest
+    needs: matrix
+    steps:
+    - name: Install json2yaml
+      run: |
+        sudo npm install -g json2yaml
+    - name: Check matrix definition
+      run: |
+        matrix='${{ needs.matrix.outputs.matrix }}'
+        echo $matrix
+        echo $matrix | jq .
+        echo $matrix | json2yaml
   test:
     name: python-${{ matrix.python }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: matrix
     timeout-minutes: 120  # default is 360
     strategy:
       fail-fast: false
-      matrix:
-        python:
-        - 3.7
-        - 3.8
-        - 3.9
-        os:
-        - ubuntu-latest
-        - macos-latest
-        include:
-        - os: windows-latest
-          python: 3.7
-        # these still have some errors:
-        # - os: windows-latest
-        #   python: 3.8
-        # - os: windows-latest
-        #   python: 3.9
+      matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
This is what happens on a repo that is not the main repo: https://github.com/jansegre/hathor-core/pull/7

This PR is largely based off https://www.cynkra.com/blog/2020-12-23-dynamic-gha/

Acceptance criteria:

- On the main repo (HathorNetwork/hathor-core), the build matrix should be the complete build matrix, the same as it currently is;
- On any other repo, the build matrix should be reduced (I chose Python-3.7 on Ubuntu);