### PR TITLE
fix(init): indexes could not be used on migrations when using cache

### DIFF
--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -92,8 +92,8 @@ class TransactionCacheStorage(BaseTransactionStorage):
         self.store.set_migration_state(migration_name, state)
 
     def pre_init(self) -> None:
-        # XXX: not calling super().pre_init() because it would run `BaseTransactionStorage.pre_init` twice.
-        self.store.pre_init()
+        # XXX: not calling self.store.pre_init() because it would run `BaseTransactionStorage.pre_init` twice.
+        super().pre_init()
         self.reactor.callLater(self.interval, self._start_flush_thread)
 
     def _enable_weakref(self) -> None:


### PR DESCRIPTION
This was noticed after we tried to deploy a node on the testnet using an old snapshot that happened to have cache enabled and the migration failed.

This is the error that happened:

```
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/hathor/transaction/storage/transaction_storage.py", line 220, in _check_and_apply_migrations
migration.run(self)
File "/usr/local/lib/python3.9/site-packages/hathor/transaction/storage/migrations/add_min_height_metadata.py", line 34, in run
for tx in storage.topological_iterator():
File "/usr/local/lib/python3.9/site-packages/hathor/transaction/storage/transaction_storage.py", line 683, in topological_iterator
assert self.indexes is not None
AssertionError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/hathor/cli/main.py", line 159, in main
sys.exit(CliManager().execute_from_command_line())
File "/usr/local/lib/python3.9/site-packages/hathor/cli/main.py", line 154, in execute_from_command_line
module.main()
File "/usr/local/lib/python3.9/site-packages/hathor/cli/run_node.py", line 301, in main
RunNode().run()
File "/usr/local/lib/python3.9/site-packages/hathor/cli/run_node.py", line 290, in __init__
self.prepare(args)
File "/usr/local/lib/python3.9/site-packages/hathor/cli/run_node.py", line 136, in prepare
self.start_manager(args)
File "/usr/local/lib/python3.9/site-packages/hathor/cli/run_node.py", line 163, in start_manager
self.manager.start()
File "/usr/local/lib/python3.9/site-packages/hathor/manager.py", line 312, in start
self._initialize_components_new()
File "/usr/local/lib/python3.9/site-packages/hathor/manager.py", line 598, in _initialize_components_new
self.tx_storage.pre_init()
File "/usr/local/lib/python3.9/site-packages/hathor/transaction/storage/cache_storage.py", line 96, in pre_init
self.store.pre_init()
File "/usr/local/lib/python3.9/site-packages/hathor/transaction/storage/transaction_storage.py", line 154, in pre_init
self._check_and_apply_migrations()
File "/usr/local/lib/python3.9/site-packages/hathor/transaction/storage/transaction_storage.py", line 224, in _check_and_apply_migrations
raise PartialMigrationError(f'Migration error state: {migration_name}') from exc
hathor.transaction.storage.exceptions.PartialMigrationError: Migration error state: add_min_height_metadata
```