### PR TITLE
fix(api): validate token_uid before using it internally

### DIFF
--- a/hathor/indexes/memory_tokens_index.py
+++ b/hathor/indexes/memory_tokens_index.py
@@ -27,6 +27,7 @@ from hathor.indexes.utils import (
 )
 from hathor.transaction import BaseTransaction, Transaction
 from hathor.transaction.base_transaction import TxVersion
+from hathor.util import is_token_uid_valid
 
 logger = get_logger()
 
@@ -168,18 +169,21 @@ class MemoryTokensIndex(TokensIndex):
         yield from self._tokens.items()
 
     def get_token_info(self, token_uid: bytes) -> TokenIndexInfo:
+        assert is_token_uid_valid(token_uid)
         if token_uid not in self._tokens:
             raise KeyError('unknown token')
         info = self._tokens[token_uid]
         return info
 
     def get_transactions_count(self, token_uid: bytes) -> int:
+        assert is_token_uid_valid(token_uid)
         if token_uid not in self._tokens:
             return 0
         info = self._tokens[token_uid]
         return len(info._transactions)
 
     def get_newest_transactions(self, token_uid: bytes, count: int) -> Tuple[List[bytes], bool]:
+        assert is_token_uid_valid(token_uid)
         if token_uid not in self._tokens:
             return [], False
         transactions = self._tokens[token_uid]._transactions
@@ -187,6 +191,7 @@ class MemoryTokensIndex(TokensIndex):
 
     def get_older_transactions(self, token_uid: bytes, timestamp: int, hash_bytes: bytes, count: int
                                ) -> Tuple[List[bytes], bool]:
+        assert is_token_uid_valid(token_uid)
         if token_uid not in self._tokens:
             return [], False
         transactions = self._tokens[token_uid]._transactions
@@ -194,6 +199,7 @@ class MemoryTokensIndex(TokensIndex):
 
     def get_newer_transactions(self, token_uid: bytes, timestamp: int, hash_bytes: bytes, count: int
                                ) -> Tuple[List[bytes], bool]:
+        assert is_token_uid_valid(token_uid)
         if token_uid not in self._tokens:
             return [], False
         transactions = self._tokens[token_uid]._transactions

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -736,3 +736,26 @@ class manualgc(AbstractContextManager):
         type(self)._nest_count -= 1
         if type(self)._nest_count == 0:
             gc.enable()
+
+
+def is_token_uid_valid(token_uid: bytes) -> bool:
+    """ Checks whether a byte sequence can be a valid token UID.
+
+    >>> is_token_uid_valid(bytes.fromhex('00'))
+    True
+
+    >>> is_token_uid_valid(bytes.fromhex('1234'))
+    False
+
+    >>> is_token_uid_valid(bytes.fromhex('000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824'))
+    True
+
+    >>> is_token_uid_valid(bytes.fromhex('000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb82400'))
+    False
+    """
+    if token_uid == settings.HATHOR_TOKEN_UID:
+        return True
+    elif len(token_uid) == 32:
+        return True
+    else:
+        return False

--- a/hathor/wallet/resources/thin_wallet/tokens.py
+++ b/hathor/wallet/resources/thin_wallet/tokens.py
@@ -19,7 +19,7 @@ from twisted.web.http import Request
 from hathor.api_util import Resource, get_args, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.conf import HathorSettings
-from hathor.util import json_dumpb
+from hathor.util import is_token_uid_valid, json_dumpb
 
 settings = HathorSettings()
 
@@ -130,6 +130,9 @@ class TokenResource(Resource):
                 token_uid = bytes.fromhex(token_uid_str)
             except (ValueError, AttributeError):
                 return json_dumpb({'success': False, 'message': 'Invalid token id'})
+
+            if not is_token_uid_valid(token_uid):
+                return json_dumpb({'success': False, 'message': 'Invalid token id format'})
 
             data = self.get_one_token_data(token_uid)
         else:

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -297,6 +297,11 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
         self.assertFalse(data['success'])
 
+        # test invalid token id
+        response = yield resource.get('thin_wallet/token', {b'id': '1234'.encode()})
+        data = response.json_value()
+        self.assertFalse(data['success'])
+
         # test unknown token id
         unknown_uid = '00000000228ed1dd74a2e1b920c1d64bf81dc63875dce4fac486001073b45a27'.encode()
         response = yield resource.get('thin_wallet/token', {b'id': unknown_uid})


### PR DESCRIPTION
This was noticed after the latest deploy. The RocksDB index implementation is stricter than the Memory implementation, so when using a token_uid of invalid length an assertion error is raised when it wasn't before. This PR fixes this behavior.