### PR TITLE
feat(storage): add fast topological iterator

### DIFF
--- a/hathor/indexes/memory_timestamp_index.py
+++ b/hathor/indexes/memory_timestamp_index.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 from sortedcontainers import SortedKeyList
 from structlog import get_logger
@@ -79,3 +79,7 @@ class MemoryTimestampIndex(TimestampIndex):
                 next_idx = txs.bisect_key_left((next_timestamp, b''))
                 next_offset -= next_idx
         return hashes, RangeIdx(next_timestamp, next_offset)
+
+    def iter(self) -> Iterator[bytes]:
+        for element in self._index:
+            yield element.hash

--- a/hathor/indexes/rocksdb_timestamp_index.py
+++ b/hathor/indexes/rocksdb_timestamp_index.py
@@ -154,3 +154,10 @@ class RocksDBTimestampIndex(TimestampIndex, RocksDBIndexUtils):
                 next_offset += 1
             n -= 1
         return hashes, RangeIdx(next_timestamp, next_offset)
+
+    def iter(self) -> Iterator[bytes]:
+        it = self._db.iterkeys(self._cf)
+        it.seek_to_first()
+        for _, key in it:
+            __, tx_hash = self._from_key(key)
+            yield tx_hash

--- a/hathor/indexes/timestamp_index.py
+++ b/hathor/indexes/timestamp_index.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import List, NamedTuple, Optional, Tuple
+from typing import Iterator, List, NamedTuple, Optional, Tuple
 
 from structlog import get_logger
 
@@ -82,5 +82,11 @@ class TimestampIndex(ABC):
     @abstractmethod
     def get_hashes_and_next_idx(self, from_idx: RangeIdx, count: int) -> Tuple[List[bytes], Optional[RangeIdx]]:
         """ Get up to count hashes if available and the next range-index, this is used by sync-v1.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def iter(self) -> Iterator[bytes]:
+        """ Iterate over the transactions in the index order, that is, sorted by timestamp.
         """
         raise NotImplementedError

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -6,6 +6,58 @@ from tests.simulation.base import SimulatorTestCase
 
 
 class BaseRandomSimulatorTestCase(SimulatorTestCase):
+    def test_topological_iterators(self):
+        # BEGIN: build random blockchain
+        manager1 = self.create_peer()
+
+        # FIXME: this second peer is only needed because of some problem on the simulator
+        manager2 = self.create_peer()
+        conn12 = FakeConnection(manager1, manager2, latency=0.150)
+        self.simulator.add_connection(conn12)
+        self.simulator.run(10)
+
+        miner1 = self.simulator.create_miner(manager1, hashpower=100e6)
+        miner1.start()
+        self.simulator.run(10)
+
+        miner2 = self.simulator.create_miner(manager1, hashpower=100e6)
+        miner2.start()
+        self.simulator.run(10)
+
+        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=2 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx1.start()
+        self.simulator.run(10)
+
+        gen_tx2 = self.simulator.create_tx_generator(manager1, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx2.start()
+        self.simulator.run(10 * 60)
+
+        miner1.stop()
+        miner2.stop()
+        gen_tx1.stop()
+        gen_tx2.stop()
+
+        self.simulator.run(5 * 60)
+        # END: build random blockchain
+
+        # XXX: sanity check that we've at least produced something
+        self.assertGreater(manager1.tx_storage.get_count_tx_blocks(), 3)
+
+        # test iterators, name is used to aid in assert messages
+        iterators = [
+            ('traditional', manager1.tx_storage._topological_sort()),
+            ('fast', manager1.tx_storage._topological_fast()),
+        ]
+        for name, it in iterators:
+            # collect all transactions
+            txs = list(it)
+            # must be complete
+            self.assertEqual(len(txs), manager1.tx_storage.get_count_tx_blocks(),
+                             f'iterator "{name}" does not cover all txs')
+            # must be topological
+            self.assertIsTopological(iter(txs),
+                                     f'iterator "{name}" is not topological')
+
     def test_one_node(self):
         manager1 = self.create_peer()
 
@@ -16,6 +68,9 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         gen_tx1 = self.simulator.create_tx_generator(manager1, rate=2 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx1.start()
         self.simulator.run(60 * 60)
+
+        # FIXME: the setup above produces 0 new blocks and transactions
+        # self.assertGreater(manager1.tx_storage.get_count_tx_blocks(), 3)
 
     def test_two_nodes(self):
         manager1 = self.create_peer()


### PR DESCRIPTION
## Measure example

I ran this on ipython after initializing the indexes, on a database with about 2.9M objects.

```
In [9]: def countit(it):
   ...:     return sum(1 for _ in it)
   ...:

In [10]: %time countit(tx_storage._topological_fast())
CPU times: user 11min 57s, sys: 0 ns, total: 11min 57s
Wall time: 11min 57s
Out[10]: 2895834

In [11]: %time countit(tx_storage._topological_sort())
CPU times: user 26min 40s, sys: 2.45 s, total: 26min 43s
Wall time: 26min 43s
Out[11]: 2895834

In [12]: %time countit(tx_storage._topological_fast())
CPU times: user 12min 4s, sys: 19.5 ms, total: 12min 4s
Wall time: 12min 4s
Out[12]: 2895834

In [13]: %time countit(tx_storage._topological_sort())
CPU times: user 23min 35s, sys: 3.75 s, total: 23min 39s
Wall time: 23min 39s
Out[13]: 2895834
```

There's some variation, but it's roughly about twice as fast, also not shown here is memory usage, which should be constant versus some significant amount that grows with the number of objects.

## Acceptance criteria

- do not change any current behavior
- have a new method for iterating that will not be used right now
- must iterate through all transactions in topological order
- add test for the current iterator
- avoid fixing possible newly discovered bugs in this PR