### PR TITLE
feat(events): realiable integration during the load phase

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -132,7 +132,6 @@ class Builder:
         event_storage = self._get_or_create_event_storage()
         event_manager = self._get_or_create_event_manager()
         tx_storage = self._get_or_create_tx_storage()
-        event_storage = self._get_or_create_event_storage()
         indexes = tx_storage.indexes
         assert indexes is not None
 

--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -24,6 +24,7 @@ from hathor.consensus import ConsensusAlgorithm
 from hathor.event import EventManager
 from hathor.event.storage import EventMemoryStorage, EventRocksDBStorage, EventStorage
 from hathor.event.websocket import EventWebsocketFactory
+from hathor.event.storage import EventStorage, EventMemoryStorage, EventRocksDBStorage
 from hathor.indexes import IndexesManager
 from hathor.manager import HathorManager
 from hathor.p2p.manager import ConnectionsManager
@@ -131,6 +132,7 @@ class Builder:
         event_storage = self._get_or_create_event_storage()
         event_manager = self._get_or_create_event_manager()
         tx_storage = self._get_or_create_tx_storage()
+        event_storage = self._get_or_create_event_storage()
         indexes = tx_storage.indexes
         assert indexes is not None
 

--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -24,7 +24,6 @@ from hathor.consensus import ConsensusAlgorithm
 from hathor.event import EventManager
 from hathor.event.storage import EventMemoryStorage, EventRocksDBStorage, EventStorage
 from hathor.event.websocket import EventWebsocketFactory
-from hathor.event.storage import EventStorage, EventMemoryStorage, EventRocksDBStorage
 from hathor.indexes import IndexesManager
 from hathor.manager import HathorManager
 from hathor.p2p.manager import ConnectionsManager

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -143,12 +143,8 @@ class CliBuilder:
                 event_storage=event_storage,
                 event_ws_factory=self.event_ws_factory,
                 pubsub=pubsub,
-                reactor=reactor,
-                emit_load_events=args.x_emit_load_events
+                reactor=reactor
             )
-        else:
-            self.check_or_raise(not args.x_emit_load_events, '--x-emit-load-events cannot be used without '
-                                                             '--x-enable-event-queue')
 
         if args.wallet_index and tx_storage.indexes is not None:
             self.log.debug('enable wallet indexes')
@@ -232,7 +228,7 @@ class CliBuilder:
 
             self.manager.enable_event_queue = True
             self.log.info('--x-enable-event-queue flag provided. '
-                          'The events detected by the full node will be stored and retrieved to clients')
+                          'The events detected by the full node will be stored and can be retrieved by clients')
 
         for description in args.listen:
             self.manager.add_listen_address(description)

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -136,15 +136,15 @@ class CliBuilder:
 
         pubsub = PubSubManager(reactor)
 
-        event_manager: Optional[EventManager] = None
         if args.x_enable_event_queue:
             self.event_ws_factory = EventWebsocketFactory(reactor, event_storage)
-            event_manager = EventManager(
-                event_storage=event_storage,
-                event_ws_factory=self.event_ws_factory,
-                pubsub=pubsub,
-                reactor=reactor
-            )
+
+        event_manager = EventManager(
+            event_storage=event_storage,
+            event_ws_factory=self.event_ws_factory,
+            pubsub=pubsub,
+            reactor=reactor
+        )
 
         if args.wallet_index and tx_storage.indexes is not None:
             self.log.debug('enable wallet indexes')
@@ -170,7 +170,6 @@ class CliBuilder:
             network=network,
             hostname=hostname,
             tx_storage=tx_storage,
-            event_storage=event_storage,
             event_manager=event_manager,
             wallet=self.wallet,
             stratum_port=args.stratum,
@@ -181,7 +180,8 @@ class CliBuilder:
             enable_sync_v2=enable_sync_v2,
             consensus_algorithm=consensus_algorithm,
             environment_info=get_environment_info(args=str(args), peer_id=peer_id.id),
-            full_verification=full_verification
+            full_verification=full_verification,
+            enable_event_queue=bool(args.x_enable_event_queue)
         )
 
         if args.data:

--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -250,7 +250,7 @@ class ResourcesBuilder:
         ws_factory.subscribe(self.manager.pubsub)
 
         # Event websocket resource
-        if args.x_enable_event_queue and self.event_ws_factory is not None:
+        if args.x_enable_event_queue:
             root.putChild(b'event_ws', WebSocketResource(self.event_ws_factory))
             root.putChild(b'event', EventResource(self.manager._event_manager))
 

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -100,8 +100,6 @@ class RunNode:
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
         parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')
-        parser.add_argument('--x-emit-load-events', action='store_true', help='Enable emission of events during the '
-                                                                              'LOAD phase')
         parser.add_argument('--peer-id-blacklist', action='extend', default=[], nargs='+', type=str,
                             help='Peer IDs to forbid connection')
         return parser

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -214,7 +214,7 @@ class EventManager:
     def _should_reload_events(self) -> bool:
         return self._previous_node_state in [None, NodeState.LOAD]
 
-    def handle_load_phase_events(self, topological_iterator: Iterator[BaseTransaction]) -> None:
+    def handle_load_phase_vertices(self, topological_iterator: Iterator[BaseTransaction]) -> None:
         """
         Either generates load phase events or not, depending on previous node state.
         Does so asynchronously so events generated here are not processed before normal event handling.

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -225,9 +225,9 @@ class EventManager:
             return
 
         for vertex in topological_iterator:
-            args = EventArguments(tx=vertex)
-
             self._reactor.callLater(
                 delay=0,
-                callable=lambda: self._handle_event(EventType.NEW_VERTEX_ACCEPTED, args)
+                callable=self._handle_event,
+                event_type=EventType.NEW_VERTEX_ACCEPTED,
+                event_args=EventArguments(tx=vertex)
             )

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -135,10 +135,6 @@ class EventManager:
         if event_specific_handler := event_specific_handlers.get(event_type):
             event_specific_handler()
 
-        # TODO: Are there any events being emitted during the load phase that are not emitted from this class?
-        # if not self._load_finished:
-        #     return
-
         self._handle_event_creation(event_type, event_args)
 
     def _handle_event_creation(self, event_type: EventType, event_args: EventArguments) -> None:

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -62,8 +62,7 @@ class EventManager:
         event_storage: EventStorage,
         event_ws_factory: EventWebsocketFactory,
         pubsub: PubSubManager,
-        reactor: Reactor,
-        emit_load_events: bool = False
+        reactor: Reactor
     ):
         self.log = logger.new()
 
@@ -71,7 +70,6 @@ class EventManager:
         self._event_storage = event_storage
         self._event_ws_factory = event_ws_factory
         self._pubsub = pubsub
-        self.emit_load_events = emit_load_events
 
         self._last_event = self._event_storage.get_last_event()
         self._last_existing_group_id = self._event_storage.get_last_group_id()
@@ -123,8 +121,9 @@ class EventManager:
         if event_specific_handler := event_specific_handlers.get(event_type):
             event_specific_handler()
 
-        if not self._load_finished and not self.emit_load_events:
-            return
+        # TODO: Are there any events being emitted during the load phase that are not emitted from this class?
+        # if not self._load_finished:
+        #     return
 
         self._handle_event_creation(event_type, event_args)
 

--- a/hathor/event/model/node_state.py
+++ b/hathor/event/model/node_state.py
@@ -1,0 +1,20 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import Enum, auto
+
+
+class NodeState(Enum):
+    LOAD = auto()
+    SYNC = auto()

--- a/hathor/event/model/node_state.py
+++ b/hathor/event/model/node_state.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from enum import Enum, auto
+from enum import Enum
 
 
 class NodeState(Enum):

--- a/hathor/event/model/node_state.py
+++ b/hathor/event/model/node_state.py
@@ -16,5 +16,5 @@ from enum import Enum, auto
 
 
 class NodeState(Enum):
-    LOAD = auto()
-    SYNC = auto()
+    LOAD = 0
+    SYNC = 1

--- a/hathor/event/storage/event_storage.py
+++ b/hathor/event/storage/event_storage.py
@@ -61,13 +61,8 @@ class EventStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def save_event_queue_enabled(self) -> None:
-        """Save that event queue feature is enabled in the storage"""
-        raise NotImplementedError
-
-    @abstractmethod
-    def save_event_queue_disabled(self) -> None:
-        """Save that event queue feature is disabled in the storage"""
+    def save_event_queue_state(self, enabled: bool) -> None:
+        """Save whether the event queue feature is enabled in the storage"""
         raise NotImplementedError
 
     @abstractmethod

--- a/hathor/event/storage/event_storage.py
+++ b/hathor/event/storage/event_storage.py
@@ -16,6 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Iterator, Optional
 
 from hathor.event.model.base_event import BaseEvent
+from hathor.event.model.node_state import NodeState
 
 
 class EventStorage(ABC):
@@ -42,4 +43,19 @@ class EventStorage(ABC):
     @abstractmethod
     def iter_from_event(self, key: int) -> Iterator[BaseEvent]:
         """ Iterate through events starting from the event with the given key"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear_events(self) -> None:
+        """Clear all stored events and related metadata."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_node_state(self, state: NodeState) -> None:
+        """Save a node state in the storage"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_node_state(self) -> Optional[NodeState]:
+        """Get the node state from the storage"""
         raise NotImplementedError

--- a/hathor/event/storage/event_storage.py
+++ b/hathor/event/storage/event_storage.py
@@ -59,3 +59,18 @@ class EventStorage(ABC):
     def get_node_state(self) -> Optional[NodeState]:
         """Get the node state from the storage"""
         raise NotImplementedError
+
+    @abstractmethod
+    def save_event_queue_enabled(self) -> None:
+        """Save that event queue feature is enabled in the storage"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_event_queue_disabled(self) -> None:
+        """Save that event queue feature is disabled in the storage"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_event_queue_state(self) -> bool:
+        """Get whether the event queue feature is enabled from the storage"""
+        raise NotImplementedError

--- a/hathor/event/storage/memory_storage.py
+++ b/hathor/event/storage/memory_storage.py
@@ -69,11 +69,8 @@ class EventMemoryStorage(EventStorage):
     def get_node_state(self) -> Optional[NodeState]:
         return self._node_state
 
-    def save_event_queue_enabled(self) -> None:
-        self._event_queue_enabled = True
-
-    def save_event_queue_disabled(self) -> None:
-        self._event_queue_enabled = False
+    def save_event_queue_state(self, enabled: bool) -> None:
+        self._event_queue_enabled = enabled
 
     def get_event_queue_state(self) -> bool:
         return self._event_queue_enabled

--- a/hathor/event/storage/memory_storage.py
+++ b/hathor/event/storage/memory_storage.py
@@ -15,6 +15,7 @@
 from typing import Iterator, List, Optional
 
 from hathor.event.model.base_event import BaseEvent
+from hathor.event.model.node_state import NodeState
 from hathor.event.storage.event_storage import EventStorage
 
 
@@ -23,6 +24,7 @@ class EventMemoryStorage(EventStorage):
         self._events: List[BaseEvent] = []
         self._last_event: Optional[BaseEvent] = None
         self._last_group_id: Optional[int] = None
+        self._node_state: Optional[NodeState] = None
 
     def save_event(self, event: BaseEvent) -> None:
         if event.id != len(self._events):
@@ -54,3 +56,14 @@ class EventMemoryStorage(EventStorage):
         while key < len(self._events):
             yield self._events[key]
             key += 1
+
+    def clear_events(self) -> None:
+        self._events = []
+        self._last_event = None
+        self._last_group_id = None
+
+    def save_node_state(self, state: NodeState) -> None:
+        self._node_state = state
+
+    def get_node_state(self) -> Optional[NodeState]:
+        return self._node_state

--- a/hathor/event/storage/memory_storage.py
+++ b/hathor/event/storage/memory_storage.py
@@ -25,6 +25,7 @@ class EventMemoryStorage(EventStorage):
         self._last_event: Optional[BaseEvent] = None
         self._last_group_id: Optional[int] = None
         self._node_state: Optional[NodeState] = None
+        self._event_queue_enabled: bool = False
 
     def save_event(self, event: BaseEvent) -> None:
         if event.id != len(self._events):
@@ -67,3 +68,12 @@ class EventMemoryStorage(EventStorage):
 
     def get_node_state(self) -> Optional[NodeState]:
         return self._node_state
+
+    def save_event_queue_enabled(self) -> None:
+        self._event_queue_enabled = True
+
+    def save_event_queue_disabled(self) -> None:
+        self._event_queue_enabled = False
+
+    def get_event_queue_state(self) -> bool:
+        return self._event_queue_enabled

--- a/hathor/event/storage/rocksdb_storage.py
+++ b/hathor/event/storage/rocksdb_storage.py
@@ -113,13 +113,7 @@ class EventRocksDBStorage(EventStorage):
 
         return NodeState(node_state_int)
 
-    def save_event_queue_enabled(self) -> None:
-        self._save_event_queue_state(True)
-
-    def save_event_queue_disabled(self) -> None:
-        self._save_event_queue_state(False)
-
-    def _save_event_queue_state(self, enabled: bool) -> None:
+    def save_event_queue_state(self, enabled: bool) -> None:
         self._db.put(
             (self._cf_meta, _KEY_EVENT_QUEUE_ENABLED),
             enabled.to_bytes(length=1, byteorder='big')

--- a/hathor/event/storage/rocksdb_storage.py
+++ b/hathor/event/storage/rocksdb_storage.py
@@ -25,6 +25,7 @@ _CF_NAME_EVENT = b'event'
 _CF_NAME_META = b'event-metadata'
 _KEY_LAST_GROUP_ID = b'last-group-id'
 _KEY_NODE_STATE = b'node-state'
+_KEY_EVENT_QUEUE_ENABLED = b'event-queue-enabled'
 
 
 class EventRocksDBStorage(EventStorage):
@@ -111,3 +112,23 @@ class EventRocksDBStorage(EventStorage):
         node_state_int = bytes_to_int(node_state_bytes)
 
         return NodeState(node_state_int)
+
+    def save_event_queue_enabled(self) -> None:
+        self._save_event_queue_state(True)
+
+    def save_event_queue_disabled(self) -> None:
+        self._save_event_queue_state(False)
+
+    def _save_event_queue_state(self, enabled: bool) -> None:
+        self._db.put(
+            (self._cf_meta, _KEY_EVENT_QUEUE_ENABLED),
+            enabled.to_bytes(length=1, byteorder='big')
+        )
+
+    def get_event_queue_state(self) -> bool:
+        enabled_bytes = self._db.get((self._cf_meta, _KEY_EVENT_QUEUE_ENABLED))
+
+        if enabled_bytes is None:
+            return False
+
+        return bool.from_bytes(enabled_bytes, byteorder='big')

--- a/hathor/event/storage/rocksdb_storage.py
+++ b/hathor/event/storage/rocksdb_storage.py
@@ -15,14 +15,16 @@
 from typing import Iterator, Optional
 
 from hathor.event.model.base_event import BaseEvent
+from hathor.event.model.node_state import NodeState
 from hathor.event.storage.event_storage import EventStorage
 from hathor.storage.rocksdb_storage import RocksDBStorage
-from hathor.transaction.util import int_to_bytes
+from hathor.transaction.util import bytes_to_int, int_to_bytes
 from hathor.util import json_dumpb
 
 _CF_NAME_EVENT = b'event'
 _CF_NAME_META = b'event-metadata'
 _KEY_LAST_GROUP_ID = b'last-group-id'
+_KEY_NODE_STATE = b'node-state'
 
 
 class EventRocksDBStorage(EventStorage):
@@ -57,11 +59,11 @@ class EventRocksDBStorage(EventStorage):
         last_group_id = self._db.get((self._cf_meta, _KEY_LAST_GROUP_ID))
         if last_group_id is None:
             return None
-        return int.from_bytes(last_group_id, byteorder='big', signed=False)
+        return bytes_to_int(last_group_id)
 
     def save_event(self, event: BaseEvent) -> None:
         if (self._last_event is None and event.id != 0) or \
-                (self._last_event is not None and event.id > self._last_event.id + 1):
+                (self._last_event is not None and event.id != self._last_event.id + 1):
             raise ValueError('invalid event.id, ids must be sequential and leave no gaps')
         event_data = json_dumpb(event.dict())
         key = int_to_bytes(event.id, 8)
@@ -84,3 +86,16 @@ class EventRocksDBStorage(EventStorage):
 
     def get_last_group_id(self) -> Optional[int]:
         return self._last_group_id
+
+    def clear_events(self) -> None:
+        self._db.drop_column_family(self._cf_event)
+        self._db.delete((self._cf_meta, _KEY_LAST_GROUP_ID))
+
+    def save_node_state(self, state: NodeState) -> None:
+        self._db.put((self._cf_meta, _KEY_NODE_STATE), int_to_bytes(state.value, 8))
+
+    def get_node_state(self) -> Optional[NodeState]:
+        node_state_bytes = self._db.get((self._cf_meta, _KEY_NODE_STATE))
+        node_state_int = bytes_to_int(node_state_bytes)
+
+        return NodeState(node_state_int)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -125,6 +125,11 @@ class HathorManager:
         if not (enable_sync_v1 or enable_sync_v1_1 or enable_sync_v2):
             raise TypeError(f'{type(self).__name__}() at least one sync version is required')
 
+        if event_storage.get_event_queue_state() is True and not event_manager:
+            raise ValueError(
+                'cannot start manager without event queue feature, as it was enabled in the previous startup'
+            )
+
         self._enable_sync_v1 = enable_sync_v1
         self._enable_sync_v2 = enable_sync_v2
 
@@ -175,6 +180,10 @@ class HathorManager:
 
         if self._event_manager:
             assert self._event_manager.event_storage == event_storage
+
+            event_storage.save_event_queue_enabled()
+        else:
+            event_storage.save_event_queue_disabled()
 
         if enable_sync_v2:
             assert self.tx_storage.indexes is not None

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -649,6 +649,12 @@ class HathorManager:
 
         # XXX: last step before actually starting is updating the last started at timestamps
         self.tx_storage.update_last_started_at(started_at)
+
+        # TODO: Can be moved to the outer method, allowing full verification? I think so, but publish(HathorEvents.LOAD_FINISHED) also has to be moved
+        if self._event_manager:
+            topological_iterator = self.tx_storage.topological_iterator()
+            self._event_manager.handle_load_phase_events(topological_iterator)
+
         self.state = self.NodeState.READY
         self.pubsub.publish(HathorEvents.LOAD_FINISHED)
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -650,8 +650,6 @@ class HathorManager:
         # XXX: last step before actually starting is updating the last started at timestamps
         self.tx_storage.update_last_started_at(started_at)
 
-        # TODO: Can be moved to the outer method, allowing full verification? I think so, but publish(
-        #  HathorEvents.LOAD_FINISHED) also has to be moved
         if self._event_manager:
             topological_iterator = self.tx_storage.topological_iterator()
             self._event_manager.handle_load_phase_events(topological_iterator)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -652,7 +652,7 @@ class HathorManager:
 
         if self._event_manager:
             topological_iterator = self.tx_storage.topological_iterator()
-            self._event_manager.handle_load_phase_events(topological_iterator)
+            self._event_manager.handle_load_phase_vertices(topological_iterator)
 
         self.state = self.NodeState.READY
         self.pubsub.publish(HathorEvents.LOAD_FINISHED)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -650,7 +650,8 @@ class HathorManager:
         # XXX: last step before actually starting is updating the last started at timestamps
         self.tx_storage.update_last_started_at(started_at)
 
-        # TODO: Can be moved to the outer method, allowing full verification? I think so, but publish(HathorEvents.LOAD_FINISHED) also has to be moved
+        # TODO: Can be moved to the outer method, allowing full verification? I think so, but publish(
+        #  HathorEvents.LOAD_FINISHED) also has to be moved
         if self._event_manager:
             topological_iterator = self.tx_storage.topological_iterator()
             self._event_manager.handle_load_phase_events(topological_iterator)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -30,7 +30,6 @@ from hathor.checkpoint import Checkpoint
 from hathor.conf import HathorSettings
 from hathor.consensus import ConsensusAlgorithm
 from hathor.event.event_manager import EventManager
-from hathor.event.storage import EventStorage
 from hathor.exception import (
     DoubleSpendingError,
     HathorError,
@@ -88,11 +87,10 @@ class HathorManager:
                  consensus_algorithm: ConsensusAlgorithm,
                  peer_id: PeerId,
                  tx_storage: TransactionStorage,
-                 event_storage: EventStorage,
+                 event_manager: EventManager,
                  network: str,
                  hostname: Optional[str] = None,
                  wallet: Optional[BaseWallet] = None,
-                 event_manager: Optional[EventManager] = None,
                  stratum_port: Optional[int] = None,
                  ssl: bool = True,
                  enable_sync_v1: bool = False,
@@ -102,7 +100,8 @@ class HathorManager:
                  checkpoints: Optional[List[Checkpoint]] = None,
                  rng: Optional[Random] = None,
                  environment_info: Optional[EnvironmentInfo] = None,
-                 full_verification: bool = False):
+                 full_verification: bool = False,
+                 enable_event_queue: bool = False):
         """
         :param reactor: Twisted reactor which handles the mainloop and the events.
         :param peer_id: Id of this node.
@@ -125,7 +124,7 @@ class HathorManager:
         if not (enable_sync_v1 or enable_sync_v1_1 or enable_sync_v2):
             raise TypeError(f'{type(self).__name__}() at least one sync version is required')
 
-        if event_storage.get_event_queue_state() is True and not event_manager:
+        if event_manager.get_event_queue_state() is True and not enable_event_queue:
             raise ValueError(
                 'cannot start manager without event queue feature, as it was enabled in the previous startup'
             )
@@ -177,13 +176,8 @@ class HathorManager:
         self.tx_storage.pubsub = self.pubsub
 
         self._event_manager = event_manager
-
-        if self._event_manager:
-            assert self._event_manager.event_storage == event_storage
-
-            event_storage.save_event_queue_enabled()
-        else:
-            event_storage.save_event_queue_disabled()
+        self._event_manager.save_event_queue_state(enable_event_queue)
+        self._enable_event_queue = enable_event_queue
 
         if enable_sync_v2:
             assert self.tx_storage.indexes is not None
@@ -294,7 +288,7 @@ class HathorManager:
                 )
                 sys.exit(-1)
 
-        if self._event_manager:
+        if self._enable_event_queue:
             self._event_manager.start(not_none(self.my_peer.id))
 
         self.state = self.NodeState.INITIALIZING
@@ -364,7 +358,7 @@ class HathorManager:
             if wait_stratum:
                 waits.append(wait_stratum)
 
-        if self._event_manager:
+        if self._enable_event_queue:
             self._event_manager.stop()
 
         self.tx_storage.flush()
@@ -405,7 +399,7 @@ class HathorManager:
 
         This method runs through all transactions, verifying them and updating our wallet.
         """
-        assert not self._event_manager, 'this method cannot be used if the events feature is enabled.'
+        assert not self._enable_event_queue, 'this method cannot be used if the events feature is enabled.'
 
         self.log.info('initialize')
         if self.wallet:
@@ -659,7 +653,7 @@ class HathorManager:
         # XXX: last step before actually starting is updating the last started at timestamps
         self.tx_storage.update_last_started_at(started_at)
 
-        if self._event_manager:
+        if self._enable_event_queue:
             topological_iterator = self.tx_storage.topological_iterator()
             self._event_manager.handle_load_phase_vertices(topological_iterator)
 

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -90,9 +90,6 @@ class HathorEvents(Enum):
 
         REORG_FINISHED
             Triggered when consensus algorithm ends all changes involved in a reorg
-
-        VERTEX_METADATA_CHANGED
-            Triggered when consensus algorithm changes a metadata of an existing vertex (transaction or block)
     """
     MANAGER_ON_START = 'manager:on_start'
     MANAGER_ON_STOP = 'manager:on_stop'

--- a/hathor/transaction/util.py
+++ b/hathor/transaction/util.py
@@ -28,6 +28,10 @@ def int_to_bytes(number: int, size: int, signed: bool = False) -> bytes:
     return number.to_bytes(size, byteorder='big', signed=signed)
 
 
+def bytes_to_int(data: bytes, signed: bool = False) -> int:
+    return int.from_bytes(data, byteorder='big', signed=signed)
+
+
 def unpack(fmt: str, buf: bytes) -> Any:
     size = struct.calcsize(fmt)
     return struct.unpack(fmt, buf[:size]), buf[size:]

--- a/hathor/transaction/util.py
+++ b/hathor/transaction/util.py
@@ -28,7 +28,16 @@ def int_to_bytes(number: int, size: int, signed: bool = False) -> bytes:
     return number.to_bytes(size, byteorder='big', signed=signed)
 
 
-def bytes_to_int(data: bytes, signed: bool = False) -> int:
+def bytes_to_int(data: bytes, *, signed: bool = False) -> int:
+    """
+    Converts data in bytes to an int. Assumes big-endian format.
+
+    Args:
+        data: bytes to be converted
+        signed: whether two's complement is used to represent the integer.
+
+    Returns: the converted data as int
+    """
     return int.from_bytes(data, byteorder='big', signed=signed)
 
 

--- a/tests/event/test_event_manager.py
+++ b/tests/event/test_event_manager.py
@@ -7,8 +7,6 @@ from hathor.pubsub import HathorEvents
 from tests import unittest
 
 
-# TODO: This test fails with Clock because of pubsub event ordering caused by
-#  ReactorThread.get_current_thread. Changing MAIN_THREAD to NOT_RUNNING makes it work
 class BaseEventManagerTest(unittest.TestCase):
     __test__ = False
 

--- a/tests/event/test_event_manager.py
+++ b/tests/event/test_event_manager.py
@@ -7,6 +7,8 @@ from hathor.pubsub import HathorEvents
 from tests import unittest
 
 
+# TODO: This test fails with Clock because of pubsub event ordering caused by
+#  ReactorThread.get_current_thread. Changing MAIN_THREAD to NOT_RUNNING makes it work
 class BaseEventManagerTest(unittest.TestCase):
     __test__ = False
 
@@ -42,19 +44,32 @@ class BaseEventManagerTest(unittest.TestCase):
         self._fake_reorg_started()
         self._fake_reorg_finished()
         self.run_to_completion()
+
         event0 = self.event_storage.get_event(0)
         event1 = self.event_storage.get_event(1)
         event2 = self.event_storage.get_event(2)
         event3 = self.event_storage.get_event(3)
         event4 = self.event_storage.get_event(4)
-        self.assertEqual(EventType(event0.type), EventType.LOAD_FINISHED)
-        self.assertEqual(EventType(event1.type), EventType.REORG_STARTED)
-        self.assertIsNotNone(event1.group_id)
-        self.assertEqual(EventType(event2.type), EventType.REORG_FINISHED)
-        self.assertIsNotNone(event2.group_id)
-        self.assertEqual(event1.group_id, event2.group_id)
-        self.assertNotEqual(event2.group_id, event3.group_id)
-        self.assertEqual(event3.group_id, event4.group_id)
+        event5 = self.event_storage.get_event(5)
+        event6 = self.event_storage.get_event(6)
+        event7 = self.event_storage.get_event(7)
+        event8 = self.event_storage.get_event(8)
+
+        self.assertEqual(EventType(event0.type), EventType.LOAD_STARTED)
+        self.assertEqual(EventType(event1.type), EventType.NEW_VERTEX_ACCEPTED)
+        self.assertEqual(EventType(event2.type), EventType.NEW_VERTEX_ACCEPTED)
+        self.assertEqual(EventType(event3.type), EventType.NEW_VERTEX_ACCEPTED)
+        self.assertEqual(EventType(event4.type), EventType.LOAD_FINISHED)
+        self.assertEqual(EventType(event5.type), EventType.REORG_STARTED)
+
+        self.assertIsNotNone(event5.group_id)
+        self.assertEqual(EventType(event6.type), EventType.REORG_FINISHED)
+        self.assertIsNotNone(event6.group_id)
+        self.assertEqual(event5.group_id, event6.group_id)
+
+        self.assertNotEqual(event6.group_id, event7.group_id)
+        self.assertIsNotNone(event7.group_id)
+        self.assertEqual(event7.group_id, event8.group_id)
 
     def test_cannot_start_group_twice(self):
         self._fake_reorg_started()

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -10,8 +10,6 @@ from tests.utils import add_new_blocks, get_genesis_key, zip_chunkify
 settings = HathorSettings()
 
 
-# TODO: This test fails with Clock because of pubsub event ordering caused by
-#  ReactorThread.get_current_thread. Changing MAIN_THREAD to NOT_RUNNING makes it work
 class BaseEventReorgTest(unittest.TestCase):
     __test__ = False
 

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -10,6 +10,8 @@ from tests.utils import add_new_blocks, get_genesis_key, zip_chunkify
 settings = HathorSettings()
 
 
+# TODO: This test fails with Clock because of pubsub event ordering caused by
+#  ReactorThread.get_current_thread. Changing MAIN_THREAD to NOT_RUNNING makes it work
 class BaseEventReorgTest(unittest.TestCase):
     __test__ = False
 
@@ -58,6 +60,10 @@ class BaseEventReorgTest(unittest.TestCase):
             pass
         expected_events_grouped = [
             [
+                (EventType.LOAD_STARTED, {}),
+                (EventType.NEW_VERTEX_ACCEPTED, {}),
+                (EventType.NEW_VERTEX_ACCEPTED, {}),
+                (EventType.NEW_VERTEX_ACCEPTED, {}),
                 (EventType.LOAD_FINISHED, {})
             ],
             # XXX: the order of the following events can vary depending on which genesis is spent/confirmed first

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -59,9 +59,9 @@ class BaseEventReorgTest(unittest.TestCase):
         expected_events_grouped = [
             [
                 (EventType.LOAD_STARTED, {}),
-                (EventType.NEW_VERTEX_ACCEPTED, {}),
-                (EventType.NEW_VERTEX_ACCEPTED, {}),
-                (EventType.NEW_VERTEX_ACCEPTED, {}),
+                (EventType.NEW_VERTEX_ACCEPTED, {'hash': settings.GENESIS_BLOCK_HASH.hex()}),
+                (EventType.NEW_VERTEX_ACCEPTED, {'hash': settings.GENESIS_TX1_HASH.hex()}),
+                (EventType.NEW_VERTEX_ACCEPTED, {'hash': settings.GENESIS_TX2_HASH.hex()}),
                 (EventType.LOAD_FINISHED, {})
             ],
             # XXX: the order of the following events can vary depending on which genesis is spent/confirmed first

--- a/tests/event/test_event_storage.py
+++ b/tests/event/test_event_storage.py
@@ -126,13 +126,13 @@ class EventStorageBaseTest(unittest.TestCase):
         assert enabled is False
 
     def test_save_event_queue_enabled_and_retrieve(self):
-        self.event_storage.save_event_queue_enabled()
+        self.event_storage.save_event_queue_state(True)
         enabled = self.event_storage.get_event_queue_state()
 
         assert enabled is True
 
     def test_save_event_queue_disabled_and_retrieve(self):
-        self.event_storage.save_event_queue_disabled()
+        self.event_storage.save_event_queue_state(False)
         enabled = self.event_storage.get_event_queue_state()
 
         assert enabled is False
@@ -158,7 +158,7 @@ class EventStorageBaseTest(unittest.TestCase):
 
         self._populate_events_and_last_group_id(n_events=n_events, last_group_id=4)
         self.event_storage.save_node_state(expected_node_state)
-        self.event_storage.save_event_queue_enabled()
+        self.event_storage.save_event_queue_state(True)
 
         events = list(self.event_storage.iter_from_event(0))
         last_group_id = self.event_storage.get_last_group_id()

--- a/tests/event/test_event_storage.py
+++ b/tests/event/test_event_storage.py
@@ -4,6 +4,7 @@ from typing import Optional
 import pytest
 
 from hathor.event.model.node_state import NodeState
+from hathor.event.storage import EventStorage
 from hathor.event.storage.memory_storage import EventMemoryStorage
 from hathor.event.storage.rocksdb_storage import EventRocksDBStorage
 from hathor.storage.rocksdb_storage import RocksDBStorage
@@ -13,6 +14,8 @@ from tests.utils import HAS_ROCKSDB, EventMocker
 
 class EventStorageBaseTest(unittest.TestCase):
     __test__ = False
+
+    event_storage: EventStorage
 
     def setUp(self):
         super().setUp()
@@ -121,7 +124,7 @@ class EventStorageBaseTest(unittest.TestCase):
     def test_clear_events_empty_database(self):
         self._test_clear_events()
 
-    def _test_clear_events(self, expected_node_state: Optional[NodeState] = None):
+    def _test_clear_events(self, expected_node_state: Optional[NodeState] = None) -> None:
         self.event_storage.clear_events()
 
         events = list(self.event_storage.iter_from_event(0))

--- a/tests/event/test_event_storage.py
+++ b/tests/event/test_event_storage.py
@@ -9,6 +9,7 @@ from tests import unittest
 from tests.utils import HAS_ROCKSDB, EventMocker
 
 
+# TODO: Implement tests for new methods
 class EventStorageBaseTest(unittest.TestCase):
     __test__ = False
 

--- a/tests/event/test_event_storage.py
+++ b/tests/event/test_event_storage.py
@@ -1,5 +1,4 @@
 import tempfile
-from typing import Optional
 
 import pytest
 

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -163,7 +163,6 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsInstance(manager._event_manager, EventManager)
         self.assertIsInstance(manager._event_manager._event_storage, EventRocksDBStorage)
         self.assertIsInstance(manager._event_manager._event_ws_factory, EventWebsocketFactory)
-        self.assertFalse(manager._event_manager.emit_load_events)
 
     def test_event_queue_with_memory_storage(self):
         manager = self._build(['--x-enable-event-queue', '--memory-storage'])
@@ -171,16 +170,7 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsInstance(manager._event_manager, EventManager)
         self.assertIsInstance(manager._event_manager._event_storage, EventMemoryStorage)
         self.assertIsInstance(manager._event_manager._event_ws_factory, EventWebsocketFactory)
-        self.assertFalse(manager._event_manager.emit_load_events)
 
     def test_event_queue_with_full_verification(self):
         args = ['--x-enable-event-queue', '--memory-storage', '--x-full-verification']
         self._build_with_error(args, '--x-full-verification cannot be used with --x-enable-event-queue')
-
-    def test_event_queue_with_emit_load_events(self):
-        manager = self._build(['--x-enable-event-queue', '--memory-storage', '--x-emit-load-events'])
-
-        self.assertIsInstance(manager._event_manager, EventManager)
-        self.assertIsInstance(manager._event_manager._event_storage, EventMemoryStorage)
-        self.assertIsInstance(manager._event_manager._event_ws_factory, EventWebsocketFactory)
-        self.assertTrue(manager._event_manager.emit_load_events)

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -58,7 +58,7 @@ class BuilderTestCase(unittest.TestCase):
         self.assertNotIn(SyncVersion.V2, manager.connections._sync_factories)
         self.assertFalse(self.resources_builder._built_prometheus)
         self.assertFalse(self.resources_builder._built_status)
-        self.assertIsNone(manager._event_manager)
+        self.assertFalse(manager._enable_event_queue)
 
     @pytest.mark.skipif(not HAS_ROCKSDB, reason='requires python-rocksdb')
     def test_cache_storage(self):


### PR DESCRIPTION
Implement changes described in https://github.com/HathorNetwork/rfcs/pull/52

Acceptance Criteria:

- Implement new `EventStorage` functionality
  - Storage and retrieval of `NodeState`
  - Storage and retrieval of event queue feature state
  - Clearing events
- Update `HathorManager`
  - Remove `event_storage` arg, make `event_manager` required, and add `enable_event_queue`
  - Initialization fails if it starts without the event queue feature, and it was enabled in a previous start
  - Handling of LOAD phase events
- Update `EventManager` to support handling of LOAD phase events
- Remove `--x-emit-load-events` CLI flag, as it's not necessary anymore in the way events are handled in the LOAD phase
- New `bytes_to_int()` function in `transaction.util`







