### PR TITLE
chore(docker): improve image generation and testing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ on:
     - v*
   schedule:
   - cron: '0 4 * * *'  # nightlies at 4am UTC
+env:
+  TEST_TAG: hathor-core:test
 jobs:
   buildx:
     name: buildx ${{ matrix.python-impl }}-${{ matrix.python-version }}
@@ -131,9 +133,16 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-${{ github.head_ref || github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-refs/heads/master-
+    - name: Build and export to Docker
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        load: true
+        tags: ${{ env.TEST_TAG }}
+    - name: Test image
+      run: docker run --rm ${{ env.TEST_TAG }} quick_test --data / --testnet
     - name: Build and push
       uses: docker/build-push-action@v2
-      id: docker_build
       with:
         context: .
         file: ${{ steps.prep.outputs.dockerfile }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
 # before changing these variables, make sure the tag $PYTHON-alpine$ALPINE exists first
 # list of valid tags hese: https://hub.docker.com/_/python
-# XXX: docker.io/python images use a `ENV PYTHON_VERSION` that would shadow an ARG of same name
 ARG PYTHON=3.7
-ARG ALPINE=3.15
+ARG DEBIAN=bullseye
 
 # stage-0: copy pyproject.toml/poetry.lock and install the production set of dependencies
-FROM python:$PYTHON-alpine$ALPINE as stage-0
+FROM python:$PYTHON-slim-$DEBIAN as stage-0
 ARG PYTHON
-RUN apk add --no-cache openssl libffi graphviz
-# XXX: adding rocksdb and rocksdb-dev separately allows reuse of the rocksdb only
-# XXX: keeping these together (no COPY from project in between) makes the installation
-#      always consistent in case rocksdb is updated on the alpine repository (I had a
-#      case where it was updated and "add rocksdb" layer was reused by "add rocksdb-dev" was not,
-#      making the python binding try to load the updated lib, this pattern will prevent that)
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb-dev
-RUN apk add openssl-dev libffi-dev build-base cargo git pkgconfig
+# install runtime first deps to speedup the dev deps and because layers will be reused on stage-1
+RUN apt-get -qy update
+RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
+# dev deps for this build start here
+RUN apt-get -qy install libssl-dev libffi-dev build-essential zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev librocksdb-dev cargo git pkg-config
+# install all deps in a virtualenv so we can just copy it over to the final image
 RUN pip --no-input --no-cache-dir install --upgrade pip wheel poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 WORKDIR /app/
@@ -26,15 +22,12 @@ COPY README.md ./
 RUN poetry build -f wheel
 RUN poetry run pip install dist/hathor-*.whl
 
-# stage-1: use production .venv (from stage-0)
-# lean and mean: this image should be about ~110MB, would be about ~470MB if using the whole stage-1
-FROM python:$PYTHON-alpine$ALPINE
+# finally: use production .venv from before
+# lean and mean: this image should be about ~50MB, would be about ~470MB if using the whole stage-1
+FROM python:$PYTHON-slim-$DEBIAN
 ARG PYTHON
-RUN apk add --no-cache openssl libffi graphviz
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb
-# XXX: rocksdb from edge now requires updated libstdc++, because it was built with it, no other runtime dep is affected
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main -u libstdc++
+RUN apt-get -qy update
+RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
 COPY --from=stage-0 /app/.venv/lib/python${PYTHON}/site-packages/ /usr/local/lib/python${PYTHON}/site-packages/
-COPY hathor ./hathor
 EXPOSE 40403 8080
 ENTRYPOINT ["python", "-m", "hathor"]

--- a/hathor/cli/main.py
+++ b/hathor/cli/main.py
@@ -44,6 +44,7 @@ class CliManager:
             oracle_encode_data,
             oracle_get_pubkey,
             peer_id,
+            quick_test,
             run_node,
             shell,
             stratum_mining,
@@ -73,6 +74,7 @@ class CliManager:
                      'Read an oracle private key and output public key hash')
         self.add_cmd('oracle', 'oracle-encode-data', oracle_encode_data, 'Encode data and sign it with a private key')
         self.add_cmd('dev', 'shell', shell, 'Run a Python shell')
+        self.add_cmd('dev', 'quick_test', quick_test, 'Similar to run_node but will quit after receiving a tx')
         self.add_cmd('dev', 'generate_nginx_config', nginx_config, 'Generate nginx config from OpenAPI json')
 
     def add_cmd(self, group: str, cmd: str, module: ModuleType, short_description: Optional[str] = None) -> None:

--- a/hathor/cli/quick_test.py
+++ b/hathor/cli/quick_test.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import Namespace
+
+from hathor.cli.run_node import RunNode
+
+
+class QuickTest(RunNode):
+
+    def register_resources(self, args: Namespace) -> None:
+        self.log.info('patching on_new_tx to quit on success')
+        orig_on_new_tx = self.manager.on_new_tx
+
+        def patched_on_new_tx(*args, **kwargs):
+            res = orig_on_new_tx(*args, **kwargs)
+            if res:
+                self.log.info('sucessfully added a tx, exit now')
+                self.manager.connections.disconnect_all_peers(force=True)
+                self.reactor.stop()
+            return res
+        self.manager.on_new_tx = patched_on_new_tx
+
+        timeout = 300
+        self.log.info('exit with error code if it take too long', timeout=timeout)
+
+        def exit_with_error():
+            import sys
+            self.log.error('took too long to get a tx, exit with error')
+            self.manager.connections.disconnect_all_peers(force=True)
+            self.reactor.stop()
+            sys.exit(1)
+        self.reactor.callLater(timeout, exit_with_error)
+
+
+def main():
+    QuickTest().run()


### PR DESCRIPTION
A trial run is running here: https://github.com/jansegre/hathor-core/runs/5760065789?check_suite_focus=true

This PR has three separate improvements:

- add a subcommand `quick_test` that will exit with success (exit_code==0) when a transaction is added to the database, or exit with failure (exit_code!=0) in any other case (including timing out if it take too long)
- add a step on the CI to test the built image before pushing the image to the repositories, this makes sure that an image which for any reason does not pass the `quick_test` check will not be uploaded
- use debian-slim instead of alpine as the base python image, this is mostly because in alpine rocksdb is not "stable", so we're subject to a lot more of instability, for example, the latest build of rocksdb depends on a version of stdlibc++ that is not on the main repository of the release we use (alpine 3.15) but instead has to be installed from the edge version, this time the update is safe, but it may be that an update in the future causes dependency installation problems much harder to solve, just switching to debian-slim seems much easier maintain, besides that's what the pypy image is based off anyway, so that would also be a little easier to maintain. 