### PR TITLE
chore(ci): update python-rocksdb to restore CI on macOS

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -200,7 +200,7 @@ python-versions = "*"
 
 [[package]]
 name = "coverage"
-version = "6.4.2"
+version = "6.4.4"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -757,7 +757,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "rocksdb"
-version = "0.9.0"
+version = "0.9.1"
 description = ""
 category = "main"
 optional = false
@@ -772,7 +772,7 @@ test = ["pytest"]
 type = "git"
 url = "https://github.com/hathornetwork/python-rocksdb.git"
 reference = "master"
-resolved_reference = "bec21991121f9ea03bdaf2f6b91dfaecd0d2b275"
+resolved_reference = "947f68a80d97c4a5621ee681ae01602ebd883f3a"
 
 [[package]]
 name = "sentry-sdk"


### PR DESCRIPTION
Changes on python-rocksdb: https://github.com/HathorNetwork/python-rocksdb/commit/947f68a80d97c4a5621ee681ae01602ebd883f3a

## Acceptance criteria

- [ ] CI should now pass on macOS
- [ ] CI should not break on other platforms