### PR TITLE
chore: add some settings configuration log when starting the node

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -215,6 +215,11 @@ class HathorManager:
         self.is_started = True
 
         self.log.info('start manager', network=self.network)
+        self.log.info(
+            'Settings configuration',
+            ws_max_subs_addrs_conn=settings.WS_MAX_SUBS_ADDRS_CONN,
+            ws_max_subs_addrs_empty=settings.WS_MAX_SUBS_ADDRS_EMPTY
+        )
         # If it's a full verification, we save on the storage that we are starting it
         # this is required because if we stop the initilization in the middle, the metadata
         # saved on the storage is not reliable anymore, only if we finish it


### PR DESCRIPTION
### Motivation

There are some configurations in the full node that must be customized depending on the use case and to know if the custom configuration worked the user needs to wait until the node full load, which may take a lot of time.

### Acceptance criteria

We should log some configuration values when starting the manager

### Unresolved questions

Should we add more config values? I've added the ones that are commonly customized by the use cases.