### PR TITLE
chore(ci): update package manager's repo before install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,10 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install Ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get -y -q install graphviz librocksdb-dev libsnappy-dev liblz4-dev
+      run: 'sudo apt-get -qy update && sudo apt-get -qy install graphviz librocksdb-dev libsnappy-dev liblz4-dev'
     - name: Install macOS dependencies
       if: matrix.os == 'macos-latest'
-      run: brew install -q graphviz rocksdb
+      run: 'brew update -q && brew install -q graphviz rocksdb'
     - name: Install Poetry
       run: pip -q --no-input install poetry
     - name: Install Poetry dependencies


### PR DESCRIPTION
Since https://github.com/Homebrew/homebrew-core/pull/95667 has been merged, which now fixed homebrew's rocksdb bottle, this PR makes the CI update the package manager's repo before installing packages (i.e. `brew update` before `brew install`, also the same for `apt-get` for consistency). With this we will get the fixed homebrew bottle sooner, otherwise we would only get when either Github's worker is updated or we reach homebrew's autoupdate date (not sure when it is).

All in all, this should be safe and ensure fresher packages (things will break sooner when packages are updated, but also be fixed sooner).