### PR TITLE
fix(cache): unexpected crash when using cache and no snapshot

### DIFF
--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -49,6 +49,9 @@ class TransactionCacheStorage(BaseTransactionStorage):
                                  transaction/blocks/metadata when returning those objects.
         :type _clone_if_needed: bool
         """
+        if store.with_index:
+            raise ValueError('internal storage cannot have indexes enabled')
+
         store.remove_cache()
         self.store = store
         self.reactor = reactor

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -13,7 +13,7 @@ class BaseCacheStorageTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        store = TransactionMemoryStorage()
+        store = TransactionMemoryStorage(with_index=False)
         self.cache_storage = TransactionCacheStorage(store, self.clock, capacity=5)
         self.cache_storage._manually_initialize()
         self.cache_storage.pre_init()

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -473,7 +473,7 @@ class CacheBinaryStorageTest(BaseCacheStorageTest):
 
     def setUp(self):
         self.directory = tempfile.mkdtemp()
-        store = TransactionBinaryStorage(self.directory)
+        store = TransactionBinaryStorage(self.directory, with_index=False)
         reactor = MemoryReactorHeapClock()
         super().setUp(TransactionCacheStorage(store, reactor, capacity=5))
 
@@ -489,7 +489,7 @@ class CacheCompactStorageTest(BaseCacheStorageTest):
         self.directory = tempfile.mkdtemp()
         # Creating random file just to test specific part of code
         tempfile.NamedTemporaryFile(dir=self.directory, delete=True)
-        store = TransactionCompactStorage(self.directory)
+        store = TransactionCompactStorage(self.directory, with_index=False)
         reactor = MemoryReactorHeapClock()
         super().setUp(TransactionCacheStorage(store, reactor, capacity=5))
 
@@ -509,7 +509,7 @@ class CacheMemoryStorageTest(BaseCacheStorageTest):
     __test__ = True
 
     def setUp(self):
-        store = TransactionMemoryStorage()
+        store = TransactionMemoryStorage(with_index=False)
         reactor = MemoryReactorHeapClock()
         super().setUp(TransactionCacheStorage(store, reactor, capacity=5))
 
@@ -537,7 +537,7 @@ class CacheRocksDBStorageTest(BaseCacheStorageTest):
 
     def setUp(self):
         self.directory = tempfile.mkdtemp()
-        store = TransactionRocksDBStorage(self.directory)
+        store = TransactionRocksDBStorage(self.directory, with_index=False)
         reactor = MemoryReactorHeapClock()
         super().setUp(TransactionCacheStorage(store, reactor, capacity=5))
 


### PR DESCRIPTION
When we use a "compound" storage (i.e. when enabling the cache layer), the inner storage instance will not have indexes, only the outer storage instance, and when the database is fresh, while running `_save_or_verify_genesis` the genesis will not be found on the database so `add_to_indexes` will be called, however this happens during construction phase, so because the inner storage is constructed before the outer storage, it doesn't have the context to know if it's OK to skip this or not.

This PR simply changes the behavior from raising an exception to returning. Raising an exception is useful to prevent situations that were constructed incorrectly, but in this case the situation is correct but it's not possible to know that from within the `add_to_indexes`.

In the future, a better solution would be using a builder pattern, so when it's time to instantiate, we have all the context needed to know whether it's OK to skip either `add_to_indexes` or `_save_or_verify_genesis`. But this will require a larger refactor.