### PR TITLE
chore(docs): fix worflow badges on rendered README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: |
         brew cleanup -q
-        brew update -q
+        # brew update -q
         brew install -q graphviz rocksdb
     - name: Install Poetry dependencies
       run: poetry install -n --no-root

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Mainnet](https://img.shields.io/badge/mainnet-live-success)](https://explorer.hathor.network/)
 [![Version](https://img.shields.io/github/v/release/HathorNetwork/hathor-core)](https://github.com/HathorNetwork/hathor-core/releases/latest)
-[![Testing](https://img.shields.io/github/workflow/status/HathorNetwork/hathor-core/tests?label=tests&logo=github)](https://github.com/HathorNetwork/hathor-core/actions?query=workflow%3Atests+branch%3Amaster)
-[![Ｄocker](https://img.shields.io/github/workflow/status/HathorNetwork/hathor-core/docker?label=build&logo=docker)](https://hub.docker.com/repository/docker/hathornetwork/hathor-core)
+[![Testing](https://img.shields.io/github/actions/workflow/status/HathorNetwork/hathor-core/main.yml?branch=master&label=tests&logo=github)](https://github.com/HathorNetwork/hathor-core/actions?query=workflow%3Atests+branch%3Amaster)
+[![Docker](https://img.shields.io/github/actions/workflow/status/HathorNetwork/hathor-core/docker.yml?branch=master&label=build&logo=docker)](https://hub.docker.com/repository/docker/hathornetwork/hathor-core)
 [![Codecov](https://img.shields.io/codecov/c/github/HathorNetwork/hathor-core?logo=codecov)](https://codecov.io/gh/hathornetwork/hathor-core)
 [![Discord](https://img.shields.io/discord/566500848570466316?logo=discord)](https://discord.com/invite/35mFEhk)
 [![License](https://img.shields.io/github/license/HathorNetwork/hathor-core)](./LICENSE.txt)


### PR DESCRIPTION
- [Broken README from v0.52.1 release](https://github.com/HathorNetwork/hathor-core/blob/v0.52.1/README.md)
- [Fixed README from this PR](https://github.com/HathorNetwork/hathor-core/blob/chore/fix-workflow-badges/README.md)

This is related to https://github.com/badges/shields/issues/8671

## Acceptance Criteria

- badges for `tests` and `build` workflows should be rendered correctly now