### PR TITLE
feat(cli): add experimental db export/import commands

### DIFF
--- a/hathor/cli/db_export.py
+++ b/hathor/cli/db_export.py
@@ -1,0 +1,146 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import struct
+from argparse import ArgumentParser, FileType, Namespace
+from typing import TYPE_CHECKING, Iterator, Optional
+
+from hathor.cli.run_node import RunNode
+
+if TYPE_CHECKING:
+    from hathor.transaction import BaseTransaction
+
+MAGIC_HEADER = b'HathDB'
+
+
+class DbExport(RunNode):
+    def start_manager(self, args: Namespace) -> None:
+        pass
+
+    def register_signal_handlers(self, args: Namespace) -> None:
+        pass
+
+    def register_resources(self, args: Namespace) -> None:
+        pass
+
+    def create_parser(self) -> ArgumentParser:
+        from hathor.conf import HathorSettings
+        settings = HathorSettings()
+
+        def max_height(arg: str) -> Optional[int]:
+            if arg.lower() == 'checkpoint':
+                if not settings.CHECKPOINTS:
+                    raise ValueError('There are no checkpoints to use')
+                return settings.CHECKPOINTS[-1].height
+            elif arg:
+                return int(arg)
+            else:
+                return None
+
+        parser = super().create_parser()
+        parser.add_argument('--export-file', type=FileType('wb', 0), required=True,
+                            help='Save the export to this file')
+        parser.add_argument('--export-iterator', choices=['metadata', 'timestamp_index', 'dfs'], default='metadata',
+                            help='Which method of iterating to use, don\'t change unless you know what it does')
+        parser.add_argument('--export-max-height', type=max_height,
+                            help='Make no assumption about the mempool when using this option. It may be partially'
+                            'exported or not, depending on the timestamps and the traversal algorithm.')
+        parser.add_argument('--export-skip-voided', action='store_true', help='Do not export voided txs/blocks')
+        return parser
+
+    def prepare(self, args: Namespace) -> None:
+
+        super().prepare(args)
+
+        # allocating io.BufferedWriter here so we "own" it
+        self.out_file = io.BufferedWriter(args.export_file)
+        if not self.out_file.seekable():
+            raise ValueError('file cannot be used because it is not seekable')
+
+        self._iter_tx: Iterator['BaseTransaction']
+        if args.export_iterator == 'metadata':
+            self._iter_tx = self.tx_storage._topological_sort_metadata()
+        elif args.export_iterator == 'timestamp_index':
+            self._iter_tx = self.tx_storage._topological_sort_timestamp_index()
+        elif args.export_iterator == 'dfs':
+            self._iter_tx = self.tx_storage._topological_sort_dfs()
+        else:
+            raise ValueError(f'unknown iterator "{args.export_iterator}"')
+
+        self.export_height = args.export_max_height
+        self.skip_voided = args.export_skip_voided
+
+    def iter_tx(self) -> Iterator['BaseTransaction']:
+        from hathor.conf import HathorSettings
+        settings = HathorSettings()
+        soft_voided_ids = set(settings.SOFT_VOIDED_TX_IDS)
+
+        for tx in self._iter_tx:
+            assert tx.hash is not None
+            # XXX: if we're skipping voided transactions, we have to be careful not to skip soft-voided ones
+            if self.skip_voided:
+                voided_by = tx.get_metadata().voided_by or set()
+                soft_voided_by = voided_by & soft_voided_ids
+                if voided_by and not soft_voided_by:
+                    continue
+            yield tx
+
+    def run(self) -> None:
+        from hathor.util import progress
+        self.log.info('export')
+        self.out_file.write(MAGIC_HEADER)
+        tx_count = 0
+        block_count = 0
+        best_height = 0
+        # XXX: pre-write the count to reserve the space, we will seek to it and write the correct value at the end
+        write_pos_count = self.out_file.tell()
+        self.out_file.write(struct.pack('!I', tx_count))
+        self.out_file.write(struct.pack('!I', block_count))
+        # estimated total, this will obviously be wrong if we're not exporting everything, but it's still better than
+        # nothing, and it's probably better to finish sooner than expected, rather than later than expected
+        total = self.tx_storage.get_count_tx_blocks()
+        for tx in progress(self.iter_tx(), log=self.log, total=total):
+            assert tx.hash is not None
+            tx_meta = tx.get_metadata()
+            if tx.is_block:
+                if not tx_meta.voided_by:
+                    # XXX: max() shouldn't be needed, but just in case
+                    best_height = max(best_height, tx_meta.height)
+                block_count += 1
+            else:
+                tx_count += 1
+            # write tx
+            if tx.is_genesis:
+                continue
+            tx_bytes = bytes(tx)
+            self.out_file.write(struct.pack('!I', len(tx_bytes)))
+            self.out_file.write(tx_bytes)
+            # stop as soon as we reach our target height (if any) and after writing it
+            if self.export_height is not None and best_height >= self.export_height:
+                break
+        # warn if we haven't reached self.export_height
+        if self.export_height is not None and best_height < self.export_height:
+            self.log.warn('max export height not reached', best_height=best_height)
+        # finally, write the correct counts and close
+        self.out_file.seek(write_pos_count)
+        self.out_file.write(struct.pack('!I', tx_count))
+        self.out_file.write(struct.pack('!I', block_count))
+        self.out_file.flush()
+        del self.out_file
+        self.log.info('exported', tx_count=tx_count, block_count=block_count)
+
+
+def main():
+    DbExport().run()

--- a/hathor/cli/db_import.py
+++ b/hathor/cli/db_import.py
@@ -1,0 +1,98 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import struct
+import sys
+from argparse import ArgumentParser, FileType, Namespace
+from typing import TYPE_CHECKING, Iterator
+
+from hathor.cli.db_export import MAGIC_HEADER
+from hathor.cli.run_node import RunNode
+
+if TYPE_CHECKING:
+    from hathor.transaction import BaseTransaction
+
+
+class DbImport(RunNode):
+    def start_manager(self, args: Namespace) -> None:
+        pass
+
+    def register_signal_handlers(self, args: Namespace) -> None:
+        pass
+
+    def register_resources(self, args: Namespace) -> None:
+        pass
+
+    def create_parser(self) -> ArgumentParser:
+        parser = super().create_parser()
+        parser.add_argument('--import-file', type=FileType('rb', 0), required=True,
+                            help='Save the export to this file')
+        return parser
+
+    def prepare(self, args: Namespace) -> None:
+        super().prepare(args)
+
+        # allocating io.BufferedReader here so we "own" it
+        self.in_file = io.BufferedReader(args.import_file)
+
+    def run(self) -> None:
+        from hathor.util import progress
+
+        header = self.in_file.read(len(MAGIC_HEADER))
+        if header != MAGIC_HEADER:
+            self.log.error('wrong header, not a valid file')
+            sys.exit(1)
+
+        tx_count, = struct.unpack('!I', self.in_file.read(4))
+        block_count, = struct.unpack('!I', self.in_file.read(4))
+        total = tx_count + block_count
+        self.log.info('import database', tx_count=tx_count, block_count=block_count)
+        self.tx_storage.pre_init()
+        actual_tx_count = 0
+        actual_block_count = 0
+        for tx in progress(self._import_txs(), log=self.log, total=total):
+            if tx.is_block:
+                actual_block_count += 1
+            else:
+                actual_tx_count += 1
+        if actual_block_count != block_count:
+            self.log.error('block count mismatch', expected=block_count, actual=actual_block_count)
+        if actual_tx_count != tx_count:
+            self.log.error('tx count mismatch', expected=tx_count, actual=actual_tx_count)
+        del self.in_file
+        self.log.info('imported', tx_count=tx_count, block_count=block_count)
+
+    def _import_txs(self) -> Iterator['BaseTransaction']:
+        from hathor.transaction.base_transaction import tx_or_block_from_bytes
+        while True:
+            # read tx
+            tx_len_bytes = self.in_file.read(4)
+            if len(tx_len_bytes) != 4:
+                break
+            tx_len, = struct.unpack('!I', tx_len_bytes)
+            tx_bytes = self.in_file.read(tx_len)
+            if len(tx_bytes) != tx_len:
+                self.log.error('unexpected end of file', expected=tx_len, got=len(tx_bytes))
+                sys.exit(2)
+            tx = tx_or_block_from_bytes(tx_bytes)
+            assert tx is not None
+            assert tx.hash is not None
+            tx.storage = self.tx_storage
+            self.manager.on_new_tx(tx, quiet=True, fails_silently=False, skip_block_weight_verification=True)
+            yield tx
+
+
+def main():
+    DbImport().run()

--- a/hathor/cli/main.py
+++ b/hathor/cli/main.py
@@ -32,6 +32,8 @@ class CliManager:
         self.longest_cmd: int = 0
 
         from . import (
+            db_export,
+            db_import,
             generate_valid_words,
             merged_mining,
             mining,
@@ -77,6 +79,8 @@ class CliManager:
         self.add_cmd('dev', 'shell', shell, 'Run a Python shell')
         self.add_cmd('dev', 'quick_test', quick_test, 'Similar to run_node but will quit after receiving a tx')
         self.add_cmd('dev', 'generate_nginx_config', nginx_config, 'Generate nginx config from OpenAPI json')
+        self.add_cmd('dev', 'x-export', db_export, 'EXPERIMENTAL: Export database to a simple format.')
+        self.add_cmd('dev', 'x-import', db_import, 'EXPERIMENTAL: Import database from exported format.')
 
     def add_cmd(self, group: str, cmd: str, module: ModuleType, short_description: Optional[str] = None) -> None:
         self.command_list[cmd] = module


### PR DESCRIPTION
This PR depends on #410, it's basically two commands (prefixed with `x-` to indicate they are experimental): `x-import` and `x-export`, that will export raw blocks+transactions with no metadata with a trivial serialization. The format is intended to be simple enough so it can be stable, it's useful for recreating a database without having to sync to the network, and also useful for running experiments related to the loading of transactions.