### PR TITLE
refactor(manager): Move contructor's parameter wallet_index and utxo_index to builder

### DIFF
--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -23,6 +23,7 @@ from structlog import get_logger
 from hathor.daa import TestMode, _set_test_mode
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
+from hathor.pubsub import PubSubManager
 from hathor.simulator.clock import HeapClock
 from hathor.simulator.miner import MinerSimulator
 from hathor.simulator.tx_generator import RandomTransactionGenerator
@@ -135,12 +136,15 @@ class Simulator:
         wallet = HDWallet(gap_limit=2)
         wallet._manually_initialize()
 
+        pubsub = PubSubManager(self._clock)
+
         assert peer_id is not None  # XXX: temporary, for checking that tests are using the peer_id
         if peer_id is None:
             peer_id = PeerId()
         tx_storage = TransactionMemoryStorage()
         manager = HathorManager(
             self._clock,
+            pubsub=pubsub,
             peer_id=peer_id,
             network=network,
             wallet=wallet,

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -50,7 +50,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
                                  transaction/blocks/metadata when returning those objects.
         :type _clone_if_needed: bool
         """
-        if store.with_index:
+        if store.indexes is not None:
             raise ValueError('internal storage cannot have indexes enabled')
 
         store.remove_cache()

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -2,6 +2,7 @@ from typing import Iterator
 
 from hathor.conf import HathorSettings
 from hathor.manager import HathorManager
+from hathor.pubsub import PubSubManager
 from hathor.transaction import BaseTransaction
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
@@ -38,35 +39,37 @@ class SimpleManagerInitializationTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.tx_storage = ModifiedTransactionMemoryStorage()
+        self.pubsub = PubSubManager(self.clock)
 
     def test_invalid_arguments(self):
         # this is a base case, it shouldn't raise any error
         # (otherwise we might not be testing the correct thing below)
-        manager = HathorManager(self.clock, tx_storage=self.tx_storage)
+        manager = HathorManager(self.clock, pubsub=self.pubsub, tx_storage=self.tx_storage)
         del manager
 
         # disabling both sync versions should be invalid
         with self.assertRaises(TypeError):
-            HathorManager(self.clock, tx_storage=self.tx_storage, enable_sync_v1=False, enable_sync_v2=False)
+            HathorManager(self.clock, pubsub=self.pubsub, tx_storage=self.tx_storage,
+                          enable_sync_v1=False, enable_sync_v2=False)
 
         # not passing a storage should be invalid
         with self.assertRaises(TypeError):
             HathorManager(self.clock)
 
     def tests_init_with_stratum(self):
-        manager = HathorManager(self.clock, tx_storage=self.tx_storage, stratum_port=50505)
+        manager = HathorManager(self.clock, pubsub=self.pubsub, tx_storage=self.tx_storage, stratum_port=50505)
         manager.start()
         manager.stop()
         del manager
 
     def test_double_start(self):
-        manager = HathorManager(self.clock, tx_storage=self.tx_storage)
+        manager = HathorManager(self.clock, pubsub=self.pubsub, tx_storage=self.tx_storage)
         manager.start()
         with self.assertRaises(Exception):
             manager.start()
 
     def test_wrong_stop(self):
-        manager = HathorManager(self.clock, tx_storage=self.tx_storage)
+        manager = HathorManager(self.clock, pubsub=self.pubsub, tx_storage=self.tx_storage)
         with self.assertRaises(Exception):
             manager.stop()
         manager.start()

--- a/tests/p2p/test_connections.py
+++ b/tests/p2p/test_connections.py
@@ -1,11 +1,7 @@
 import sys
-import tempfile
 
 import pytest
 
-from hathor.manager import HathorManager
-from hathor.transaction.storage import TransactionMemoryStorage
-from hathor.wallet import Wallet
 from tests import unittest
 from tests.utils import run_server
 
@@ -22,12 +18,7 @@ class ConnectionsTest(unittest.TestCase):
         process3.terminate()
 
     def test_manager_connections(self):
-        tx_storage = TransactionMemoryStorage()
-        tmpdir = tempfile.mkdtemp()
-        self.tmpdirs.append(tmpdir)
-        wallet = Wallet(directory=tmpdir)
-        wallet.unlock(b'teste')
-        manager = HathorManager(self.clock, tx_storage=tx_storage, wallet=wallet)
+        manager = self.create_peer('testnet', enable_sync_v1=True, enable_sync_v2=False)
 
         endpoint = 'tcp://127.0.0.1:8005'
         manager.connections.connect_to(endpoint, use_ssl=True)

--- a/tests/resources/transaction/test_utxo_search.py
+++ b/tests/resources/transaction/test_utxo_search.py
@@ -14,15 +14,9 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
     __test__ = False
 
     def setUp(self):
-        super().setUp()
+        super().setUp(utxo_index=True)
         self.web = StubSite(UtxoSearchResource(self.manager))
         self.manager.wallet.unlock(b'MYPASS')
-
-    def _manager_kwargs(self):
-        # TODO: when we are in Python 3.9+ we could use `return super()._manger_kwargs() | {'utxo_index': True}`
-        kwargs = super()._manager_kwargs()
-        kwargs.update(utxo_index=True)
-        return kwargs
 
     @inlineCallbacks
     def test_simple_gets(self):

--- a/tests/resources/wallet/test_lock.py
+++ b/tests/resources/wallet/test_lock.py
@@ -9,7 +9,7 @@ class BaseLockTest(_BaseResourceTest._ResourceTest):
     __test__ = False
 
     def setUp(self):
-        super().setUp()
+        super().setUp(unlock_wallet=False)
         self.web = StubSite(LockWalletResource(self.manager))
         self.web_unlock = StubSite(UnlockWalletResource(self.manager))
         self.web_state = StubSite(StateWalletResource(self.manager))

--- a/tests/resources/wallet/test_unlock.py
+++ b/tests/resources/wallet/test_unlock.py
@@ -10,7 +10,7 @@ class BaseUnlockTest(_BaseResourceTest._ResourceTest):
     __test__ = False
 
     def setUp(self):
-        super().setUp()
+        super().setUp(unlock_wallet=False)
         self.web = StubSite(UnlockWalletResource(self.manager))
         self.web_lock = StubSite(LockWalletResource(self.manager))
         self.web_state = StubSite(StateWalletResource(self.manager))


### PR DESCRIPTION
## Acceptance Criteria

1) Remove `wallet_index` and `utxo_index` from `HathorManager`'s constructor.
2) Refactor tests to use `self.create_peer(...)` instead of instantiating `HathorManager` directly.
3) Remove `TransactionStorage.with_index` attribute as a preparation to move the `IndexManager` instantiation to the builder.