### PR TITLE
chore: add RocksDB and EventManager builder configs

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -87,7 +87,7 @@ class Builder:
         self._rocksdb_path: Optional[str] = None
         self._rocksdb_storage: Optional[RocksDBStorage] = None
         self._rocksdb_cache_capacity: Optional[int] = None
-        self._with_rocksdb_index: Optional[bool] = None
+        self._rocksdb_with_index: Optional[bool] = None
 
         self._tx_storage: Optional[TransactionStorage] = None
         self._event_storage: Optional[EventStorage] = None
@@ -275,8 +275,8 @@ class Builder:
             use_memory_index = self._force_memory_index
 
             kwargs = {}
-            if self._with_rocksdb_index is not None:
-                kwargs = dict(with_index=self._with_rocksdb_index)
+            if self._rocksdb_with_index is not None:
+                kwargs = dict(with_index=self._rocksdb_with_index)
 
             return TransactionRocksDBStorage(
                 rocksdb_storage,
@@ -329,7 +329,7 @@ class Builder:
         self.check_if_can_modify()
         self._storage_type = StorageType.ROCKSDB
         self._rocksdb_path = path
-        self._with_rocksdb_index = with_index
+        self._rocksdb_with_index = with_index
         self._rocksdb_cache_capacity = cache_capacity
         return self
 

--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -310,11 +310,6 @@ class Builder:
 
         return self._event_manager
 
-    def with_event_manager(self, *, event_ws_factory: EventWebsocketFactory) -> 'Builder':
-        self.check_if_can_modify()
-        self._event_ws_factory = event_ws_factory
-        return self
-
     def use_memory(self) -> 'Builder':
         self.check_if_can_modify()
         self._storage_type = StorageType.MEMORY
@@ -386,6 +381,11 @@ class Builder:
         self.check_if_can_modify()
         self.enable_address_index()
         self.enable_tokens_index()
+        return self
+
+    def enable_event_manager(self, *, event_ws_factory: EventWebsocketFactory) -> 'Builder':
+        self.check_if_can_modify()
+        self._event_ws_factory = event_ws_factory
         return self
 
     def set_tx_storage(self, tx_storage: TransactionStorage) -> 'Builder':

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -30,6 +30,7 @@ from hathor.checkpoint import Checkpoint
 from hathor.conf import HathorSettings
 from hathor.consensus import ConsensusAlgorithm
 from hathor.event.event_manager import EventManager
+from hathor.event.storage import EventStorage
 from hathor.exception import (
     DoubleSpendingError,
     HathorError,
@@ -87,6 +88,7 @@ class HathorManager:
                  consensus_algorithm: ConsensusAlgorithm,
                  peer_id: PeerId,
                  tx_storage: TransactionStorage,
+                 event_storage: EventStorage,
                  network: str,
                  hostname: Optional[str] = None,
                  wallet: Optional[BaseWallet] = None,
@@ -167,6 +169,9 @@ class HathorManager:
         self.tx_storage.pubsub = self.pubsub
 
         self._event_manager = event_manager
+
+        if self._event_manager:
+            assert self._event_manager.event_storage == event_storage
 
         if enable_sync_v2:
             assert self.tx_storage.indexes is not None

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -159,7 +159,7 @@ class Simulator:
             .use_memory()
 
         if event_ws_factory:
-            builder.with_event_manager(event_ws_factory=event_ws_factory)
+            builder.enable_event_manager(event_ws_factory=event_ws_factory)
 
         artifacts = builder.build()
 

--- a/tests/event/test_event_manager.py
+++ b/tests/event/test_event_manager.py
@@ -1,10 +1,9 @@
 from unittest.mock import Mock
 
-from hathor.event import EventManager
 from hathor.event.model.event_type import EventType
 from hathor.event.storage.memory_storage import EventMemoryStorage
 from hathor.event.websocket import EventWebsocketFactory
-from hathor.pubsub import HathorEvents, PubSubManager
+from hathor.pubsub import HathorEvents
 from tests import unittest
 
 
@@ -13,21 +12,13 @@ class BaseEventManagerTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.event_storage = EventMemoryStorage()
-        self.event_ws_factory = Mock(spec_set=EventWebsocketFactory)
         self.network = 'testnet'
-        pubsub = PubSubManager(self.clock)
-        self.event_manager = EventManager(
-            event_storage=self.event_storage,
-            event_ws_factory=self.event_ws_factory,
-            pubsub=pubsub,
-            reactor=self.clock
-        )
+        self.event_storage = EventMemoryStorage()
         self.manager = self.create_peer(
             self.network,
-            event_manager=self.event_manager,
-            pubsub=pubsub,
-            full_verification=False
+            event_ws_factory=Mock(spec_set=EventWebsocketFactory),
+            full_verification=False,
+            event_storage=self.event_storage
         )
 
     def test_if_event_is_persisted(self):

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -1,11 +1,9 @@
 from unittest.mock import Mock
 
 from hathor.conf import HathorSettings
-from hathor.event import EventManager
 from hathor.event.model.event_type import EventType
 from hathor.event.storage import EventMemoryStorage
 from hathor.event.websocket import EventWebsocketFactory
-from hathor.pubsub import PubSubManager
 from tests import unittest
 from tests.utils import add_new_blocks, get_genesis_key
 
@@ -18,20 +16,12 @@ class BaseEventReorgTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.network = 'testnet'
-        self.event_ws_factory = Mock(spec_set=EventWebsocketFactory)
         self.event_storage = EventMemoryStorage()
-        pubsub = PubSubManager(self.clock)
-        self.event_manager = EventManager(
-            event_storage=self.event_storage,
-            event_ws_factory=self.event_ws_factory,
-            pubsub=pubsub,
-            reactor=self.clock
-        )
         self.manager = self.create_peer(
             self.network,
-            event_manager=self.event_manager,
-            pubsub=pubsub,
-            full_verification=False
+            event_ws_factory=Mock(spec_set=EventWebsocketFactory),
+            full_verification=False,
+            event_storage=self.event_storage
         )
 
         # read genesis keys

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -185,7 +185,7 @@ class TestCase(unittest.TestCase):
             builder.set_event_manager(event_manager)
 
         if event_ws_factory:
-            builder.with_event_manager(event_ws_factory=event_ws_factory)
+            builder.enable_event_manager(event_ws_factory=event_ws_factory)
 
         if tx_storage is not None:
             builder.set_tx_storage(tx_storage)

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -145,7 +145,7 @@ class TestCase(unittest.TestCase):
     def create_peer(self, network, peer_id=None, wallet=None, tx_storage=None, unlock_wallet=True, wallet_index=False,
                     capabilities=None, full_verification=True, enable_sync_v1=None, enable_sync_v2=None,
                     checkpoints=None, utxo_index=False, event_manager=None, use_memory_index=None, start_manager=True,
-                    pubsub=None):
+                    pubsub=None, event_storage=None, event_ws_factory=None):
         if enable_sync_v1 is None:
             assert hasattr(self, '_enable_sync_v1'), ('`_enable_sync_v1` has no default by design, either set one on '
                                                       'the test class or pass `enable_sync_v1` by argument')
@@ -178,12 +178,19 @@ class TestCase(unittest.TestCase):
                 wallet.unlock(b'MYPASS')
         builder.set_wallet(wallet)
 
+        if event_storage:
+            builder.set_event_storage(event_storage)
+
         if event_manager:
             builder.set_event_manager(event_manager)
 
+        if event_ws_factory:
+            builder.with_event_manager(event_ws_factory=event_ws_factory)
+
         if tx_storage is not None:
             builder.set_tx_storage(tx_storage)
-        elif self.use_memory_storage:
+
+        if self.use_memory_storage:
             builder.use_memory()
         else:
             directory = tempfile.mkdtemp()


### PR DESCRIPTION
Acceptance Criteria:

- Make `HathorManager` receive a required `EventStorage`
  - This will be necessary on https://github.com/HathorNetwork/hathor-core/pull/555, to check if the event queue feature was enabled in the previous run
- `Builder` changes
  - Add `peer_id` to builder artifacts
  - Make memory be the default storage type
  - Add RockDB's `cache_capacity` and `with_index` configs
  - Add `enable_event_manager()` auxiliary method
- Update usages of `Builder`, (`CliBuilder` and `Simulator`) to use event related configs
  







