### PR TITLE
feat: Add safeguards for partially validated transactions [part 1/2]

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -366,11 +366,14 @@ class HathorSettings(NamedTuple):
     # List of soft voided transaction.
     SOFT_VOIDED_TX_IDS: List[bytes] = []
 
-    # Identifier used in metadata's voided_by.
+    # Identifier used in metadata's voided_by to mark a tx as soft-voided.
     SOFT_VOIDED_ID: bytes = b'tx-non-grata'
 
     # Identifier used in metadata's voided_by when an unexpected exception occurs at consensus.
     CONSENSUS_FAIL_ID: bytes = b'consensus-fail'
+
+    # Identifier used in metadata's voided_by to mark a tx as partially validated.
+    PARTIALLY_VALIDATED_ID: bytes = b'pending-validation'
 
     ENABLE_EVENT_QUEUE_FEATURE: bool = False
 

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -83,6 +83,11 @@ class ConsensusAlgorithm:
         """Run a consensus update with its own context, indexes will be updated accordingly."""
         from hathor.transaction import Block, Transaction
 
+        # XXX: first make sure we can run the consensus update on this tx:
+        meta = base.get_metadata()
+        assert meta.voided_by is None or (settings.PARTIALLY_VALIDATED_ID not in meta.voided_by)
+        assert meta.validation.is_fully_connected()
+
         # this context instance will live only while this update is running
         context = self.create_context()
 

--- a/hathor/graphviz.py
+++ b/hathor/graphviz.py
@@ -52,6 +52,7 @@ class GraphvizVisualizer:
         self.voided_attrs = dict(style='dashed,filled', penwidth='0.25', fillcolor='#BDC3C7')
         self.soft_voided_attrs = dict(style='dashed,filled', penwidth='0.25', fillcolor='#CCCCFF')
         self.conflict_attrs = dict(style='dashed,filled', penwidth='2.0', fillcolor='#BDC3C7')
+        self.not_fully_validated_attrs = dict(style='dashed,filled', penwidth='0.25', fillcolor='#F9FFAB')
 
         # Labels
         self.labels: Dict[bytes, str] = {}
@@ -95,6 +96,9 @@ class GraphvizVisualizer:
                 node_attrs.update(self.soft_voided_attrs)
             else:
                 node_attrs.update(self.voided_attrs)
+
+        if not meta.validation.is_fully_connected():
+            node_attrs.update(self.not_fully_validated_attrs)
 
         return node_attrs
 

--- a/hathor/indexes/base_index.py
+++ b/hathor/indexes/base_index.py
@@ -15,11 +15,15 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
+from structlog import get_logger
+
 from hathor.indexes.scope import Scope
 from hathor.transaction.base_transaction import BaseTransaction
 
 if TYPE_CHECKING:  # pragma: no cover
     from hathor.indexes.manager import IndexesManager
+
+logger = get_logger()
 
 
 class BaseIndex(ABC):
@@ -28,6 +32,8 @@ class BaseIndex(ABC):
     This class exists so we can interact with indexes without knowing anything specific to its implemented. It was
     created to generalize how we initialize indexes and keep track of which ones are up-to-date.
     """
+    def __init__(self) -> None:
+        self.log = logger.new()
 
     def init_start(self, indexes_manager: 'IndexesManager') -> None:
         """ This method will always be called when starting the index manager, regardless of initialization state.

--- a/hathor/indexes/manager.py
+++ b/hathor/indexes/manager.py
@@ -319,12 +319,12 @@ class MemoryIndexesManager(IndexesManager):
         if self.utxo is None:
             self.utxo = MemoryUtxoIndex()
 
-    def enable_deps_index(self) -> None:
+    def enable_mempool_index(self) -> None:
         from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
         if self.mempool_tips is None:
             self.mempool_tips = MemoryMempoolTipsIndex()
 
-    def enable_mempool_index(self) -> None:
+    def enable_deps_index(self) -> None:
         from hathor.indexes.memory_deps_index import MemoryDepsIndex
         if self.deps is None:
             self.deps = MemoryDepsIndex()
@@ -373,13 +373,13 @@ class RocksDBIndexesManager(IndexesManager):
         if self.utxo is None:
             self.utxo = RocksDBUtxoIndex(self._db)
 
-    def enable_deps_index(self) -> None:
+    def enable_mempool_index(self) -> None:
         from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
         if self.mempool_tips is None:
             # XXX: use of RocksDBMempoolTipsIndex is very slow and was suspended
             self.mempool_tips = MemoryMempoolTipsIndex()
 
-    def enable_mempool_index(self) -> None:
+    def enable_deps_index(self) -> None:
         from hathor.indexes.memory_deps_index import MemoryDepsIndex
         if self.deps is None:
             # XXX: use of RocksDBDepsIndex is currently suspended until it is fixed

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import deque
-from typing import TYPE_CHECKING, Deque
+from typing import TYPE_CHECKING, Deque, Optional
 
 from OpenSSL.crypto import X509
 from structlog import get_logger
@@ -157,9 +157,16 @@ class FakeConnection:
 
         return True
 
-    def run_until_complete(self, debug=False, force=False):
+    def run_until_empty(self, max_steps: Optional[int] = None, debug: bool = False, force: bool = False) -> None:
+        """ Step until the connection reports as empty, optionally raise an assert if it takes more than `max_steps`.
+        """
+        steps = 0
         while not self.is_empty():
+            steps += 1
+            if max_steps is not None and steps > max_steps:
+                raise AssertionError('took more steps than expected')
             self.run_one_step(debug=debug, force=force)
+        self.log.debug('conn empty', steps=steps)
 
     def _deliver_message(self, proto, data, debug=False):
         proto.dataReceived(data)

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -239,16 +239,27 @@ class Simulator:
 
     def run_until_complete(self,
                            max_interval: float,
+                           min_interval: float = 0.0,
                            step: float = DEFAULT_STEP_INTERVAL,
                            status_interval: float = DEFAULT_STATUS_INTERVAL) -> bool:
         """ Will stop when all peers have synced/errored (-> True), or when max_interval is elapsed (-> False).
 
+        Optionally keep running for at least `min_interval` ignoring the stop condition.
+
         Make sure miners/tx_generators are stopped or this will almost certainly run until max_interval.
         """
         assert self._started
+        steps = 0
+        interval = 0.0
+        initial = self._clock.seconds()
         for _ in self._run(max_interval, step, status_interval):
-            if all(not conn.can_step() for conn in self._connections):
+            steps += 1
+            latest_time = self._clock.seconds()
+            interval = latest_time - initial
+            if interval > min_interval and all(not conn.can_step() for conn in self._connections):
+                self.log.debug('run_until_complete: all done', steps=steps, dt=interval)
                 return True
+        self.log.debug('run_until_complete: max steps exceeded', steps=steps, dt=interval)
         return False
 
     def run(self,

--- a/hathor/simulator/trigger.py
+++ b/hathor/simulator/trigger.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hathor.simulator.miner import AbstractMiner
+    from hathor.simulator.tx_generator import RandomTransactionGenerator
     from hathor.wallet import BaseWallet
 
 
@@ -54,3 +55,19 @@ class StopAfterMinimumBalance(Trigger):
     def should_stop(self) -> bool:
         balance = self.wallet.balance[self.token_uid].available
         return balance >= self.minimum_balance
+
+
+class StopAfterNTransactions(Trigger):
+    """Stop the simulation after N transactions are found."""
+    def __init__(self, tx_generator: 'RandomTransactionGenerator', *, quantity: int) -> None:
+        self.tx_generator = tx_generator
+        self.quantity = quantity
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset the counter, so this trigger can be reused."""
+        self.initial_counter = self.tx_generator.transactions_found
+
+    def should_stop(self) -> bool:
+        diff = self.tx_generator.transactions_found - self.initial_counter
+        return diff >= self.quantity

--- a/hathor/simulator/tx_generator.py
+++ b/hathor/simulator/tx_generator.py
@@ -62,6 +62,7 @@ class RandomTransactionGenerator:
 
         # Most recent transactions generated here.
         # The lowest index has the most recent transaction.
+        self.transactions_found: int = 0
         self.latest_transactions: Deque[Transaction] = deque()
 
         self.double_spending_only = False
@@ -87,6 +88,7 @@ class RandomTransactionGenerator:
         if self.tx:
             ret = self.manager.propagate_tx(self.tx, fails_silently=False)
             assert ret is True
+            self.transactions_found += 1
             self.latest_transactions.appendleft(self.tx.hash)
             if len(self.latest_transactions) > self.MAX_LATEST_TRANSACTIONS_LEN:
                 self.latest_transactions.pop()

--- a/hathor/transaction/storage/memory_storage.py
+++ b/hathor/transaction/storage/memory_storage.py
@@ -85,6 +85,7 @@ class TransactionMemoryStorage(BaseTransactionStorage):
             tx = self._clone(self.transactions[hash_bytes])
             if hash_bytes in self.metadata:
                 tx._metadata = self._clone(self.metadata[hash_bytes])
+            assert tx._metadata is not None
             return tx
         else:
             raise TransactionDoesNotExist(hash_bytes.hex())

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -275,6 +275,8 @@ class Transaction(BaseTransaction):
 
     def verify_checkpoint(self, checkpoints: List[Checkpoint]) -> None:
         assert self.storage is not None
+        if self.is_genesis:
+            return
         meta = self.get_metadata()
         # at least one child must be checkpoint validated
         for child_tx in map(self.storage.get_transaction, meta.children):

--- a/tests/consensus/test_consensus.py
+++ b/tests/consensus/test_consensus.py
@@ -120,8 +120,8 @@ class BaseConsensusTestCase(unittest.TestCase):
         manager = self.create_peer('testnet', tx_storage=self.tx_storage)
 
         # Mine a few blocks in a row with no transaction but the genesis
-        blocks = add_new_blocks(manager, 3, advance_clock=15)
-        add_blocks_unlock_reward(manager)
+        add_new_blocks(manager, 3, advance_clock=15)
+        blocks = add_blocks_unlock_reward(manager)
 
         # Add some transactions between blocks
         add_new_transactions(manager, 5, advance_clock=15)

--- a/tests/consensus/test_soft_voided.py
+++ b/tests/consensus/test_soft_voided.py
@@ -1,6 +1,7 @@
 from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
+from hathor.simulator.trigger import StopAfterNTransactions
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_new_tx
@@ -43,8 +44,8 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         gen_tx2 = simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx2.start()
 
-        while not gen_tx2.latest_transactions:
-            simulator.run(600)
+        trigger = StopAfterNTransactions(gen_tx2, quantity=1)
+        self.assertTrue(simulator.run(7200, trigger=trigger))
 
         yield gen_tx2
 

--- a/tests/consensus/test_soft_voided3.py
+++ b/tests/consensus/test_soft_voided3.py
@@ -1,6 +1,7 @@
 from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
+from hathor.simulator.trigger import StopAfterNTransactions
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_custom_tx, gen_new_tx
@@ -44,8 +45,8 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         gen_tx2 = simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx2.start()
 
-        while not gen_tx2.latest_transactions:
-            simulator.run(300)
+        trigger = StopAfterNTransactions(gen_tx2, quantity=1)
+        self.assertTrue(simulator.run(7200, trigger=trigger))
 
         yield gen_tx2
 

--- a/tests/consensus/test_soft_voided4.py
+++ b/tests/consensus/test_soft_voided4.py
@@ -1,6 +1,7 @@
 from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
+from hathor.simulator.trigger import StopAfterNTransactions
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_new_double_spending
@@ -38,8 +39,8 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         gen_tx2 = simulator.create_tx_generator(manager2, rate=10 / 60., hashpower=1e6, ignore_no_funds=True)
         gen_tx2.start()
 
-        while not gen_tx2.latest_transactions:
-            simulator.run(600)
+        trigger = StopAfterNTransactions(gen_tx2, quantity=1)
+        self.assertTrue(simulator.run(7200, trigger=trigger))
 
         yield gen_tx2
 

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -215,8 +215,8 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self.conn.run_one_step()
         conn.run_one_step()
         # continue until messages stop
-        self.conn.run_until_complete()
-        conn.run_until_complete()
+        self.conn.run_until_empty()
+        conn.run_until_empty()
         self.run_to_completion()
         # one of the peers will close the connection. We don't know which on, as it depends
         # on the peer ids

--- a/tests/resources/transaction/test_tx.py
+++ b/tests/resources/transaction/test_tx.py
@@ -3,6 +3,7 @@ from twisted.internet.defer import inlineCallbacks
 from hathor.transaction import Transaction
 from hathor.transaction.resources import TransactionResource
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.transaction_metadata import ValidationState
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
@@ -84,6 +85,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                   '2dc703120a77192fc16eda9ed22e1b88ac40200000218def416095b08602003d3c40fb04737e1a2a848cfd2592490a71cd'
                   '0248b9e7d6a626f45dec86975b00f4dd53f84f1f0091125250b044e49023fbbd0f74f6093cdd2226fdff3e09a1000002be')
         tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
+        tx.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx)
 
         tx_parent1_hex = ('0001010102001c382847d8440d05da95420bee2ebeb32bc437f82a9ae47b0745c8a29a7b0d001c382847d844'
@@ -95,6 +97,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           '5250b044e49023fbbd0f74f6093cdd2226fdff3e09a1001f16fe62e3433bcc74b262c11a1fa94fcb38484f4d'
                           '8fb080f53a0c9c57ddb000000120')
         tx_parent1 = Transaction.create_from_struct(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
+        tx_parent1.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx_parent1)
 
         tx_parent2_hex = ('0001000103001f16fe62e3433bcc74b262c11a1fa94fcb38484f4d8fb080f53a0c9c57ddb001006946304402'
@@ -106,6 +109,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           '62e3433bcc74b262c11a1fa94fcb38484f4d8fb080f53a0c9c57ddb00065329457d13410ac711318bd941e16'
                           'd57709926b76e64763bf19c3f13eeac30000016d')
         tx_parent2 = Transaction.create_from_struct(bytes.fromhex(tx_parent2_hex), self.manager.tx_storage)
+        tx_parent2.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx_parent2)
 
         tx_input_hex = ('0001010203007231eee3cb6160d95172a409d634d0866eafc8775f5729fff6a61e7850aba500b3ab76c5337b55'
@@ -120,6 +124,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                         '5e95ac369b31f46188ac40200000218def416082eba802000e4e54b2922c1fa34b5d427f1e96885612e28673ac'
                         'cfaf6e7ceb2ba91c9c84009c8174d4a46ebcc789d1989e3dec5b68cffeef239fd8cf86ef62728e2eacee000001b6')
         tx_input = Transaction.create_from_struct(bytes.fromhex(tx_input_hex), self.manager.tx_storage)
+        tx_input.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx_input)
 
         # XXX: this is completely dependant on MemoryTokensIndex implementation, hence use_memory_storage=True
@@ -186,6 +191,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                   '7851af043c11e19f28675b010e8cf4d8da3278f126d2429490a804a7fb2c000023b318c91dcfd4b967b205dc938f9f5e2fd'
                   '5114256caacfb8f6dd13db33000020393')
         tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
+        tx.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx)
 
         tx_parent1_hex = ('0001010203000023b318c91dcfd4b967b205dc938f9f5e2fd5114256caacfb8f6dd13db330000023b318c91dcfd'
@@ -200,6 +206,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           '08ef288ac40311513e4fef9d161087be202000023b318c91dcfd4b967b205dc938f9f5e2fd5114256caacfb8f6d'
                           'd13db3300038c3d3b69ce90bb88c0c4d6a87b9f0c349e5b10c9b7ce6714f996e512ac16400021261')
         tx_parent1 = Transaction.create_from_struct(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
+        tx_parent1.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx_parent1)
 
         tx_parent2_hex = ('000201040000476810205cb3625d62897fcdad620e01d66649869329640f5504d77e960d01006a473045022100c'
@@ -213,6 +220,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           '00d810')
         tx_parent2_bytes = bytes.fromhex(tx_parent2_hex)
         tx_parent2 = TokenCreationTransaction.create_from_struct(tx_parent2_bytes, self.manager.tx_storage)
+        tx_parent2.get_metadata().validation = ValidationState.FULL
         self.manager.tx_storage.save_transaction(tx_parent2)
 
         # Both inputs are the same as the last parent, so no need to manually add them

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -31,9 +31,11 @@ class BaseCacheStorageTest(unittest.TestCase):
         super().tearDown()
 
     def _get_new_tx(self, nonce):
+        from hathor.transaction.transaction_metadata import ValidationState
         tx = Transaction(nonce=nonce, storage=self.cache_storage)
         tx.update_hash()
         meta = TransactionMetadata(hash=tx.hash)
+        meta.validation = ValidationState.FULL
         tx._metadata = meta
         return tx
 

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -30,6 +30,7 @@ from hathor.transaction.exceptions import (
 )
 from hathor.transaction.scripts import P2PKH, parse_address_script
 from hathor.transaction.storage import TransactionMemoryStorage
+from hathor.transaction.transaction_metadata import ValidationState
 from hathor.transaction.util import int_to_bytes
 from hathor.wallet import Wallet
 from tests import unittest
@@ -197,6 +198,7 @@ class BaseTransactionTest(unittest.TestCase):
 
     def test_children_update(self):
         tx = self._gen_tx_spending_genesis_block()
+        tx.get_metadata().validation = ValidationState.FULL
 
         # get info before update
         children_len = []

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -223,6 +223,21 @@ class BaseTransactionStorageTest(unittest.TestCase):
     def test_save_tx(self):
         self.validate_save(self.tx)
 
+    def test_pre_save_validation_invalid_tx_1(self):
+        self.tx.get_metadata().validation = ValidationState.BASIC
+        with self.assertRaises(AssertionError):
+            self.validate_save(self.tx)
+
+    def test_pre_save_validation_invalid_tx_2(self):
+        self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        with self.assertRaises(AssertionError):
+            self.validate_save(self.tx)
+
+    def test_pre_save_validation_success(self):
+        self.tx.get_metadata().validation = ValidationState.BASIC
+        self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        self.validate_save(self.tx)
+
     def test_save_token_creation_tx(self):
         tx = create_tokens(self.manager, propagate=False)
         tx.get_metadata().validation = ValidationState.FULL

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -55,6 +55,8 @@ class BaseBasicWalletTest(unittest.TestCase):
             self.assertEqual(key, key2)
 
     def test_wallet_create_transaction(self):
+        from hathor.transaction.transaction_metadata import ValidationState
+
         genesis_private_key_bytes = get_private_key_bytes(
             self.genesis_private_key,
             encryption_algorithm=serialization.BestAvailableEncryption(PASSWORD)
@@ -84,6 +86,7 @@ class BaseBasicWalletTest(unittest.TestCase):
         tx1 = w.prepare_transaction_compute_inputs(Transaction, [out], self.storage)
         tx1.storage = self.storage
         tx1.update_hash()
+        tx1.get_metadata().validation = ValidationState.FULL
         self.storage.save_transaction(tx1)
         w.on_new_tx(tx1)
         self.assertEqual(len(w.spent_txs), 1)
@@ -99,6 +102,7 @@ class BaseBasicWalletTest(unittest.TestCase):
                                                       outputs=[out], tx_storage=self.storage)
         tx2.storage = self.storage
         tx2.update_hash()
+        tx2.get_metadata().validation = ValidationState.FULL
         self.storage.save_transaction(tx2)
         w.on_new_tx(tx2)
         self.assertEqual(len(w.spent_txs), 2)

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -25,6 +25,8 @@ class BaseWalletHDTest(unittest.TestCase):
         self.TOKENS = self.BLOCK_TOKENS
 
     def test_transaction_and_balance(self):
+        from hathor.transaction.transaction_metadata import ValidationState
+
         # generate a new block and check if we increase balance
         new_address = self.wallet.get_unused_address()
         out = WalletOutputInfo(decode_address(new_address), self.TOKENS, timelock=None)
@@ -42,6 +44,7 @@ class BaseWalletHDTest(unittest.TestCase):
         tx1.update_hash()
         tx1.verify_script(tx1.inputs[0], block)
         tx1.storage = self.tx_storage
+        tx1.get_metadata().validation = ValidationState.FULL
         self.wallet.on_new_tx(tx1)
         self.tx_storage.save_transaction(tx1)
         self.assertEqual(len(self.wallet.spent_txs), 1)
@@ -60,6 +63,7 @@ class BaseWalletHDTest(unittest.TestCase):
         tx2.update_hash()
         tx2.storage = self.tx_storage
         tx2.verify_script(tx2.inputs[0], tx1)
+        tx2.get_metadata().validation = ValidationState.FULL
         self.tx_storage.save_transaction(tx2)
         self.wallet.on_new_tx(tx2)
         self.assertEqual(len(self.wallet.spent_txs), 2)


### PR DESCRIPTION
## Acceptance criteria

1. Void all partially validated transactions.
2. Show partially validated transactions in yellow in Graphviz.
3. Fix wrong method names in `IndexManager`: `enable_deps_index` and `enable_mempool_index`.
4. Fix `RocksDBDepsIndex` when new transactions are added.
5. Add some tools for `Simulator` and related classes.
6. Add trigger `StopAfterNTransactions` for simulators.
7. Check `ValidationState` with `meta.voided_by` before saving metadata to storage.
8. Fix some flaky tests using `StopAfterNTransactions`.