### PR TITLE
feat(indexes): add manual tips-index initialization

### DIFF
--- a/slow_tests/test_simulator.py
+++ b/slow_tests/test_simulator.py
@@ -6,8 +6,8 @@ from hathor.transaction import BaseTransaction
 from hathor.transaction.genesis import genesis_transactions
 from hathor.wallet import HDWallet
 from tests import unittest
-from tests.utils import FakeConnection, MinerSimulator, RandomTransactionGenerator, Simulator
 from tests.clock import HeapClock
+from tests.utils import FakeConnection, MinerSimulator, RandomTransactionGenerator, Simulator
 
 
 class HathorSyncMethodsTestCase(unittest.TestCase):

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -6,58 +6,6 @@ from tests.simulation.base import SimulatorTestCase
 
 
 class BaseRandomSimulatorTestCase(SimulatorTestCase):
-    def test_topological_iterators(self):
-        # BEGIN: build random blockchain
-        manager1 = self.create_peer()
-
-        # FIXME: this second peer is only needed because of some problem on the simulator
-        manager2 = self.create_peer()
-        conn12 = FakeConnection(manager1, manager2, latency=0.150)
-        self.simulator.add_connection(conn12)
-        self.simulator.run(10)
-
-        miner1 = self.simulator.create_miner(manager1, hashpower=100e6)
-        miner1.start()
-        self.simulator.run(10)
-
-        miner2 = self.simulator.create_miner(manager1, hashpower=100e6)
-        miner2.start()
-        self.simulator.run(10)
-
-        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=2 / 60., hashpower=1e6, ignore_no_funds=True)
-        gen_tx1.start()
-        self.simulator.run(10)
-
-        gen_tx2 = self.simulator.create_tx_generator(manager1, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
-        gen_tx2.start()
-        self.simulator.run(10 * 60)
-
-        miner1.stop()
-        miner2.stop()
-        gen_tx1.stop()
-        gen_tx2.stop()
-
-        self.simulator.run(5 * 60)
-        # END: build random blockchain
-
-        # XXX: sanity check that we've at least produced something
-        self.assertGreater(manager1.tx_storage.get_count_tx_blocks(), 3)
-
-        # test iterators, name is used to aid in assert messages
-        iterators = [
-            ('traditional', manager1.tx_storage._topological_sort()),
-            ('fast', manager1.tx_storage._topological_fast()),
-        ]
-        for name, it in iterators:
-            # collect all transactions
-            txs = list(it)
-            # must be complete
-            self.assertEqual(len(txs), manager1.tx_storage.get_count_tx_blocks(),
-                             f'iterator "{name}" does not cover all txs')
-            # must be topological
-            self.assertIsTopological(iter(txs),
-                                     f'iterator "{name}" is not topological')
-
     def test_one_node(self):
         manager1 = self.create_peer()
 

--- a/tests/tx/test_indexes3.py
+++ b/tests/tx/test_indexes3.py
@@ -1,0 +1,116 @@
+from hathor.simulator import FakeConnection
+from tests import unittest
+from tests.simulation.base import SimulatorTestCase
+
+
+class BaseSimulatorIndexesTestCase(SimulatorTestCase):
+    def _build_randomized_blockchain(self):
+        manager = self.create_peer()
+
+        # FIXME: this second peer is only needed because of some problem on the simulator
+        manager2 = self.create_peer()
+        conn12 = FakeConnection(manager, manager2, latency=0.150)
+        self.simulator.add_connection(conn12)
+        self.simulator.run(10)
+
+        miner1 = self.simulator.create_miner(manager, hashpower=100e6)
+        miner1.start()
+        self.simulator.run(10)
+
+        miner2 = self.simulator.create_miner(manager, hashpower=100e6)
+        miner2.start()
+        self.simulator.run(10)
+
+        gen_tx1 = self.simulator.create_tx_generator(manager, rate=2 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx1.start()
+        self.simulator.run(10)
+
+        gen_tx2 = self.simulator.create_tx_generator(manager, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx2.start()
+        self.simulator.run(10 * 60)
+
+        miner1.stop()
+        miner2.stop()
+        gen_tx1.stop()
+        gen_tx2.stop()
+
+        self.simulator.run(5 * 60)
+        return manager
+
+    def test_tips_index_initialization(self):
+        from intervaltree import IntervalTree
+
+        # XXX: this test makes use of the internals of TipsIndex
+        manager = self._build_randomized_blockchain()
+        tx_storage = manager.tx_storage
+        assert tx_storage.indexes is not None
+
+        # XXX: sanity check that we've at least produced something
+        self.assertGreater(tx_storage.get_count_tx_blocks(), 3)
+
+        # base tips indexes
+        base_all_tips_tree = tx_storage.indexes.all_tips.tree.copy()
+        base_block_tips_tree = tx_storage.indexes.block_tips.tree.copy()
+        base_tx_tips_tree = tx_storage.indexes.tx_tips.tree.copy()
+
+        # reset the indexes and force a manual initialization
+        tx_storage._reset_cache()
+        manager._initialize_components()
+
+        reinit_all_tips_tree = tx_storage.indexes.all_tips.tree.copy()
+        reinit_block_tips_tree = tx_storage.indexes.block_tips.tree.copy()
+        reinit_tx_tips_tree = tx_storage.indexes.tx_tips.tree.copy()
+
+        self.assertEqual(reinit_all_tips_tree, base_all_tips_tree)
+        self.assertEqual(reinit_block_tips_tree, base_block_tips_tree)
+        self.assertEqual(reinit_tx_tips_tree, base_tx_tips_tree)
+
+        # reset again but now initilize from the new function
+        # XXX: manually reset each index, because we're using MemoryTimestampIndex and we need that for the new init
+        for tip_index in [tx_storage.indexes.all_tips, tx_storage.indexes.block_tips, tx_storage.indexes.tx_tips]:
+            tip_index.tx_last_interval = {}
+            tip_index.tree = IntervalTree()
+        tx_storage.indexes._manually_initialize_tips_indexes(tx_storage)
+
+        newinit_all_tips_tree = tx_storage.indexes.all_tips.tree.copy()
+        newinit_block_tips_tree = tx_storage.indexes.block_tips.tree.copy()
+        newinit_tx_tips_tree = tx_storage.indexes.tx_tips.tree.copy()
+
+        self.assertEqual(newinit_all_tips_tree, base_all_tips_tree)
+        self.assertEqual(newinit_block_tips_tree, base_block_tips_tree)
+        self.assertEqual(newinit_tx_tips_tree, base_tx_tips_tree)
+
+    def test_topological_iterators(self):
+        manager = self._build_randomized_blockchain()
+        tx_storage = manager.tx_storage
+
+        # XXX: sanity check that we've at least produced something
+        self.assertGreater(tx_storage.get_count_tx_blocks(), 3)
+
+        # test iterators, name is used to aid in assert messages
+        iterators = [
+            ('traditional', tx_storage._topological_sort()),
+            ('fast', tx_storage._topological_fast()),
+        ]
+        for name, it in iterators:
+            # collect all transactions
+            txs = list(it)
+            # must be complete
+            self.assertEqual(len(txs), tx_storage.get_count_tx_blocks(),
+                             f'iterator "{name}" does not cover all txs')
+            # must be topological
+            self.assertIsTopological(iter(txs),
+                                     f'iterator "{name}" is not topological')
+
+
+class SyncV1SimulatorIndexesTestCase(unittest.SyncV1Params, BaseSimulatorIndexesTestCase):
+    __test__ = True
+
+
+class SyncV2SimulatorIndexesTestCase(unittest.SyncV2Params, BaseSimulatorIndexesTestCase):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeSimulatorIndexesTestCase(unittest.SyncBridgeParams, SyncV2SimulatorIndexesTestCase):
+    __test__ = True


### PR DESCRIPTION
## Measure example

A standalone test suggests that there initialization time should drop by about half:

This was run on a modified version of `HathorManager.start` to not reset the existing rocksdb indexes and to use the `_topological_fast` iterator:

```
In [1]: %time manager.start()
2022-04-14 19:19:33 [info     ] [hathor.manager] start manager                  network=mainnet
2022-04-14 19:19:33 [info     ] [hathor.p2p.manager] update whitelist
2022-04-14 19:19:33 [info     ] [hathor.manager] initialize
2022-04-14 19:49:42 [info     ] [hathor.manager] ready                          blocks=0 height=0 total_dt=<1ms tx_count=0 tx_rate=? txs=0
2022-04-14 19:49:42 [info     ] [hathor.p2p.manager] listen on                      endpoint=tcp:9101
CPU times: user 30min 3s, sys: 4.51 s, total: 30min 7s
Wall time: 30min 8s
```

While on the same hardware initialization using all rocksdb indexes takes about double the time:

```
In [1]: manager.start()
2022-04-14 18:09:54 [info     ] [hathor.manager] start manager                  network=mainnet
2022-04-14 18:09:54 [info     ] [hathor.p2p.manager] update whitelist
2022-04-14 18:09:54 [info     ] [hathor.manager] initialize
2022-04-14 18:12:28 [info     ] [hathor.manager] load transactions...           dt=~30s height=58185 latest_ts=2020-01-24 01:40:05 total=58539 tx_new=58539 tx_rate=1951.270225979218
...
2022-04-14 19:11:45 [info     ] [hathor.manager] load transactions...           dt=~30s height=2259960 latest_ts=2022-03-03 17:53:24 total=2895818 tx_new=123 tx_rate=4.06934933520013
2022-04-14 19:11:55 [info     ] [hathor.manager] ready                          blocks=2267901 height=2259960 total_dt=~3716s tx_count=2895834 tx_rate=779.1259755028108 txs=627933
2022-04-14 19:11:55 [info     ] [hathor.p2p.manager] listen on                      endpoint=tcp:9101
```

However this is just a peek into what should be expected in the near future, this PR does not include everything required to enable this speed up, that will be left to the next PR on this series.

## Acceptance criteria

- do not change any current behavior
- have a new method for initializing the tips indexes that will not be used right now
- the new initializer must produce the same exact interval trees
- test both the current and new initializers
- avoid fixing possible newly discovered bugs in this PR