### PR TITLE
feat(events): emit reorg event during consensus

### DIFF
--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -14,11 +14,14 @@
 
 from collections import defaultdict, deque
 from enum import Enum
-from typing import Any, Callable, Deque, Dict, List, Tuple, cast
+from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, List, Tuple, cast
 
 from twisted.internet.interfaces import IReactorFromThreads
 
 from hathor.util import Reactor, ReactorThread
+
+if TYPE_CHECKING:
+    from hathor.transaction import BaseTransaction, Block
 
 
 class HathorEvents(Enum):
@@ -166,6 +169,13 @@ class HathorEvents(Enum):
 class EventArguments:
     """Simple object for storing event arguments.
     """
+
+    # XXX: add these as needed, these attributes don't always exist, but when they do these are their types
+    tx: 'BaseTransaction'
+    reorg_size: int
+    old_best_block: 'Block'
+    new_best_block: 'Block'
+    common_block: 'Block'
 
     def __init__(self, **kwargs: Any) -> None:
         for key, value in kwargs.items():

--- a/hathor/simulator/miner.py
+++ b/hathor/simulator/miner.py
@@ -63,7 +63,7 @@ class MinerSimulator:
         """ Called when a new tx or block is received. It updates the current mining to the
         new block.
         """
-        tx = args.tx  # type: ignore
+        tx = args.tx
         if not tx.is_block:
             return
         if not self.block:

--- a/tests/event/test_event_manager.py
+++ b/tests/event/test_event_manager.py
@@ -14,25 +14,31 @@ class BaseEventManagerTest(unittest.TestCase):
         self.event_manager = self.manager.event_manager
 
     def test_if_event_is_persisted(self):
-        self.manager.pubsub.publish(HathorEvents.NETWORK_BEST_BLOCK_FOUND,
-                                    event={"test": "test1"})
+        block = self.manager.tx_storage.get_best_block()
+        self.manager.pubsub.publish(HathorEvents.NETWORK_BEST_BLOCK_FOUND, tx=block)
         self.run_to_completion()
         self.assertIsNotNone(self.event_storage.get_event(0))
 
+    def _fake_reorg_started(self):
+        block = self.manager.tx_storage.get_best_block()
+        # XXX: since we're faking these events, they don't neet to be consistent
+        self.manager.pubsub.publish(HathorEvents.REORG_STARTED, old_best_height=1, old_best_block=block,
+                                    new_best_height=1, new_best_block=block, reorg_size=1, common_block=block)
+
+    def _fake_reorg_finished(self):
+        self.manager.pubsub.publish(HathorEvents.REORG_FINISHED)
+
     def test_event_group(self):
-        self.manager.pubsub.publish(HathorEvents.REORG_STARTED,
-                                    event={"test": "test1"})
-        self.manager.pubsub.publish(HathorEvents.REORG_FINISHED,
-                                    event={"test": "test2"})
-        self.manager.pubsub.publish(HathorEvents.REORG_STARTED,
-                                    event={"test": "test3"})
-        self.manager.pubsub.publish(HathorEvents.REORG_FINISHED,
-                                    event={"test": "test4"})
+        self._fake_reorg_started()
+        self._fake_reorg_finished()
+        self._fake_reorg_started()
+        self._fake_reorg_finished()
         self.run_to_completion()
-        event1 = self.event_storage.get_event(0)
-        event2 = self.event_storage.get_event(1)
-        event3 = self.event_storage.get_event(2)
-        event4 = self.event_storage.get_event(3)
+        # XXX: 0 is a tx update
+        event1 = self.event_storage.get_event(1)
+        event2 = self.event_storage.get_event(2)
+        event3 = self.event_storage.get_event(3)
+        event4 = self.event_storage.get_event(4)
         self.assertEqual(HathorEvents(event1.type), HathorEvents.REORG_STARTED)
         self.assertIsNotNone(event1.group_id)
         self.assertEqual(HathorEvents(event2.type), HathorEvents.REORG_FINISHED)
@@ -42,35 +48,34 @@ class BaseEventManagerTest(unittest.TestCase):
         self.assertEqual(event3.group_id, event4.group_id)
 
     def test_cannot_start_group_twice(self):
-        self.manager.pubsub.publish(HathorEvents.REORG_STARTED,
-                                    event={"test": "test1"})
+        self._fake_reorg_started()
         self.run_to_completion()
         with self.assertRaises(AssertionError):
-            self.manager.pubsub.publish(HathorEvents.REORG_STARTED,
-                                        event={"test": "test1"})
+            self._fake_reorg_started()
             self.run_to_completion()
 
     def test_cannot_finish_group_that_was_not_started(self):
         with self.assertRaises(AssertionError):
-            self.manager.pubsub.publish(HathorEvents.REORG_FINISHED,
-                                        event={"test": "test1"})
+            self._fake_reorg_finished()
             self.run_to_completion()
 
     def test_cannot_finish_group_twice(self):
-        self.manager.pubsub.publish(HathorEvents.REORG_STARTED,
-                                    event={"test": "test1"})
-        self.manager.pubsub.publish(HathorEvents.REORG_FINISHED,
-                                    event={"test": "test2"})
+        self._fake_reorg_started()
+        self._fake_reorg_finished()
         self.run_to_completion()
         with self.assertRaises(AssertionError):
-            self.manager.pubsub.publish(HathorEvents.REORG_FINISHED,
-                                        event={"test": "test3"})
+            self._fake_reorg_finished()
             self.run_to_completion()
 
 
-class EventManagerWithSyncV1(unittest.SyncV1Params, BaseEventManagerTest):
+class SyncV1EventManager(unittest.SyncV1Params, BaseEventManagerTest):
     __test__ = True
 
 
-class EventManagerWithSyncV2(unittest.SyncV1Params, BaseEventManagerTest):
+class SyncV2EventManager(unittest.SyncV1Params, BaseEventManagerTest):
     __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeEventManagerTest(unittest.SyncBridgeParams, SyncV2EventManager):
+    pass

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -1,0 +1,131 @@
+from hathor.conf import HathorSettings
+from tests import unittest
+from tests.utils import add_new_blocks, get_genesis_key
+
+settings = HathorSettings()
+
+
+class BaseEventReorgTest(unittest.TestCase):
+    __test__ = False
+
+    def setUp(self):
+        super().setUp()
+        self.network = 'testnet'
+        self.manager = self.create_peer(self.network, event_storage=True)
+        self.event_manager = self.manager.event_manager
+        self.event_storage = self.event_manager.event_storage
+
+        # read genesis keys
+        self.genesis_private_key = get_genesis_key()
+        self.genesis_public_key = self.genesis_private_key.public_key()
+
+    def test_reorg_events(self):
+        from hathor.pubsub import HathorEvents
+
+        assert settings.REWARD_SPEND_MIN_BLOCKS == 10, 'this test was made with this hardcoded value in mind'
+
+        # add some blocks
+        blocks = add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
+
+        # make a re-org
+        self.log.debug('make reorg block')
+        block_to_replace = blocks[8]
+        tb0 = self.manager.make_custom_block_template(block_to_replace.parents[0], block_to_replace.parents[1:])
+        b0 = tb0.generate_mining_block(self.manager.rng, storage=self.manager.tx_storage)
+        b0.weight = 10
+        b0.resolve()
+        b0.verify()
+        self.manager.propagate_tx(b0, fails_silently=False)
+        self.log.debug('reorg block propagated')
+        self.run_to_completion()
+
+        # check events
+        event_count = self.event_storage.get_last_event().id + 1
+        events = []
+        for i in range(event_count):
+            events.append(self.event_storage.get_event(i))
+
+        # events are separated into portions that are sorted (indicated by using lists) and portions that are unsorted
+        # (indicated by using a custom class), the unsorted parts mean that the given events must be present, but not
+        # necessarily in the given order, to check that we sort both the expected and actual events by tx hash to be
+        # able to match them, but only for the "unsorted" portions will, for the "sorted" portions the order is
+        # expected to be the given one
+        class unsorted(list):
+            pass
+        expected_events_grouped = [
+            # XXX: the order of the following events can vary depending on which genesis is spent/confirmed first
+            unsorted([
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': settings.GENESIS_BLOCK_HASH.hex()}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': settings.GENESIS_TX1_HASH.hex()}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': settings.GENESIS_TX2_HASH.hex()}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[0].hash_hex}),
+            ]),
+            # XXX: these events must always have this order
+            [
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[0].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[1].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[1].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[2].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[2].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[3].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[3].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[4].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[4].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[5].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[5].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[6].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[6].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[7].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[7].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[8].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[8].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[9].hash_hex}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': blocks[9].hash_hex}),
+                (HathorEvents.REORG_STARTED, {'reorg_size': 2, 'previous_best_block': blocks[9].hash_hex,
+                                              'new_best_block': b0.hash_hex}),
+            ],
+            # XXX: for some reason the metadata update order of these events isn't always the same
+            unsorted([
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[8].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': blocks[9].hash_hex}),
+                (HathorEvents.CONSENSUS_TX_UPDATE, {'hash': b0.hash_hex}),
+            ]),
+            # XXX: these events must always have this order
+            [
+                (HathorEvents.REORG_FINISHED, {}),
+                (HathorEvents.NETWORK_NEW_TX_ACCEPTED, {'hash': b0.hash_hex}),
+            ],
+        ]
+
+        def zipchunkify(iterable, groups):
+            it = iter(iterable)
+            for group in groups:
+                list_to_yield = []
+                for _ in range(len(group)):
+                    list_to_yield.append(next(it))
+                yield list_to_yield, group
+
+        self.assertEqual(len(events), sum(map(len, expected_events_grouped)))
+
+        for actual_events, expected_events in zipchunkify(events, expected_events_grouped):
+            if isinstance(expected_events, unsorted):
+                actual_events.sort(key=lambda i: i.data.get('hash', ''))
+                expected_events.sort(key=lambda i: i[1].get('hash', ''))
+            for actual_event, expected_event in zip(actual_events, expected_events):
+                expected_event_type, expected_partial_data = expected_event
+                self.assertEqual(HathorEvents(actual_event.type), expected_event_type)
+                for expected_data_key, expected_data_value in expected_partial_data.items():
+                    self.assertEqual(actual_event.data[expected_data_key], expected_data_value)
+
+
+class SyncV1EventReorgTest(unittest.SyncV1Params, BaseEventReorgTest):
+    __test__ = True
+
+
+class SyncV2EventReorgTest(unittest.SyncV1Params, BaseEventReorgTest):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeEventReorgTest(unittest.SyncBridgeParams, SyncV2EventReorgTest):
+    pass

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -156,6 +156,17 @@ class TestCase(unittest.TestCase):
         if utxo_index:
             tx_storage.indexes.enable_utxo_index()
 
+        if event_storage is True:
+            # XXX: either bool or Optional[EventStorage] is accepted for event_storage
+            if self.use_memory_storage:
+                from hathor.event.storage import EventMemoryStorage
+                event_storage = EventMemoryStorage()
+            else:
+                from hathor.event.storage import EventRocksDBStorage
+                event_storage = EventRocksDBStorage(rocksdb_storage)
+        elif event_storage is False:
+            event_storage = None
+
         manager = HathorManager(
             self.clock,
             pubsub=pubsub,


### PR DESCRIPTION
Relevant design is [here](https://github.com/HathorNetwork/hathor-core/issues/405).

## Acceptance Criteria

- `REORG_STARTED` and `REORG_FINISHED` must be correctly emitted with their corresponding groups