### PR TITLE
refactor(builder): HathorManager stops building ConsensusAlgorithm itself

### DIFF
--- a/hathor/builder.py
+++ b/hathor/builder.py
@@ -26,6 +26,7 @@ from twisted.internet.posixbase import PosixReactorBase
 from twisted.web import server
 from twisted.web.resource import Resource
 
+from hathor.consensus import ConsensusAlgorithm
 from hathor.event import EventManager
 from hathor.event.resources.event import EventResource
 from hathor.exception import BuilderError
@@ -163,6 +164,9 @@ class CliBuilder:
             self.log.debug('enable utxo index')
             tx_storage.indexes.enable_utxo_index()
 
+        soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
+        consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=pubsub)
+
         self.manager = HathorManager(
             reactor,
             pubsub=pubsub,
@@ -177,7 +181,7 @@ class CliBuilder:
             checkpoints=settings.CHECKPOINTS,
             enable_sync_v1=enable_sync_v1,
             enable_sync_v2=enable_sync_v2,
-            soft_voided_tx_ids=set(settings.SOFT_VOIDED_TX_IDS),
+            consensus_algorithm=consensus_algorithm,
             environment_info=get_environment_info(args=str(args), peer_id=peer_id.id),
         )
 

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Generator, List, Optional, Set
 from mnemonic import Mnemonic
 from structlog import get_logger
 
+from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import TestMode, _set_test_mode
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
@@ -138,6 +139,10 @@ class Simulator:
 
         pubsub = PubSubManager(self._clock)
 
+        if soft_voided_tx_ids is None:
+            soft_voided_tx_ids = set()
+        consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=pubsub)
+
         assert peer_id is not None  # XXX: temporary, for checking that tests are using the peer_id
         if peer_id is None:
             peer_id = PeerId()
@@ -145,6 +150,7 @@ class Simulator:
         manager = HathorManager(
             self._clock,
             pubsub=pubsub,
+            consensus_algorithm=consensus_algorithm,
             peer_id=peer_id,
             network=network,
             wallet=wallet,
@@ -152,7 +158,6 @@ class Simulator:
             enable_sync_v2=enable_sync_v2,
             tx_storage=tx_storage,
             rng=Random(self.rng.getrandbits(64)),
-            soft_voided_tx_ids=soft_voided_tx_ids,
         )
 
         manager.reactor = self._clock

--- a/tests/consensus/test_soft_voided2.py
+++ b/tests/consensus/test_soft_voided2.py
@@ -56,8 +56,8 @@ class BaseConsensusSimulatorTestCase(SimulatorTestCase):
         self.graphviz.labels[txF1.hash] = f'txF1-{i}'
 
         if not self.skip_asserts:
-            self.assertIn(txF1.hash, manager1.soft_voided_tx_ids)
-            self.assertIn(txF2.hash, manager1.soft_voided_tx_ids)
+            self.assertIn(txF1.hash, manager1.consensus_algorithm.soft_voided_tx_ids)
+            self.assertIn(txF2.hash, manager1.consensus_algorithm.soft_voided_tx_ids)
 
         txG = add_custom_tx(manager1, [(txF2, 0)], base_parent=tx_base, address=address)
         self.graphviz.labels[txG.hash] = f'txG-{i}'

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -9,6 +9,7 @@ from twisted.internet.threads import deferToThread
 from twisted.trial import unittest
 
 from hathor.conf import HathorSettings
+from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import TestMode, _set_test_mode
 from hathor.pubsub import PubSubManager
 from hathor.simulator.clock import MemoryReactorHeapClock
@@ -57,7 +58,17 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
         wallet = Wallet(directory=self.tmpdir)
         wallet.unlock(b'teste')
-        self.manager = HathorManager(self.reactor, pubsub=self.pubsub, tx_storage=self.tx_storage, wallet=wallet)
+
+        soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
+        consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=self.pubsub)
+
+        self.manager = HathorManager(
+            self.reactor,
+            pubsub=self.pubsub,
+            consensus_algorithm=consensus_algorithm,
+            tx_storage=self.tx_storage,
+            wallet=wallet
+        )
 
         self.tx_storage.indexes.enable_address_index(self.manager.pubsub)
         self.tx_storage.indexes.enable_tokens_index()

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -11,6 +11,7 @@ from twisted.trial import unittest
 
 from hathor.builder import CliBuilder
 from hathor.conf import HathorSettings
+from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import TestMode, _set_test_mode
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
@@ -169,9 +170,13 @@ class TestCase(unittest.TestCase):
         if utxo_index:
             tx_storage.indexes.enable_utxo_index()
 
+        soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
+        consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=pubsub)
+
         manager = HathorManager(
             self.clock,
             pubsub=pubsub,
+            consensus_algorithm=consensus_algorithm,
             peer_id=peer_id,
             network=network,
             wallet=wallet,


### PR DESCRIPTION
## Acceptance criteria

1) Refactor to build the `ConsensusAlgorithm` object outside of `HathorManager`.
2) Refactor `HathorManager` to require a `ConsensusAlgorithm` object.
3) Remove `HathorManager.soft_voided_tx_ids` attribute.