### PR TITLE
docs(readme): fix `poetry install` command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,6 @@ git clone git@github.com:HathorNetwork/hathor-core.git && cd hathor-core
 poetry install
 ```
 
-*Optionally* if you've installed the RocksDB lib:
-
-```
-poetry install -E rocksdb
-```
-
 ### Running the full-node
 
 ```


### PR DESCRIPTION
The README still references `-E rocksdb` which is not needed anymore and will also not work.