### PR TITLE
chore(tests): mark flaky tests

### DIFF
--- a/tests/tx/test_indexes3.py
+++ b/tests/tx/test_indexes3.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hathor.simulator import FakeConnection
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
@@ -37,6 +39,7 @@ class BaseSimulatorIndexesTestCase(SimulatorTestCase):
         self.simulator.run(5 * 60)
         return manager
 
+    @pytest.mark.flaky(max_runs=3, min_passes=1)
     def test_tips_index_initialization(self):
         from intervaltree import IntervalTree
 
@@ -80,6 +83,7 @@ class BaseSimulatorIndexesTestCase(SimulatorTestCase):
         self.assertEqual(newinit_block_tips_tree, base_block_tips_tree)
         self.assertEqual(newinit_tx_tips_tree, base_tx_tips_tree)
 
+    @pytest.mark.flaky(max_runs=3, min_passes=1)
     def test_topological_iterators(self):
         manager = self._build_randomized_blockchain()
         tx_storage = manager.tx_storage


### PR DESCRIPTION
These tests were added recently and they both use the simulator in a way that will sometimes fail, which has nothing to do with what is being tested. I think it makes sense to have them as flaky and avoid having to re-run the failed jobs when it occasionally happens.