### PR TITLE
feat(events): remove NETWORK_NEW_TX_VOIDED event

### DIFF
--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -33,7 +33,6 @@ _GROUP_END_EVENTS = {
 
 _SUBSCRIBE_EVENTS = [
     HathorEvents.NETWORK_NEW_TX_ACCEPTED,
-    HathorEvents.NETWORK_NEW_TX_VOIDED,
     HathorEvents.NETWORK_BEST_BLOCK_FOUND,
     HathorEvents.NETWORK_ORPHAN_BLOCK_FOUND,
     HathorEvents.LOAD_STARTED,
@@ -75,7 +74,6 @@ _EVENT_EXTRACT_MAP: Dict[HathorEvents, Callable[[EventArguments], Dict[str, Any]
     HathorEvents.LOAD_STARTED: _empty,
     HathorEvents.LOAD_FINISHED: _empty,
     HathorEvents.NETWORK_NEW_TX_ACCEPTED: _extract_tx,
-    HathorEvents.NETWORK_NEW_TX_VOIDED: _extract_tx,
     HathorEvents.NETWORK_BEST_BLOCK_FOUND: _extract_tx,
     HathorEvents.NETWORK_ORPHAN_BLOCK_FOUND: _extract_tx,
     HathorEvents.REORG_STARTED: _extract_reorg,

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -34,10 +34,6 @@ class HathorEvents(Enum):
             Triggered when a peer connection to the network fails
             Publishes the peer id and the peers count
 
-        NETWORK_NEW_TX_VOIDED
-            Triggered when a new transaction is voided in the network
-            Publishes a tx object
-
         NETWORK_BEST_BLOCK_FOUND
             Triggered when a new block is accepted in the network
             Publishes a block object

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -129,8 +129,6 @@ class HathorEvents(Enum):
 
     CONSENSUS_TX_REMOVED = 'consensus:tx_removed'
 
-    NETWORK_NEW_TX_VOIDED = 'network:new_tx_voided'
-
     NETWORK_BEST_BLOCK_FOUND = 'network:best_block_found'
 
     NETWORK_ORPHAN_BLOCK_FOUND = 'network:orphan_block_found'


### PR DESCRIPTION
After discussing with @jansegre , we came to the conclusion that this event is not necessary and its meaning will be covered be the `TX_METADATA_CHANGED` / `BLOCK_METADATA_CHANGED` events.