### PR TITLE
feat: monitor tx cache hits/misses

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -73,6 +73,7 @@ class RunNode:
         parser.add_argument('--utxo-index', action='store_true',
                             help='Create an index of UTXOs by token/address/amount and allow searching queries')
         parser.add_argument('--prometheus', action='store_true', help='Send metric data to Prometheus')
+        parser.add_argument('--prometheus-prefix', default='', help='A prefix that will be added in all Prometheus metrics')
         parser.add_argument('--cache', action='store_true', help='Use cache for tx storage')
         parser.add_argument('--cache-size', type=int, help='Number of txs to keep on cache')
         parser.add_argument('--cache-interval', type=int, help='Cache flush interval')
@@ -409,7 +410,10 @@ class RunNode:
         cpu = get_cpu_profiler()
 
         if args.prometheus:
-            kwargs: Dict[str, Any] = {'metrics': self.manager.metrics}
+            kwargs: Dict[str, Any] = {
+                'metrics': self.manager.metrics,
+                'metrics_prefix': args.prometheus_prefix
+            }
 
             if args.data:
                 kwargs['path'] = os.path.join(args.data, 'prometheus')

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -73,7 +73,8 @@ class RunNode:
         parser.add_argument('--utxo-index', action='store_true',
                             help='Create an index of UTXOs by token/address/amount and allow searching queries')
         parser.add_argument('--prometheus', action='store_true', help='Send metric data to Prometheus')
-        parser.add_argument('--prometheus-prefix', default='', help='A prefix that will be added in all Prometheus metrics')
+        parser.add_argument('--prometheus-prefix', default='',
+                            help='A prefix that will be added in all Prometheus metrics')
         parser.add_argument('--cache', action='store_true', help='Use cache for tx storage')
         parser.add_argument('--cache-size', type=int, help='Number of txs to keep on cache')
         parser.add_argument('--cache-interval', type=int, help='Cache flush interval')

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -46,8 +46,6 @@ class Metrics:
     best_block_height: int
     hash_rate: float
     peers: int
-    tx_hash_rate: float
-    block_hash_rate: float
     best_block_weight: float
     weight_tx_deque_len: int
     weight_block_deque_len: int
@@ -101,12 +99,6 @@ class Metrics:
 
         # Peers connected
         self.peers = 0
-
-        # Hash rate of tx
-        self.tx_hash_rate = 0.0
-
-        # Hash rate of block
-        self.block_hash_rate = 0
 
         # Length of the tx deque
         self.weight_tx_deque_len = 60

--- a/hathor/prometheus.py
+++ b/hathor/prometheus.py
@@ -26,9 +26,6 @@ if TYPE_CHECKING:
 
 settings = HathorSettings()
 
-# Having a prefix makes it easier in Prometheus to know the origin of each metric
-METRICS_PREFIX = 'hathor_core:'
-
 # Define prometheus metrics and it's explanation
 METRIC_INFO = {
     'transactions': 'Number of transactions',
@@ -52,7 +49,7 @@ class PrometheusMetricsExporter:
     """ Class that sends hathor metrics to a node exporter that will be read by Prometheus
     """
 
-    def __init__(self, metrics: 'Metrics', path: str, filename: str = 'hathor.prom'):
+    def __init__(self, metrics: 'Metrics', path: str, filename: str = 'hathor.prom', metrics_prefix: str = ''):
         """
         :param metrics: Metric object that stores all the hathor metrics
         :type metrics: :py:class:`hathor.metrics.Metrics`
@@ -64,6 +61,7 @@ class PrometheusMetricsExporter:
         :type filename: str
         """
         self.metrics = metrics
+        self.metrics_prefix = metrics_prefix
 
         # Create full directory, if does not exist
         os.makedirs(path, exist_ok=True)
@@ -95,7 +93,7 @@ class PrometheusMetricsExporter:
         self.registry = CollectorRegistry()
 
         for name, comment in METRIC_INFO.items():
-            self.metric_gauges[name] = Gauge(METRICS_PREFIX + name, comment, registry=self.registry)
+            self.metric_gauges[name] = Gauge(self.metrics_prefix + name, comment, registry=self.registry)
 
     def start(self) -> None:
         """ Starts exporter

--- a/hathor/prometheus.py
+++ b/hathor/prometheus.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 
 settings = HathorSettings()
 
+# Having a prefix makes it easier in Prometheus to know the origin of each metric
+METRICS_PREFIX = 'hathor_core:'
+
 # Define prometheus metrics and it's explanation
 METRIC_INFO = {
     'transactions': 'Number of transactions',
@@ -40,6 +43,8 @@ METRIC_INFO = {
     'blocks_found': 'Number of blocks found by the miner in stratum',
     'estimated_hash_rate': 'Estimated hash rate for stratum miners',
     'send_token_timeouts': 'Number of times send_token API has timed-out',
+    'transaction_cache_hits': 'Number of hits in the transactions cache',
+    'transaction_cache_misses': 'Number of misses in the transactions cache',
 }
 
 
@@ -90,7 +95,7 @@ class PrometheusMetricsExporter:
         self.registry = CollectorRegistry()
 
         for name, comment in METRIC_INFO.items():
-            self.metric_gauges[name] = Gauge(name, comment, registry=self.registry)
+            self.metric_gauges[name] = Gauge(METRICS_PREFIX + name, comment, registry=self.registry)
 
     def start(self) -> None:
         """ Starts exporter

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -1,0 +1,33 @@
+from hathor.metrics import Metrics
+from hathor.pubsub import PubSubManager
+from hathor.transaction.storage import TransactionCacheStorage, TransactionMemoryStorage
+from hathor.util import reactor
+from tests import unittest
+
+
+class MetricsTest(unittest.TestCase):
+    def test_cache_data_collection(self):
+        """Test if cache-related data is correctly being collected from the
+            TransactionCacheStorage
+        """
+        # Preparation
+        base_storage = TransactionMemoryStorage(with_index=False)
+        tx_storage = TransactionCacheStorage(base_storage, reactor)
+        pubsub = PubSubManager(reactor)
+
+        metrics = Metrics(
+            pubsub=pubsub,
+            avg_time_between_blocks=30,
+            tx_storage=tx_storage,
+            reactor=reactor
+        )
+
+        tx_storage.stats["hit"] = 10
+        tx_storage.stats["miss"] = 20
+
+        # Execution
+        metrics._collect_data()
+
+        # Assertion
+        self.assertEquals(metrics.transaction_cache_hits, 10)
+        self.assertEquals(metrics.transaction_cache_misses, 20)

--- a/tests/tx/test_prometheus.py
+++ b/tests/tx/test_prometheus.py
@@ -31,23 +31,23 @@ class BasePrometheusTest(unittest.TestCase):
 
         with open(full_path, 'r') as f:
             text = f.read().split('\n')
-            self.assertEqual(text[5], 'blocks 1.0')
-            self.assertEqual(text[2], 'transactions 2.0')
+            self.assertEqual(text[5], 'hathor_core:blocks 1.0')
+            self.assertEqual(text[2], 'hathor_core:transactions 2.0')
 
         add_new_blocks(self.manager, 30, advance_clock=1)
         add_new_transactions(self.manager, 5, advance_clock=1)
 
         with open(full_path, 'r') as f:
             text = f.read().split('\n')
-            self.assertEqual(text[5], 'blocks 1.0')
-            self.assertEqual(text[2], 'transactions 2.0')
+            self.assertEqual(text[5], 'hathor_core:blocks 1.0')
+            self.assertEqual(text[2], 'hathor_core:transactions 2.0')
 
         self.run_to_completion()
         prometheus.set_new_metrics()
         with open(full_path, 'r') as f:
             text = f.read().split('\n')
-            self.assertEqual(text[5], 'blocks 31.0')
-            self.assertEqual(text[2], 'transactions 7.0')
+            self.assertEqual(text[5], 'hathor_core:blocks 31.0')
+            self.assertEqual(text[2], 'hathor_core:transactions 7.0')
 
         # Removing tmpdir
         shutil.rmtree(tmpdir)

--- a/tests/tx/test_prometheus.py
+++ b/tests/tx/test_prometheus.py
@@ -31,23 +31,23 @@ class BasePrometheusTest(unittest.TestCase):
 
         with open(full_path, 'r') as f:
             text = f.read().split('\n')
-            self.assertEqual(text[5], 'hathor_core:blocks 1.0')
-            self.assertEqual(text[2], 'hathor_core:transactions 2.0')
+            self.assertEqual(text[5], 'blocks 1.0')
+            self.assertEqual(text[2], 'transactions 2.0')
 
         add_new_blocks(self.manager, 30, advance_clock=1)
         add_new_transactions(self.manager, 5, advance_clock=1)
 
         with open(full_path, 'r') as f:
             text = f.read().split('\n')
-            self.assertEqual(text[5], 'hathor_core:blocks 1.0')
-            self.assertEqual(text[2], 'hathor_core:transactions 2.0')
+            self.assertEqual(text[5], 'blocks 1.0')
+            self.assertEqual(text[2], 'transactions 2.0')
 
         self.run_to_completion()
         prometheus.set_new_metrics()
         with open(full_path, 'r') as f:
             text = f.read().split('\n')
-            self.assertEqual(text[5], 'hathor_core:blocks 31.0')
-            self.assertEqual(text[2], 'hathor_core:transactions 7.0')
+            self.assertEqual(text[5], 'blocks 31.0')
+            self.assertEqual(text[2], 'transactions 7.0')
 
         # Removing tmpdir
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
Design: https://github.com/HathorNetwork/ops-tools/issues/433

### Acceptance Criteria
- We should have a metric of number of hits/misses in the cache during execution
- We should log the number of cache hits/misses during initialization phase
- Add a CLI option to set the prefix for all Prometheus metrics.

### TODO
- [ ] We should update the Gitbook page https://hathor.gitbook.io/hathor/guides/full-node/command-line-reference with the new CLI option