### PR TITLE
fix(simulator): ignore additional arguments on overriden verify_pow

### DIFF
--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -57,7 +57,7 @@ class Simulator:
         """
         from hathor.transaction import BaseTransaction
 
-        def verify_pow(self: BaseTransaction) -> None:
+        def verify_pow(self: BaseTransaction, *args: Any, **kwargs: Any) -> None:
             assert self.hash is not None
 
         cls._original_verify_pow = BaseTransaction.verify_pow

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -6,6 +6,13 @@ from tests.simulation.base import SimulatorTestCase
 
 
 class BaseRandomSimulatorTestCase(SimulatorTestCase):
+    def test_verify_pow(self):
+        manager1 = self.create_peer()
+        # just get one of the genesis, we don't really need to create any transaction
+        tx = next(iter(manager1.tx_storage.get_all_genesis()))
+        # optional argument must be valid, it just has to not raise any exception, there's no assert for that
+        tx.verify_pow(0.)
+
     def test_one_node(self):
         manager1 = self.create_peer()
 


### PR DESCRIPTION
I'm not really sure how this bug remained here for so long. In short, this is what happens:

```
_________________ SyncV1StratumJobTest.test_min_share_weight __________________

self = <tests.tx.test_stratum.SyncV1StratumJobTest testMethod=test_min_share_weight>

    def test_min_share_weight(self):
        # submit a job
        nonce = self._get_nonce()
>       self._submit(self.job['job_id'], nonce)

tests\tx\test_stratum.py:225: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests\tx\test_stratum.py:172: in _submit
    self.protocol.lineReceived(
hathor\stratum\stratum.py:207: in lineReceived
    return self.handle_request(data['method'], data.get('params'), msgid)
hathor\stratum\stratum.py:421: in handle_request
    return self.handle_submit(params, msgid)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <hathor.stratum.stratum.StratumProtocol object at 0x000001F9A02D3FA0>
params = {'job_id': '51d96d195a55426498b9faafe5ecf393', 'nonce': '0x0'}
msgid = '2a5438c5f64a4b5c992758d900a8b6b5'

    def handle_submit(self, params: Dict, msgid: Optional[str]) -> None:
        """ Handles submit request by validating and propagating the result
    
        :param params: a dict containing a valid uui4 hex as `job_id` and a valid transaction nonce as `nonce`
        :type params: Dict
    
        :param msgid: JSON-RPC 2.0 message id
        :type msgid: Optional[UUID]
        """
        from hathor.merged_mining.bitcoin import sha256d_hash
    
        self.log.debug('handle submit', msgid=msgid, params=params)
    
        if 'job_id' not in params or 'nonce' not in params:
            return self.send_error(INVALID_PARAMS, msgid, {'params': params, 'required': ['job_id', 'nonce']})
    
        if not valid_uuid(params['job_id']):
            return self.send_error(INVALID_PARAMS, msgid, {
                'job_id': params['job_id'],
                'message': 'job_id is invalid uuid4'
            })
    
        job_id = UUID(params['job_id'])
        job = self.jobs.get(job_id)
    
        if job is None:
            return self.send_error(JOB_NOT_FOUND, msgid, {
                'current_job': self.current_job and self.current_job.id.hex,
                'job_id': job_id.hex
            })
    
        # It may take a while for pubsub to get a new job.
        # To avoid propagating the same tx multiple times, we check if it has already been submitted.
        if job is not self.current_job or job.submitted is not None:
            return self.send_error(STALE_JOB, msgid, {
                'current_job': self.current_job and self.current_job.id.hex,
                'job_id': job_id.hex
            })
    
        tx = job.tx.clone()
        block_base = tx.get_header_without_nonce()
        block_base_hash = sha256d_hash(block_base)
        # Stratum sends the nonce as a big-endian hexadecimal string.
        if params.get('aux_pow'):
            assert isinstance(tx, MergeMinedBlock), 'expected MergeMinedBlock got ' + type(tx).__name__
            tx.aux_pow = BitcoinAuxPow.from_bytes(bytes.fromhex(params['aux_pow']))
            tx.nonce = 0
        else:
            tx.nonce = int(params['nonce'], 16)
        tx.update_hash()
        assert tx.hash is not None
    
        self.log.debug('share received', block=tx, block_base=block_base.hex(), block_base_hash=block_base_hash.hex())
    
        try:
>           tx.verify_pow(job.weight)
E           TypeError: Simulator._apply_patches.<locals>.verify_pow() takes 1 positional argument but 2 were given
```

The problem is that `BaseTransaction.verify_pow` has an optional argument in its signature, the optional argument is to verify the pow against a different weight (than the transaction), this is only used in `hathor/stratum/stratum.py` to check that a job was correctly mined, the job has its own weight, usually smaller than the transaction/block that it is mining.

Now, the simulator overrides the `BaseTransaction.verify_pow` function with its own, in order to disable weight verification altogether so it can simulate most of the code without worrying about actually having to mine transactions/blocks. However, the function being used to replace the original `verify_pow` was missing the optional argument, which normally won't cause any problem because the argument was optional and only used in one specific case.

However apparently the case is triggered by chance (and very rarely). I've added a test case to directly use the optional argument that as causing the problem. Also I've opted to use a very generic `*args, **kwargs` approach, because that's usually what should be done when blindly overriding methods.