### PR TITLE
bugfix: fix initialization order bugs

### DIFF
--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -14,12 +14,11 @@
 
 from argparse import ArgumentParser, Namespace
 
-from hathor.cli.events_simulator.scenario import Scenario
-
 DEFAULT_PORT = 8080
 
 
 def create_parser() -> ArgumentParser:
+    from hathor.cli.events_simulator.scenario import Scenario
     from hathor.cli.util import create_parser
 
     parser = create_parser()

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -54,6 +54,7 @@ class EventManager:
     """
 
     _peer_id: str
+    _is_running: bool = False
     _load_finished: bool = False
 
     @property
@@ -85,9 +86,11 @@ class EventManager:
     def start(self, peer_id: str) -> None:
         self._peer_id = peer_id
         self._event_ws_factory.start()
+        self._is_running = True
 
     def stop(self):
         self._event_ws_factory.stop()
+        self._is_running = False
 
     def _assert_closed_event_group(self):
         # XXX: we must check that the last event either does not belong to an event group or that it just closed an
@@ -110,6 +113,8 @@ class EventManager:
             self._pubsub.subscribe(event, self._handle_event)
 
     def _handle_event(self, event_type: HathorEvents, event_args: EventArguments) -> None:
+        assert self._is_running, 'Cannot handle event, EventManager is not started.'
+
         event_type = _EVENT_CONVERTERS.get(event_type, event_type)
         event_specific_handlers = {
             HathorEvents.LOAD_FINISHED: self._handle_load_finished

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -84,11 +84,15 @@ class EventManager:
         self._subscribe_events()
 
     def start(self, peer_id: str) -> None:
+        assert self._is_running is False, 'Cannot start, EventManager is already running'
+
         self._peer_id = peer_id
         self._event_ws_factory.start()
         self._is_running = True
 
     def stop(self):
+        assert self._is_running is True, 'Cannot stop, EventManager is not running'
+
         self._event_ws_factory.stop()
         self._is_running = False
 

--- a/hathor/event/websocket/factory.py
+++ b/hathor/event/websocket/factory.py
@@ -48,10 +48,14 @@ class EventWebsocketFactory(WebSocketServerFactory):
 
     def start(self):
         """Start the WebSocket server. Required to be able to send events."""
+        assert self._is_running is False, 'Cannot start, EventWebsocketFactory is already running'
+
         self._is_running = True
 
     def stop(self):
         """Stop the WebSocket server. No events can be sent."""
+        assert self._is_running is True, 'Cannot stop, EventWebsocketFactory is not running'
+
         self._is_running = False
 
         for connection in self._connections:

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -269,6 +269,9 @@ class HathorManager:
                 )
                 sys.exit(-1)
 
+        if self._event_manager:
+            self._event_manager.start(not_none(self.my_peer.id))
+
         self.state = self.NodeState.INITIALIZING
         self.pubsub.publish(HathorEvents.MANAGER_ON_START)
         self.connections.start()
@@ -304,9 +307,6 @@ class HathorManager:
 
         if self.stratum_factory:
             self.stratum_factory.start()
-
-        if self._event_manager:
-            self._event_manager.start(not_none(self.my_peer.id))
 
         # Start running
         self.tx_storage.start_running_manager()


### PR DESCRIPTION
Acceptance Criteria:

- Fix bug that was preventing node initialization due to incorrect import order
  - The Event Simulator indirectly imported code that used `get_settings` before it was called by `run_node` with the correct configuration, therefore generating a `loading config twice with a different file` error.
- Fix bug that was preventing node initialization with the events feature due to incorrect start order
  - The `HathorManager` was sending events relevant to the `EventManager` before starting it.