### PR TITLE
fix(p2p): Fix too many connection failures at startup

### DIFF
--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -206,11 +206,10 @@ class ConnectionsManager:
             conn.disconnect(force=force)
 
     def on_connection_failure(self, failure: Failure, peer: Optional[PeerId], endpoint: IStreamClientEndpoint) -> None:
-        self.log.warn('connection failure', endpoint=endpoint, failure=failure.getErrorMessage())
+        connecting_peer = self.connecting_peers[endpoint]
+        connection_string = connecting_peer.connection_string
+        self.log.warn('connection failure', endpoint=connection_string, failure=failure.getErrorMessage())
         self.connecting_peers.pop(endpoint)
-        if peer is not None:
-            now = int(self.reactor.seconds())
-            peer.increment_retry_attempt(now)
 
     def on_peer_connect(self, protocol: HathorProtocol) -> None:
         """Called when a new connection is established."""
@@ -224,12 +223,11 @@ class ConnectionsManager:
     def on_peer_ready(self, protocol: HathorProtocol) -> None:
         """Called when a peer is ready."""
         assert protocol.peer is not None
+        protocol.peer = self.peer_storage.add_or_merge(protocol.peer)
         assert protocol.peer.id is not None
 
         self.handshaking_peers.remove(protocol)
         self.received_peer_storage.pop(protocol.peer.id, None)
-
-        self.peer_storage.add_or_merge(protocol.peer)
 
         # we emit the event even if it's a duplicate peer as a matching
         # NETWORK_PEER_DISCONNECTED will be emmited regardless
@@ -308,7 +306,7 @@ class ConnectionsManager:
         """
         if peer.id == self.my_peer.id:
             return
-        self.received_peer_storage.add_or_merge(peer)
+        peer = self.received_peer_storage.add_or_merge(peer)
         self.connect_to_if_not_connected(peer, 0)
 
     def reconnect_to_all(self) -> None:
@@ -423,6 +421,11 @@ class ConnectionsManager:
 
         If `use_ssl` is True, then the connection will be wraped by a TLS.
         """
+        for connecting_peer in self.connecting_peers.values():
+            if connecting_peer.connection_string == description:
+                self.log.debug('skipping because we are already connecting to this endpoint', endpoint=description)
+                return
+
         if use_ssl is None:
             use_ssl = self.ssl
         connection_string, peer_id = description_to_connection_string(description)
@@ -441,12 +444,16 @@ class ConnectionsManager:
         else:
             factory = self.client_factory
 
+        if peer is not None:
+            now = int(self.reactor.seconds())
+            peer.increment_retry_attempt(now)
+
         deferred = endpoint.connect(factory)
         self.connecting_peers[endpoint] = _ConnectingPeer(connection_string, deferred)
 
         deferred.addCallback(self._connect_to_callback, peer, endpoint, connection_string, peer_id)
         deferred.addErrback(self.on_connection_failure, peer, endpoint)
-        self.log.info('connect to ', endpoint=description)
+        self.log.info('connect to ', endpoint=description, peer=str(peer))
 
     def listen(self, description: str, use_ssl: Optional[bool] = None) -> IStreamServerEndpoint:
         """ Start to listen to new connection according to the description.

--- a/hathor/p2p/peer_storage.py
+++ b/hathor/p2p/peer_storage.py
@@ -32,16 +32,18 @@ class PeerStorage(Dict[str, PeerId]):
             raise ValueError('Peer has already been added')
         self[peer.id] = peer
 
-    def add_or_merge(self, peer: PeerId) -> None:
+    def add_or_merge(self, peer: PeerId) -> PeerId:
         """ Add a peer to the storage if it has not been added yet.
         Otherwise, merge the current peer with the given one.
         """
         assert peer.id is not None
         if peer.id not in self:
             self.add(peer)
+            return peer
         else:
             current = self[peer.id]
             current.merge(peer)
+            return current
 
     def remove(self, peer: PeerId) -> None:
         """ Remove a peer from the storage


### PR DESCRIPTION
Fixes [internal-issues #115](https://github.com/HathorNetwork/internal-issues/issues/115).

## Background

Full nodes have been logging a lot of connection failure during startup. Together with these messages, there are many "maximum number of connections" and "no file description available" errors.

Here are a few examples:

```
2022-09-02 05:26:05 [warning  ] [hathor.p2p.manager] connection failure             endpoint=tcp://18.159.135.6:40403 failure=Couldn't bind: 24: Too many open files.
2022-09-02 05:26:05 [warning  ] [hathor.p2p.manager] reached maximum number of connections max_connections=125
```

## Acceptance criteria

1) Stop trying to connect multiple times to the same endpoints at startup.
2) Stop reaching the maximum number of connections at startup.