### PR TITLE
feat(events): remove NETWORK_BEST_BLOCK_FOUND and NETWORK_ORPHAN_BLOCK_FOUND events

### DIFF
--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -34,8 +34,6 @@ _GROUP_END_EVENTS = {
 
 _SUBSCRIBE_EVENTS = [
     HathorEvents.NETWORK_NEW_TX_ACCEPTED,
-    HathorEvents.NETWORK_BEST_BLOCK_FOUND,
-    HathorEvents.NETWORK_ORPHAN_BLOCK_FOUND,
     HathorEvents.LOAD_STARTED,
     HathorEvents.LOAD_FINISHED,
     HathorEvents.REORG_STARTED,

--- a/hathor/event/model/base_event.py
+++ b/hathor/event/model/base_event.py
@@ -24,8 +24,6 @@ _EVENT_DATA_MAP: Dict[HathorEvents, Type[BaseEventData]] = {
     HathorEvents.LOAD_STARTED: EmptyData,
     HathorEvents.LOAD_FINISHED: EmptyData,
     HathorEvents.NETWORK_NEW_TX_ACCEPTED: TxData,
-    HathorEvents.NETWORK_BEST_BLOCK_FOUND: TxData,
-    HathorEvents.NETWORK_ORPHAN_BLOCK_FOUND: TxData,
     HathorEvents.REORG_STARTED: ReorgData,
     HathorEvents.REORG_FINISHED: EmptyData,
     HathorEvents.VERTEX_METADATA_CHANGED: TxData,

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -34,14 +34,6 @@ class HathorEvents(Enum):
             Triggered when a peer connection to the network fails
             Publishes the peer id and the peers count
 
-        NETWORK_BEST_BLOCK_FOUND
-            Triggered when a new block is accepted in the network
-            Publishes a block object
-
-        NETWORK_ORPHAN_BLOCK_FOUND
-            Triggered when a new block is voided in the network
-            Publishes a block object
-
         NETWORK_PEER_CONNECTED:
             Triggered when a new peer connects to the network
             Publishes the peer protocol and the peers count
@@ -121,10 +113,6 @@ class HathorEvents(Enum):
     CONSENSUS_TX_UPDATE = 'consensus:tx_update'
 
     CONSENSUS_TX_REMOVED = 'consensus:tx_removed'
-
-    NETWORK_BEST_BLOCK_FOUND = 'network:best_block_found'
-
-    NETWORK_ORPHAN_BLOCK_FOUND = 'network:orphan_block_found'
 
     WALLET_OUTPUT_RECEIVED = 'wallet:output_received'
 

--- a/tests/event/test_event_manager.py
+++ b/tests/event/test_event_manager.py
@@ -30,7 +30,7 @@ class BaseEventManagerTest(unittest.TestCase):
 
     def test_if_event_is_persisted(self):
         block = self.manager.tx_storage.get_best_block()
-        self.manager.pubsub.publish(HathorEvents.NETWORK_BEST_BLOCK_FOUND, tx=block)
+        self.manager.pubsub.publish(HathorEvents.NETWORK_NEW_TX_ACCEPTED, tx=block)
         self.run_to_completion()
         self.assertIsNotNone(self.event_storage.get_event(0))
 


### PR DESCRIPTION
Acceptance Criteria:

- Remove `NETWORK_BEST_BLOCK_FOUND` event
- Remove `NETWORK_ORPHAN_BLOCK_FOUND` event

Just like in https://github.com/HathorNetwork/hathor-core/pull/529, where `NETWORK_NEW_TX_VOIDED` was removed, after discussing with @jansegre we came to the conclusion that these two events are not necessary and can be removed as well. Their functionality is already covered by existing events. It may be necessary, though, to add new attributes in the event body to represent the different types. This will be clearer when implementing an use case, and then a new PR may be created.