### PR TITLE
fix(version): copy the BUILD_VERSION file into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,8 @@ ARG PYTHON
 RUN apt-get -qy update
 RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
 COPY --from=stage-0 /app/.venv/lib/python${PYTHON}/site-packages/ /usr/local/lib/python${PYTHON}/site-packages/
+# XXX: copy optional BUILD_VERSION file using ...VERSIO[N] instead of ...VERSION* to ensure only one file will be copied
+# XXX: also copying the README.md because we need at least one existing file
+COPY README.md BUILD_VERSIO[N] /
 EXPOSE 40403 8080
 ENTRYPOINT ["python", "-m", "hathor"]

--- a/Dockerfile.pypy
+++ b/Dockerfile.pypy
@@ -29,5 +29,8 @@ ARG PYTHON
 RUN apt-get -qy update && apt-get -qy upgrade
 RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
 COPY --from=stage-0 /app/.venv/lib/pypy${PYTHON}/site-packages/ /opt/pypy/lib/pypy${PYTHON}/site-packages/
+# XXX: copy optional BUILD_VERSION file using ...VERSIO[N] instead of ...VERSION* to ensure only one file will be copied
+# XXX: also copying the README.md because we need at least one existing file
+COPY README.md BUILD_VERSIO[N] /
 EXPOSE 40403 8080
 ENTRYPOINT ["pypy", "-m", "hathor"]


### PR DESCRIPTION
### Acceptance Criteria

Our built Docker images should contain the BUILD_VERSION file, so they are able to report the injected version when running.

### How to test

1. Create a BUILD_VERSION file in your local repo:
```
cat <<EOF > BUILD_VERSION                         
1.2.3
EOF
```

2. Build the image with `docker build -t local/hathor-core .`

3. Run it with `docker run -it local/hathor-core run_node`

The first log should contain the right version.

4. Remove the BUILD_VERSION file and build and run the image again. The version should now contain the `-local` prefix.