### PR TITLE
feat(logs): show settings location on startup

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -103,6 +103,7 @@ class RunNode:
         import hathor
         from hathor.cli.util import check_or_exit
         from hathor.conf import HathorSettings
+        from hathor.conf.get_settings import get_settings_module
         from hathor.daa import TestMode, _set_test_mode
         from hathor.manager import HathorManager
         from hathor.p2p.peer_discovery import BootstrapPeerDiscovery, DNSPeerDiscovery
@@ -119,6 +120,7 @@ class RunNode:
         from hathor.wallet import HDWallet, Wallet
 
         settings = HathorSettings()
+        settings_module = get_settings_module()  # only used for logging its location
         self.log = logger.new()
 
         from setproctitle import setproctitle
@@ -156,7 +158,8 @@ class RunNode:
             genesis=genesis.GENESIS_HASH.hex()[:7],
             my_peer_id=str(peer_id.id),
             python=python,
-            platform=platform.platform()
+            platform=platform.platform(),
+            settings=settings_module.__file__,
         )
 
         def create_wallet():

--- a/hathor/conf/get_settings.py
+++ b/hathor/conf/get_settings.py
@@ -14,6 +14,7 @@
 
 import importlib
 import os
+from types import ModuleType
 
 from hathor.conf.settings import HathorSettings as Settings
 
@@ -25,6 +26,13 @@ def HathorSettings() -> Settings:
         Get the file from environment variable 'HATHOR_CONFIG_FILE'
         If not set we return the config file of the mainnet
     """
+    settings_module = get_settings_module()
+    settings = getattr(settings_module, 'SETTINGS')
+    assert isinstance(settings, Settings)
+    return settings
+
+
+def get_settings_module() -> ModuleType:
     global _config_file
     # Import config file for network
     default_file = 'hathor.conf.mainnet'
@@ -37,4 +45,4 @@ def HathorSettings() -> Settings:
         module = importlib.import_module(config_file)
     except ModuleNotFoundError:
         module = importlib.import_module(default_file)
-    return module.SETTINGS  # type: ignore
+    return module


### PR DESCRIPTION
This is what it looks like on my machine:

```
2022-01-13 02:32:58 [info     ] [hathor.cli.run_node] hathor-core v0.46.0            genesis=3fdff62 hathor=0.46.0 my_peer_id=7181d232a16ba95001de22d3151b027ed31677c8cd6dc7eb88d538b250186bbf pid=28656 platform=Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-glibc2.29 python=3.8.10-CPython settings=/home/jan/Projects/hathor-nodes/data-1/conf.py
2022-01-13 02:32:58 [info     ] [hathor.cli.run_node] with storage                   path=/home/jan/Projects/hathor-nodes/data-1 storage_class=TransactionRocksDBStorage
2022-01-13 02:32:58 [info     ] [hathor.cli.run_node] with cache                     capacity=100000 interval=5
2022-01-13 02:32:58 [info     ] [hathor.manager] start manager                  network=mainnet
```

I think this will help people using custom settings know their settings was actually loaded.