### PR TITLE
feat(api): add UTXO search API

### DIFF
--- a/hathor/api_util.py
+++ b/hathor/api_util.py
@@ -68,7 +68,7 @@ def parse_args(args: Dict[bytes, List[bytes]], expected_args: List[str]) -> Dict
     # if there are expected args missing, we return None
     diff = expected_set.difference(args_set)
     if diff:
-        return {'success': False, 'missing': ', '.join(diff)}
+        return {'success': False, 'missing': ', '.join(sorted(diff))}
 
     ret: Dict[str, str] = dict()
     for arg2 in expected_args:

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -70,6 +70,8 @@ class RunNode:
         parser.add_argument('--unlock-wallet', action='store_true', help='Ask for password to unlock wallet')
         parser.add_argument('--wallet-index', action='store_true',
                             help='Create an index of transactions by address and allow searching queries')
+        parser.add_argument('--utxo-index', action='store_true',
+                            help='Create an index of UTXOs by token/address/amount and allow searching queries')
         parser.add_argument('--prometheus', action='store_true', help='Send metric data to Prometheus')
         parser.add_argument('--cache', action='store_true', help='Use cache for tx storage')
         parser.add_argument('--cache-size', type=int, help='Number of txs to keep on cache')
@@ -257,6 +259,7 @@ class RunNode:
             tx_storage=self.tx_storage,
             wallet=self.wallet,
             wallet_index=args.wallet_index,
+            utxo_index=args.utxo_index,
             stratum_port=args.stratum,
             ssl=True,
             checkpoints=settings.CHECKPOINTS,
@@ -353,6 +356,7 @@ class RunNode:
             TransactionAccWeightResource,
             TransactionResource,
             TxParentsResource,
+            UtxoSearchResource,
             ValidateAddressResource,
         )
         from hathor.version_resource import VersionResource
@@ -451,6 +455,11 @@ class RunNode:
                 # /p2p
                 (b'peers', AddPeersResource(self.manager), p2p_resource),
             ]
+            # XXX: only enable UTXO search API if the index is enabled
+            if args.utxo_index:
+                resources.extend([
+                    (b'utxo_search', UtxoSearchResource(self.manager), root),
+                ])
 
             if args.enable_debug_api:
                 debug_resource = Resource()

--- a/hathor/transaction/resources/__init__.py
+++ b/hathor/transaction/resources/__init__.py
@@ -23,21 +23,23 @@ from hathor.transaction.resources.push_tx import PushTxResource
 from hathor.transaction.resources.transaction import TransactionResource
 from hathor.transaction.resources.transaction_confirmation import TransactionAccWeightResource
 from hathor.transaction.resources.tx_parents import TxParentsResource
+from hathor.transaction.resources.utxo_search import UtxoSearchResource
 from hathor.transaction.resources.validate_address import ValidateAddressResource
 
 __all__ = [
     'BlockAtHeightResource',
     'CreateTxResource',
+    'DashboardTransactionResource',
     'DecodeTxResource',
-    'PushTxResource',
     'GetBlockTemplateResource',
     'GraphvizFullResource',
     'GraphvizNeighboursResource',
+    'MempoolResource',
+    'PushTxResource',
     'SubmitBlockResource',
     'TransactionAccWeightResource',
     'TransactionResource',
-    'DashboardTransactionResource',
     'TxParentsResource',
+    'UtxoSearchResource',
     'ValidateAddressResource',
-    'MempoolResource',
 ]

--- a/hathor/transaction/resources/utxo_search.py
+++ b/hathor/transaction/resources/utxo_search.py
@@ -1,0 +1,258 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from hathor.api_util import (
+    Resource,
+    get_arg_default,
+    get_args,
+    get_missing_params_msg,
+    parse_args,
+    parse_int,
+    set_cors,
+)
+from hathor.cli.openapi_files.register import register_resource
+from hathor.conf import HathorSettings
+from hathor.crypto.util import decode_address
+from hathor.util import json_dumpb
+from hathor.wallet.exceptions import InvalidAddress
+
+if TYPE_CHECKING:
+    from twisted.web.http import Request
+
+    from hathor.manager import HathorManager
+
+
+settings = HathorSettings()
+
+
+@register_resource
+class UtxoSearchResource(Resource):
+    """ Implements a web server API to return a list of UTXOs that fit a given search criteria.
+
+    You must run with option `--status <PORT>` and `--utxo-index`.
+    """
+    isLeaf = True
+
+    def __init__(self, manager: 'HathorManager'):
+        # Important to have the manager so we can know the tx_storage
+        self.manager = manager
+
+    def render_GET(self, request: 'Request') -> bytes:
+        """ Get request /utxo_search/ that returns available UTXOs for the specified criteria
+
+            'token_uid': hex, the UID of the token to be considered ('00' for HTR)
+            'address': string, the address from the script of the outputs
+            'target_amount': int, the results will aim to be enough to complete this amount
+            'target_timestamp': int, optional, what timestamp to consider for timelocked outputs
+            'target_height': int, optional, what height to consider for rewards (which are always heightlocked)
+
+            :rtype: string (json)
+        """
+
+        # setup
+        tx_storage = self.manager.tx_storage
+        assert tx_storage.indexes is not None
+        if tx_storage.indexes.utxo is None:
+            request.setResponseCode(503)
+            return json_dumpb({'success': False})
+
+        utxo_index = tx_storage.indexes.utxo
+        height_index = tx_storage.indexes.height
+
+        request.setHeader(b'content-type', b'application/json; charset=utf-8')
+        set_cors(request, 'GET')
+
+        # parse required parameters
+        raw_args = get_args(request)
+        parsed = parse_args(raw_args, ['token_uid', 'address', 'target_amount'])
+        if not parsed['success']:
+            return get_missing_params_msg(parsed['missing'])
+
+        args = parsed['args']
+
+        # token_uid parameter must be a valid hash
+        try:
+            token_uid = bytes.fromhex(args['token_uid'])
+            if token_uid != settings.HATHOR_TOKEN_UID and len(token_uid) != 32:
+                raise ValueError('not a valid hash length')
+        except ValueError as e:
+            return json_dumpb({
+                'success': False,
+                'message': f'Failed to parse \'token_uid\': {e}'
+            })
+
+        # target amount parameter must be an integer
+        try:
+            target_amount = parse_int(args['target_amount'])
+        except ValueError as e:
+            return json_dumpb({
+                'success': False,
+                'message': f'Failed to parse \'target_amount\': {e}'
+            })
+
+        # address parameter must be a valid address
+        try:
+            address = args['address']
+            # XXX: calling decode address just so it raises an error if it fails
+            decode_address(address)
+        except InvalidAddress as e:
+            return json_dumpb({
+                'success': False,
+                'message': f'Failed to parse \'address\': {e}'
+            })
+
+        # check the current best block to have a target_timestamp and target_height
+        best_block_height, best_block_hash = height_index.get_height_tip()
+        best_block = tx_storage.get_transaction(best_block_hash)
+
+        target_timestamp = get_arg_default(raw_args, 'target_timestamp', best_block.timestamp)
+        target_height = get_arg_default(raw_args, 'target_height', best_block_height)
+
+        # collect UTXOs
+        iter_utxos = utxo_index.iter_utxos(token_uid=token_uid, address=address, target_amount=target_amount,
+                                           target_timestamp=target_timestamp, target_height=target_height)
+
+        utxo_list = [{
+            'txid': utxo.tx_id.hex(),
+            'index': utxo.index,
+            'amount': utxo.amount,
+            'timelock': utxo.timelock,
+            'heightlock': utxo.heightlock,
+        } for utxo in iter_utxos]
+
+        data = {'success': True, 'utxos': utxo_list}
+        return json_dumpb(data)
+
+
+UtxoSearchResource.openapi = {
+    '/utxo_search': {
+        'x-visibility': 'public',
+        'x-rate-limit': {
+            'global': [
+                {
+                    'rate': '10r/s',
+                    'burst': 100,
+                    'delay': 50
+                }
+            ],
+            'per-ip': [
+                {
+                    'rate': '1r/s',
+                    'burst': 10,
+                    'delay': 3
+                }
+            ]
+        },
+        'get': {
+            'tags': ['utxo'],
+            'operationId': 'utxo_search',
+            'summary': 'Search UTXOs with given address/token/amount',
+            'description': (
+              'For a given token-uid, address and target-amount, get a list of UTXOs that are candidates to be inputs '
+              'for a total of target-value. The resulsts will try to include the first UTXO with value higher or '
+              'equal value as target-amount. No more than 256 entries will ever be returned by this API.'
+             ),
+            'parameters': [
+                {
+                    'name': 'token_uid',
+                    'in': 'query',
+                    'description': 'The UID of the token formatted as a HEX string, use "00" for HTR',
+                    'required': True,
+                    'schema': {
+                        'type': 'string'
+                    }
+                },
+                {
+                    'name': 'target_amount',
+                    'in': 'query',
+                    'description': 'The target amount that the UTXOs should sum-up to, 1 means 0.01 HTR',
+                    'required': True,
+                    'schema': {
+                        'type': 'int'
+                    }
+                },
+                {
+                    'name': 'address',
+                    'in': 'query',
+                    'description': 'The address that all UTXOs have',
+                    'required': True,
+                    'schema': {
+                        'type': 'str'
+                    }
+                },
+                {
+                    'name': 'target_timestamp',
+                    'in': 'query',
+                    'description': (
+                        'What timestamp to consider for timelocked outputs, by default uses the timestamp '
+                        'from the current best block'
+                    ),
+                    'required': False,
+                    'schema': {
+                        'type': 'int'
+                    }
+                },
+                {
+                    'name': 'target_height',
+                    'in': 'query',
+                    'description': (
+                        'What timestamp to consider for reward outputs (which are heightlocked), by default uses the '
+                        'height from the current best block'
+                    ),
+                    'required': False,
+                    'schema': {
+                        'type': 'int'
+                    }
+                },
+            ],
+            'responses': {
+                '200': {
+                    'description': 'Success',
+                    'content': {
+                        'application/json': {
+                            'examples': {
+                                'success': {
+                                    'summary': 'Success UTXO search',
+                                    'value': {
+                                        'success': True,
+                                        'utxos': [
+                                            {
+                                                'txid': (
+                                                    '339f47da87435842b0b1b528ecd9eac2495ce983b3e9c923a37e1befbe12c792'
+                                                ),
+                                                'index': 0,
+                                                'amount': 1_000_000_000,
+                                                'timelock': None,
+                                                'heightlock': 10,
+                                            },
+                                        ]
+                                    }
+                                },
+                                'error': {
+                                    'summary': 'Invalid parameter',
+                                    'value': {
+                                        'success': False,
+                                        'message': 'Failed to parse \'address\': foobar'
+                                    }
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/resources/transaction/test_utxo_search.py
+++ b/tests/resources/transaction/test_utxo_search.py
@@ -1,0 +1,123 @@
+from twisted.internet.defer import inlineCallbacks
+
+from hathor.conf import HathorSettings
+from hathor.crypto.util import decode_address
+from hathor.transaction.resources import UtxoSearchResource
+from tests import unittest
+from tests.resources.base_resource import StubSite, _BaseResourceTest
+from tests.utils import add_blocks_unlock_reward, add_new_blocks
+
+settings = HathorSettings()
+
+
+class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
+    __test__ = False
+
+    def setUp(self):
+        super().setUp()
+        self.web = StubSite(UtxoSearchResource(self.manager))
+        self.manager.wallet.unlock(b'MYPASS')
+
+    def _manager_kwargs(self):
+        # TODO: when we are in Python 3.9+ we could use `return super()._manger_kwargs() | {'utxo_index': True}`
+        kwargs = super()._manager_kwargs()
+        kwargs.update(utxo_index=True)
+        return kwargs
+
+    @inlineCallbacks
+    def test_simple_gets(self):
+        address = self.get_address(0).encode('ascii')
+
+        add_new_blocks(self.manager, 4, advance_clock=1)
+
+        # Error1: No parameter
+        response1 = yield self.web.get("utxo_search")
+        data1 = response1.json_value()
+        self.assertFalse(data1['success'])
+        self.assertEqual(data1['message'], 'Missing parameter: address, target_amount, token_uid')
+
+        # Error2: Invalid parameter
+        response2 = yield self.web.get("utxo_search", {b'token_uid': b'c',
+                                                       b'address': address, b'target_amount': b'1'})
+        data2 = response2.json_value()
+        self.assertFalse(data2['success'])
+        self.assertEqual(
+            data2['message'],
+            r'''Failed to parse 'token_uid': non-hexadecimal number found in fromhex() arg at position 1''',
+        )
+
+        # Success empty address
+        response3 = yield self.web.get("utxo_search", {b'token_uid': b'00',
+                                                       b'address': address, b'target_amount': b'1'})
+        data3 = response3.json_value()
+        self.assertTrue(data3['success'])
+        self.assertEqual(data3['utxos'], [])
+
+        # Add some blocks with the address that we have, we'll have 4 outputs of 64.00 HTR each, 256.00 HTR in total
+        blocks = add_new_blocks(self.manager, 4, advance_clock=1, address=decode_address(address))
+        add_blocks_unlock_reward(self.manager)
+
+        # Success non-empty address with small amount (0.01 HTR), we should get the earliest block with 64.00 HTR
+        response4 = yield self.web.get("utxo_search", {b'token_uid': b'00',
+                                                       b'address': address, b'target_amount': b'1'})
+        data4 = response4.json_value()
+        self.assertTrue(data4['success'])
+        self.assertEqual(data4['utxos'], [{
+            'txid': b.hash_hex,
+            'index': 0,
+            'amount': 6400,
+            'timelock': None,
+            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+        } for b in blocks[:1]])
+
+        # Success non-empty address with medium amount, will require more than one output
+        response5 = yield self.web.get("utxo_search", {b'token_uid': b'00',
+                                                       b'address': address, b'target_amount': b'6500'})
+        data5 = response5.json_value()
+        self.assertTrue(data5['success'])
+        self.assertEqual(data5['utxos'], [{
+            'txid': b.hash_hex,
+            'index': 0,
+            'amount': 6400,
+            'timelock': None,
+            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+        } for b in blocks[4:1:-1]])
+
+        # Success non-empty address with exact amount, will require all UTXOs
+        response5 = yield self.web.get("utxo_search", {b'token_uid': b'00',
+                                                       b'address': address, b'target_amount': b'25600'})
+        data5 = response5.json_value()
+        self.assertTrue(data5['success'])
+        self.assertEqual(data5['utxos'], [{
+            'txid': b.hash_hex,
+            'index': 0,
+            'amount': 6400,
+            'timelock': None,
+            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+        } for b in blocks[::-1]])
+
+        # Success non-empty address with excessive amount, will require all UTXOs, even if it's not enough
+        response5 = yield self.web.get("utxo_search", {b'token_uid': b'00',
+                                                       b'address': address, b'target_amount': b'30000'})
+        data5 = response5.json_value()
+        self.assertTrue(data5['success'])
+        self.assertEqual(data5['utxos'], [{
+            'txid': b.hash_hex,
+            'index': 0,
+            'amount': 6400,
+            'timelock': None,
+            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+        } for b in blocks[::-1]])
+
+
+class SyncV1UtxoSearchTest(unittest.SyncV1Params, BaseUtxoSearchTest):
+    __test__ = True
+
+
+class SyncV2UtxoSearchTest(unittest.SyncV2Params, BaseUtxoSearchTest):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeUtxoSearchTest(unittest.SyncBridgeParams, SyncV2UtxoSearchTest):
+    pass


### PR DESCRIPTION
Currently the API looks like this:

```
curl 'localhost:9000/v1a/utxo_search?token_uid=00&address=HJpSx3KCqMTPvHwEEj26SfPMGGQqijY6au&target_amount=1' | jq
{
  "success": true,
  "utxos": [
    {
      "txid": "4299c78120b59ff2eef5c10afb3c93e3e255dbec62342e9f0ef6c546d7810084",
      "index": 0,
      "amount": 6400,
      "timelock": null,
      "heightlock": 15
    }
  ]
}
```

Undecided:

- should we include the address for each utxo? maybe in the future we can support multiple addresses in a single API and that would work with the same format if it included the address
- should we include any indication that there were UTXOs with that address that were not included (and maybe the reason they were not included, like maximum number of outputs or target_amount sum reached)
- should we include whether there is an UTXO with an amount higher than target_amount, which is an information that is very obvious to deduce from the result, but maybe could be useful?