### PR TITLE
feat(init): speed up initialization

### DIFF
--- a/hathor/exception.py
+++ b/hathor/exception.py
@@ -22,3 +22,8 @@ class InvalidNewTransaction(HathorError):
     """Raised when a new received tx/block is not valid.
     """
     pass
+
+
+class InitializationError(HathorError):
+    """Raised when there's anything wrong during initialization that should cause it to be aborted.
+    """

--- a/hathor/indexes/address_index.py
+++ b/hathor/indexes/address_index.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Iterable, List, Optional
 
 from structlog import get_logger
 
+from hathor.indexes.base_index import BaseIndex
 from hathor.transaction import BaseTransaction
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -25,10 +26,13 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = get_logger()
 
 
-class AddressIndex(ABC):
+class AddressIndex(BaseIndex):
     """ Index of inputs/outputs by address
     """
     pubsub: Optional['PubSubManager']
+
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        self.add_tx(tx)
 
     def publish_tx(self, tx: BaseTransaction, *, addresses: Optional[Iterable[str]] = None) -> None:
         """ Publish WALLET_ADDRESS_HISTORY for all addresses of a transaction.

--- a/hathor/indexes/base_index.py
+++ b/hathor/indexes/base_index.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from hathor.transaction.base_transaction import BaseTransaction
+
+
+class BaseIndex(ABC):
+    """ All indexes must inherit from this index.
+
+    This class exists so we can interact with indexes without knowing anything specific to its implemented. It was
+    created to generalize how we initialize indexes and keep track of which ones are up-to-date.
+    """
+
+    @abstractmethod
+    def get_db_name(self) -> Optional[str]:
+        """ The returned string is used to generate the relevant attributes for storing an indexe's state in the db.
+
+        If None is returned, the database will not store the index initialization state and they will always be
+        initialized. This is the expected mode that memory-only indexes will use.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        """ When the index needs to be initialized, this function will be called for every tx in topological order.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def force_clear(self) -> None:
+        """ Clear any existing data in the index.
+        """
+        raise NotImplementedError

--- a/hathor/indexes/deps_index.py
+++ b/hathor/indexes/deps_index.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Iterator, List
 
+from hathor.indexes.base_index import BaseIndex
 from hathor.transaction import BaseTransaction, Block
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -48,7 +49,7 @@ def get_requested_from_height(tx: BaseTransaction) -> int:
     return block.get_metadata().height
 
 
-class DepsIndex(ABC):
+class DepsIndex(BaseIndex):
     """ Index of dependencies between transactions
 
     This index exists to accelerate queries related to the partial validation mechanism needed by sync-v2. More
@@ -103,6 +104,12 @@ class DepsIndex(ABC):
     - The "needed" and "ready" concepts should be easier to understand, but are harder to ascii-draw, thus I skipped
       them.
     """
+
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        tx_meta = tx.get_metadata()
+        if tx_meta.voided_by:
+            return
+        self.add_tx(tx, partial=False)
 
     @abstractmethod
     def add_tx(self, tx: BaseTransaction, partial: bool = True) -> None:

--- a/hathor/indexes/manager.py
+++ b/hathor/indexes/manager.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple
 
 from structlog import get_logger
 
 from hathor.indexes.address_index import AddressIndex
+from hathor.indexes.base_index import BaseIndex
 from hathor.indexes.deps_index import DepsIndex
 from hathor.indexes.height_index import HeightIndex
 from hathor.indexes.mempool_tips_index import MempoolTipsIndex
@@ -25,6 +27,7 @@ from hathor.indexes.timestamp_index import TimestampIndex
 from hathor.indexes.tips_index import TipsIndex
 from hathor.indexes.tokens_index import TokensIndex
 from hathor.transaction import BaseTransaction
+from hathor.util import progress
 
 if TYPE_CHECKING:  # pragma: no cover
     import rocksdb
@@ -35,12 +38,20 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = get_logger()
 
 
+class _IndexFilter(Enum):
+    ALL = auto()  # block or tx, voided or not
+    ALL_BLOCKS = auto()  # only blocks that are not voided
+    VALID_TXS = auto()  # only transactions that are not voided
+
+
 class IndexesManager(ABC):
     """ IndexesManager manages all the indexes that we will have in the system
 
     The idea is for the manager to handle all method calls to indexes,
     so it will know which index is better to use in each moment
     """
+
+    log = get_logger()
 
     all_tips: TipsIndex
     block_tips: TipsIndex
@@ -56,6 +67,39 @@ class IndexesManager(ABC):
     addresses: Optional[AddressIndex]
     tokens: Optional[TokensIndex]
 
+    def __init_checks__(self):
+        """ Implementations must call this at the **end** of their __init__ for running ValueError checks."""
+        # check if every index has a unique db_name
+        indexes_db_names = set()
+        for index in self.iter_all_indexes():
+            index_db_name = index.get_db_name()
+            if index_db_name is None:
+                continue
+            if index_db_name in indexes_db_names:
+                raise ValueError(f'duplicate index name "{index_db_name}", already in use by another index')
+            indexes_db_names.add(index_db_name)
+
+    def iter_all_indexes(self) -> Iterator[BaseIndex]:
+        """ Iterate over all of the indexes abstracted by this manager, hiding their specific implementation details"""
+        for _, index in self._iter_all_indexes_with_filter():
+            yield index
+
+    def _iter_all_indexes_with_filter(self) -> Iterator[Tuple[_IndexFilter, BaseIndex]]:
+        """ Same as `iter_all_indexes()`, but includes a filter for what transactions an index is interested in."""
+        yield _IndexFilter.ALL, self.all_tips
+        yield _IndexFilter.ALL_BLOCKS, self.block_tips
+        yield _IndexFilter.VALID_TXS, self.tx_tips
+        yield _IndexFilter.ALL, self.sorted_all
+        yield _IndexFilter.ALL_BLOCKS, self.sorted_blocks
+        yield _IndexFilter.VALID_TXS, self.sorted_txs
+        yield _IndexFilter.ALL, self.deps
+        yield _IndexFilter.ALL, self.height
+        yield _IndexFilter.ALL, self.mempool_tips
+        if self.addresses is not None:
+            yield _IndexFilter.ALL, self.addresses
+        if self.tokens is not None:
+            yield _IndexFilter.ALL, self.tokens
+
     @abstractmethod
     def enable_address_index(self, pubsub: 'PubSubManager') -> None:
         """Enable address index. It does nothing if it has already been enabled."""
@@ -66,23 +110,74 @@ class IndexesManager(ABC):
         """Enable tokens index. It does nothing if it has already been enabled."""
         raise NotImplementedError
 
-    def _manually_initialize_tips_indexes(self, tx_storage: 'TransactionStorage') -> None:
-        """ Initialize the tips indexes, populating them from a tx_storage that is otherwise complete.
-
-        XXX: this method requires timestamp indexes to be complete and up-to-date with the rest of the database
-        XXX: this method is not yet being used
+    def force_clear_all(self) -> None:
+        """ Force clear all indexes.
         """
-        for tx in tx_storage._topological_sort_timestamp_index():
-            tx_meta = tx.get_metadata()
-            if not tx_meta.validation.is_final():
+        for index in self.iter_all_indexes():
+            index.force_clear()
+
+    def _manually_initialize(self, tx_storage: 'TransactionStorage') -> None:
+        """ Initialize the indexes, checking the indexes that need initialization, and the optimal iterator to use.
+        """
+        from hathor.transaction.genesis import BLOCK_GENESIS
+        from hathor.transaction.storage.transaction_storage import NULL_INDEX_LAST_STARTED_AT
+
+        db_last_started_at = tx_storage.get_last_started_at()
+
+        indexes_to_init: List[Tuple[_IndexFilter, BaseIndex]] = []
+        for index_filter, index in self._iter_all_indexes_with_filter():
+            index_db_name = index.get_db_name()
+            if index_db_name is None:
+                indexes_to_init.append((index_filter, index))
                 continue
+            index_last_started_at = tx_storage.get_index_last_started_at(index_db_name)
+            if db_last_started_at != index_last_started_at:
+                indexes_to_init.append((index_filter, index))
 
-            self.all_tips.add_tx(tx)
+        if indexes_to_init:
+            self.log.debug('there are indexes that need initialization',
+                           indexes_to_init=[i for _, i in indexes_to_init])
+        else:
+            self.log.debug('there are no indexes that need initialization')
 
+        # make sure that all the indexes that we're rebuilding are cleared
+        for _, index in indexes_to_init:
+            index_db_name = index.get_db_name()
+            if index_db_name:
+                tx_storage.set_index_last_started_at(index_db_name, NULL_INDEX_LAST_STARTED_AT)
+            index.force_clear()
+
+        block_count = 0
+        tx_count = 0
+        latest_timestamp = BLOCK_GENESIS.timestamp
+        first_timestamp = BLOCK_GENESIS.timestamp
+
+        for tx in progress(tx_storage.topological_iterator(), log=self.log):
+            # XXX: these would probably make more sense to be their own simple "indexes" instead of how it is here
+            latest_timestamp = max(tx.timestamp, latest_timestamp)
+            first_timestamp = min(tx.timestamp, first_timestamp)
             if tx.is_block:
-                self.block_tips.add_tx(tx)
-            elif not tx_meta.voided_by:
-                self.tx_tips.add_tx(tx)
+                block_count += 1
+            else:
+                tx_count += 1
+
+            tx_meta = tx.get_metadata()
+
+            # feed each transaction to the indexes that they are interested in
+            for index_filter, index in indexes_to_init:
+                if index_filter is _IndexFilter.ALL:
+                    index.init_loop_step(tx)
+                elif index_filter is _IndexFilter.ALL_BLOCKS:
+                    if tx.is_block:
+                        index.init_loop_step(tx)
+                elif index_filter is _IndexFilter.VALID_TXS:
+                    # XXX: all indexes that use this filter treat soft-voided as voided, nothing special needed
+                    if tx.is_transaction and not tx_meta.voided_by:
+                        index.init_loop_step(tx)
+                else:
+                    assert False, 'impossible filter'
+
+        tx_storage._update_caches(block_count, tx_count, latest_timestamp, first_timestamp)
 
     def add_tx(self, tx: BaseTransaction) -> bool:
         """ Add a transaction to the indexes
@@ -162,6 +257,9 @@ class MemoryIndexesManager(IndexesManager):
         self.mempool_tips = MemoryMempoolTipsIndex()
         self.deps = MemoryDepsIndex()
 
+        # XXX: this has to be at the end of __init__, after everything has been initialized
+        self.__init_checks__()
+
     def enable_address_index(self, pubsub: 'PubSubManager') -> None:
         from hathor.indexes.memory_address_index import MemoryAddressIndex
         if self.addresses is None:
@@ -176,8 +274,8 @@ class MemoryIndexesManager(IndexesManager):
 class RocksDBIndexesManager(IndexesManager):
     def __init__(self, db: 'rocksdb.DB') -> None:
         from hathor.indexes.memory_deps_index import MemoryDepsIndex
+        from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
         from hathor.indexes.rocksdb_height_index import RocksDBHeightIndex
-        from hathor.indexes.rocksdb_mempool_tips_index import RocksDBMempoolTipsIndex
         from hathor.indexes.rocksdb_timestamp_index import RocksDBTimestampIndex
 
         self._db = db
@@ -186,15 +284,18 @@ class RocksDBIndexesManager(IndexesManager):
         self.block_tips = TipsIndex()
         self.tx_tips = TipsIndex()
 
-        self.sorted_all = RocksDBTimestampIndex(self._db, cf_name=b'timestamp-sorted-all')
-        self.sorted_blocks = RocksDBTimestampIndex(self._db, cf_name=b'timestamp-sorted-blocks')
-        self.sorted_txs = RocksDBTimestampIndex(self._db, cf_name=b'timestamp-sorted-txs')
+        self.sorted_all = RocksDBTimestampIndex(self._db, 'all')
+        self.sorted_blocks = RocksDBTimestampIndex(self._db, 'blocks')
+        self.sorted_txs = RocksDBTimestampIndex(self._db, 'txs')
 
         self.addresses = None
         self.tokens = None
         self.height = RocksDBHeightIndex(self._db)
-        self.mempool_tips = RocksDBMempoolTipsIndex(self._db)
+        self.mempool_tips = MemoryMempoolTipsIndex()  # use of RocksDBMempoolTipsIndex is very slow and was suspended
         self.deps = MemoryDepsIndex()  # use of RocksDBDepsIndex is currently suspended until it is fixed
+
+        # XXX: this has to be at the end of __init__, after everything has been initialized
+        self.__init_checks__()
 
     def enable_address_index(self, pubsub: 'PubSubManager') -> None:
         from hathor.indexes.rocksdb_address_index import RocksDBAddressIndex

--- a/hathor/indexes/memory_address_index.py
+++ b/hathor/indexes/memory_address_index.py
@@ -30,11 +30,20 @@ logger = get_logger()
 class MemoryAddressIndex(AddressIndex):
     """ Index of inputs/outputs by address
     """
+
+    index: DefaultDict[str, Set[bytes]]
+
     def __init__(self, pubsub: Optional['PubSubManager'] = None) -> None:
-        self.index: DefaultDict[str, Set[bytes]] = defaultdict(set)
         self.pubsub = pubsub
+        self.force_clear()
         if self.pubsub:
             self.subscribe_pubsub_events()
+
+    def get_db_name(self) -> Optional[str]:
+        return None
+
+    def force_clear(self) -> None:
+        self.index = defaultdict(set)
 
     def subscribe_pubsub_events(self) -> None:
         """ Subscribe wallet index to receive voided/winner tx pubsub events

--- a/hathor/indexes/memory_deps_index.py
+++ b/hathor/indexes/memory_deps_index.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, FrozenSet, Iterator, List, Set, Tuple
+from typing import TYPE_CHECKING, Dict, FrozenSet, Iterator, List, Optional, Set, Tuple
 
 from structlog import get_logger
 
@@ -27,17 +27,26 @@ logger = get_logger()
 
 
 class MemoryDepsIndex(DepsIndex):
+    # Reverse dependency mapping
+    _rev_dep_index: Dict[bytes, Set[bytes]]
+
+    # Ready to be validated cache
+    _txs_with_deps_ready: Set[bytes]
+
+    # Next to be downloaded
+    _needed_txs_index: Dict[bytes, Tuple[int, bytes]]
+
     def __init__(self):
         self.log = logger.new()
+        self.force_clear()
 
-        # Reverse dependency mapping
-        self._rev_dep_index: Dict[bytes, Set[bytes]] = {}
+    def get_db_name(self) -> Optional[str]:
+        return None
 
-        # Ready to be validated cache
-        self._txs_with_deps_ready: Set[bytes] = set()
-
-        # Next to be downloaded
-        self._needed_txs_index: Dict[bytes, Tuple[int, bytes]] = {}
+    def force_clear(self) -> None:
+        self._rev_dep_index = {}
+        self._txs_with_deps_ready = set()
+        self._needed_txs_index = {}
 
     def add_tx(self, tx: BaseTransaction, partial: bool = True) -> None:
         assert tx.hash is not None

--- a/hathor/indexes/memory_height_index.py
+++ b/hathor/indexes/memory_height_index.py
@@ -24,6 +24,12 @@ class MemoryHeightIndex(HeightIndex):
     _index: List[IndexEntry]
 
     def __init__(self) -> None:
+        self.force_clear()
+
+    def get_db_name(self) -> Optional[str]:
+        return None
+
+    def force_clear(self) -> None:
         self._index = [BLOCK_GENESIS_ENTRY]
 
     def _add(self, height: int, block_hash: bytes, timestamp: int, *, can_reorg: bool) -> None:

--- a/hathor/indexes/memory_mempool_tips_index.py
+++ b/hathor/indexes/memory_mempool_tips_index.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Set
+from typing import Iterable, Optional, Set
 
 from structlog import get_logger
 
@@ -26,6 +26,12 @@ class MemoryMempoolTipsIndex(ByteCollectionMempoolTipsIndex):
 
     def __init__(self):
         self.log = logger.new()
+        self.force_clear()
+
+    def get_db_name(self) -> Optional[str]:
+        return None
+
+    def force_clear(self) -> None:
         self._index = set()
 
     def _discard(self, tx: bytes) -> None:

--- a/hathor/indexes/memory_timestamp_index.py
+++ b/hathor/indexes/memory_timestamp_index.py
@@ -37,6 +37,12 @@ class MemoryTimestampIndex(TimestampIndex):
 
     def __init__(self) -> None:
         self.log = logger.new()
+        self.force_clear()
+
+    def get_db_name(self) -> Optional[str]:
+        return None
+
+    def force_clear(self) -> None:
         self._index = SortedKeyList(key=lambda x: (x.timestamp, x.hash))
 
     def add_tx(self, tx: BaseTransaction) -> bool:

--- a/hathor/indexes/memory_tokens_index.py
+++ b/hathor/indexes/memory_tokens_index.py
@@ -68,6 +68,12 @@ class MemoryTokenIndexInfo(TokenIndexInfo):
 class MemoryTokensIndex(TokensIndex):
     def __init__(self) -> None:
         self.log = logger.new()
+        self.force_clear()
+
+    def get_db_name(self) -> Optional[str]:
+        return None
+
+    def force_clear(self) -> None:
         self._tokens: Dict[bytes, MemoryTokenIndexInfo] = defaultdict(MemoryTokenIndexInfo)
 
     def _add_to_index(self, tx: BaseTransaction, index: int) -> None:

--- a/hathor/indexes/mempool_tips_index.py
+++ b/hathor/indexes/mempool_tips_index.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Collection
 from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Set, cast
 
 import structlog
 
+from hathor.indexes.base_index import BaseIndex
 from hathor.transaction import BaseTransaction, Transaction
 from hathor.util import not_none
 
@@ -25,8 +26,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from hathor.transaction.storage import TransactionStorage
 
 
-class MempoolTipsIndex(ABC):
+class MempoolTipsIndex(BaseIndex):
     """Index to access the tips of the mempool transactions, which haven't been confirmed by a block."""
+
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        self.update(tx)
 
     # originally tx_storage.update_mempool_tips
     @abstractmethod

--- a/hathor/indexes/rocksdb_address_index.py
+++ b/hathor/indexes/rocksdb_address_index.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = get_logger()
 
 _CF_NAME_ADDRESS_INDEX = b'address-index'
+_DB_NAME: str = 'address'
 
 
 class RocksDBAddressIndex(AddressIndex, RocksDBIndexUtils):
@@ -46,16 +47,19 @@ class RocksDBAddressIndex(AddressIndex, RocksDBIndexUtils):
     """
     def __init__(self, db: 'rocksdb.DB', *, cf_name: Optional[bytes] = None,
                  pubsub: Optional['PubSubManager'] = None) -> None:
-        RocksDBIndexUtils.__init__(self, db)
         self.log = logger.new()
-
-        # column family stuff
-        self._cf_name = cf_name or _CF_NAME_ADDRESS_INDEX
-        self._cf = self._fresh_cf(self._cf_name)
+        RocksDBIndexUtils.__init__(self, db, cf_name or _CF_NAME_ADDRESS_INDEX)
 
         self.pubsub = pubsub
         if self.pubsub:
             self.subscribe_pubsub_events()
+
+    def get_db_name(self) -> Optional[str]:
+        # XXX: we don't need it to be parametrizable, so this is fine
+        return _DB_NAME
+
+    def force_clear(self) -> None:
+        self.clear()
 
     def _to_key(self, address: str, tx: Optional[BaseTransaction] = None) -> bytes:
         import struct

--- a/hathor/indexes/rocksdb_deps_index.py
+++ b/hathor/indexes/rocksdb_deps_index.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 _CF_NAME_DEPS_INDEX = b'deps-index'
+_DB_NAME: str = 'deps'
 
 
 class _Tag(Enum):
@@ -73,12 +74,15 @@ class RocksDBDepsIndex(DepsIndex, RocksDBIndexUtils):
         if not _force:
             # See: https://github.com/HathorNetwork/hathor-core/issues/412
             raise TypeError('This class should not be used')
-        RocksDBIndexUtils.__init__(self, db)
         self.log = logger.new()
+        RocksDBIndexUtils.__init__(self, db, cf_name or _CF_NAME_DEPS_INDEX)
 
-        # column family stuff
-        self._cf_name = cf_name or _CF_NAME_DEPS_INDEX
-        self._cf = self._fresh_cf(self._cf_name)
+    def get_db_name(self) -> Optional[str]:
+        # XXX: we don't need it to be parametrizable, so this is fine
+        return _DB_NAME
+
+    def force_clear(self) -> None:
+        self.clear()
 
     def _to_key_ready(self, tx_hash: Optional[bytes] = None) -> bytes:
         """Make a key for accessing READY txs 'set'"""

--- a/hathor/indexes/rocksdb_height_index.py
+++ b/hathor/indexes/rocksdb_height_index.py
@@ -27,6 +27,7 @@ settings = HathorSettings()
 logger = get_logger()
 
 _CF_NAME_HEIGHT_INDEX = b'height-index'
+_DB_NAME: str = 'height'
 
 
 class RocksDBHeightIndex(HeightIndex, RocksDBIndexUtils):
@@ -44,15 +45,15 @@ class RocksDBHeightIndex(HeightIndex, RocksDBIndexUtils):
     """
 
     def __init__(self, db: 'rocksdb.DB', *, cf_name: Optional[bytes] = None) -> None:
-        RocksDBIndexUtils.__init__(self, db)
         self.log = logger.new()
+        RocksDBIndexUtils.__init__(self, db, cf_name or _CF_NAME_HEIGHT_INDEX)
 
-        # column family stuff
-        self._cf_name = cf_name or _CF_NAME_HEIGHT_INDEX
-        self._cf = self._fresh_cf(self._cf_name)
+    def get_db_name(self) -> Optional[str]:
+        # XXX: we don't need it to be parametrizable, so this is fine
+        return _DB_NAME
 
-        # XXX: when we stop using a fresh column-family we have to figure-out when to not run this
-        self._init_db()
+    def force_clear(self) -> None:
+        self.clear()
 
     def _init_db(self) -> None:
         """ Initialize the database with the genesis entry."""

--- a/hathor/indexes/rocksdb_mempool_tips_index.py
+++ b/hathor/indexes/rocksdb_mempool_tips_index.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = get_logger()
 
 _CF_NAME_MEMPOOL_TIPS_INDEX = b'mempool-tips-index'
+_DB_NAME: str = 'mempool_tips'
 
 
 class RocksDBMempoolTipsIndex(ByteCollectionMempoolTipsIndex):
@@ -34,6 +35,13 @@ class RocksDBMempoolTipsIndex(ByteCollectionMempoolTipsIndex):
         self.log = logger.new()
         _cf_name = cf_name or _CF_NAME_MEMPOOL_TIPS_INDEX
         self._index = RocksDBSimpleSet(db, self.log, cf_name=_cf_name)
+
+    def get_db_name(self) -> Optional[str]:
+        # XXX: we don't need it to be parametrizable, so this is fine
+        return _DB_NAME
+
+    def force_clear(self) -> None:
+        self._index.clear()
 
     def _discard(self, tx: bytes) -> None:
         self._index.discard(tx)

--- a/hathor/indexes/rocksdb_timestamp_index.py
+++ b/hathor/indexes/rocksdb_timestamp_index.py
@@ -38,13 +38,16 @@ class RocksDBTimestampIndex(TimestampIndex, RocksDBIndexUtils):
     It works nicely because rocksdb uses a tree sorted by key under the hood.
     """
 
-    def __init__(self, db: 'rocksdb.DB', *, cf_name: bytes) -> None:
-        RocksDBIndexUtils.__init__(self, db)
+    def __init__(self, db: 'rocksdb.DB', name: str) -> None:
         self.log = logger.new()
+        RocksDBIndexUtils.__init__(self, db, f'timestamp-sorted-{name}'.encode())
+        self._name = name
 
-        # column family stuff
-        self._cf_name = cf_name
-        self._cf = self._fresh_cf(self._cf_name)
+    def get_db_name(self) -> Optional[str]:
+        return f'timestamp_{self._name}'
+
+    def force_clear(self) -> None:
+        self.clear()
 
     def _to_key(self, timestamp: int, tx_hash: Optional[bytes] = None) -> bytes:
         """Make a key for a timestamp and optionally tx_hash, the key represents the membership itself."""

--- a/hathor/indexes/rocksdb_tokens_index.py
+++ b/hathor/indexes/rocksdb_tokens_index.py
@@ -39,6 +39,7 @@ settings = HathorSettings()
 logger = get_logger()
 
 _CF_NAME_TOKENS_INDEX = b'tokens-index'
+_DB_NAME: str = 'tokens'
 
 # the following type is used to help a little bit to distinguish when we're using a byte sequence that should only be
 # internally used
@@ -91,12 +92,15 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
     """
 
     def __init__(self, db: 'rocksdb.DB', *, cf_name: Optional[bytes] = None) -> None:
-        RocksDBIndexUtils.__init__(self, db)
         self.log = logger.new()
+        RocksDBIndexUtils.__init__(self, db, cf_name or _CF_NAME_TOKENS_INDEX)
 
-        # column family stuff
-        self._cf_name = cf_name or _CF_NAME_TOKENS_INDEX
-        self._cf = self._fresh_cf(self._cf_name)
+    def get_db_name(self) -> Optional[str]:
+        # XXX: we don't need it to be parametrizable, so this is fine
+        return _DB_NAME
+
+    def force_clear(self) -> None:
+        self.clear()
 
     def _to_internal_token_uid(self, token_uid: bytes) -> _InternalUid:
         """Normalizes a token_uid so that the native token (\x00) will have the same length as custom tokens."""

--- a/hathor/indexes/timestamp_index.py
+++ b/hathor/indexes/timestamp_index.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Iterator, List, NamedTuple, Optional, Tuple
 
 from structlog import get_logger
 
+from hathor.indexes.base_index import BaseIndex
 from hathor.transaction import BaseTransaction
 
 logger = get_logger()
@@ -27,9 +28,12 @@ class RangeIdx(NamedTuple):
     offset: int
 
 
-class TimestampIndex(ABC):
+class TimestampIndex(BaseIndex):
     """ Index of transactions sorted by their timestamps.
     """
+
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        self.add_tx(tx)
 
     @abstractmethod
     def add_tx(self, tx: BaseTransaction) -> bool:

--- a/hathor/indexes/tokens_index.py
+++ b/hathor/indexes/tokens_index.py
@@ -15,6 +15,7 @@
 from abc import ABC, abstractmethod
 from typing import Iterator, List, NamedTuple, Optional, Tuple
 
+from hathor.indexes.base_index import BaseIndex
 from hathor.transaction import BaseTransaction
 
 
@@ -57,9 +58,15 @@ class TokenIndexInfo(ABC):
         raise NotImplementedError
 
 
-class TokensIndex(ABC):
+class TokensIndex(BaseIndex):
     """ Index of tokens by token uid
     """
+
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        tx_meta = tx.get_metadata()
+        if tx_meta.voided_by:
+            return
+        self.add_tx(tx)
 
     @abstractmethod
     def add_tx(self, tx: BaseTransaction) -> None:

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -832,7 +832,8 @@ class BaseTransaction(ABC):
             #        which requires the use of a storage, this is a workaround that should be fixed, places where this
             #        happens include generating new mining blocks and some tests
             height = self.calculate_height() if self.storage else 0
-            metadata = TransactionMetadata(hash=self.hash, accumulated_weight=self.weight, height=height)
+            score = self.weight if self.is_genesis else 0
+            metadata = TransactionMetadata(hash=self.hash, accumulated_weight=self.weight, height=height, score=score)
             self._metadata = metadata
         if not metadata.hash:
             metadata.hash = self.hash
@@ -844,7 +845,8 @@ class BaseTransaction(ABC):
         recalculating all metadata.
         """
         assert self.storage is not None
-        self._metadata = TransactionMetadata(hash=self.hash,
+        score = self.weight if self.is_genesis else 0
+        self._metadata = TransactionMetadata(hash=self.hash, score=score,
                                              accumulated_weight=self.weight,
                                              height=self.calculate_height())
         self._metadata._tx_ref = weakref.ref(self)

--- a/tests/tx/test_indexes2.py
+++ b/tests/tx/test_indexes2.py
@@ -45,7 +45,7 @@ class SimpleIndexesTestCase(unittest.TestCase):
         from hathor.indexes.memory_timestamp_index import MemoryTimestampIndex
         from hathor.indexes.rocksdb_timestamp_index import RocksDBTimestampIndex
         from hathor.indexes.timestamp_index import RangeIdx
-        rocksdb_index = RocksDBTimestampIndex(self.create_tmp_rocksdb_db(), cf_name=b'foo')
+        rocksdb_index = RocksDBTimestampIndex(self.create_tmp_rocksdb_db(), 'foo')
         memory_index = MemoryTimestampIndex()
         for tx in self.transactions:
             rocksdb_index.add_tx(tx)

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -436,6 +436,10 @@ class TransactionBinaryStorageTest(BaseTransactionStorageTest):
         shutil.rmtree(self.directory)
         super().tearDown()
 
+    def test_storage_new_blocks(self):
+        self.tx_storage._always_use_topological_dfs = True
+        super().test_storage_new_blocks()
+
 
 class TransactionCompactStorageTest(BaseTransactionStorageTest):
     __test__ = True
@@ -451,6 +455,10 @@ class TransactionCompactStorageTest(BaseTransactionStorageTest):
         subfolders_path = os.path.join(self.directory, 'tx')
         subfolders = os.listdir(subfolders_path)
         self.assertEqual(settings.STORAGE_SUBFOLDERS, len(subfolders))
+
+    def test_storage_new_blocks(self):
+        self.tx_storage._always_use_topological_dfs = True
+        super().test_storage_new_blocks()
 
     def tearDown(self):
         shutil.rmtree(self.directory)
@@ -510,6 +518,25 @@ class TransactionRocksDBStorageTest(BaseTransactionStorageTest):
     def setUp(self):
         self.directory = tempfile.mkdtemp()
         super().setUp(TransactionRocksDBStorage(self.directory))
+
+    def tearDown(self):
+        shutil.rmtree(self.directory)
+        super().tearDown()
+
+    def test_storage_new_blocks(self):
+        self.tx_storage._always_use_topological_dfs = True
+        super().test_storage_new_blocks()
+
+
+@pytest.mark.skipif(not HAS_ROCKSDB, reason='requires python-rocksdb')
+class CacheRocksDBStorageTest(BaseCacheStorageTest):
+    __test__ = True
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        store = TransactionRocksDBStorage(self.directory)
+        reactor = MemoryReactorHeapClock()
+        super().setUp(TransactionCacheStorage(store, reactor, capacity=5))
 
     def tearDown(self):
         shutil.rmtree(self.directory)


### PR DESCRIPTION
Using the latest snapshot (`data-20220303175324.tar.gz`) as a base, initialization is about 60% faster when using all existing in-disk indexes (some indexes are still in-memory only), and about 120% faster than using all in-disk indexes but rebuilding them on every initialization (the current behavior before this PR):

- cold run (all indexes rebuilt, in-disk will be reused later):
  ```
  2022-05-11 20:55:29 [info     ] [hathor.indexes.manager] loaded                         blocks=2267901 height=2259960 total_dt=~3509s tx_count=2895834 tx_rate=825.1686592546121 txs=627933
  ```` 
- hot run (only in-memory indexes are rebuilt):
  ```
  2022-05-11 21:29:53 [info     ] [hathor.indexes.manager] loaded                         blocks=2267901 height=2259960 total_dt=~1596s tx_count=2895834 tx_rate=1814.152552360921 txs=627933
  ```
- hot run (all in-memory indexes are rebuilt, no in-disk index is used):
  ```
  2022-05-11 22:19:42 [info     ] [hathor.indexes.manager] loaded                         blocks=2267901 height=2259960 total_dt=~2615s tx_count=2895834 tx_rate=1107.2753905973273 txs=627933
  ```

But still in-disk indexes are not enabled by default, they require cli argument `--x-rocksdb-indexes`.

Last bits:

- [x] `hathor/indexes/address_index.py:36` tx_meta.voided_by should not be skipped, add a test for that
- [x] `hathor/indexes/deps_index.py:110` check whether the it really makes sense to filter-out voided txs
- [x] `hathor/indexes/tips_index.py:63` check whether looking at validation.is_final makes sense for all indexes
- [x] `hathor/indexes/manager.py:44` check if soft-voided txs are handled correctly
- [x] `hathor/indexes/manager.py:147` move iterator selector to the storage and only consider DFS sort when a flag is used