### PR TITLE
chore(ci): fix docker image pre-build for testing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -137,8 +137,13 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        file: ${{ steps.prep.outputs.dockerfile }}
+        build-args: PYTHON=${{ matrix.python-version }}
+        pull: true
         load: true
         tags: ${{ env.TEST_TAG }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
     - name: Test image
       run: docker run --rm ${{ env.TEST_TAG }} quick_test --data / --testnet
     - name: Build and push


### PR DESCRIPTION
The image pre-build and testing was added recently, but it wasn't setup properly, so it has always been building a single configuration (the Dockerfile's default), instead of using the specific build-args from the job's matrix unit. This PR fixes that and also fixes the pull/cache strategy used on the final build. Because the final build still uses the same arguments as before, it wasn't affected, and the only effect the current changes will have is increasing the chance of cache hits.

A test run was made here: https://github.com/jansegre/hathor-core/actions/runs/2265019983