### PR TITLE
feat(mypy-daemon): implement mypy daemon commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cover/
 /coverage*
 
 .mypy_cache
+.dmypy.json
 .pytest_cache
 
 extras/docker/_build/

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ tests-full:
 mypy:
 	mypy -p hathor -p tests
 
+.PHONY: dmypy
+dmypy:
+	dmypy run --timeout 86400 -- -p hathor -p tests
+
 .PHONY: flake8
 flake8:
 	flake8 $(py_sources)
@@ -71,6 +75,9 @@ check-version:
 
 .PHONY: check
 check: check-version flake8 isort-check mypy
+
+.PHONY: check
+dcheck: check-version flake8 isort-check dmypy
 
 # formatting:
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ check-version:
 .PHONY: check
 check: check-version flake8 isort-check mypy
 
-.PHONY: check
+.PHONY: dcheck
 dcheck: check-version flake8 isort-check dmypy
 
 # formatting:

--- a/hathor/conf/get_settings.py
+++ b/hathor/conf/get_settings.py
@@ -15,10 +15,11 @@
 import importlib
 import os
 from types import ModuleType
+from typing import Optional
 
 from hathor.conf.settings import HathorSettings as Settings
 
-_config_file = None
+_config_file: Optional[str] = None
 
 
 def HathorSettings() -> Settings:


### PR DESCRIPTION
Implement `make dmypy` and `make dcheck` commands, analogous to the existing `make mypy` and `make check`.

[Mypy daemon](https://mypy.readthedocs.io/en/stable/mypy_daemon.html) is a mypy server running in the background. Once started, each subsequent `dmypy` call is 10 or more times faster than the regular `mypy` command, according to the docs. In my setup, `dmypy` runs almost instantaneously while `mypy` can take several minutes sometimes, really slowing down the workflow when you're fighting with type hints.

I set a timeout of `86400` seconds (1 day) in the command, that is, the daemon will shut down itself after 1 day of inactivity. It can also be stopped manually before that with the `dmypy stop` command.