### PR TITLE
feat: add flags related to the event mechanism

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -101,7 +101,6 @@ class RunNode:
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help='Use RocksDB indexes (currently opt-in)')
         parser.add_argument('--enable-event-queue', action='store_true', help='Enable event queue mechanism')
         parser.add_argument('--retain-events', action='store_true', help='Retain all events in the local database')
-        parser.add_argument('--skip-load-events', action='store_true', help='Skip events during full-node loading')
         return parser
 
     def prepare(self, args: Namespace) -> None:
@@ -308,7 +307,6 @@ class RunNode:
                            The events detected by the full node will be stored and retrieved to clients')
 
             self.manager.retain_events = args.retain_events is True
-            self.manager.skip_load_events = args.skip_load_events is True
 
         for description in args.listen:
             self.manager.add_listen_address(description)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -303,7 +303,7 @@ class RunNode:
 
         if args.enable_event_queue:
             self.manager.enable_event_queue = True
-            self.log.info('--enable-event-queue flag provided. ' \
+            self.log.info('--enable-event-queue flag provided. '
                           'The events detected by the full node will be stored and retrieved to clients')
 
             self.manager.retain_events = args.retain_events is True

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -303,10 +303,13 @@ class RunNode:
 
         if args.enable_event_queue:
             self.manager.enable_event_queue = True
-            self.log.info('--enable-event-queue flag provided." \
-                           The events detected by the full node will be stored and retrieved to clients')
+            self.log.info('--enable-event-queue flag provided. ' \
+                          'The events detected by the full node will be stored and retrieved to clients')
 
             self.manager.retain_events = args.retain_events is True
+        elif args.retain_events:
+            self.log.error('You cannot use --retain-events without --enable-event-queue.')
+            sys.exit(-1)
 
         for description in args.listen:
             self.manager.add_listen_address(description)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -99,6 +99,8 @@ class RunNode:
                             help='Disable support for running sync-v1. DO NOT ENABLE, IT WILL BREAK.')
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help='Use RocksDB indexes (currently opt-in)')
+        parser.add_argument('--enable-event-queue', action='store_true', help='Enable event queue mechanism')
+        parser.add_argument('--retain-events', action='store_true', help='Retain events on database once they are retrieved by the user')
         return parser
 
     def prepare(self, args: Namespace) -> None:
@@ -298,6 +300,12 @@ class RunNode:
             self.manager._full_verification = True
         if args.x_fast_init_beta:
             self.log.warn('--x-fast-init-beta is now the default, no need to specify it')
+
+        if args.enable_event_queue:
+            self.manager.enable_event_queue = True
+            self.log.info('--enable-event-queue flag provided. The events detected by the full node will be stored and retrieved to clients')
+
+            self.manager.retain_events = args.retain_events is True
 
         for description in args.listen:
             self.manager.add_listen_address(description)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -99,8 +99,8 @@ class RunNode:
                             help='Disable support for running sync-v1. DO NOT ENABLE, IT WILL BREAK.')
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help='Use RocksDB indexes (currently opt-in)')
-        parser.add_argument('--enable-event-queue', action='store_true', help='Enable event queue mechanism')
-        parser.add_argument('--retain-events', action='store_true', help='Retain all events in the local database')
+        parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')
+        parser.add_argument('--x-retain-events', action='store_true', help='Retain all events in the local database')
         return parser
 
     def prepare(self, args: Namespace) -> None:
@@ -301,14 +301,18 @@ class RunNode:
         if args.x_fast_init_beta:
             self.log.warn('--x-fast-init-beta is now the default, no need to specify it')
 
-        if args.enable_event_queue:
+        if args.x_enable_event_queue:
+            if not settings.ENABLE_EVENT_QUEUE_FEATURE:
+                self.log.error('The event queue feature is not available yet')
+                sys.exit(-1)
+
             self.manager.enable_event_queue = True
-            self.log.info('--enable-event-queue flag provided. '
+            self.log.info('--x-enable-event-queue flag provided. '
                           'The events detected by the full node will be stored and retrieved to clients')
 
-            self.manager.retain_events = args.retain_events is True
-        elif args.retain_events:
-            self.log.error('You cannot use --retain-events without --enable-event-queue.')
+            self.manager.retain_events = args.x_retain_events is True
+        elif args.x_retain_events:
+            self.log.error('You cannot use --x-retain-events without --x-enable-event-queue.')
             sys.exit(-1)
 
         for description in args.listen:

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -100,7 +100,8 @@ class RunNode:
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help='Use RocksDB indexes (currently opt-in)')
         parser.add_argument('--enable-event-queue', action='store_true', help='Enable event queue mechanism')
-        parser.add_argument('--retain-events', action='store_true', help='Retain events on database once they are retrieved by the user')
+        parser.add_argument('--retain-events', action='store_true', help='Retain all events in the local database')
+        parser.add_argument('--skip-load-events', action='store_true', help='Skip events during full-node loading')
         return parser
 
     def prepare(self, args: Namespace) -> None:
@@ -303,9 +304,11 @@ class RunNode:
 
         if args.enable_event_queue:
             self.manager.enable_event_queue = True
-            self.log.info('--enable-event-queue flag provided. The events detected by the full node will be stored and retrieved to clients')
+            self.log.info('--enable-event-queue flag provided." \
+                           The events detected by the full node will be stored and retrieved to clients')
 
             self.manager.retain_events = args.retain_events is True
+            self.manager.skip_load_events = args.skip_load_events is True
 
         for description in args.listen:
             self.manager.add_listen_address(description)

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -332,3 +332,5 @@ class HathorSettings(NamedTuple):
 
     # Identifier used in metadata's voided_by.
     SOFT_VOIDED_ID: bytes = b'tx-non-grata'
+
+    ENABLE_EVENT_QUEUE_FEATURE: bool = False

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -207,6 +207,10 @@ class HathorManager:
         # It tells full node to retain all generated events. Otherwise, they will be deleted after retrieval
         self.retain_events = False
 
+        # Activated with --skip-load-events flag. It will be ignored if --enable-event-queue is not provided
+        # It tell full node to skip event generation when full node is loading local data
+        self.skip_load_events = False
+
         # List of whitelisted peers
         self.peers_whitelist: List[str] = []
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -199,6 +199,14 @@ class HathorManager:
         # Can be activated on the command line with --full-verification
         self._full_verification = False
 
+        # Activated with --enable-event-queue flag
+        # It activates the event mechanism inside full node
+        self.enable_event_queue = False
+
+        # Activated with --retain-events flag. It will be ignored if --enable-event-queue is not provided
+        # It tells full node to retain all generated events. Otherwise, they will be deleted after retrieval
+        self.retain_events = False
+
         # List of whitelisted peers
         self.peers_whitelist: List[str] = []
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -207,10 +207,6 @@ class HathorManager:
         # It tells full node to retain all generated events. Otherwise, they will be deleted after retrieval
         self.retain_events = False
 
-        # Activated with --skip-load-events flag. It will be ignored if --enable-event-queue is not provided
-        # It tell full node to skip event generation when full node is loading local data
-        self.skip_load_events = False
-
         # List of whitelisted peers
         self.peers_whitelist: List[str] = []
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -199,11 +199,11 @@ class HathorManager:
         # Can be activated on the command line with --full-verification
         self._full_verification = False
 
-        # Activated with --enable-event-queue flag
+        # Activated with --x-enable-event-queue flag
         # It activates the event mechanism inside full node
         self.enable_event_queue = False
 
-        # Activated with --retain-events flag. It will be ignored if --enable-event-queue is not provided
+        # Activated with --x-retain-events flag. It will be ignored if --enable-event-queue is not provided
         # It tells full node to retain all generated events. Otherwise, they will be deleted after retrieval
         self.retain_events = False
 


### PR DESCRIPTION
### Acceptance Criteria

User can now start the full node with `--enable-event-queue` and `--retain-events`. The full-node manager will handle these flags. Subsequent PR's will use this value to manage the events inside the full node.

More information can be found on [the design](https://github.com/HathorNetwork/hathor-core/issues/405).

### Testing

Manual tests on Manager were performed. These were the results:

| INPUT - Flags        |                    |OUTPUT - Manager value |    |           
|----------------------|-----------------|------------------------|--------------
| --enable-event-queue | --retain-events | enable_event_queue     | retain_events |
| TRUE | TRUE | TRUE | TRUE 
| TRUE | FALSE | TRUE | FALSE 
| FALSE | FALSE | FALSE | FALSE


These results just state that `--retain-events` will only be considered if `--enable-event-queue` flag is given. If only `--retain-events` is given, we will throw an error and the full node will not be initialized. 