### PR TITLE
chore(ci): fix installing dependencies on macos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         brew cleanup -q
         # brew update -q
-        brew install -q graphviz rocksdb
+        brew install -q graphviz rocksdb pkg-config
     - name: Install Poetry dependencies
       run: poetry install -n --no-root
     - name: Cache mypy


### PR DESCRIPTION
## Acceptance Criteria

- CI run for macos should be working again
- nothing else must be affected