### PR TITLE
fix: database corruption when stopping node with cache enabled

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -36,7 +36,7 @@ from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion, sum_weights
 from hathor.transaction.exceptions import TxValidationError
-from hathor.transaction.storage import TransactionCacheStorage, TransactionStorage
+from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.util import LogDuration, Random, Reactor
 from hathor.wallet import BaseWallet

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -319,8 +319,7 @@ class HathorManager:
             if wait_stratum:
                 waits.append(wait_stratum)
 
-        if isinstance(self.tx_storage, TransactionCacheStorage):
-            self.tx_storage.flush()
+        self.tx_storage.flush()
 
         return defer.DeferredList(waits)
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -36,7 +36,7 @@ from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion, sum_weights
 from hathor.transaction.exceptions import TxValidationError
-from hathor.transaction.storage import TransactionStorage
+from hathor.transaction.storage import TransactionStorage, TransactionCacheStorage
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.util import LogDuration, Random, Reactor
 from hathor.wallet import BaseWallet
@@ -318,6 +318,10 @@ class HathorManager:
             wait_stratum = self.stratum_factory.stop()
             if wait_stratum:
                 waits.append(wait_stratum)
+
+        if isinstance(self.tx_storage, TransactionCacheStorage):
+            self.tx_storage.flush()
+
         return defer.DeferredList(waits)
 
     def do_discovery(self) -> None:

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -36,7 +36,7 @@ from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion, sum_weights
 from hathor.transaction.exceptions import TxValidationError
-from hathor.transaction.storage import TransactionStorage, TransactionCacheStorage
+from hathor.transaction.storage import TransactionCacheStorage, TransactionStorage
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.util import LogDuration, Random, Reactor
 from hathor.wallet import BaseWallet

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -217,3 +217,6 @@ class TransactionCacheStorage(BaseTransactionStorage):
 
     def get_value(self, key: str) -> Optional[str]:
         return self.store.get_value(key)
+
+    def flush(self):
+        self._flush_to_storage(self.dirty_txs.copy())

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -749,6 +749,7 @@ class TransactionStorage(ABC):
                 continue
             self.set_index_last_started_at(index_db_name, timestamp)
 
+    @abstractmethod
     def flush(self) -> None:
         """Flushes the storage. It's called during shutdown of the node, for instance.
 
@@ -1125,8 +1126,4 @@ class BaseTransactionStorage(TransactionStorage):
         return result
 
     def flush(self) -> None:
-        """Flushes the storage. It's called during shutdown of the node, for instance.
-
-           Should be implemented by storages that provide some kind of in-memory cache
-        """
         pass

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -749,6 +749,13 @@ class TransactionStorage(ABC):
                 continue
             self.set_index_last_started_at(index_db_name, timestamp)
 
+    def flush(self) -> None:
+        """Flushes the storage. It's called during shutdown of the node, for instance.
+
+           Should be implemented by storages that provide some kind of in-memory cache
+        """
+        raise NotImplementedError
+
 
 class BaseTransactionStorage(TransactionStorage):
     def __init__(self, with_index: bool = True, pubsub: Optional[Any] = None) -> None:
@@ -1116,3 +1123,10 @@ class BaseTransactionStorage(TransactionStorage):
                     used.add(parent_hash)
                     pending_visits.append(parent_hash)
         return result
+
+    def flush(self) -> None:
+        """Flushes the storage. It's called during shutdown of the node, for instance.
+
+           Should be implemented by storages that provide some kind of in-memory cache
+        """
+        pass


### PR DESCRIPTION
fixes: https://github.com/HathorNetwork/hathor-core/issues/487

### Acceptance Criteria
We shouldn't corrupt the database when stopping the node.

There is a better description of the error and the exact scenario that triggered it in the issue above.

I've only observed this when running a local fullnode and stopping it with `Ctrl + C`, but I'm not sure if this couldn't also happen when running it with Docker in the cloud.