### PR TITLE
feat(p2p): cache peer certificate options

### DIFF
--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -75,6 +75,7 @@ class PeerId:
         self.retry_interval = 5
         self.retry_attempts = 0
         self.flags = set()
+        self._certificate_options: Optional[CertificateOptions] = None
 
         if auto_generate_keys:
             self.generate_keys()
@@ -283,9 +284,17 @@ class PeerId:
         return self.certificate
 
     def get_certificate_options(self) -> CertificateOptions:
-        """ Return certificate options
-            With certificate generated and signed with peer private key
+        """ Return certificate options With certificate generated and signed with peer private key
+
+        The result is cached so subsequent calls are really cheap.
         """
+        if self._certificate_options is None:
+            self._certificate_options = self._get_certificate_options()
+        return self._certificate_options
+
+    def _get_certificate_options(self) -> CertificateOptions:
+        """Implementation of get_certificate_options, this should be cached to avoid opening the same static file
+        multiple times"""
         certificate = self.get_certificate()
         openssl_certificate = X509.from_cryptography(certificate)
         assert self.private_key is not None


### PR DESCRIPTION
**Review of this should be low priority.**

When setting up an environment on a M1 Mac, which has a low `ulimit -n` value by default, before any tuning it would frequently fail to open new connections because `PeerId.get_certificate_options` would not be able to open `settings.CA_FILEPATH`. Although some tuning can get rid of the symptom, it showed that a static file is being unnecessarily re-opened multiple times.

This PR basically caches the result of the implementation of `get_certificate_options` so it doesn't have to open the same file multiple times.