### PR TITLE
feat(indexes): add UTXO index

### DIFF
--- a/hathor/indexes/deps_index.py
+++ b/hathor/indexes/deps_index.py
@@ -111,6 +111,12 @@ class DepsIndex(BaseIndex):
             return
         self.add_tx(tx, partial=False)
 
+    def update(self, tx: BaseTransaction) -> None:
+        assert tx.hash is not None
+        tx_meta = tx.get_metadata()
+        if tx_meta.validation.is_fully_connected():
+            self.remove_ready_for_validation(tx.hash)
+
     @abstractmethod
     def add_tx(self, tx: BaseTransaction, partial: bool = True) -> None:
         """Update 'deps' and 'needed' sub-indexes, removing them when necessary (i.e. validation is complete).

--- a/hathor/indexes/memory_utxo_index.py
+++ b/hathor/indexes/memory_utxo_index.py
@@ -1,0 +1,134 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import DefaultDict, Iterator, NamedTuple, Optional, Union
+
+from sortedcontainers import SortedSet
+from structlog import get_logger
+
+from hathor.indexes.utxo_index import UtxoIndex, UtxoIndexItem
+
+logger = get_logger()
+
+
+class _IndexKey(NamedTuple):
+    token_uid: bytes
+    address: str
+
+
+class _NoLockItem(NamedTuple):
+    amount: int
+    tx_id: bytes
+    # XXX: using idx instead of index because `def index` exists in parent class
+    idx: int
+
+
+class _TimeLockItem(NamedTuple):
+    timelock: int
+    amount: int
+    tx_id: bytes
+    # XXX: using idx instead of index because `def index` exists in parent class
+    idx: int
+
+
+class _HeightLockItem(NamedTuple):
+    heightlock: int
+    amount: int
+    tx_id: bytes
+    # XXX: using idx instead of index because `def index` exists in parent class
+    idx: int
+
+
+@dataclass(frozen=True)
+class _IndexItem:
+    nolock: 'SortedSet[_NoLockItem]' = field(default_factory=SortedSet)
+    timelock: 'SortedSet[_TimeLockItem]' = field(default_factory=SortedSet)
+    heightlock: 'SortedSet[_HeightLockItem]' = field(default_factory=SortedSet)
+
+
+class MemoryUtxoIndex(UtxoIndex):
+    _index: DefaultDict[_IndexKey, _IndexItem]
+
+    def __init__(self):
+        super().__init__()
+        self._index = defaultdict(_IndexItem)
+
+    def get_db_name(self) -> Optional[str]:
+        return None
+
+    def force_clear(self) -> None:
+        self._index.clear()
+
+    def _add_utxo(self, item: UtxoIndexItem) -> None:
+        self.log.debug('add utxo', item=item)
+        subindex = self._index[_IndexKey(item.token_uid, item.address)]
+        if item.timelock is not None:
+            subindex.timelock.add(_TimeLockItem(item.timelock, item.amount, item.tx_id, item.index))
+        elif item.heightlock is not None:
+            subindex.heightlock.add(_HeightLockItem(item.heightlock, item.amount, item.tx_id, item.index))
+        else:
+            subindex.nolock.add(_NoLockItem(item.amount, item.tx_id, item.index))
+
+    def _remove_utxo(self, item: UtxoIndexItem) -> None:
+        self.log.debug('del utxo', item=item)
+        subindex = self._index[_IndexKey(item.token_uid, item.address)]
+        if item.timelock is not None:
+            subindex.timelock.discard(_TimeLockItem(item.timelock, item.amount, item.tx_id, item.index))
+        elif item.heightlock is not None:
+            subindex.heightlock.discard(_HeightLockItem(item.heightlock, item.amount, item.tx_id, item.index))
+        else:
+            subindex.nolock.discard(_NoLockItem(item.amount, item.tx_id, item.index))
+
+    def _iter_utxos_nolock(self, *, token_uid: bytes, address: str, target_amount: int) -> Iterator[UtxoIndexItem]:
+        subindex = self._index[_IndexKey(token_uid, address)].nolock
+        # this will point to the next value that is equal or higher than target_amount
+        idx_next_amount = subindex.bisect((target_amount,)) + 1
+        for i in subindex.islice(stop=idx_next_amount, reverse=True):
+            yield UtxoIndexItem(token_uid, i.tx_id, i.idx, address, i.amount, None, None)
+
+    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: int,
+                             target_timestamp: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        import math
+        seek_timestamp: Union[int, float]
+        if target_timestamp is None:
+            seek_timestamp = math.inf
+        else:
+            seek_timestamp = target_timestamp
+        subindex = self._index[_IndexKey(token_uid, address)].timelock
+        # this will point to the next value that is equal or higher than target_amount
+        idx_next_amount = subindex.bisect((seek_timestamp, target_amount)) + 1
+        for i in subindex.islice(stop=idx_next_amount, reverse=True):
+            # it might happen that the first one is out of the timestamp range
+            if i.timelock > seek_timestamp:
+                continue
+            yield UtxoIndexItem(token_uid, i.tx_id, i.idx, address, i.amount, i.timelock, None)
+
+    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: int,
+                               target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        import math
+        seek_height: Union[int, float]
+        if target_height is None:
+            seek_height = math.inf
+        else:
+            seek_height = target_height
+        subindex = self._index[_IndexKey(token_uid, address)].heightlock
+        # this will point to the next value that is equal or higher than target_amount
+        idx_next_amount = subindex.bisect((seek_height, target_amount)) + 1
+        for i in subindex.islice(stop=idx_next_amount, reverse=True):
+            # it might happen that the first one is out of the heightlock range
+            if i.heightlock > seek_height:
+                continue
+            yield UtxoIndexItem(token_uid, i.tx_id, i.idx, address, i.amount, None, i.heightlock)

--- a/hathor/indexes/rocksdb_utils.py
+++ b/hathor/indexes/rocksdb_utils.py
@@ -13,11 +13,37 @@
 # limitations under the License.
 
 from collections.abc import Collection
-from typing import TYPE_CHECKING, Dict, Iterable, Iterator
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, NewType
+
+from hathor.conf import HathorSettings
 
 if TYPE_CHECKING:  # pragma: no cover
     import rocksdb
     import structlog
+
+
+settings = HathorSettings()
+
+# the following type is used to help a little bit to distinguish when we're using a byte sequence that should only be
+# internally used
+InternalUid = NewType('InternalUid', bytes)
+_INTERNAL_HATHOR_TOKEN_UID = InternalUid(b'\x00' * 32)
+
+
+def to_internal_token_uid(token_uid: bytes) -> InternalUid:
+    """Normalizes a token_uid so that the native token (\x00) will have the same length as custom tokens."""
+    if token_uid == settings.HATHOR_TOKEN_UID:
+        return _INTERNAL_HATHOR_TOKEN_UID
+    assert len(token_uid) == 32
+    return InternalUid(token_uid)
+
+
+def from_internal_token_uid(token_uid: InternalUid) -> bytes:
+    """De-normalizes the token_uid so that the native token is b'\x00' as expected"""
+    assert len(token_uid) == 32
+    if token_uid == _INTERNAL_HATHOR_TOKEN_UID:
+        return settings.HATHOR_TOKEN_UID
+    return token_uid
 
 
 def incr_key(key: bytes) -> bytes:

--- a/hathor/indexes/rocksdb_utxo_index.py
+++ b/hathor/indexes/rocksdb_utxo_index.py
@@ -1,0 +1,365 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Iterator, Optional
+
+from structlog import get_logger
+
+from hathor.crypto.util import decode_address, get_address_b58_from_bytes
+from hathor.indexes.rocksdb_utils import InternalUid, RocksDBIndexUtils, from_internal_token_uid, to_internal_token_uid
+from hathor.indexes.utxo_index import UtxoIndex, UtxoIndexItem
+
+if TYPE_CHECKING:  # pragma: no cover
+    import rocksdb
+
+logger = get_logger()
+
+_DB_NAME: str = 'utxos'
+_CF_NAME_UTXO_INDEX = b'utxo-index'
+
+
+class _Tag(Enum):
+    INVALID = 0x00
+    NOLOCK = 0x01
+    TIMELOCK = 0x02
+    HEIGHTLOCK = 0x03
+
+
+@dataclass(frozen=True)
+class _KeyBase:
+    tag: _Tag = _Tag.INVALID
+
+    def __post_init__(self) -> None:
+        assert self.tag is not _Tag.INVALID
+
+    def __bytes__(self) -> bytes:
+        array = bytearray()
+        self._bytes(array)
+        return bytes(array)
+
+    def _bytes(self, array: bytearray) -> None:
+        array.append(self.tag.value)
+        assert len(array) == 1
+
+
+@dataclass(frozen=True)
+class _SeekKeyBase(_KeyBase):
+    token_uid_internal: InternalUid = InternalUid(b'')
+    address: bytes = b''
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert len(self.token_uid_internal) == 32
+        assert len(self.address) == 25
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(self.token_uid_internal)
+        array.extend(self.address)
+        assert len(array) == 1 + 32 + 25
+
+
+@dataclass(frozen=True)
+class _SeekKeyNoLock(_SeekKeyBase):
+    tag: _Tag = _Tag.NOLOCK
+    amount: int = -1
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert self.tag is _Tag.NOLOCK
+        assert self.amount > 0
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(struct.pack('>Q', self.amount))
+        assert len(array) == 1 + 32 + 25 + 8
+
+
+@dataclass(frozen=True)
+class _KeyNoLock(_SeekKeyNoLock):
+    tx_id: bytes = b''
+    index: int = -1
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert len(self.tx_id) == 32
+        assert self.index >= 0
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(self.tx_id)
+        array.append(self.index)
+        assert len(array) == 1 + 32 + 25 + 8 + 32 + 1
+
+    def to_index_item(self) -> UtxoIndexItem:
+        return UtxoIndexItem(
+            token_uid=from_internal_token_uid(self.token_uid_internal),
+            tx_id=self.tx_id,
+            index=self.index,
+            address=get_address_b58_from_bytes(self.address),
+            amount=self.amount,
+            timelock=None,
+            heightlock=None,
+        )
+
+
+@dataclass(frozen=True)
+class _SeekKeyTimeLock(_SeekKeyBase):
+    tag: _Tag = _Tag.TIMELOCK
+    timelock: int = -1
+    amount: int = -1
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert self.timelock >= 0
+        assert self.amount > 0
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(struct.pack('>I', self.timelock))
+        array.extend(struct.pack('>Q', self.amount))
+        assert len(array) == 1 + 32 + 25 + 4 + 8
+
+
+@dataclass(frozen=True)
+class _KeyTimeLock(_SeekKeyTimeLock):
+    tx_id: bytes = b''
+    index: int = -1
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert len(self.tx_id) == 32
+        assert self.index >= 0
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(self.tx_id)
+        array.append(self.index)
+        assert len(array) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+
+    def to_index_item(self) -> UtxoIndexItem:
+        return UtxoIndexItem(
+            token_uid=from_internal_token_uid(self.token_uid_internal),
+            tx_id=self.tx_id,
+            index=self.index,
+            address=get_address_b58_from_bytes(self.address),
+            amount=self.amount,
+            timelock=self.timelock,
+            heightlock=None,
+        )
+
+
+@dataclass(frozen=True)
+class _SeekKeyHeightLock(_SeekKeyBase):
+    tag: _Tag = _Tag.HEIGHTLOCK
+    heightlock: int = -1
+    amount: int = -1
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert self.tag is _Tag.HEIGHTLOCK
+        assert self.heightlock >= 0
+        assert self.amount > 0
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(struct.pack('>I', self.heightlock))
+        array.extend(struct.pack('>Q', self.amount))
+        assert len(array) == 1 + 32 + 25 + 4 + 8
+
+
+@dataclass(frozen=True)
+class _KeyHeightLock(_SeekKeyHeightLock):
+    tx_id: bytes = b''
+    index: int = -1
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert len(self.tx_id) == 32
+        assert self.index >= 0
+
+    def _bytes(self, array: bytearray) -> None:
+        super()._bytes(array)
+        array.extend(self.tx_id)
+        array.append(self.index)
+        assert len(array) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+
+    def to_index_item(self) -> UtxoIndexItem:
+        return UtxoIndexItem(
+            token_uid=from_internal_token_uid(self.token_uid_internal),
+            tx_id=self.tx_id,
+            index=self.index,
+            address=get_address_b58_from_bytes(self.address),
+            amount=self.amount,
+            timelock=None,
+            heightlock=self.heightlock,
+        )
+
+
+def _parse_key(key: bytes) -> _KeyBase:
+    assert len(key) >= 1
+    tag = _Tag(key[0])
+    if tag is _Tag.INVALID:
+        raise ValueError('invalid tag found')
+    elif tag is _Tag.NOLOCK:
+        assert len(key) == 1 + 32 + 25 + 8 + 32 + 1
+        return _KeyNoLock(
+            tag=tag,
+            token_uid_internal=InternalUid(key[1:33]),
+            address=key[33:58],
+            amount=struct.unpack('>Q', key[58:66])[0],
+            tx_id=key[66:98],
+            index=key[98],
+        )
+    elif tag is _Tag.TIMELOCK:
+        assert len(key) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+        return _KeyTimeLock(
+            tag=tag,
+            token_uid_internal=InternalUid(key[1:33]),
+            address=key[33:58],
+            timelock=struct.unpack('>I', key[58:62])[0],
+            amount=struct.unpack('>Q', key[62:70])[0],
+            tx_id=key[70:102],
+            index=key[102],
+        )
+    elif tag is _Tag.HEIGHTLOCK:
+        assert len(key) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+        return _KeyHeightLock(
+            tag=tag,
+            token_uid_internal=InternalUid(key[1:33]),
+            address=key[33:58],
+            heightlock=struct.unpack('>I', key[58:62])[0],
+            amount=struct.unpack('>Q', key[62:70])[0],
+            tx_id=key[70:102],
+            index=key[102],
+        )
+    else:
+        # XXX: if/elif is exhaustive for all possible tags and invalid tag value will fail sooner
+        raise NotImplementedError('unreachable')
+
+
+def _key_from_index_item(item: UtxoIndexItem) -> _KeyBase:
+    if item.timelock is not None:
+        return _KeyTimeLock(
+            token_uid_internal=to_internal_token_uid(item.token_uid),
+            address=decode_address(item.address),
+            timelock=item.timelock,
+            amount=item.amount,
+            tx_id=item.tx_id,
+            index=item.index,
+        )
+    elif item.heightlock is not None:
+        return _KeyHeightLock(
+            token_uid_internal=to_internal_token_uid(item.token_uid),
+            address=decode_address(item.address),
+            heightlock=item.heightlock,
+            amount=item.amount,
+            tx_id=item.tx_id,
+            index=item.index,
+        )
+    else:
+        return _KeyNoLock(
+            token_uid_internal=to_internal_token_uid(item.token_uid),
+            address=decode_address(item.address),
+            amount=item.amount,
+            tx_id=item.tx_id,
+            index=item.index,
+        )
+
+
+class RocksDBUtxoIndex(UtxoIndex, RocksDBIndexUtils):
+    """ Index of UTXO information by token_uid+address.
+
+    This index uses the following key formats:
+
+        key_nolock     = [tag][token_uid][address][amount][tx_id][index] tag=NOLOCK
+                         |1b-||--32b----||--25b--||--8b--||-32b-||-1b--|
+
+        key_timelock   = [tag][token_uid][address][timelock][amount][tx_id][index] tag=TIMELOCK
+                         |1b-||--32b----||--25b--||--4b----||--8b--||-32b-||-1b--|
+
+        key_heightlock = [tag][token_uid][address][heightlock][amount][tx_id][index] tag=HEIGHTLOCK
+                         |1b-||--32b----||--25b--||--4b------||--8b--||-32b-||-1b--|
+
+    It works nicely because rocksdb uses a tree sorted by key under the hood.
+    """
+
+    def __init__(self, db: 'rocksdb.DB', *, cf_name: Optional[bytes] = None) -> None:
+        super().__init__()
+        self.log = logger.new()
+        RocksDBIndexUtils.__init__(self, db, cf_name or _CF_NAME_UTXO_INDEX)
+
+    def get_db_name(self) -> Optional[str]:
+        return _DB_NAME
+
+    def force_clear(self) -> None:
+        self.clear()
+
+    def _add_utxo(self, item: UtxoIndexItem) -> None:
+        key = bytes(_key_from_index_item(item))
+        self._db.put((self._cf, key), b'')
+
+    def _remove_utxo(self, item: UtxoIndexItem) -> None:
+        key = bytes(_key_from_index_item(item))
+        self._db.delete((self._cf, key))
+
+    def _iter_utxos_nolock(self, *, token_uid: bytes, address: str, target_amount: int) -> Iterator[UtxoIndexItem]:
+        seek = _SeekKeyNoLock(token_uid_internal=to_internal_token_uid(token_uid), address=decode_address(address),
+                              amount=target_amount + 1)
+        for key in self._iter_keys(seek):
+            if not isinstance(key, _KeyNoLock):
+                break
+            if key.token_uid_internal != seek.token_uid_internal or key.address != seek.address:
+                break
+            yield key.to_index_item()
+
+    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: int,
+                             target_timestamp: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        seek = _SeekKeyTimeLock(token_uid_internal=to_internal_token_uid(token_uid), address=decode_address(address),
+                                amount=target_amount, timelock=(target_timestamp or 0xfffffffe) + 1)
+        for key in self._iter_keys(seek):
+            if not isinstance(key, _KeyTimeLock):
+                break
+            if key.token_uid_internal != seek.token_uid_internal or key.address != seek.address:
+                break
+            i = key.to_index_item()
+            # it might happen that the first one is out of the timelock range
+            if i.timelock is not None and i.timelock > seek.timelock:
+                continue
+            yield i
+
+    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: int,
+                               target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        seek = _SeekKeyHeightLock(token_uid_internal=to_internal_token_uid(token_uid), address=decode_address(address),
+                                  amount=target_amount, heightlock=(target_height or 0xfffffffe) + 1)
+        for key in self._iter_keys(seek):
+            if not isinstance(key, _KeyHeightLock):
+                break
+            if key.token_uid_internal != seek.token_uid_internal or key.address != seek.address:
+                break
+            i = key.to_index_item()
+            # it might happen that the first one is out of the heightlock range
+            if i.heightlock is not None and i.heightlock > seek.heightlock:
+                continue
+            yield i
+
+    def _iter_keys(self, seek: _SeekKeyBase) -> Iterator[_KeyBase]:
+        it: Any = reversed(self._db.iterkeys(self._cf))
+        it.seek_for_prev(bytes(seek))
+        for _cf, k in it:
+            key = _parse_key(k)
+            yield key

--- a/hathor/indexes/utxo_index.py
+++ b/hathor/indexes/utxo_index.py
@@ -1,0 +1,283 @@
+# Copyright 2022 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from structlog import get_logger
+
+from hathor.conf import HathorSettings
+from hathor.indexes.base_index import BaseIndex
+from hathor.transaction import BaseTransaction, TxOutput
+from hathor.transaction.scripts import parse_address_script
+from hathor.util import sorted_merger
+
+logger = get_logger()
+settings = HathorSettings()
+
+
+@dataclass(frozen=True)
+class UtxoIndexItem:
+    token_uid: bytes
+    tx_id: bytes
+    index: int
+    address: str
+    amount: int
+    timelock: Optional[int]
+    heightlock: Optional[int]
+
+    def __repr__(self):
+        return (
+            'UtxoIndexItem('
+            f'token_uid={self.token_uid.hex()},'
+            f'tx_id={self.tx_id.hex()},'
+            f'index={self.index},'
+            f'address={self.address},'
+            f'amount={self.amount},'
+            f'timelock={self.timelock},'
+            f'heightlock={self.heightlock}'
+            ')'
+        )
+
+    @classmethod
+    def from_tx_output(cls, tx: BaseTransaction, index: int, tx_output: TxOutput) -> 'UtxoIndexItem':
+        assert tx.hash is not None
+
+        if tx_output.is_token_authority():
+            raise ValueError('UtxoIndexItem cannot be used with a token authority output')
+
+        address_script = parse_address_script(tx_output.script)
+        if address_script is None:
+            raise ValueError('UtxoIndexItem can only be used with scripts supported by `parse_address_script`')
+
+        tx_meta = tx.get_metadata()
+
+        heightlock: Optional[int] = tx_meta.height + settings.REWARD_SPEND_MIN_BLOCKS if tx.is_block else None
+        # XXX: timelock forced to None when there is a heightlock
+        timelock: Optional[int] = address_script.get_timelock() if heightlock is None else None
+        # XXX: that is, at least one of them must but None
+        assert timelock is None or heightlock is None
+
+        return cls(
+            token_uid=tx.get_token_uid(tx_output.get_token_index()),
+            tx_id=tx.hash,
+            index=index,
+            address=address_script.address,
+            amount=tx_output.value,
+            timelock=timelock,
+            heightlock=heightlock,
+        )
+
+
+def _should_skip_output(tx_output: TxOutput) -> bool:
+    if tx_output.is_token_authority():
+        return True
+    if parse_address_script(tx_output.script) is None:
+        return True
+    return False
+
+
+class UtxoIndex(BaseIndex):
+    """ Index of UTXOs by address+token
+
+    This index is currently optional and only used for an optional API.
+
+    It is expected to be called with only non-voided transactions and blocks, including the genesis. It ignores
+    token-authority outputs and data-only outputs, generally outputs that don't have an amount or a script where an
+    address can be extracted from.
+    """
+
+    def __init__(self):
+        self.log = logger.new()
+
+    # interface methods provided by the base class
+
+    def init_loop_step(self, tx: BaseTransaction) -> None:
+        self.update(tx)
+
+    def update(self, tx: BaseTransaction) -> None:
+        tx_meta = tx.get_metadata()
+        if tx_meta.voided_by:
+            self._update_voided(tx)
+        else:
+            self._update_executed(tx)
+
+    def del_tx(self, tx: BaseTransaction) -> None:
+        self._update_voided(tx)
+
+    def _update_executed(self, tx: BaseTransaction) -> None:
+        """ This method processes both inputs and output from a transaction.
+
+        - mark transaction as added
+        - inputs are removed from the index
+        """
+        tx_meta = tx.get_metadata()
+        assert tx.hash is not None
+        assert not tx_meta.voided_by
+        log = self.log.new(tx=tx.hash_hex)
+        log.debug('update executed')
+        # remove all inputs
+        for tx_input in tx.inputs:
+            spent_tx = tx.get_spent_tx(tx_input)
+            spent_tx_output = spent_tx.outputs[tx_input.index]
+            log_it = log.new(tx_id=spent_tx.hash_hex, index=tx_input.index)
+            if _should_skip_output(spent_tx_output):
+                log_it.debug('ignore input')
+                continue
+            log_it.debug('remove output that became spent')
+            self._remove_utxo(UtxoIndexItem.from_tx_output(spent_tx, tx_input.index, spent_tx_output))
+        # add outputs that aren't spent
+        for index, tx_output in enumerate(tx.outputs):
+            log_it = log.new(index=index)
+            if _should_skip_output(tx_output):
+                log_it.debug('ignore output')
+                continue
+            spent_by = tx_meta.get_output_spent_by(index)
+            if spent_by is not None:
+                log_it.debug('do not add output that is spent', spent_by=spent_by.hex())
+                continue
+            log_it.debug('add new unspent output')
+            self._add_utxo(UtxoIndexItem.from_tx_output(tx, index, tx_output))
+
+    def _update_voided(self, tx: BaseTransaction) -> None:
+        """ This method does the opposite of _update_executed when processing the given transaction.
+
+        - inputs are added back to the index
+        - outpus are removed from the index
+        """
+        tx_meta = tx.get_metadata()
+        assert tx.hash is not None
+        assert tx_meta.voided_by
+        log = self.log.new(tx=tx.hash_hex)
+        log.debug('update voided')
+        # remove all outputs
+        for index, tx_output in enumerate(tx.outputs):
+            log_it = log.new(index=index)
+            if _should_skip_output(tx_output):
+                log_it.debug('ignore output')
+                continue
+            log_it.debug('remove voided output')
+            self._remove_utxo(UtxoIndexItem.from_tx_output(tx, index, tx_output))
+        # re-add inputs that aren't voided
+        for tx_input in tx.inputs:
+            spent_tx = tx.get_spent_tx(tx_input)
+            spent_tx_output = spent_tx.outputs[tx_input.index]
+            log_it = log.new(tx_id=spent_tx.hash_hex, index=tx_input.index)
+            if _should_skip_output(spent_tx_output):
+                log_it.debug('ignore input')
+                continue
+            if spent_tx.get_metadata().voided_by:
+                log_it.debug('do not re-add input that spend voided')
+                continue
+            spent_tx_meta = spent_tx.get_metadata()
+            spent_by = spent_tx_meta.get_output_spent_by(tx_input.index)
+            if spent_by is not None and spent_by != tx.hash:
+                log_it.debug('do not re-add input that is spent by other tx', spent_by=spent_by.hex())
+                continue
+            log_it.debug('re-add input that became unspent')
+            self._add_utxo(UtxoIndexItem.from_tx_output(spent_tx, tx_input.index, spent_tx_output))
+
+    def iter_utxos(self, *, address: str, target_amount: int, token_uid: Optional[bytes] = None,
+                   target_timestamp: Optional[int] = None,
+                   target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        """ Search UTXOs for a given token_uid+address+target_value, if no token_uid is given, HTR is assumed.
+        """
+        actual_token_uid = token_uid if token_uid is not None else settings.HATHOR_TOKEN_UID
+        iter_nolock = self._iter_utxos_nolock(token_uid=actual_token_uid, address=address,
+                                              target_amount=target_amount)
+        iter_timelock = self._iter_utxos_timelock(token_uid=actual_token_uid, address=address,
+                                                  target_amount=target_amount,
+                                                  target_timestamp=target_timestamp)
+        iter_heightlock = self._iter_utxos_heightlock(token_uid=actual_token_uid, address=address,
+                                                      target_amount=target_amount,
+                                                      target_height=target_height)
+        iter_utxos = sorted_merger(
+            iter_nolock,
+            iter_timelock,
+            iter_heightlock,
+            key=lambda item: (item.amount, item.tx_id, item.index),
+            reverse=True,
+        )
+
+        next_higher: Optional[UtxoIndexItem] = None
+        amount_sum = 0
+        count_utxos = 0
+        # we may have up to 3 items with amount higher than target_amount, skip until we get one lower, then yield it
+        # and start counting the amount_sum
+        for utxo_item in iter_utxos:
+            if utxo_item.amount >= target_amount:
+                next_higher = utxo_item
+            else:
+                amount_sum += utxo_item.amount
+                count_utxos += 1
+                if next_higher is not None:
+                    yield next_higher
+                yield utxo_item
+                break
+        else:
+            # XXX: because we didn't break, yield next_higher now
+            if next_higher is not None:
+                yield next_higher
+        # now that the next higher is out of the way, continue from where we were and stop when we reach a sum enough
+        # to cover the target amount
+        for utxo_item in iter_utxos:
+            if amount_sum >= target_amount:
+                break
+            # there's also no point in yielding more outputs than can be used as inputs, if there are more, the caller
+            # will just have to use the larger than target_amount UTXO (if there is any), or consolidate UTXOs first
+            if count_utxos >= settings.MAX_NUM_INPUTS:
+                break
+            amount_sum += utxo_item.amount
+            count_utxos += 1
+            yield utxo_item
+
+    # internal methods that the base class needs to be implemented
+
+    @abstractmethod
+    def _add_utxo(self, item: UtxoIndexItem) -> None:
+        """ Internal method to add a UTXO and its associated data.
+
+        Note: this method is MUST BE idempotent, calling _add_utxo a second time MUST NOT fail.
+        Note: timelock and heightlock CANNOT be both not None, that is AT MOST one will be given.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _remove_utxo(self, item: UtxoIndexItem) -> None:
+        """ Internal method to add a UTXO and its associated data.
+
+        Note: this method is MUST BE idempotent, calling _remove_utxo a second time MUST NOT fail.
+        """
+        raise NotImplementedError
+
+    # all of the iterators should start with the next UTXO with amount higher than target_amount, if there are any, and
+    # then yield UTXOs with amounts in decreasing order until there are no more UTXOs
+
+    @abstractmethod
+    def _iter_utxos_nolock(self, *, token_uid: bytes, address: str, target_amount: int) -> Iterator[UtxoIndexItem]:
+        """Iterate over all UTXOs that DO NOT HAVE any locks."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: int,
+                             target_timestamp: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        """Iterate over all UTXOs that ONLY HAVE timelocks that will be unlocked at target_timestamp."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: int,
+                               target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
+        """Iterate over all UTXOs that ONLY HAVE heightlocks that will be unlocked at target_height."""
+        raise NotImplementedError

--- a/hathor/transaction/storage/binary_storage.py
+++ b/hathor/transaction/storage/binary_storage.py
@@ -59,8 +59,8 @@ class TransactionBinaryStorage(BaseTransactionStorage):
         except FileNotFoundError:
             pass
 
-    def save_transaction(self, tx, *, only_metadata=False, add_to_indexes=False):
-        super().save_transaction(tx, only_metadata=only_metadata, add_to_indexes=add_to_indexes)
+    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False) -> None:
+        super().save_transaction(tx, only_metadata=only_metadata)
         self._save_transaction(tx, only_metadata=only_metadata)
         self._save_to_weakref(tx)
 

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -119,13 +119,12 @@ class TransactionCacheStorage(BaseTransactionStorage):
         self.store.remove_transaction(tx)
         self._remove_from_weakref(tx)
 
-    def save_transaction(self, tx: BaseTransaction, *, only_metadata: bool = False,
-                         add_to_indexes: bool = False) -> None:
+    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False) -> None:
         self._save_transaction(tx)
         self._save_to_weakref(tx)
 
         # call super which adds to index if needed
-        super().save_transaction(tx, only_metadata=only_metadata, add_to_indexes=add_to_indexes)
+        super().save_transaction(tx, only_metadata=only_metadata)
 
     def get_all_genesis(self) -> Set[BaseTransaction]:
         return self.store.get_all_genesis()

--- a/hathor/transaction/storage/compact_storage.py
+++ b/hathor/transaction/storage/compact_storage.py
@@ -73,9 +73,8 @@ class TransactionCompactStorage(BaseTransactionStorage):
         except FileNotFoundError:
             pass
 
-    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False,
-                         add_to_indexes: bool = False) -> None:
-        super().save_transaction(tx, only_metadata=only_metadata, add_to_indexes=add_to_indexes)
+    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False) -> None:
+        super().save_transaction(tx, only_metadata=only_metadata)
         self._save_transaction(tx, only_metadata=only_metadata)
         self._save_to_weakref(tx)
 

--- a/hathor/transaction/storage/memory_storage.py
+++ b/hathor/transaction/storage/memory_storage.py
@@ -48,9 +48,8 @@ class TransactionMemoryStorage(BaseTransactionStorage):
         self.transactions.pop(tx.hash, None)
         self.metadata.pop(tx.hash, None)
 
-    def save_transaction(self, tx: BaseTransaction, *, only_metadata: bool = False,
-                         add_to_indexes: bool = False) -> None:
-        super().save_transaction(tx, only_metadata=only_metadata, add_to_indexes=add_to_indexes)
+    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False) -> None:
+        super().save_transaction(tx, only_metadata=only_metadata)
         self._save_transaction(tx, only_metadata=only_metadata)
 
     def _save_transaction(self, tx: BaseTransaction, *, only_metadata: bool = False) -> None:

--- a/hathor/transaction/storage/rocksdb_storage.py
+++ b/hathor/transaction/storage/rocksdb_storage.py
@@ -114,9 +114,8 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
         self._db.delete((self._cf_meta, tx.hash))
         self._remove_from_weakref(tx)
 
-    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False,
-                         add_to_indexes: bool = False) -> None:
-        super().save_transaction(tx, only_metadata=only_metadata, add_to_indexes=add_to_indexes)
+    def save_transaction(self, tx: 'BaseTransaction', *, only_metadata: bool = False) -> None:
+        super().save_transaction(tx, only_metadata=only_metadata)
         self._save_transaction(tx, only_metadata=only_metadata)
         self._save_to_weakref(tx)
 

--- a/tests/tx/test_blockchain.py
+++ b/tests/tx/test_blockchain.py
@@ -60,7 +60,8 @@ class BaseBlockchainTestCase(unittest.TestCase):
             meta = block.get_metadata()
             score = sum_weights(score, block.weight)
             self.assertAlmostEqual(score, meta.score)
-            self.assertAlmostEqual(manager.consensus_algorithm.block_algorithm.calculate_score(block), meta.score)
+            consensus_context = manager.consensus_algorithm.create_context()
+            self.assertAlmostEqual(consensus_context.block_algorithm.calculate_score(block), meta.score)
 
         # Mine 15 more blocks with 10 transactions between each block
         for _ in range(15):
@@ -73,7 +74,8 @@ class BaseBlockchainTestCase(unittest.TestCase):
                 meta = block.get_metadata()
                 score = sum_weights(score, block.weight)
                 self.assertAlmostEqual(score, meta.score)
-                self.assertAlmostEqual(manager.consensus_algorithm.block_algorithm.calculate_score(block), meta.score)
+                consensus_context = manager.consensus_algorithm.create_context()
+                self.assertAlmostEqual(consensus_context.block_algorithm.calculate_score(block), meta.score)
 
         self.assertConsensusValid(manager)
 

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -161,7 +161,8 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.assertEqual(set(tx_parents_hash), {self.genesis_txs[0].hash, self.genesis_txs[1].hash})
 
     def validate_save(self, obj):
-        self.tx_storage.save_transaction(obj, add_to_indexes=True)
+        self.tx_storage.save_transaction(obj)
+        self.tx_storage.add_to_indexes(obj)
 
         loaded_obj1 = self.tx_storage.get_transaction(obj.hash)
 
@@ -330,10 +331,12 @@ class BaseTransactionStorageTest(unittest.TestCase):
         # 2 token uids
         tx.tokens.append(bytes.fromhex('00001c5c0b69d13b05534c94a69b2c8272294e6b0c536660a3ac264820677024'))
         tx.resolve()
+        tx._metadata.hash = tx.hash
         self.validate_save(tx)
         # no tokens
         tx.tokens = []
         tx.resolve()
+        tx._metadata.hash = tx.hash
         self.validate_save(tx)
 
     def _add_new_block(self, parents=None):

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -108,7 +108,7 @@ class TestCase(unittest.TestCase):
 
     def create_peer(self, network, peer_id=None, wallet=None, tx_storage=None, unlock_wallet=True, wallet_index=False,
                     capabilities=None, full_verification=True, enable_sync_v1=None, enable_sync_v2=None,
-                    checkpoints=None):
+                    checkpoints=None, utxo_index=False):
         if enable_sync_v1 is None:
             assert hasattr(self, '_enable_sync_v1'), ('`_enable_sync_v1` has no default by design, either set one on '
                                                       'the test class or pass `enable_sync_v1` by argument')
@@ -141,6 +141,7 @@ class TestCase(unittest.TestCase):
             wallet=wallet,
             tx_storage=tx_storage,
             wallet_index=wallet_index,
+            utxo_index=utxo_index,
             capabilities=capabilities,
             rng=self.rng,
             enable_sync_v1=enable_sync_v1,


### PR DESCRIPTION
Mini-design:

## High-level

Provide an API that can be used to query UTXOs given an address/tokenid, and provide some type of filtering by amount that can be used to allow for users to easily implement their own UTXO selection algorithm. It is important to note that some UTXOs may not be "spendable", since the API should be primarily used for cases where "spendable" outputs are the only that make sense, the API will not include them. We could in the future add an option to include locked (not spendable) UTXOs as well, but this is out of the scope of this initial implementation.

### Making queries

User inputs:

- `address`
- `token_uid`
- `target_amount`
- optional: `target_timestamp` (defaults to the timestamp of the best block)
- optional: `target_height` (defaults to the height of the best block)
- optional: `max_count` (defaults to 256)

API outputs:

- list of UTXOs with amounts varying from the next amount higher than `target_amount` and then amounts from equal to `target_amount` until it sums up to `target_amount`, each entry will have:
  - `txid` 
  - `index`
  - `amount`
  - optional: `timelock`
  - optional: `heightlock`
- the returned list will have at most `max_count` elements
- `has_more`, whether there are more spendable UTXOs that weren't included on the list due to either `max_count` or the `target_amount`

## Low-level

### Index implementation

- in-memory:
  ```
  Dict[Tuple[token_uid, bytes], Tuple[NoLockUtxos, TimelockUtxos, HeightlockUtxos]]
  NoLockUtxos = SortedKeyList[Tuple[bytes, int]]  # tuples are (txid, index)
  TimelockUtxos = SortedKeyList[Tuple[int, bytes, int]]  # tuples are (timelock, txid, index)
  HeightlockUtxos = SortedKeyList[Tuple[int, bytes, int]]  # tuples are (heightlock, txid, index)
  ```
  (note: this annotation is not exactly what will be in code, but it's just to give an idea) where the dict key is a tuple of token_uid and byte-serialized address
- in-disk: Only use RocksDB keys, with the following format:
  ```
  [token_uid][address][lock_tag][amount][tx_id][index] lock_tag=NO_LOCK
  |--32b----||--25b--||--1b----||--4b--||-32b-||-1b--|

  [token_uid][address][lock_tag][timelock][amount][tx_id][index] lock_tag=TIME_LOCK
  |--32b----||--25b--||--1b----||--4b----||--4b--||-32b-||-1b--|

  [token_uid][address][lock_tag][heightlock][amount][tx_id][index] lock_tag=HEIGHT_LOCK
  |--32b----||--25b--||--1b----||--4b------||--4b--||-32b-||-1b--|
  ```
  since entries are naturally sorted in RocksDB this already has the property that we want (important to note that the amount must be always serialized with big-endian, because rocksdb does byte-oriented sorting, this is already done in other indexes though, so it's not special to this one in particular)

Both implementations will have 3 "heads" to iterate on when searching for UTXOs, we can trivially make an iterator that merges these 3 into one by always yielding from the head with the next sorted value.

### API definition

Deferred to #425

## Unresolved questions

- Should we ignore token-creation/authority/data-only utxos? I'm leaning towards _yes we should_, this could easily be supported later (amount/value would make no sense, so the API will need specific parameters for that).
- While implementing the index I realized that an output can be BOTH timelocked and heightlocked, specifically only when a mined block uses a timelock script for its output. This is case never happened and will most likely never happen (I can't see any reason miners wouldn't want to unlock an output as fast as possible), so to keep everything consistent, when there is BOTH a timelock and a heightlock, I'll ignore the timelock and only use the heightlock, my guess is that this is might not even be properly handled on the wallets, ignoring the timelock seems like a fair and consistent compromise. It's also perfectly fine to improve this in the future.
- Another problem that I found was that just sorting UTXOs with either timelock/heightlock by (timelock, amount) or (heightlock, amount), makes it so they aren't sorted by amount for different values of timelock/heightlock, meaning that it will break the latter assumption when sort-merging. However this may not be very big deal _for now_, the results will certainly be out of order in a few cases, but for the end-user, and in particular, for the use-cases that we know are going to use this when it is released. But we have to make a decision, I'd say it's between:
  1. Leaving the implementation as is (with cases where the ordering by amount is not respected);
  2. Excluding timelocked/heightlocked UTXOs for now;
  3. Putting them together with the nolock UTXOs and post-filtering (which is a complete solution, but will not be efficient on some situations);
  4. Designing a complete and efficient solution; Which, while I think it _may_ be possible, I don't have a good idea of what that would be.

