### PR TITLE
chore(ci): temporarily remove macOS from test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,9 @@ jobs:
         import json
         full_matrix = {
           'python': ['3.7', '3.8', '3.9', '3.10'],
-          'os': ['ubuntu-latest', 'macos-latest', 'windows-latest'],
+          # XXX: temporarily removing 'macos-latest' until python-rocksdb build is fixed
+          # 'os': ['ubuntu-latest', 'macos-latest', 'windows-latest'],
+          'os': ['ubuntu-latest', 'windows-latest'],
           # XXX: tests fail on these, not sure why, when running them individually each on passes, but not on `make tests`
           # 'include': [
           #   {'os': 'ubuntu-latest', 'python': 'pypy-3.7'},


### PR DESCRIPTION
This is a workaround for the issue on #384 while it is not properly fixed. These set of changes will allow the CI tests (but not the docker builds) to keep working, but #384 will a need a fix anyway before we can make a new release. The expectation should be to commit the reverse of this commit before we make any release. Should I create and leave open the reversal of this commit?