### PR TITLE
feat(storage): add an alternative fast topological iterator

### DIFF
--- a/hathor/graphviz.py
+++ b/hathor/graphviz.py
@@ -123,7 +123,8 @@ class GraphvizVisualizer:
     def get_nodes_iterator(self) -> Iterator[BaseTransaction]:
         """ Return an iterator.
         """
-        return self.storage._topological_sort()
+        # TODO: check if it's safe to use one of the two faster iterators
+        return self.storage._topological_sort_dfs()
 
     def dot(self, format: str = 'pdf') -> Digraph:
         """Return a Graphviz object of the DAG of verifications.

--- a/hathor/indexes/manager.py
+++ b/hathor/indexes/manager.py
@@ -70,7 +70,7 @@ class IndexesManager(ABC):
         XXX: this method requires timestamp indexes to be complete and up-to-date with the rest of the database
         XXX: this method is not yet being used
         """
-        for tx in tx_storage._topological_fast():
+        for tx in tx_storage._topological_sort_timestamp_index():
             tx_meta = tx.get_metadata()
             if not tx_meta.validation.is_final():
                 continue

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -386,7 +386,7 @@ class HathorManager:
                 tx.reset_metadata()
 
         self.log.debug('load blocks and transactions')
-        for tx in self.tx_storage._topological_sort():
+        for tx in self.tx_storage._topological_sort_dfs():
             if self._full_verification:
                 tx.update_initial_metadata()
 

--- a/hathor/wallet/hd_wallet.py
+++ b/hathor/wallet/hd_wallet.py
@@ -297,7 +297,7 @@ class HDWallet(BaseWallet):
             :param tx_storage: storage from where I should load the txs
             :type tx_storage: :py:class:`hathor.transaction.storage.transaction_storage.TransactionStorage`
         """
-        for tx in tx_storage._topological_sort():
+        for tx in tx_storage._topological_sort_dfs():
             self.on_new_tx(tx)
 
     def validate_words(self):

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -146,7 +146,7 @@ class BaseCacheStorageTest(unittest.TestCase):
         tx = add_new_transactions(self.manager, 1, advance_clock=1)[0]
 
         total = 0
-        for tx in self.cache_storage._topological_sort_dfs(root=tx, visited=dict()):
+        for tx in self.cache_storage._run_topological_sort_dfs(root=tx, visited=dict()):
             total += 1
         self.assertEqual(total, 5)
 

--- a/tests/tx/test_indexes3.py
+++ b/tests/tx/test_indexes3.py
@@ -39,13 +39,19 @@ class BaseSimulatorIndexesTestCase(SimulatorTestCase):
         self.simulator.run(5 * 60)
         return manager
 
+    def setUp(self):
+        super().setUp()
+
+        # XXX: having this on the setUp makes it so when this fails it's an error (E) and not a failure (F), which has
+        #      slightly different meaning
+        self.manager = self._build_randomized_blockchain()
+
     @pytest.mark.flaky(max_runs=3, min_passes=1)
     def test_tips_index_initialization(self):
         from intervaltree import IntervalTree
 
         # XXX: this test makes use of the internals of TipsIndex
-        manager = self._build_randomized_blockchain()
-        tx_storage = manager.tx_storage
+        tx_storage = self.manager.tx_storage
         assert tx_storage.indexes is not None
 
         # XXX: sanity check that we've at least produced something
@@ -58,7 +64,7 @@ class BaseSimulatorIndexesTestCase(SimulatorTestCase):
 
         # reset the indexes and force a manual initialization
         tx_storage._reset_cache()
-        manager._initialize_components()
+        self.manager._initialize_components()
 
         reinit_all_tips_tree = tx_storage.indexes.all_tips.tree.copy()
         reinit_block_tips_tree = tx_storage.indexes.block_tips.tree.copy()
@@ -85,26 +91,31 @@ class BaseSimulatorIndexesTestCase(SimulatorTestCase):
 
     @pytest.mark.flaky(max_runs=3, min_passes=1)
     def test_topological_iterators(self):
-        manager = self._build_randomized_blockchain()
-        tx_storage = manager.tx_storage
+        tx_storage = self.manager.tx_storage
 
         # XXX: sanity check that we've at least produced something
-        self.assertGreater(tx_storage.get_count_tx_blocks(), 3)
+        total_count = tx_storage.get_count_tx_blocks()
+        self.assertGreater(total_count, 3)
+
+        # XXX: sanity check that the children metadata is properly set (this is needed for one of the iterators)
+        for tx in tx_storage.get_all_transactions():
+            assert tx.hash is not None
+            for parent_tx in map(tx_storage.get_transaction, tx.parents):
+                self.assertIn(tx.hash, parent_tx.get_metadata().children)
 
         # test iterators, name is used to aid in assert messages
         iterators = [
-            ('traditional', tx_storage._topological_sort()),
-            ('fast', tx_storage._topological_fast()),
+            ('dfs', tx_storage._topological_sort_dfs()),
+            ('timestamp_index', tx_storage._topological_sort_timestamp_index()),
+            ('metadata', tx_storage._topological_sort_metadata()),
         ]
         for name, it in iterators:
             # collect all transactions
             txs = list(it)
             # must be complete
-            self.assertEqual(len(txs), tx_storage.get_count_tx_blocks(),
-                             f'iterator "{name}" does not cover all txs')
+            self.assertEqual(len(txs), total_count, f'iterator "{name}" does not cover all txs')
             # must be topological
-            self.assertIsTopological(iter(txs),
-                                     f'iterator "{name}" is not topological')
+            self.assertIsTopological(iter(txs), f'iterator "{name}" is not topological')
 
 
 class SyncV1SimulatorIndexesTestCase(unittest.SyncV1Params, BaseSimulatorIndexesTestCase):

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -358,7 +358,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         add_new_transactions(self.manager, 1, advance_clock=1)
 
         total = 0
-        for tx in self.tx_storage._topological_sort():
+        for tx in self.tx_storage._topological_sort_dfs():
             total += 1
 
         # added blocks + genesis txs + added tx


### PR DESCRIPTION
This alternative topological iterator that is significantly faster over the traditional one, nearly as fast as the other one added recently and has a good advantage in that is doesn't need the timestamp indexes to be up-to-date. Which in turn makes it so it can be used for speeding up the rebuilding of indexes, and also other cases where we don't want to rely on the timestamp index, however it cannot be used to rebuild the metadata.