### PR TITLE
ci: add commit sha on nigthly image tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,8 @@ jobs:
         default_python = 'python' + extract_pyver(dockerfile_cpython)
         default_pypy = 'pypy' + extract_pyver(dockerfile_pypy)
         if '${{ github.event_name }}' == 'schedule':
-            base_version = 'nightly'
+            commit_short_sha = '${{ github.sha }}'[:8]
+            base_version = 'nightly-' + commit_short_sha
         elif ref.startswith('refs/tags/'):
             base_version = ref[10:].split('-', 1)[0]
         elif ref.startswith('refs/heads/'):


### PR DESCRIPTION
### Acceptance Criteria

- Add the git commit sha in nightly Docker images tag

### Notes

For the schedule event, which is the one we use to build nightlies, the commit sha of the default branch is the one included in the build context: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

This is enough for us, since we will always build nightlies from the default branch.

