### PR TITLE
fix(cli): regression made it so testnet couldn't be selected

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -24,8 +24,6 @@ from autobahn.twisted.resource import WebSocketResource
 from structlog import get_logger
 from twisted.web.resource import Resource
 
-from hathor.util import get_environment_info
-
 logger = get_logger()
 # LOGGING_CAPTURE_STDOUT = True
 
@@ -129,7 +127,7 @@ class RunNode:
             TransactionRocksDBStorage,
             TransactionStorage,
         )
-        from hathor.util import reactor
+        from hathor.util import get_environment_info, reactor
         from hathor.wallet import HDWallet, Wallet
 
         settings = HathorSettings()


### PR DESCRIPTION
I noticed the issue during [this CI run](https://github.com/HathorNetwork/hathor-core/actions/runs/3274465137/jobs/5388027001) logs the following:

```
Run docker run --rm hathor-core:test quick_test --data / --testnet
  docker run --rm hathor-core:test quick_test --data / --testnet
  shell: /usr/bin/bash -e {0}
  env:
    TEST_TAG: hathor-core:test
2022-10-18 14:50:56 [error    ] [hathor.cli.main] Uncaught exception:            
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/hathor/cli/main.py", line 159, in main
    sys.exit(CliManager().execute_from_command_line())
  File "/usr/local/lib/python3.8/site-packages/hathor/cli/main.py", line 154, in execute_from_command_line
    module.main()
  File "/usr/local/lib/python3.8/site-packages/hathor/cli/quick_test.py", line 62, in main
    QuickTest().run()
  File "/usr/local/lib/python3.8/site-packages/hathor/cli/run_node.py", line 713, in __init__
    self.prepare(args)
  File "/usr/local/lib/python3.8/site-packages/hathor/cli/quick_test.py", line 28, in prepare
    super().prepare(args)
  File "/usr/local/lib/python3.8/site-packages/hathor/cli/run_node.py", line 116, in prepare
    from hathor.daa import TestMode, _set_test_mode
  File "/usr/local/lib/python3.8/site-packages/hathor/daa.py", line 36, in <module>
    settings = HathorSettings()
  File "/usr/local/lib/python3.8/site-packages/hathor/conf/get_settings.py", line 29, in HathorSettings
    settings_module = get_settings_module()
  File "/usr/local/lib/python3.8/site-packages/hathor/conf/get_settings.py", line 43, in get_settings_module
    raise Exception('loading config twice with a different file')
Exception: loading config twice with a different file
Error: Process completed with exit code 2.
```

Which basically happens because `hathor.conf.settings` is imported before the cli arg which selects the correct conf to use has the chance to run. This regression was introduced by #490.

Currently we prevent the issue from happening by avoiding to import any `hathor` modules outside of methods when making `hathor.cli` modules, but there is no linter to catch this, and it was missed during review. We can probably improve this in the future to avoid the issue from happening "silently" (a CI task failed, but only _after_ the PR was merged).
