### PR TITLE
chore(ci): update base runners and small tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,17 +22,19 @@ jobs:
         import json
         full_matrix = {
           'python': ['3.7', '3.8', '3.9', '3.10'],
-          'os': ['ubuntu-latest', 'macos-latest', 'windows-latest'],
+          # available OS's: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
+          # XXX: ubuntu-22.04 comes with an OpenSSL version that has disabled RIPEMD-160, this breaks hathor.crypto.util.get_hash160, which require code workarounds
+          'os': ['ubuntu-20.04', 'macos-12', 'windows-2022'],
           # XXX: tests fail on these, not sure why, when running them individually each on passes, but not on `make tests`
           # 'include': [
-          #   {'os': 'ubuntu-latest', 'python': 'pypy-3.7'},
-          #   {'os': 'ubuntu-latest', 'python': 'pypy-3.8'},
+          #   {'os': 'ubuntu-22.04', 'python': 'pypy-3.7'},
+          #   {'os': 'ubuntu-22.04', 'python': 'pypy-3.8'},
           # ],
         }
         # this is the fastest one:
         reduced_matrix = {
           'python': ['3.9'],
-          'os': ['ubuntu-latest'],
+          'os': ['ubuntu-20.04'],
         }
         github_repository = os.environ['GITHUB_REPOSITORY']
         if github_repository.lower() == 'hathornetwork/hathor-core':
@@ -69,13 +71,20 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Ubuntu dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: 'sudo apt-get -qy update && sudo apt-get -qy install graphviz librocksdb-dev libsnappy-dev liblz4-dev'
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get -qy update
+        sudo apt-get -qy install graphviz librocksdb-dev libsnappy-dev liblz4-dev
     - name: Install macOS dependencies
-      if: matrix.os == 'macos-latest'
-      run: 'brew update -q && brew install -q graphviz rocksdb'
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        brew cleanup -q
+        brew update -q
+        brew install -q graphviz rocksdb
     - name: Install Poetry
-      run: pip -q --no-input install poetry
+      run: |
+        pip --no-input --no-cache-dir install --upgrade pip wheel
+        pip --no-input --no-cache-dir install poetry
     - name: Install Poetry dependencies
       run: poetry install -n --no-root
     - name: Cache mypy
@@ -93,4 +102,4 @@ jobs:
       run: poetry run make tests
     - name: Upload coverage
       uses: codecov/codecov-action@v1
-      if: matrix.python == 3.9 && matrix.os == 'ubuntu-latest'
+      if: matrix.python == 3.9 && startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
This PR updates the base OS used by the runners to explicit versions instead of "latest", particularly to update to `macos-12` (becase `macos-latest` is `macos-11`, which is already breaking in Python 3.10).