### PR TITLE
feat(cli): make rocksdb indexes the default for rocksdb storage

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -17,7 +17,7 @@ import json
 import os
 import platform
 import sys
-from argparse import ArgumentParser, Namespace
+from argparse import SUPPRESS, ArgumentParser, Namespace
 from typing import Any, Callable, Dict, List, Tuple
 
 from autobahn.twisted.resource import WebSocketResource
@@ -57,8 +57,10 @@ class RunNode:
         parser.add_argument('--data', help='Data directory')
         storage = parser.add_mutually_exclusive_group()
         storage.add_argument('--rocksdb-storage', action='store_true', help='Use RocksDB storage backend (default)')
-        storage.add_argument('--memory-storage', action='store_true', help='Do not use any storage')
+        storage.add_argument('--memory-storage', action='store_true', help='Do not use a persistent storage')
         storage.add_argument('--json-storage', action='store_true', help='Use legacy JSON storage (not recommended)')
+        parser.add_argument('--memory-indexes', action='store_true',
+                            help='Use memory indexes when using RocksDB storage (startup is significantly slower)')
         parser.add_argument('--rocksdb-cache', type=int, help='RocksDB block-table cache size (bytes)', default=None)
         parser.add_argument('--wallet', help='Set wallet type. Options are hd (Hierarchical Deterministic) or keypair',
                             default=None)
@@ -82,10 +84,7 @@ class RunNode:
         parser.add_argument('--allow-mining-without-peers', action='store_true', help='Allow mining without peers')
         fvargs = parser.add_mutually_exclusive_group()
         fvargs.add_argument('--x-full-verification', action='store_true', help='Fully validate the local database')
-        fvargs.add_argument('--x-fast-init-beta', action='store_true',
-                            help='Execute a fast initialization, which skips some transaction verifications. '
-                            'This is still a beta feature as it may cause issues when restarting the full node '
-                            'after a crash.')
+        fvargs.add_argument('--x-fast-init-beta', action='store_true', help=SUPPRESS)
         parser.add_argument('--procname-prefix', help='Add a prefix to the process name', default='')
         parser.add_argument('--allow-non-standard-script', action='store_true', help='Accept non-standard scripts on '
                             '/push-tx API')
@@ -100,7 +99,7 @@ class RunNode:
         v2args.add_argument('--x-sync-v2-only', action='store_true',
                             help='Disable support for running sync-v1. DO NOT ENABLE, IT WILL BREAK.')
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
-        parser.add_argument('--x-rocksdb-indexes', action='store_true', help='Use RocksDB indexes (currently opt-in)')
+        parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
         parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')
         parser.add_argument('--x-retain-events', action='store_true', help='Retain all events in the local database')
         parser.add_argument('--peer-id-blacklist', action='extend', default=[], nargs='+', type=str,
@@ -220,11 +219,10 @@ class RunNode:
             if args.rocksdb_storage:
                 self.log.warn('--rocksdb-storage is now implied, no need to specify it')
             cache_capacity = args.rocksdb_cache
-            use_memory_indexes = not args.x_rocksdb_indexes
             rocksdb_storage = RocksDBStorage(path=args.data, cache_capacity=cache_capacity)
             tx_storage = TransactionRocksDBStorage(rocksdb_storage,
                                                    with_index=(not args.cache),
-                                                   use_memory_indexes=use_memory_indexes)
+                                                   use_memory_indexes=args.memory_indexes)
         self.log.info('with storage', storage_class=type(tx_storage).__name__, path=args.data)
         if args.cache:
             check_or_exit(not args.memory_storage, '--cache should not be used with --memory-storage')
@@ -306,6 +304,14 @@ class RunNode:
             self.manager._full_verification = True
         if args.x_fast_init_beta:
             self.log.warn('--x-fast-init-beta is now the default, no need to specify it')
+        if args.x_rocksdb_indexes:
+            self.log.warn('--x-rocksdb-indexes is now the default, no need to specify it')
+            if args.memory_indexes:
+                self.log.error('You cannot use --memory-indexes and --x-rocksdb-indexes.')
+                sys.exit(-1)
+
+        if args.memory_indexes and (args.memory_storage or args.json_storage):
+            self.log.warn('--memory-indexes is implied for memory storage or JSON storage')
 
         if args.x_enable_event_queue:
             if not settings.ENABLE_EVENT_QUEUE_FEATURE:


### PR DESCRIPTION
## Acceptance criteria

- Starting the node with no specific parameters should default to using the rocksdb indexes (when rocksdb storage is used, which is already default);
- Setting the node to use memory storage should still imply memory indexes;
- There should be an option to use memory indexes with rocksdb storage;
- Using the old `--x-rocksdb-indexes` parameter should work but give a warning that it is deprecated (it basically has no effect now anyway);