### PR TITLE
chore(ci): update some CI actions and make docker build more robust

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180  # default is 360
     strategy:
+      fail-fast: false
       matrix:
         python-impl:
         - python
@@ -105,11 +106,9 @@ jobs:
         print('::set-output name=created::' + datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
         print('::set-output name=dockerfile::' + dockerfile)
     - name: Set up QEMU  # arm64 is not available natively
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: arm64
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         version: latest
         install: true
@@ -128,7 +127,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         # this key is setup such that every branch has its cache and new branches can reuse dev's cache, but not the other way around
@@ -150,6 +149,7 @@ jobs:
       run: docker run --rm ${{ env.TEST_TAG }} quick_test --data / --testnet
     - name: Build and push
       uses: docker/build-push-action@v2
+      continue-on-error: ${{ matrix.python-impl == 'pypy' }}  # PyPy is not first-class and has been causing some build failures
       with:
         context: .
         file: ${{ steps.prep.outputs.dockerfile }}

--- a/Dockerfile.pypy
+++ b/Dockerfile.pypy
@@ -7,7 +7,7 @@ ARG DEBIAN=bullseye
 FROM pypy:$PYTHON-slim-$DEBIAN as stage-0
 ARG PYTHON
 # install runtime first deps to speedup the dev deps and because layers will be reused on stage-1
-RUN apt-get -qy update
+RUN apt-get -qy update && apt-get -qy upgrade
 RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
 # dev deps for this build start here
 RUN apt-get -qy install libssl-dev libffi-dev build-essential zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev librocksdb-dev cargo git pkg-config
@@ -26,7 +26,7 @@ RUN poetry run pip install dist/hathor-*.whl
 # lean and mean: this image should be about ~50MB, would be about ~470MB if using the whole stage-1
 FROM pypy:$PYTHON-slim-$DEBIAN
 ARG PYTHON
-RUN apt-get -qy update
+RUN apt-get -qy update && apt-get -qy upgrade
 RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
 COPY --from=stage-0 /app/.venv/lib/pypy${PYTHON}/site-packages/ /opt/pypy/lib/pypy${PYTHON}/site-packages/
 EXPOSE 40403 8080


### PR DESCRIPTION
This PR updates a few actions and tweaks to accept failures on the builds of PyPy docker images. There have been a few failures and more investigation is needed, in the mean time, since PyPy does not have first-class support, failures will not stop the build of the other images.

Test run: https://github.com/jansegre/hathor-core/actions/runs/2449232482