### PR TITLE
fix(indexes): RocksDB empty address test fail for some multisig addresses

### DIFF
--- a/hathor/indexes/rocksdb_address_index.py
+++ b/hathor/indexes/rocksdb_address_index.py
@@ -148,11 +148,15 @@ class RocksDBAddressIndex(AddressIndex, RocksDBIndexUtils):
     def is_address_empty(self, address: str) -> bool:
         self.log.debug('seek to', address=address)
         it = self._db.iterkeys(self._cf)
-        it.seek(self._to_key(address))
-        res = it.get()
-        if not res:
+        seek_key = self._to_key(address)
+        it.seek(seek_key)
+        cf_key = it.get()
+        if not cf_key:
             return True
-        _cf, key = res
+        _cf, key = cf_key
+        # XXX: this means we reached the end it did not found any key
+        if key == seek_key:
+            return True
         addr, _, _ = self._from_key(key)
         is_empty = addr != address
         self.log.debug('seek empty', is_empty=is_empty)


### PR DESCRIPTION
These issue was caught recently. In short it happens because the behavior of the RocksDB key iterator's `get` method is to return the key that was given to seek when it falls through the end of the database, so the method that was prepared to only accept keys that can be found in the database would fail because the seek key is always a prefix and not a key that could be in the database.

In practice this was found happening on wallets that have a multisig address which when they start loading will open a websocket connection and send a subscribe command, which will end up calling the empty address check which before this fix would raise an AssertionError and cause the alert that generated this incident: https://github.com/HathorNetwork/on-call-incidents/issues/50

The test added fails before the fix. The fix adds an additional query (a database get) to the empty key test implementation, but this seems unavoidable, and also it is as fast as a seek so the complexity is not affected.