### PR TITLE
feat: p2p readiness healthcheck

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -360,7 +360,13 @@ class RunNode:
             DebugRejectResource,
         )
         from hathor.mining.ws import MiningWebsocketFactory
-        from hathor.p2p.resources import AddPeersResource, MiningInfoResource, MiningResource, StatusResource
+        from hathor.p2p.resources import (
+            AddPeersResource,
+            HealthcheckReadinessResource,
+            MiningInfoResource,
+            MiningResource,
+            StatusResource,
+        )
         from hathor.profiler import get_cpu_profiler
         from hathor.profiler.resources import CPUProfilerResource, ProfilerResource
         from hathor.prometheus import PrometheusMetricsExporter
@@ -479,6 +485,7 @@ class RunNode:
                 (b'execute', NanoContractExecuteResource(self.manager), contracts_resource),
                 # /p2p
                 (b'peers', AddPeersResource(self.manager), p2p_resource),
+                (b'readiness', HealthcheckReadinessResource(self.manager), p2p_resource),
             ]
             # XXX: only enable UTXO search API if the index is enabled
             if args.utxo_index:

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -154,6 +154,31 @@ class HathorSettings(NamedTuple):
     # that the peer is synced (in seconds).
     P2P_SYNC_THRESHOLD: int = 60
 
+    # This multiplier will be used to decide whether the fullnode has had recent activity in the p2p sync.
+    # This info will be used in the readiness endpoint as one of the checks.
+    #
+    # We will multiply it by the AVG_TIME_BETWEEN_BLOCKS, and compare the result with the gap between the
+    # current time and the latest timestamp in the database.
+    #
+    # If the gap is bigger than the calculated threshold, than we will say the fullnode is not ready (unhealthy).
+    #
+    # Using (P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER * AVG_TIME_BETWEEN_BLOCKS) as threshold will have false
+    # positives.
+    # The probability of a false positive is exp(-N), assuming the hash rate is constant during the period.
+    # In other words, a false positive is likely to occur every exp(N) blocks. If the hash rate decreases
+    # quickly, this probability gets bigger.
+    #
+    # For instance, P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER=5 would get a false positive every 90 minutes.
+    # For P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER=10, we would have a false positive every 8 days.
+    # For P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER=15, we would have a false positive every 3 years.
+    #
+    # On the other side, using higher numbers will lead to a higher delay for the fullnode to start reporting
+    # as not ready.
+    #
+    # So for use cases that may need more reponsiveness on this readiness check, at the cost of some eventual false
+    # positive, it could be a good idea to decrease the value in this setting.
+    P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER: int = 15
+
     # Whether to warn the other peer of the reason for closing the connection
     WHITELIST_WARN_BLOCKED_PEERS: bool = False
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -62,6 +62,10 @@ class HathorManager:
         # This node is ready to establish new connections, sync, and exchange transactions.
         READY = 'READY'
 
+    class UnhealthinessReason(str, Enum):
+        NO_RECENT_ACTIVITY = "Node doesn't have recent blocks"
+        NO_SYNCED_PEER = "Node doesn't have a synced peer"
+
     def __init__(self, reactor: Reactor, peer_id: Optional[PeerId] = None, network: Optional[str] = None,
                  hostname: Optional[str] = None, pubsub: Optional[PubSubManager] = None,
                  wallet: Optional[BaseWallet] = None, tx_storage: Optional[TransactionStorage] = None,
@@ -1082,10 +1086,10 @@ class HathorManager:
 
     def is_healthy(self) -> Tuple[bool, Optional[str]]:
         if not self.has_recent_activity():
-            return False, "Node doesn't have recent blocks"
+            return False, HathorManager.UnhealthinessReason.NO_RECENT_ACTIVITY
 
         if not self.connections.has_synced_peer():
-            return False, "Node doesn't have a synced peer"
+            return False, HathorManager.UnhealthinessReason.NO_SYNCED_PEER
 
         return True, None
 

--- a/hathor/p2p/resources/__init__.py
+++ b/hathor/p2p/resources/__init__.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 from hathor.p2p.resources.add_peers import AddPeersResource
+from hathor.p2p.resources.healthcheck import HealthcheckReadinessResource
 from hathor.p2p.resources.mining import MiningResource
 from hathor.p2p.resources.mining_info import MiningInfoResource
 from hathor.p2p.resources.status import StatusResource
 
-__all__ = ['AddPeersResource', 'StatusResource', 'MiningResource', 'MiningInfoResource']
+__all__ = [
+    'AddPeersResource',
+    'StatusResource',
+    'MiningResource',
+    'MiningInfoResource',
+    'HealthcheckReadinessResource'
+]

--- a/hathor/p2p/resources/healthcheck.py
+++ b/hathor/p2p/resources/healthcheck.py
@@ -27,7 +27,7 @@ class HealthcheckReadinessResource(Resource):
 
 
 HealthcheckReadinessResource.openapi = {
-    '/p2p/status': {
+    '/p2p/readiness': {
         'x-visibility': 'public',
         'x-rate-limit': {
             'global': [

--- a/hathor/p2p/resources/healthcheck.py
+++ b/hathor/p2p/resources/healthcheck.py
@@ -6,6 +6,8 @@ from hathor.util import json_dumpb
 
 @register_resource
 class HealthcheckReadinessResource(Resource):
+    isLeaf = True
+
     def __init__(self, manager: HathorManager):
         self.manager = manager
 

--- a/hathor/p2p/resources/healthcheck.py
+++ b/hathor/p2p/resources/healthcheck.py
@@ -1,0 +1,105 @@
+from hathor.api_util import Resource
+from hathor.cli.openapi_files.register import register_resource
+from hathor.manager import HathorManager
+from hathor.util import json_dumpb
+
+
+@register_resource
+class HealthcheckReadinessResource(Resource):
+    def __init__(self, manager: HathorManager):
+        self.manager = manager
+
+    def render_GET(self, request):
+        """ GET request /p2p/readiness/
+            Checks if the fullnode is considered ready from the perpective of the sync mechanism
+
+            :rtype: string (json)
+        """
+        healthy, reason = self.manager.is_healthy()
+
+        if not healthy:
+            request.setResponseCode(503)
+            return json_dumpb({'success': False, 'reason': reason})
+
+        return json_dumpb({'success': True})
+
+
+HealthcheckReadinessResource.openapi = {
+    '/p2p/status': {
+        'x-visibility': 'public',
+        'x-rate-limit': {
+            'global': [
+                {
+                    'rate': '200r/s',
+                    'burst': 200,
+                    'delay': 100
+                }
+            ],
+            'per-ip': [
+                {
+                    'rate': '3r/s',
+                    'burst': 10,
+                    'delay': 3
+                }
+            ]
+        },
+        'get': {
+            'tags': ['p2p'],
+            'operationId': 'readiness',
+            'summary': 'Readiness status of the fullnode',
+            'description': '''
+Returns 200 if the fullnode should be considered ready from the perspective of the sync mechanism.
+
+Returns 503 otherwise. The response will contain the reason why it is not ready in this case.
+
+We currently check 2 things for the readiness:
+1. Whether the fullnode has recent block activity, i.e. if the fullnode has blocks with recent timestamps.
+2. Whether the fullnode has at least one synced peer
+
+It's possible to customize the behavior of this endpoint by tweaking what should be considered recent activity.
+See the setting P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER and the comment above it in hathor/conf/settings.py
+for more info.
+            ''',
+            'responses': {
+                '200': {
+                    'description': 'Ready',
+                    'content': {
+                        'application/json': {
+                            'examples': {
+                                'ready': {
+                                    'summary': 'Ready',
+                                    'value': {
+                                        'success': True
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                '503': {
+                    'description': 'Not Ready',
+                    'content': {
+                        'application/json': {
+                            'examples': {
+                                'no_recent_activity': {
+                                    'summary': 'Node with no recent activity',
+                                    'value': {
+                                        'success': False,
+                                        'reason': "Node doesn't have recent blocks"
+                                    }
+                                },
+                                'no_synced_peer': {
+                                    'summary': 'Node with no synced peer',
+                                    'value': {
+                                        'success': False,
+                                        'reason': "Node doesn't have a synced peer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+}

--- a/tests/resources/p2p/test_healthcheck.py
+++ b/tests/resources/p2p/test_healthcheck.py
@@ -1,0 +1,95 @@
+from twisted.internet.defer import inlineCallbacks
+
+from hathor.manager import HathorManager
+from hathor.p2p.resources.healthcheck import HealthcheckReadinessResource
+from hathor.simulator import FakeConnection
+from tests import unittest
+from tests.resources.base_resource import StubSite, _BaseResourceTest
+from tests.utils import add_new_blocks
+
+
+class BaseHealthcheckReadinessTest(_BaseResourceTest._ResourceTest):
+    __test__ = False
+
+    def setUp(self):
+        super().setUp()
+        self.web = StubSite(HealthcheckReadinessResource(self.manager))
+
+    @inlineCallbacks
+    def test_get_no_recent_activity(self):
+        """Scenario where the node doesn't have a recent block
+        """
+        response = yield self.web.get("p2p/readiness")
+        data = response.json_value()
+
+        self.assertEqual(data['success'], False)
+        self.assertEqual(data['reason'], HathorManager.UnhealthinessReason.NO_RECENT_ACTIVITY)
+
+    @inlineCallbacks
+    def test_get_no_connected_peer(self):
+        """Scenario where the node doesn't have any connected peer
+        """
+        # This will make sure the node has recent activity
+        add_new_blocks(self.manager, 5)
+
+        self.assertEqual(self.manager.has_recent_activity(), True)
+
+        response = yield self.web.get("p2p/readiness")
+        data = response.json_value()
+
+        self.assertEqual(data['success'], False)
+        self.assertEqual(data['reason'], HathorManager.UnhealthinessReason.NO_SYNCED_PEER)
+
+    @inlineCallbacks
+    def test_get_peer_out_of_sync(self):
+        """Scenario where the node is connected with a peer but not synced
+        """
+        # This will make sure the node has recent activity
+        add_new_blocks(self.manager, 5)
+
+        self.manager2 = self.create_peer('testnet')
+        self.conn1 = FakeConnection(self.manager, self.manager2)
+        self.conn1.run_one_step()  # HELLO
+        self.conn1.run_one_step()  # PEER-ID
+        self.conn1.run_one_step()  # READY
+
+        self.assertEqual(self.manager2.state, self.manager2.NodeState.READY)
+
+        response = yield self.web.get("p2p/readiness")
+        data = response.json_value()
+
+        self.assertEqual(data['success'], False)
+        self.assertEqual(data['reason'], HathorManager.UnhealthinessReason.NO_SYNCED_PEER)
+
+    @inlineCallbacks
+    def test_get_ready(self):
+        """Scenario where the node is ready
+        """
+        self.manager2 = self.create_peer('testnet')
+        self.conn1 = FakeConnection(self.manager, self.manager2)
+
+        # This will make sure the node has recent activity
+        add_new_blocks(self.manager, 5)
+
+        # This will make sure the peers are synced
+        while not self.conn1.is_empty():
+            self.conn1.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        response = yield self.web.get("p2p/readiness")
+        data = response.json_value()
+
+        self.assertEqual(data['success'], True)
+
+
+class SyncV1StatusTest(unittest.SyncV1Params, BaseHealthcheckReadinessTest):
+    __test__ = True
+
+
+class SyncV2StatusTest(unittest.SyncV2Params, BaseHealthcheckReadinessTest):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeStatusTest(unittest.SyncBridgeParams, SyncV2StatusTest):
+    pass


### PR DESCRIPTION
design: https://github.com/HathorNetwork/ops-tools/issues/431

### Acceptance Criteria
- We should have a new endpoint `/p2p/readiness` that checks if:
    - The node has blocks with a recent timestamp
    - The node has at least one connected and synced peer