### PR TITLE
tests: Non-stopped simulator causing other tests to fail

### DIFF
--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -62,6 +62,7 @@ class Simulator:
 
         def verify_pow(self: BaseTransaction, *args: Any, **kwargs: Any) -> None:
             assert self.hash is not None
+            logger.new().debug('Skipping BaseTransaction.verify_pow() for simulator')
 
         cls._original_verify_pow = BaseTransaction.verify_pow
         BaseTransaction.verify_pow = verify_pow

--- a/tests/simulation/test_trigger.py
+++ b/tests/simulation/test_trigger.py
@@ -19,6 +19,10 @@ class TriggerTestCase(unittest.TestCase):
         print('Simulation seed config:', self.simulator.seed)
         print('-' * 30)
 
+    def tearDown(self):
+        super().tearDown()
+        self.simulator.stop()
+
     def test_stop_after_n_mined_blocks(self):
         miner1 = self.simulator.create_miner(self.manager1, hashpower=1e6)
         miner1.start()


### PR DESCRIPTION
Fixes https://github.com/HathorNetwork/hathor-core/issues/574.

## Acceptance criteria

1. Stop simulator on `tearDown()`.