### PR TITLE
feat: allow version overwriting by creating a BUILD_VERSION file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ isort-check:
 
 .PHONY: check-version
 check-version:
-	bash ./extras/check_version.sh
+	bash ./extras/check_version.sh $(VERSION)
 
 .PHONY: check
 check: check-version flake8 isort-check mypy

--- a/extras/check_version.sh
+++ b/extras/check_version.sh
@@ -3,7 +3,6 @@
 OPENAPI_FILE="hathor/cli/openapi_files/openapi_base.json"
 SRC_FILE="hathor/version.py"
 PACKAGE_FILE="pyproject.toml"
-BUILD_VERSION_FILE="BUILD_VERSION"
 
 OPENAPI_VERSION=`grep "version\":" ${OPENAPI_FILE} | cut -d'"' -f4`
 SRC_VERSION=`grep "BASE_VERSION =" ${SRC_FILE} | cut -d "'" -f2`
@@ -26,14 +25,12 @@ if [[ x${PACKAGE_VERSION}x != x${OPENAPI_VERSION}x ]]; then
 	EXITCODE=-1
 fi
 
-if [[ -f "$BUILD_VERSION_FILE" ]]; then
-	# Get the build version and ignore the suffix
-    BUILD_VERSION=$(cat "$BUILD_VERSION_FILE" | cut -d"-" -f1)
-
-	if [[ x${PACKAGE_VERSION}x != x${BUILD_VERSION}x ]]; then
-		echo "Version different in ${PACKAGE_FILE} and ${BUILD_VERSION_FILE}"
-		EXITCODE=-1
-	fi
+# We expect an optional argument containing a version string to be checked against the others
+if [[ $# -eq 1 ]]; then
+    if [[ x${PACKAGE_VERSION}x != x$1x ]]; then
+        echo "Version different in ${PACKAGE_FILE} and passed argument"
+        EXITCODE=-1
+    fi
 fi
 
 exit $EXITCODE

--- a/extras/check_version.sh
+++ b/extras/check_version.sh
@@ -4,8 +4,11 @@
 # This script will check all source files containing the project version and exit with an error code -1 in case
 # they don't match.
 #
-# An optional argument is also accepted containing a version string to be checked agaisnt the others.
-# E.g: ./extras/check_version.sh 0.52.1
+# usage: ./extras/check_version.sh [version]
+#
+# example: ./extras/check_version.sh 0.52.1
+#
+# When a version is provided, it is checked against the package version.
 ###
 
 OPENAPI_FILE="hathor/cli/openapi_files/openapi_base.json"

--- a/extras/check_version.sh
+++ b/extras/check_version.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+###
+# This script will check all source files containing the project version and exit with an error code -1 in case
+# they don't match.
+#
+# An optional argument is also accepted containing a version string to be checked agaisnt the others.
+# E.g: ./extras/check_version.sh 0.52.1
+###
+
 OPENAPI_FILE="hathor/cli/openapi_files/openapi_base.json"
 SRC_FILE="hathor/version.py"
 PACKAGE_FILE="pyproject.toml"

--- a/extras/check_version.sh
+++ b/extras/check_version.sh
@@ -3,9 +3,10 @@
 OPENAPI_FILE="hathor/cli/openapi_files/openapi_base.json"
 SRC_FILE="hathor/version.py"
 PACKAGE_FILE="pyproject.toml"
+BUILD_VERSION_FILE="BUILD_VERSION"
 
 OPENAPI_VERSION=`grep "version\":" ${OPENAPI_FILE} | cut -d'"' -f4`
-SRC_VERSION=`grep "__version__" ${SRC_FILE} | cut -d "'" -f2`
+SRC_VERSION=`grep "BASE_VERSION =" ${SRC_FILE} | cut -d "'" -f2`
 PACKAGE_VERSION=`grep '^version' ${PACKAGE_FILE} | cut -d '"' -f2`
 
 # For debugging:
@@ -23,6 +24,16 @@ fi
 if [[ x${PACKAGE_VERSION}x != x${OPENAPI_VERSION}x ]]; then
 	echo "Version different in ${PACKAGE_FILE} and ${OPENAPI_FILE}"
 	EXITCODE=-1
+fi
+
+if [[ -f "$BUILD_VERSION_FILE" ]]; then
+	# Get the build version and ignore the suffix
+    BUILD_VERSION=$(cat "$BUILD_VERSION_FILE" | cut -d"-" -f1)
+
+	if [[ x${PACKAGE_VERSION}x != x${BUILD_VERSION}x ]]; then
+		echo "Version different in ${PACKAGE_FILE} and ${BUILD_VERSION_FILE}"
+		EXITCODE=-1
+	fi
 fi
 
 exit $EXITCODE

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -12,4 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.53.0'
+import os
+
+BASE_VERSION = '0.53.0'
+
+DEFAULT_VERSION_SUFFIX = "-local"
+BUILD_VERSION_FILE_PATH = "./BUILD_VERSION"
+
+
+def _get_build_version():
+    if not os.path.isfile(BUILD_VERSION_FILE_PATH):
+        return None
+
+    with open(BUILD_VERSION_FILE_PATH, 'r') as f:
+        build_version = f.readline()
+
+        return build_version
+
+
+def _get_version():
+    local_version = BASE_VERSION + DEFAULT_VERSION_SUFFIX
+    return _get_build_version() or local_version
+
+
+__version__ = _get_version()

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -13,24 +13,47 @@
 # limitations under the License.
 
 import os
+import re
+from typing import Optional
+
+from structlog import get_logger
 
 BASE_VERSION = '0.53.0'
 
 DEFAULT_VERSION_SUFFIX = "-local"
 BUILD_VERSION_FILE_PATH = "./BUILD_VERSION"
 
+# Valid formats: 1.2.3, 1.2.3-rc.1 and nightly-ab49c20f
+BUILD_VERSION_REGEX = r"^(\d+\.\d+\.\d+(-rc\.\d+)?|nightly-[a-f0-9]{7,8})$"
 
-def _get_build_version():
+
+logger = get_logger()
+
+
+def _get_build_version() -> Optional[str]:
+    """Try to get the build version from BUILD_VERSION_FILE_PATH and validate it.
+
+    :return: The build version or None, if there is no file or the version is invalid.
+    """
     if not os.path.isfile(BUILD_VERSION_FILE_PATH):
         return None
 
     with open(BUILD_VERSION_FILE_PATH, 'r') as f:
         build_version = f.readline()
+        match = re.match(BUILD_VERSION_REGEX, build_version)
 
-        return build_version
+        if match:
+            return build_version
+        else:
+            logger.warn("A build version with an invalid format was found. Ignoring it.", build_version=build_version)
+            return None
 
 
-def _get_version():
+def _get_version() -> str:
+    """Get the current hathor-core version from the build version or the default one with a local suffix
+
+    :return: The current hathor-core version
+    """
     local_version = BASE_VERSION + DEFAULT_VERSION_SUFFIX
     return _get_build_version() or local_version
 

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -65,7 +65,7 @@ def _get_local_version() -> str:
     git_head = _get_git_revision_short_hash()
 
     if git_head:
-        return f"{BASE_VERSION}-{_get_git_revision_short_hash()}-{DEFAULT_VERSION_SUFFIX}"
+        return f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}"
 
     return f"{BASE_VERSION}-{DEFAULT_VERSION_SUFFIX}"
 

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from unittest.mock import patch
 
 from twisted.internet.defer import inlineCallbacks
@@ -8,6 +9,8 @@ from hathor.version import BASE_VERSION, DEFAULT_VERSION_SUFFIX, _get_version
 from hathor.version_resource import VersionResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
+
+TMP_DIR = tempfile.gettempdir()
 
 
 class BaseVersionTest(_BaseResourceTest._ResourceTest):
@@ -23,23 +26,23 @@ class BaseVersionTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
         self.assertEqual(data['version'], hathor.__version__)
 
-    @patch('hathor.version.BUILD_VERSION_FILE_PATH', '/tmp/BUILD_VERSION')
+    @patch('hathor.version.BUILD_VERSION_FILE_PATH', TMP_DIR + '/BUILD_VERSION')
     def test_local_version(self):
         """Test that we will return a version with the default prefix when the BUILD_VERSION file
             does not exist.
         """
         self.assertEqual(_get_version(), BASE_VERSION + DEFAULT_VERSION_SUFFIX)
 
-    @patch('hathor.version.BUILD_VERSION_FILE_PATH', '/tmp/BUILD_VERSION')
+    @patch('hathor.version.BUILD_VERSION_FILE_PATH', TMP_DIR + '/BUILD_VERSION')
     def test_build_version(self):
         """Test that we will return the version from the BUILD_VERSION file when it exists.
         """
-        with open('/tmp/BUILD_VERSION', 'w') as build_version_file:
+        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
             build_version_file.write(BASE_VERSION + '-nightly')
 
         self.assertEqual(_get_version(), BASE_VERSION + '-nightly')
 
-        os.remove('/tmp/BUILD_VERSION')
+        os.remove(TMP_DIR + '/BUILD_VERSION')
 
 
 class SyncV1VersionTest(unittest.SyncV1Params, BaseVersionTest):

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -1,6 +1,10 @@
+import os
+from unittest.mock import patch
+
 from twisted.internet.defer import inlineCallbacks
 
 import hathor
+from hathor.version import BASE_VERSION, DEFAULT_VERSION_SUFFIX, _get_version
 from hathor.version_resource import VersionResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
@@ -18,6 +22,24 @@ class BaseVersionTest(_BaseResourceTest._ResourceTest):
         response = yield self.web.get("version")
         data = response.json_value()
         self.assertEqual(data['version'], hathor.__version__)
+
+    @patch('hathor.version.BUILD_VERSION_FILE_PATH', '/tmp/BUILD_VERSION')
+    def test_local_version(self):
+        """Test that we will return a version with the default prefix when the BUILD_VERSION file
+            does not exist.
+        """
+        self.assertEqual(_get_version(), BASE_VERSION + DEFAULT_VERSION_SUFFIX)
+
+    @patch('hathor.version.BUILD_VERSION_FILE_PATH', '/tmp/BUILD_VERSION')
+    def test_build_version(self):
+        """Test that we will return the version from the BUILD_VERSION file when it exists.
+        """
+        with open('/tmp/BUILD_VERSION', 'w') as build_version_file:
+            build_version_file.write(BASE_VERSION + '-nightly')
+
+        self.assertEqual(_get_version(), BASE_VERSION + '-nightly')
+
+        os.remove('/tmp/BUILD_VERSION')
 
 
 class SyncV1VersionTest(unittest.SyncV1Params, BaseVersionTest):

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -35,12 +35,28 @@ class BaseVersionTest(_BaseResourceTest._ResourceTest):
 
     @patch('hathor.version.BUILD_VERSION_FILE_PATH', TMP_DIR + '/BUILD_VERSION')
     def test_build_version(self):
-        """Test that we will return the version from the BUILD_VERSION file when it exists.
+        """Test that we will return the version from the BUILD_VERSION file if it is valid,
+            or the local version if the BUILD_VERSION is invalid.
         """
         with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
-            build_version_file.write(BASE_VERSION + '-nightly')
+            build_version_file.write(BASE_VERSION)
+        self.assertEqual(_get_version(), BASE_VERSION)
 
-        self.assertEqual(_get_version(), BASE_VERSION + '-nightly')
+        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
+            build_version_file.write(BASE_VERSION + '-rc.1')
+        self.assertEqual(_get_version(), BASE_VERSION + '-rc.1')
+
+        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
+            build_version_file.write('nightly-a4b3f9c2')
+        self.assertEqual(_get_version(), 'nightly-a4b3f9c2')
+
+        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
+            build_version_file.write('v1.2.3')
+        self.assertEqual(_get_version(), BASE_VERSION + '-local')
+
+        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
+            build_version_file.write('1.2.3-beta')
+        self.assertEqual(_get_version(), BASE_VERSION + '-local')
 
         os.remove(TMP_DIR + '/BUILD_VERSION')
 

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -1,4 +1,4 @@
-import os
+import shutil
 import subprocess
 import tempfile
 from unittest.mock import patch
@@ -11,8 +11,6 @@ from hathor.version_resource import VersionResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 
-TMP_DIR = tempfile.gettempdir()
-
 
 class BaseVersionTest(_BaseResourceTest._ResourceTest):
     __test__ = False
@@ -20,6 +18,11 @@ class BaseVersionTest(_BaseResourceTest._ResourceTest):
     def setUp(self):
         super().setUp()
         self.web = StubSite(VersionResource(self.manager))
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.tmp_dir)
 
     @inlineCallbacks
     def test_get(self):
@@ -27,44 +30,44 @@ class BaseVersionTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
         self.assertEqual(data['version'], hathor.__version__)
 
-    @patch('hathor.version.BUILD_VERSION_FILE_PATH', TMP_DIR + '/BUILD_VERSION')
     def test_local_version(self):
         """Test that we will return a version with the default prefix when the BUILD_VERSION file
             does not exist.
         """
-        git_head = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
-        self.assertEqual(_get_version(), f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}")
+        with patch('hathor.version.BUILD_VERSION_FILE_PATH', self.tmp_dir + '/BUILD_VERSION'):
+            git_head = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+            self.assertEqual(_get_version(), f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}")
 
-    @patch('hathor.version.BUILD_VERSION_FILE_PATH', TMP_DIR + '/BUILD_VERSION')
     def test_build_version(self):
         """Test that we will return the version from the BUILD_VERSION file if it is valid,
             or the local version if the BUILD_VERSION is invalid.
         """
-        # Valid BUILD_VERSION files
-        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
-            build_version_file.write(BASE_VERSION)
-        self.assertEqual(_get_version(), BASE_VERSION)
+        file_path = self.tmp_dir + '/BUILD_VERSION'
 
-        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
-            build_version_file.write(BASE_VERSION + '-rc.1')
-        self.assertEqual(_get_version(), BASE_VERSION + '-rc.1')
+        with patch('hathor.version.BUILD_VERSION_FILE_PATH', file_path):
+            # Valid BUILD_VERSION files
+            with open(file_path, 'w') as build_version_file:
+                build_version_file.write(BASE_VERSION)
+            self.assertEqual(_get_version(), BASE_VERSION)
 
-        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
-            build_version_file.write('nightly-a4b3f9c2')
-        self.assertEqual(_get_version(), 'nightly-a4b3f9c2')
+            with open(file_path, 'w') as build_version_file:
+                build_version_file.write(BASE_VERSION + '-rc.1')
+            self.assertEqual(_get_version(), BASE_VERSION + '-rc.1')
 
-        # Invalid BUILD_VERSION files
-        git_head = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+            with open(file_path, 'w') as build_version_file:
+                build_version_file.write('nightly-a4b3f9c2')
+            self.assertEqual(_get_version(), 'nightly-a4b3f9c2')
 
-        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
-            build_version_file.write('v1.2.3')
-        self.assertEqual(_get_version(), f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}")
+            # Invalid BUILD_VERSION files
+            git_head = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
 
-        with open(TMP_DIR + '/BUILD_VERSION', 'w') as build_version_file:
-            build_version_file.write('1.2.3-beta')
-        self.assertEqual(_get_version(), f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}")
+            with open(file_path, 'w') as build_version_file:
+                build_version_file.write('v1.2.3')
+            self.assertEqual(_get_version(), f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}")
 
-        os.remove(TMP_DIR + '/BUILD_VERSION')
+            with open(file_path, 'w') as build_version_file:
+                build_version_file.write('1.2.3-beta')
+            self.assertEqual(_get_version(), f"{BASE_VERSION}-{git_head}-{DEFAULT_VERSION_SUFFIX}")
 
 
 class SyncV1VersionTest(unittest.SyncV1Params, BaseVersionTest):


### PR DESCRIPTION
### Acceptance Criteria

1. We should be able to overwrite the version reported by hathor-core by creating a BUILD_VERSION file with the new version.
2. We should allow an optional arg in our `check_version.sh` script containing an additional version against which we should check


These mechanisms will be used mainly by CI/CD to inject the built version into Docker images and validate it.