### PR TITLE
feat: add best_block and best_block_tips to dag on status

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,5 +199,3 @@ redoc-cli bundle hathor/cli/openapi_files/openapi.json --output index.html
 
 [open-issue]: https://github.com/HathorNetwork/hathor-core/issues/new
 [create-pr]: https://github.com/HathorNetwork/hathor-core/compare
-
-.

--- a/README.md
+++ b/README.md
@@ -199,3 +199,5 @@ redoc-cli bundle hathor/cli/openapi_files/openapi.json --output index.html
 
 [open-issue]: https://github.com/HathorNetwork/hathor-core/issues/new
 [create-pr]: https://github.com/HathorNetwork/hathor-core/compare
+
+.

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -187,12 +187,12 @@ StatusResource.openapi = {
                                             'latest_timestamp': 1539271483,
                                             'best_block_tips': [
                                                 {
-                                                    'hash': '000006c',
+                                                    'hash': '000007eb968a6cdf0499e2d033faf1e163e0dc9cf41876acad4d421836972038',  # noqa: E501
                                                     'height': 0
                                                 }
                                             ],
                                             'best_block': {
-                                                'hash': '000006c',
+                                                'hash': '000007eb968a6cdf0499e2d033faf1e163e0dc9cf41876acad4d421836972038',  # noqa: E501
                                                 'height': 0
                                             }
                                         }

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -81,6 +81,15 @@ class StatusResource(Resource):
             })
 
         app = 'Hathor v{}'.format(hathor.__version__)
+
+        best_block_tips = []
+        for tip in self.manager.tx_storage.get_best_block_tips():
+            tx = self.manager.tx_storage.get_transaction(tip)
+            meta = tx.get_metadata()
+            best_block_tips.append({'hash': tx.hash_hex, 'height': meta.height})
+
+        best_block = self.manager.tx_storage.get_best_block()
+
         data = {
             'server': {
                 'id': self.manager.connections.my_peer.id,
@@ -100,6 +109,11 @@ class StatusResource(Resource):
             'dag': {
                 'first_timestamp': self.manager.tx_storage.first_timestamp,
                 'latest_timestamp': self.manager.tx_storage.latest_timestamp,
+                'best_block_tips': best_block_tips,
+                'best_block': {
+                    'hash': best_block.hash_hex,
+                    'height': best_block.get_metadata().height,
+                },
             }
         }
         return json_dumpb(data)
@@ -170,7 +184,17 @@ StatusResource.openapi = {
                                         },
                                         'dag': {
                                             'first_timestamp': 1539271481,
-                                            'latest_timestamp': 1539271483
+                                            'latest_timestamp': 1539271483,
+                                            'best_block_tips': [
+                                                {
+                                                    'hash': '000006c',
+                                                    'height': 0
+                                                }
+                                            ],
+                                            'best_block': {
+                                                'hash': '000006c',
+                                                'height': 0
+                                            }
                                         }
                                     }
                                 }

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -32,17 +32,27 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
         # We have the genesis block
         self.assertEqual(len(dag_data['best_block_tips']), 1)
         self.assertIsNotNone(dag_data['best_block_tips'][0])
-        # As we don't have a type, we most check if the keys are there,
+        # As we don't have a type, we must check if the keys are there,
         # and the types are correct
         self.assertIn('hash', dag_data['best_block_tips'][0])
         self.assertIn('height', dag_data['best_block_tips'][0])
         self.assertIsInstance(dag_data['best_block_tips'][0]['hash'], str)
         self.assertIsInstance(dag_data['best_block_tips'][0]['height'], int)
+        self.assertEqual(
+            dag_data['best_block_tips'][0]['hash'],
+            '339f47da87435842b0b1b528ecd9eac2495ce983b3e9c923a37e1befbe12c792'
+        )
+        self.assertEqual(dag_data['best_block_tips'][0]['height'], 0)
         self.assertIsNotNone(dag_data['best_block'])
         self.assertIn('hash', dag_data['best_block'])
         self.assertIn('height', dag_data['best_block'])
         self.assertIsInstance(dag_data['best_block']['hash'], str)
         self.assertIsInstance(dag_data['best_block']['height'], int)
+        self.assertEqual(
+            dag_data['best_block']['hash'],
+            '339f47da87435842b0b1b528ecd9eac2495ce983b3e9c923a37e1befbe12c792'
+        )
+        self.assertEqual(dag_data['best_block']['height'], 0)
 
     @inlineCallbacks
     def test_handshaking(self):

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -6,6 +6,7 @@ from hathor.p2p.resources import StatusResource
 from hathor.simulator import FakeConnection
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
+from hathor.conf.unittests import SETTINGS
 
 
 class BaseStatusTest(_BaseResourceTest._ResourceTest):
@@ -38,20 +39,14 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
         self.assertIn('height', dag_data['best_block_tips'][0])
         self.assertIsInstance(dag_data['best_block_tips'][0]['hash'], str)
         self.assertIsInstance(dag_data['best_block_tips'][0]['height'], int)
-        self.assertEqual(
-            dag_data['best_block_tips'][0]['hash'],
-            '339f47da87435842b0b1b528ecd9eac2495ce983b3e9c923a37e1befbe12c792'
-        )
+        self.assertEqual(dag_data['best_block_tips'][0]['hash'], SETTINGS.GENESIS_BLOCK_HASH.hex())
         self.assertEqual(dag_data['best_block_tips'][0]['height'], 0)
         self.assertIsNotNone(dag_data['best_block'])
         self.assertIn('hash', dag_data['best_block'])
         self.assertIn('height', dag_data['best_block'])
         self.assertIsInstance(dag_data['best_block']['hash'], str)
         self.assertIsInstance(dag_data['best_block']['height'], int)
-        self.assertEqual(
-            dag_data['best_block']['hash'],
-            '339f47da87435842b0b1b528ecd9eac2495ce983b3e9c923a37e1befbe12c792'
-        )
+        self.assertEqual(dag_data['best_block']['hash'], SETTINGS.GENESIS_BLOCK_HASH.hex())
         self.assertEqual(dag_data['best_block']['height'], 0)
 
     @inlineCallbacks

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -22,10 +22,27 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
     def test_get(self):
         response = yield self.web.get("status")
         data = response.json_value()
+
         server_data = data.get('server')
         self.assertEqual(server_data['app_version'], 'Hathor v{}'.format(hathor.__version__))
         self.assertEqual(server_data['network'], 'testnet')
         self.assertGreater(server_data['uptime'], 0)
+
+        dag_data = data.get('dag')
+        # We have the genesis block
+        self.assertEqual(len(dag_data['best_block_tips']), 1)
+        self.assertIsNotNone(dag_data['best_block_tips'][0])
+        # As we don't have a type, we most check if the keys are there,
+        # and the types are correct
+        self.assertIn('hash', dag_data['best_block_tips'][0])
+        self.assertIn('height', dag_data['best_block_tips'][0])
+        self.assertIsInstance(dag_data['best_block_tips'][0]['hash'], str)
+        self.assertIsInstance(dag_data['best_block_tips'][0]['height'], int)
+        self.assertIsNotNone(dag_data['best_block'])
+        self.assertIn('hash', dag_data['best_block'])
+        self.assertIn('height', dag_data['best_block'])
+        self.assertIsInstance(dag_data['best_block']['hash'], str)
+        self.assertIsInstance(dag_data['best_block']['height'], int)
 
     @inlineCallbacks
     def test_handshaking(self):

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -2,11 +2,11 @@ from twisted.internet import endpoints
 from twisted.internet.defer import inlineCallbacks
 
 import hathor
+from hathor.conf.unittests import SETTINGS
 from hathor.p2p.resources import StatusResource
 from hathor.simulator import FakeConnection
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from hathor.conf.unittests import SETTINGS
 
 
 class BaseStatusTest(_BaseResourceTest._ResourceTest):


### PR DESCRIPTION
### Motivation

This addition will allow the hathor-p2p-monitor to monitor synchronization with sync-v2 peers in a simplified way.

Ref.: https://github.com/HathorNetwork/hathor-p2p-monitor/pull/69

### Acceptance criteria

- add `best_block` and `best_block_tips` to dag property of `/status`

