### PR TITLE
fix(pubsub): Calling events out-of-order

### DIFF
--- a/hathor/indexes/memory_address_index.py
+++ b/hathor/indexes/memory_address_index.py
@@ -50,9 +50,7 @@ class MemoryAddressIndex(AddressIndex):
         """
         assert self.pubsub is not None
         # Subscribe to voided/winner events
-        events = [HathorEvents.STORAGE_TX_VOIDED, HathorEvents.STORAGE_TX_WINNER]
-        for event in events:
-            self.pubsub.subscribe(event, self.handle_tx_event)
+        self.pubsub.subscribe(HathorEvents.CONSENSUS_TX_UPDATE, self.handle_tx_event)
 
     def add_tx(self, tx: BaseTransaction) -> None:
         """ Add tx inputs and outputs to the wallet index (indexed by its addresses).

--- a/hathor/indexes/rocksdb_address_index.py
+++ b/hathor/indexes/rocksdb_address_index.py
@@ -88,9 +88,7 @@ class RocksDBAddressIndex(AddressIndex, RocksDBIndexUtils):
         """
         assert self.pubsub is not None
         # Subscribe to voided/winner events
-        events = [HathorEvents.STORAGE_TX_VOIDED, HathorEvents.STORAGE_TX_WINNER]
-        for event in events:
-            self.pubsub.subscribe(event, self.handle_tx_event)
+        self.pubsub.subscribe(HathorEvents.CONSENSUS_TX_UPDATE, self.handle_tx_event)
 
     def add_tx(self, tx: BaseTransaction) -> None:
         """ Add tx inputs and outputs to the wallet index (indexed by its addresses).

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -159,7 +159,7 @@ class HathorManager:
             self.tx_storage.indexes.enable_utxo_index()
 
         self.soft_voided_tx_ids = soft_voided_tx_ids or set()
-        self.consensus_algorithm = ConsensusAlgorithm(self.soft_voided_tx_ids)
+        self.consensus_algorithm = ConsensusAlgorithm(self.soft_voided_tx_ids, pubsub=self.pubsub)
 
         self.peer_discoveries: List[PeerDiscovery] = []
 

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
+from collections import defaultdict, deque
 from enum import Enum
-from typing import Any, Callable, Dict, List, cast
+from typing import Any, Callable, Deque, Dict, List, Tuple, cast
 
 from twisted.internet.interfaces import IReactorFromThreads
 
@@ -35,12 +35,8 @@ class HathorEvents(Enum):
             Triggered when a peer disconnects from the network
             Publishes the peer protocol
 
-        STORAGE_TX_VOIDED:
-            Triggered when a tx is marked as voided because of a conflict
-            Publishes the tx object
-
-        STORAGE_TX_WINNER:
-            Triggered when a tx is marked as winner of a conflict
+        CONSENSUS_TX_UPDATE:
+            Triggered when a tx is changed by the consensus algorithm
             Publishes the tx object
 
         WALLET_OUTPUT_RECEIVED:
@@ -80,9 +76,7 @@ class HathorEvents(Enum):
 
     NETWORK_NEW_TX_ACCEPTED = 'network:new_tx_accepted'
 
-    STORAGE_TX_VOIDED = 'storage:tx_voided'
-
-    STORAGE_TX_WINNER = 'storage:tx_winner'
+    CONSENSUS_TX_UPDATE = 'consensus:tx_update'
 
     WALLET_OUTPUT_RECEIVED = 'wallet:output_received'
 
@@ -128,6 +122,7 @@ class PubSubManager:
 
     def __init__(self, reactor: Reactor) -> None:
         self._subscribers = defaultdict(list)
+        self.queue: Deque[Tuple[PubSubCallable, HathorEvents, EventArguments]] = deque()
         self.reactor = reactor
 
     def subscribe(self, key: HathorEvents, fn: PubSubCallable) -> None:
@@ -148,6 +143,29 @@ class PubSubManager:
         if fn in self._subscribers[key]:
             self._subscribers[key].remove(fn)
 
+    def _call_next(self):
+        """Execute next call if it exists."""
+        if not self.queue:
+            return
+        fn, key, args = self.queue.popleft()
+        fn(key, args)
+        if self.queue:
+            self._schedule_call_next()
+
+    def _schedule_call_next(self):
+        """Schedule next call's execution."""
+        reactor_thread = ReactorThread.get_current_thread(self.reactor)
+        if reactor_thread == ReactorThread.MAIN_THREAD:
+            self.reactor.callLater(0, self._call_next)
+        elif reactor_thread == ReactorThread.NOT_MAIN_THREAD:
+            # XXX: does this always hold true? an assert could be tricky because it is a zope.interface
+            reactor = cast(IReactorFromThreads, self.reactor)
+            # We're taking a conservative approach, since not all functions might need to run
+            # on the main thread [yan 2019-02-20]
+            reactor.callFromThread(self._call_next)
+        else:
+            raise NotImplementedError
+
     def publish(self, key: HathorEvents, **kwargs: Any) -> None:
         """Publish a new event.
 
@@ -163,11 +181,8 @@ class PubSubManager:
         for fn in self._subscribers[key]:
             if reactor_thread == ReactorThread.NOT_RUNNING:
                 fn(key, args)
-            elif reactor_thread == ReactorThread.MAIN_THREAD:
-                self.reactor.callLater(0, fn, key, args)
-            elif reactor_thread == ReactorThread.NOT_MAIN_THREAD:
-                # XXX: does this always hold true? an assert could be tricky because it is a zope.interface
-                reactor = cast(IReactorFromThreads, self.reactor)
-                # We're taking a conservative approach, since not all functions might need to run
-                # on the main thread [yan 2019-02-20]
-                reactor.callFromThread(fn, key, args)
+            else:
+                is_empty = bool(not self.queue)
+                self.queue.append((fn, key, args))
+                if is_empty:
+                    self._schedule_call_next()

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -84,14 +84,14 @@ class Simulator:
         """ This is used by when starting instances of Simulator to determine when to run _apply_patches"""
         assert cls._patches_rc >= 0
         cls._patches_rc += 1
-        if cls._patches_rc < 2:
+        if cls._patches_rc == 1:
             # patches not yet applied
             cls._apply_patches()
 
     @classmethod
     def _patches_rc_decrement(cls):
         """ This is used by when stopping instances of Simulator to determine when to run _remove_patches"""
-        assert cls._patches_rc >= 0
+        assert cls._patches_rc > 0
         cls._patches_rc -= 1
         if cls._patches_rc == 0:
             # patches not needed anymore

--- a/tests/consensus/test_consensus2.py
+++ b/tests/consensus/test_consensus2.py
@@ -32,7 +32,7 @@ class BaseConsensusSimulatorTestCase(SimulatorTestCase):
         txF2 = add_custom_tx(manager1, [(txB, 0), (txD1, 0)])
         self.graphviz.labels[txF2.hash] = f'txF2-{i}'
 
-        txD2 = add_custom_tx(manager1, [(txC, 0)], base_parent=tx_base)
+        txD2 = add_custom_tx(manager1, [(txC, 0)], base_parent=tx_base, inc_timestamp=1)
         self.graphviz.labels[txD2.hash] = f'txD2-{i}'
         txE = add_custom_tx(manager1, [(txD2, 0)], base_parent=tx_base)
         self.graphviz.labels[txE.hash] = f'txE-{i}'

--- a/tests/consensus/test_consensus5.py
+++ b/tests/consensus/test_consensus5.py
@@ -64,7 +64,7 @@ class BaseConsensusSimulatorTestCase(SimulatorTestCase):
         self.graphviz.labels[txC1.hash] = 'txC1'
         self.assertTrue(manager1.propagate_tx(txC1))
 
-        txC2 = gen_custom_tx(manager1, [(txA2, 0)])
+        txC2 = gen_custom_tx(manager1, [(txA2, 0)], inc_timestamp=1)
         self.graphviz.labels[txC2.hash] = 'txC2'
         self.assertTrue(manager1.propagate_tx(txC2))
 

--- a/tests/consensus/test_soft_voided.py
+++ b/tests/consensus/test_soft_voided.py
@@ -1,6 +1,6 @@
 from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
-from hathor.simulator import FakeConnection
+from hathor.simulator import FakeConnection, Simulator
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_new_tx
@@ -18,36 +18,40 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
             tx2_voided_by = tx2_meta.voided_by or set()
             self.assertNotIn(settings.SOFT_VOIDED_ID, tx2_voided_by)
 
-    def test_soft_voided(self):
-        txA_hash = bytes.fromhex('4586c5428e8d666ea59684c1cd9286d2b9d9e89b4939207db47412eeaabc48b2')
-        soft_voided_tx_ids = set([
-            txA_hash,
-        ])
-
-        manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids)
+    def _run_test(self, simulator, soft_voided_tx_ids):
+        manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids, simulator=simulator)
         manager1.allow_mining_without_peers()
 
-        miner1 = self.simulator.create_miner(manager1, hashpower=5e6)
+        miner1 = simulator.create_miner(manager1, hashpower=5e6)
         miner1.start()
-        self.simulator.run(60)
+        simulator.run(60)
 
-        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx1 = simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx1.start()
-        self.simulator.run(300)
+        simulator.run(300)
 
-        manager2 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids)
+        manager2 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids, simulator=simulator)
         manager2.soft_voided_tx_ids = soft_voided_tx_ids
 
         graphviz = GraphvizVisualizer(manager2.tx_storage, include_verifications=True, include_funds=True)
 
         conn12 = FakeConnection(manager1, manager2, latency=0.001)
-        self.simulator.add_connection(conn12)
+        simulator.add_connection(conn12)
 
-        miner2 = self.simulator.create_miner(manager2, hashpower=10e6)
+        miner2 = simulator.create_miner(manager2, hashpower=10e6)
         miner2.start()
-        gen_tx2 = self.simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx2 = simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx2.start()
-        self.simulator.run(900)
+
+        while not gen_tx2.latest_transactions:
+            simulator.run(600)
+
+        yield gen_tx2
+
+        self.assertEqual(1, len(soft_voided_tx_ids))
+        txA_hash = list(soft_voided_tx_ids)[0]
+
+        simulator.run(300)
 
         txA = manager2.tx_storage.get_transaction(txA_hash)
         metaA = txA.get_metadata()
@@ -64,7 +68,7 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         self.assertEqual({txA.hash}, metaD1.voided_by)
         graphviz.labels[txD1.hash] = 'txD1'
 
-        txD2 = add_custom_tx(manager2, [(txB, 0)])
+        txD2 = add_custom_tx(manager2, [(txB, 0)], inc_timestamp=1)
         metaD2 = txD2.get_metadata()
         self.assertEqual({txA.hash, txD2.hash}, metaD2.voided_by)
         graphviz.labels[txD2.hash] = 'txD2'
@@ -123,6 +127,27 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         # Uncomment lines below to visualize the DAG and the blockchain.
         # dot = graphviz.dot()
         # dot.render('dot0')
+
+    def _get_txA_hash(self):
+        simulator = Simulator(seed=self.simulator.seed)
+        simulator.start()
+
+        try:
+            it = self._run_test(simulator, set())
+            gen_tx = next(it)
+            txA_hash = gen_tx.latest_transactions[0]
+        finally:
+            simulator.stop()
+
+        return txA_hash
+
+    def test_soft_voided(self):
+        txA_hash = self._get_txA_hash()
+        soft_voided_tx_ids = set([
+            txA_hash,
+        ])
+        for _ in self._run_test(self.simulator, soft_voided_tx_ids):
+            pass
 
 
 class SyncV1SoftVoidedTestCase(unittest.SyncV1Params, BaseSoftVoidedTestCase):

--- a/tests/consensus/test_soft_voided3.py
+++ b/tests/consensus/test_soft_voided3.py
@@ -1,5 +1,6 @@
 from hathor.conf import HathorSettings
-from hathor.simulator import FakeConnection
+from hathor.graphviz import GraphvizVisualizer
+from hathor.simulator import FakeConnection, Simulator
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_custom_tx, gen_new_tx
@@ -17,49 +18,58 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
             tx2_voided_by = tx2_meta.voided_by or set()
             self.assertNotIn(settings.SOFT_VOIDED_ID, tx2_voided_by)
 
-    def test_soft_voided(self):
-        txA_hash = bytes.fromhex('4586c5428e8d666ea59684c1cd9286d2b9d9e89b4939207db47412eeaabc48b2')
-        soft_voided_tx_ids = set([
-            txA_hash,
-        ])
-
-        manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids)
+    def _run_test(self, simulator, soft_voided_tx_ids):
+        manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids, simulator=simulator)
         manager1.allow_mining_without_peers()
 
-        miner1 = self.simulator.create_miner(manager1, hashpower=5e6)
+        miner1 = simulator.create_miner(manager1, hashpower=5e6)
         miner1.start()
-        self.simulator.run(60)
+        simulator.run(60)
 
-        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx1 = simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx1.start()
-        self.simulator.run(300)
+        simulator.run(300)
 
-        manager2 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids)
+        manager2 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids, simulator=simulator)
         manager2.soft_voided_tx_ids = soft_voided_tx_ids
 
-        conn12 = FakeConnection(manager1, manager2, latency=0.001)
-        self.simulator.add_connection(conn12)
+        graphviz = GraphvizVisualizer(manager2.tx_storage, include_verifications=True, include_funds=True)
 
-        miner2 = self.simulator.create_miner(manager2, hashpower=10e6)
+        conn12 = FakeConnection(manager1, manager2, latency=0.001)
+        simulator.add_connection(conn12)
+
+        miner2 = simulator.create_miner(manager2, hashpower=10e6)
         miner2.start()
 
-        gen_tx2 = self.simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx2 = simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx2.start()
-        self.simulator.run(900)
+
+        while not gen_tx2.latest_transactions:
+            simulator.run(300)
+
+        yield gen_tx2
+
+        self.assertEqual(1, len(soft_voided_tx_ids))
+        txA_hash = list(soft_voided_tx_ids)[0]
+
+        simulator.run(300)
         miner2.stop()
         gen_tx2.stop()
 
         txA = manager2.tx_storage.get_transaction(txA_hash)
         metaA = txA.get_metadata()
         self.assertEqual({settings.SOFT_VOIDED_ID, txA.hash}, metaA.voided_by)
+        graphviz.labels[txA.hash] = 'txA'
 
         txB = add_custom_tx(manager2, [(txA, 0)])
         metaB = txB.get_metadata()
         self.assertEqual({txA.hash}, metaB.voided_by)
+        graphviz.labels[txB.hash] = 'txB'
 
         txD1 = add_custom_tx(manager2, [(txB, 0)])
         metaD1 = txD1.get_metadata()
         self.assertEqual({txA.hash}, metaD1.voided_by)
+        graphviz.labels[txD1.hash] = 'txD1'
 
         blk1 = manager2.generate_mining_block()
         self.assertNoParentsAreSoftVoided(blk1)
@@ -71,8 +81,9 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         self.assertTrue(manager2.propagate_tx(blk1, fails_silently=False))
         blk1meta = blk1.get_metadata()
         self.assertIsNone(blk1meta.voided_by)
+        graphviz.labels[blk1.hash] = 'blk1'
 
-        self.simulator.run(10)
+        simulator.run(10)
         address = manager2.wallet.get_unused_address(mark_as_used=True)
         txC = gen_new_tx(manager2, address, 6400)
         if txD1.hash not in txC.parents:
@@ -82,16 +93,43 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         manager2.propagate_tx(txC, fails_silently=False)
         metaC = txC.get_metadata()
         self.assertIsNone(metaC.voided_by)
+        graphviz.labels[txC.hash] = 'txC'
 
         txD2 = gen_custom_tx(manager2, [(txB, 0)])
         txD2.timestamp = txD1.timestamp + 2
         txD2.update_hash()
         manager2.propagate_tx(txD2, fails_silently=False)
+        graphviz.labels[txD2.hash] = 'txD2'
 
         blk1meta = blk1.get_metadata()
         self.assertIsNone(blk1meta.voided_by)
         metaC = txC.get_metadata()
         self.assertIsNone(metaC.voided_by)
+
+        # Uncomment lines below to visualize the DAG and the blockchain.
+        # dot = graphviz.dot()
+        # dot.render('test_soft_voided3')
+
+    def _get_txA_hash(self):
+        simulator = Simulator(seed=self.simulator.seed)
+        simulator.start()
+
+        try:
+            it = self._run_test(simulator, set())
+            tx_gen = next(it)
+            txA_hash = tx_gen.latest_transactions[0]
+        finally:
+            simulator.stop()
+
+        return txA_hash
+
+    def test_soft_voided(self):
+        txA_hash = self._get_txA_hash()
+        soft_voided_tx_ids = set([
+            txA_hash,
+        ])
+        for _ in self._run_test(self.simulator, soft_voided_tx_ids):
+            pass
 
 
 class SyncV1SoftVoidedTestCase(unittest.SyncV1Params, BaseSoftVoidedTestCase):

--- a/tests/consensus/test_soft_voided4.py
+++ b/tests/consensus/test_soft_voided4.py
@@ -1,6 +1,6 @@
 from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
-from hathor.simulator import FakeConnection
+from hathor.simulator import FakeConnection, Simulator
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_new_double_spending
@@ -11,48 +11,63 @@ settings = HathorSettings()
 class BaseSoftVoidedTestCase(SimulatorTestCase):
     seed_config = 5988775361793628169
 
-    def test_soft_voided(self):
-        txA_hash = bytes.fromhex('4586c5428e8d666ea59684c1cd9286d2b9d9e89b4939207db47412eeaabc48b2')
-        txB_hash = bytes.fromhex('d19bee149abdce63bbfd523c90c3cf110563970a34100b2a62583a1eba48dfc8')
-        soft_voided_tx_ids = set([
-            txA_hash,
-            txB_hash,
-        ])
-
-        manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids)
+    def _run_test(self, simulator, soft_voided_tx_ids):
+        manager1 = self.create_peer(soft_voided_tx_ids=set(soft_voided_tx_ids), simulator=simulator)
         manager1.allow_mining_without_peers()
 
-        miner1 = self.simulator.create_miner(manager1, hashpower=5e6)
+        miner1 = simulator.create_miner(manager1, hashpower=5e6)
         miner1.start()
-        self.simulator.run(60)
+        simulator.run(60)
 
-        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx1 = simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx1.start()
-        self.simulator.run(300)
+        simulator.run(300)
+        gen_tx1.stop()
 
-        manager2 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids)
-        manager2.soft_voided_tx_ids = soft_voided_tx_ids
+        manager2 = self.create_peer(soft_voided_tx_ids=set(soft_voided_tx_ids), simulator=simulator)
+        manager2.soft_voided_tx_ids = set(soft_voided_tx_ids)
 
         self.graphviz = GraphvizVisualizer(manager2.tx_storage, include_verifications=True, include_funds=True)
 
         conn12 = FakeConnection(manager1, manager2, latency=0.001)
-        self.simulator.add_connection(conn12)
+        simulator.add_connection(conn12)
 
-        miner2 = self.simulator.create_miner(manager2, hashpower=10e6)
+        miner2 = simulator.create_miner(manager2, hashpower=10e6)
         miner2.start()
 
-        gen_tx2 = self.simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx2 = simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx2.start()
-        self.simulator.run(900)
+
+        while not gen_tx2.latest_transactions:
+            simulator.run(600)
+
+        yield gen_tx2
+
+        simulator.run(300)
+
+        yield gen_tx2
+
+        miner1.stop()
         miner2.stop()
+        simulator.run(300)
+
+        yield gen_tx2
+
         gen_tx2.stop()
+
+        self.assertEqual(2, len(soft_voided_tx_ids))
+        txA_hash = soft_voided_tx_ids[0]
+        txB_hash = soft_voided_tx_ids[1]
+        self.graphviz.labels[txA_hash] = 'txA'
+        self.graphviz.labels[txB_hash] = 'txB'
 
         txB = manager2.tx_storage.get_transaction(txB_hash)
 
         # Get the tx confirmed by the soft voided that will be voided
         tx_base = manager2.tx_storage.get_transaction(txB.parents[0])
         txC = gen_new_double_spending(manager2, use_same_parents=False, tx=tx_base)
-        txC.weight = 25
+        self.graphviz.labels[tx_base.hash] = 'tx_base'
+        txC.weight = 30
         txC.parents = tx_base.parents
         txC.update_hash()
         self.graphviz.labels[txC.hash] = 'txC'
@@ -68,19 +83,28 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         blk1 = manager2.generate_mining_block()
         if txC.hash not in blk1.parents:
             blk1.parents[1] = txC.hash
+            blk1.update_timestamp(int(manager2.reactor.seconds()))
         blk1.nonce = self.rng.getrandbits(32)
         blk1.update_hash()
+
+        # Uncomment lines below to visualize the DAG and the blockchain.
+        # dot = self.graphviz.dot()
+        # dot.render('dot0')
+
         self.assertTrue(manager2.propagate_tx(blk1, fails_silently=False))
         blk1meta = blk1.get_metadata()
+        self.graphviz.labels[blk1.hash] = 'blk1'
         self.assertIsNone(blk1meta.voided_by)
 
         blk2 = manager2.generate_mining_block()
         if txC.hash not in blk2.parents:
             blk2.parents[1] = txC.hash
+            blk2.update_timestamp(int(manager2.reactor.seconds()))
         blk2.nonce = self.rng.getrandbits(32)
         blk2.update_hash()
         self.assertTrue(manager2.propagate_tx(blk2, fails_silently=False))
         blk2meta = blk2.get_metadata()
+        self.graphviz.labels[blk2.hash] = 'blk2'
         self.assertIsNone(blk2meta.voided_by)
 
         # Create block that confirms soft voided
@@ -91,17 +115,55 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         blk3.update_hash()
         self.assertTrue(manager2.propagate_tx(blk3, fails_silently=False))
         blk3meta = blk3.get_metadata()
+        self.graphviz.labels[blk3.hash] = 'blk3'
 
-        self.simulator.run(10)
+        simulator.run(10)
         txD = add_custom_tx(manager2, [(txC, 0)], base_parent=txB)
-
-        # dot = self.graphviz.dot()
-        # dot.render('dot0')
+        self.graphviz.labels[txD.hash] = 'txD'
 
         blk3meta = blk3.get_metadata()
         self.assertEqual(blk3meta.voided_by, {tx_base.hash, blk3meta.hash})
         metaD = txD.get_metadata()
         self.assertEqual(metaD.voided_by, {tx_base.hash})
+
+    def _get_txA_hash(self):
+        simulator = Simulator(seed=self.simulator.seed)
+        simulator.start()
+
+        try:
+            it = self._run_test(simulator, set())
+            gen_tx = next(it)
+            txA_hash = gen_tx.latest_transactions[0]
+        finally:
+            simulator.stop()
+
+        return txA_hash
+
+    def _get_txB_hash(self, txA_hash):
+        simulator = Simulator(seed=self.simulator.seed)
+        simulator.start()
+
+        try:
+            it = self._run_test(simulator, set([txA_hash]))
+            _ = next(it)
+            _ = next(it)
+            gen_tx = next(it)
+            txB_hash = gen_tx.latest_transactions[0]
+        finally:
+            simulator.stop()
+
+        return txB_hash
+
+    def test_soft_voided(self):
+        txA_hash = self._get_txA_hash()
+        txB_hash = self._get_txB_hash(txA_hash)
+        self.assertNotEqual(txA_hash, txB_hash)
+        soft_voided_tx_ids = [
+            txA_hash,
+            txB_hash,
+        ]
+        for _ in self._run_test(self.simulator, soft_voided_tx_ids):
+            pass
 
 
 class SyncV1SoftVoidedTestCase(unittest.SyncV1Params, BaseSoftVoidedTestCase):

--- a/tests/simulation/base.py
+++ b/tests/simulation/base.py
@@ -23,7 +23,7 @@ class SimulatorTestCase(unittest.TestCase):
         self.simulator.stop()
         super().tearDown()
 
-    def create_peer(self, enable_sync_v1=None, enable_sync_v2=None, soft_voided_tx_ids=None):
+    def create_peer(self, enable_sync_v1=None, enable_sync_v2=None, soft_voided_tx_ids=None, simulator=None):
         if enable_sync_v1 is None:
             assert hasattr(self, '_enable_sync_v1'), ('`_enable_sync_v1` has no default by design, either set one on '
                                                       'the test class or pass `enable_sync_v1` by argument')
@@ -33,8 +33,10 @@ class SimulatorTestCase(unittest.TestCase):
                                                       'the test class or pass `enable_sync_v2` by argument')
             enable_sync_v2 = self._enable_sync_v2
         assert enable_sync_v1 or enable_sync_v2, 'enable at least one sync version'
-        return self.simulator.create_peer(
-            peer_id=self.get_random_peer_id_from_pool(),
+        if simulator is None:
+            simulator = self.simulator
+        return simulator.create_peer(
+            peer_id=self.get_random_peer_id_from_pool(rng=simulator.rng),
             soft_voided_tx_ids=soft_voided_tx_ids,
             enable_sync_v1=enable_sync_v1,
             enable_sync_v2=enable_sync_v2,

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -32,6 +32,7 @@ from tests.utils import (
     add_blocks_unlock_reward,
     add_new_blocks,
     add_new_transactions,
+    add_new_tx,
     create_tokens,
 )
 
@@ -351,6 +352,18 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.manager.propagate_tx(block, fails_silently=False)
         self.reactor.advance(5)
         return block
+
+    def test_best_block_tips_cache(self):
+        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+        self.manager.wallet.unlock(b'MYPASS')
+        spent_blocks = add_new_blocks(self.manager, 10)
+        self.assertEqual(self.tx_storage._best_block_tips_cache, [spent_blocks[-1].hash])
+        unspent_blocks = add_blocks_unlock_reward(self.manager)
+        self.assertEqual(self.tx_storage._best_block_tips_cache, [unspent_blocks[-1].hash])
+        latest_blocks = add_blocks_unlock_reward(self.manager)
+        unspent_address = self.manager.wallet.get_unused_address()
+        add_new_tx(self.manager, unspent_address, 100)
+        self.assertEqual(self.tx_storage._best_block_tips_cache, [latest_blocks[-1].hash])
 
     def test_topological_sort(self):
         _set_test_mode(TestMode.TEST_ALL_WEIGHT)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,17 +50,17 @@ def resolve_block_bytes(block_bytes):
 
 def add_custom_tx(manager: HathorManager, tx_inputs: List[Tuple[BaseTransaction, int]], *, n_outputs: int = 1,
                   base_parent: Optional[Transaction] = None, weight: Optional[float] = None,
-                  resolve: bool = False, address: Optional[str] = None) -> Transaction:
+                  resolve: bool = False, address: Optional[str] = None, inc_timestamp: int = 0) -> Transaction:
     """Add a custom tx based on the gen_custom_tx(...) method."""
     tx = gen_custom_tx(manager, tx_inputs, n_outputs=n_outputs, base_parent=base_parent, weight=weight,
-                       resolve=resolve, address=address)
+                       resolve=resolve, address=address, inc_timestamp=inc_timestamp)
     manager.propagate_tx(tx, fails_silently=False)
     return tx
 
 
 def gen_custom_tx(manager: HathorManager, tx_inputs: List[Tuple[BaseTransaction, int]], *, n_outputs: int = 1,
                   base_parent: Optional[Transaction] = None, weight: Optional[float] = None,
-                  resolve: bool = False, address: Optional[str] = None) -> Transaction:
+                  resolve: bool = False, address: Optional[str] = None, inc_timestamp: int = 0) -> Transaction:
     """Generate a custom tx based on the inputs and outputs. It gives full control to the
     inputs and can be used to generate conflicts and specific patterns in the DAG."""
     wallet = manager.wallet
@@ -117,6 +117,7 @@ def gen_custom_tx(manager: HathorManager, tx_inputs: List[Tuple[BaseTransaction,
     assert len(tx2.parents) == 2
 
     tx2.weight = weight or 25
+    tx2.timestamp += inc_timestamp
     if resolve:
         tx2.resolve()
     else:


### PR DESCRIPTION
Fixes https://github.com/HathorNetwork/hathor-core/issues/481.

## Acceptance criteria

1. Fix calling events out-of-order.
2. Fix wallet wrongfully adding utxos of voided transactions.
3. Remove hard-coded hash from `tests/consensus/test_soft_voided.py`.
4. Refactor events: replace `STORAGE_TX_WINNER` and `STORAGE_TX_VOIDED` by `CONSENSUS_TX_UPDATE`.
