### PR TITLE
chore(dockerfile): also install git and pkg-config on setup step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache openssl libffi graphviz
 #      making the python binding try to load the updated lib, this pattern will prevent that)
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb-dev
-RUN apk add openssl-dev libffi-dev build-base cargo
+RUN apk add openssl-dev libffi-dev build-base cargo git pkgconfig
 RUN pip --no-input --no-cache-dir install --upgrade pip wheel poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 WORKDIR /app/

--- a/Dockerfile.pypy
+++ b/Dockerfile.pypy
@@ -9,7 +9,7 @@ FROM pypy:$PYTHON-slim-$DEBIAN as stage-0
 RUN apt-get -qy update
 RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
 # dev deps for this build start here
-RUN apt-get -qy install libssl-dev libffi-dev build-essential zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev librocksdb-dev cargo
+RUN apt-get -qy install libssl-dev libffi-dev build-essential zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev librocksdb-dev cargo git pkg-config
 # install all deps in a virtualenv so we can just copy it over to the final image
 RUN pip --no-input --no-cache-dir install --upgrade pip wheel poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true


### PR DESCRIPTION
This PR fixes a regression from #385 

We introduced a package that installs directly from a git repository instead of from pypi, this makes git a requirement on the Dockerfile step that installs the poetry dependencies. This PR includes installing git on the correct step.

A CI run testing this change is running my fork: https://github.com/jansegre/hathor-core/actions/runs/2054361752