### PR TITLE
feat(sync): Limit number of sync running simultaneously

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -194,6 +194,9 @@ class CliBuilder:
             full_verification=full_verification
         )
 
+        if args.data:
+            self.manager.set_cmd_path(args.data)
+
         if args.allow_mining_without_peers:
             self.manager.allow_mining_without_peers()
 

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -373,3 +373,9 @@ class HathorSettings(NamedTuple):
     EVENT_API_DEFAULT_BATCH_SIZE: int = 100
 
     EVENT_API_MAX_BATCH_SIZE: int = 1000
+
+    # Maximum number of sync running simultaneously.
+    MAX_ENABLED_SYNC: int = 16
+
+    # Time to update the peers that are running sync.
+    SYNC_UPDATE_INTERVAL: int = 10 * 60  # seconds

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -127,6 +127,8 @@ class HathorManager:
         self._enable_sync_v1 = enable_sync_v1
         self._enable_sync_v2 = enable_sync_v2
 
+        self._cmd_path: Optional[str] = None
+
         self.log = logger.new()
 
         if rng is None:
@@ -1222,6 +1224,14 @@ class HathorManager:
                           vertex_count=vertex_count, **self.environment_info.as_dict())
 
             self.lc_check_sync_state.stop()
+
+    def set_cmd_path(self, path: str) -> None:
+        """Set the cmd path, where sysadmins can place files to communicate with the full node."""
+        self._cmd_path = path
+
+    def get_cmd_path(self) -> Optional[str]:
+        """Return the cmd path. If no cmd path is set, returns None."""
+        return self._cmd_path
 
 
 class ParentTxs(NamedTuple):

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, Iterable, NamedTuple, Optional, Set, Union
+import os
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union
 
 from structlog import get_logger
 from twisted.internet import endpoints
@@ -27,6 +28,7 @@ from hathor.p2p.netfilter.factory import NetfilterFactory
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.peer_storage import PeerStorage
 from hathor.p2p.protocol import HathorProtocol
+from hathor.p2p.rate_limiter import RateLimiter
 from hathor.p2p.states.ready import ReadyState
 from hathor.p2p.sync_factory import SyncManagerFactory
 from hathor.p2p.sync_version import SyncVersion
@@ -48,6 +50,26 @@ settings = HathorSettings()
 WHITELIST_REQUEST_TIMEOUT = 45
 
 
+def parse_text(text: str) -> List[str]:
+    ret: List[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith('#'):
+            continue
+        ret.append(line)
+    return ret
+
+
+class _SyncRotateInfo(NamedTuple):
+    candidates: List[str]
+    old: Set[str]
+    new: Set[str]
+    to_disable: Set[str]
+    to_enable: Set[str]
+
+
 class _ConnectingPeer(NamedTuple):
     connection_string: str
     endpoint_deferred: Deferred
@@ -63,6 +85,11 @@ class PeerConnectionsMetrics(NamedTuple):
 class ConnectionsManager:
     """ It manages all peer-to-peer connections and events related to control messages.
     """
+    MAX_ENABLED_SYNC = settings.MAX_ENABLED_SYNC
+    SYNC_UPDATE_INTERVAL = settings.SYNC_UPDATE_INTERVAL
+
+    class GlobalRateLimiter:
+        SEND_TIPS = 'NodeSyncTimestamp.send_tips'
 
     connections: Set[HathorProtocol]
     connected_peers: Dict[str, HathorProtocol]
@@ -70,6 +97,8 @@ class ConnectionsManager:
     handshaking_peers: Set[HathorProtocol]
     whitelist_only: bool
     _sync_factories: Dict[SyncVersion, SyncManagerFactory]
+
+    rate_limiter: RateLimiter
 
     def __init__(self, reactor: Reactor, my_peer: PeerId, server_factory: 'HathorServerFactory',
                  client_factory: 'HathorClientFactory', pubsub: PubSubManager, manager: 'HathorManager',
@@ -98,6 +127,10 @@ class ConnectionsManager:
 
         self.max_connections: int = settings.PEER_MAX_CONNECTIONS
 
+        # Global rate limiter for all connections.
+        self.rate_limiter = RateLimiter(self.reactor)
+        self.enable_rate_limiter()
+
         # All connections.
         self.connections = set()
 
@@ -121,6 +154,17 @@ class ConnectionsManager:
         self.lc_reconnect = LoopingCall(self.reconnect_to_all)
         self.lc_reconnect.clock = self.reactor
 
+        # A timer to update sync of all peers.
+        self.lc_sync_update = LoopingCall(self.sync_update)
+        self.lc_sync_update.clock = self.reactor
+        self.lc_sync_update_interval: float = 5  # seconds
+
+        # Peers that always have sync enabled.
+        self.always_enable_sync: Set[str] = set()
+
+        # Timestamp of the last time sync was updated.
+        self._last_sync_rotate: float = 0.
+
         # A timer to try to reconnect to the disconnect known peers.
         if settings.ENABLE_PEER_WHITELIST:
             self.wl_reconnect = LoopingCall(self.update_whitelist)
@@ -141,8 +185,21 @@ class ConnectionsManager:
         if enable_sync_v2:
             self._sync_factories[SyncVersion.V2] = SyncV1Factory(self)
 
+    def disable_rate_limiter(self) -> None:
+        """Disable global rate limiter."""
+        self.rate_limiter.unset_limit(self.GlobalRateLimiter.SEND_TIPS)
+
+    def enable_rate_limiter(self, max_hits: int = 16, window_seconds: float = 1) -> None:
+        """Enable global rate limiter. This method can be called to change the current rate limit."""
+        self.rate_limiter.set_limit(
+            self.GlobalRateLimiter.SEND_TIPS,
+            max_hits,
+            window_seconds
+        )
+
     def start(self) -> None:
         self.lc_reconnect.start(5, now=False)
+        self.lc_sync_update.start(self.lc_sync_update_interval, now=False)
         if settings.ENABLE_PEER_WHITELIST:
             self._start_whitelist_reconnect()
 
@@ -164,6 +221,9 @@ class ConnectionsManager:
     def stop(self) -> None:
         if self.lc_reconnect.running:
             self.lc_reconnect.stop()
+
+        if self.lc_sync_update.running:
+            self.lc_sync_update.stop()
 
     def _get_peers_count(self) -> PeerConnectionsMetrics:
         """Get a dict containing the count of peers in each state"""
@@ -279,6 +339,12 @@ class ConnectionsManager:
 
         # In case it was a retry, we must reset the data only here, after it gets ready
         protocol.peer.reset_retry_timestamp()
+
+        if len(self.connected_peers) <= self.MAX_ENABLED_SYNC:
+            protocol.enable_sync()
+
+        if protocol.peer.id in self.always_enable_sync:
+            protocol.enable_sync()
 
         # Notify other peers about this new peer connection.
         for conn in self.iter_ready_connections():
@@ -560,3 +626,197 @@ class ConnectionsManager:
         protocol = self.connected_peers.get(peer_id)
         if protocol:
             self.drop_connection(protocol)
+
+    def sync_update(self) -> None:
+        """Update the subset of connections that running the sync algorithm."""
+        try:
+            self._sync_update_cmds()
+        except Exception:
+            self.log.error('_sync_update_cmds failed', exc_info=True)
+
+        try:
+            self._sync_rotate_if_needed()
+        except Exception:
+            self.log.error('_sync_rotate_if_needed failed', exc_info=True)
+
+    def _sync_update_cmds(self) -> None:
+        """Run sync_update commands.
+        """
+        self._sync_update_cmd_always_enable_sync()
+        self._sync_update_cmd_p2p_params()
+
+    def _sync_update_cmd_p2p_params(self) -> None:
+        """`p2p_params.txt` should contain a list of parameters and their values.
+
+        Supported parameters:
+        - p2p.max_enabled_sync [quantity:int]
+        - p2p.rate_limiter.global.send_tips [max_hits:int] [window_seconds:float]
+        """
+        cmd_path = self.manager.get_cmd_path()
+        if cmd_path is None:
+            return
+
+        p2p_params_path = os.path.join(cmd_path, 'p2p_params.txt')
+        if not os.path.isfile(p2p_params_path):
+            return
+
+        params = []
+        with open(p2p_params_path, 'r') as fp:
+            for line in parse_text(fp.read()):
+                parts = [x.strip() for x in line.split(' ')]
+                parts = [x for x in parts if x.strip()]
+                if len(parts) == 0:
+                    continue
+                params.append((parts[0], parts[1:]))
+
+        self._execute_cmds(params)
+
+    def _execute_cmds(self, params: List[Tuple[str, List[str]]]) -> None:
+        key_processors = {
+            'p2p.max_enabled_sync': self._cmd_p2p_max_enabled_sync,
+            'p2p.rate_limiter.global.send_tips': self._cmd_rate_limiter_global_send_tips,
+        }
+        for key, args in params:
+            if key not in key_processors:
+                self.log.warn('execution failed: unknown key', key=key, args=args)
+                continue
+            fn = key_processors[key]
+            fn(key, args)
+
+    def _cmd_p2p_max_enabled_sync(self, key: str, args: List[str]) -> None:
+        if len(args) != 1:
+            self.log.warn('execution failed: invalid args', key=key, args=args)
+            return
+        try:
+            value = int(args[0])
+        except ValueError:
+            self.log.warn('execution failed: invalid args', key=key, args=args)
+            return
+        if value == self.MAX_ENABLED_SYNC:
+            return
+        self.log.warn(f'{key} changed', old=self.MAX_ENABLED_SYNC, new=value)
+        self.MAX_ENABLED_SYNC = value
+        self._sync_rotate_if_needed(force=True)
+
+    def _cmd_rate_limiter_global_send_tips(self, key: str, args: List[str]) -> None:
+        if len(args) != 2:
+            self.log.warn('execution failed: invalid args', key=key, args=args)
+            return
+        try:
+            max_hits = int(args[0])
+            window_seconds = float(args[1])
+        except ValueError:
+            self.log.warn('execution failed: invalid args', key=key, args=args)
+            return
+        limit = self.rate_limiter.get_limit(self.GlobalRateLimiter.SEND_TIPS)
+        if (max_hits, window_seconds) == limit:
+            return
+        self.log.warn(f'{key} changed', old=limit, new=(max_hits, window_seconds))
+        if window_seconds == 0:
+            self.disable_rate_limiter()
+        else:
+            self.enable_rate_limiter(max_hits, window_seconds)
+
+    def _sync_update_cmd_always_enable_sync(self) -> None:
+        """`always_enable_sync.txt` should contain a list of peer ids that will always have sync enabled.
+        It ignores lines starting with '#'.
+        """
+        cmd_path = self.manager.get_cmd_path()
+        if cmd_path is None:
+            return
+
+        always_sync_path = os.path.join(cmd_path, 'always_enable_sync.txt')
+        if not os.path.isfile(always_sync_path):
+            return
+
+        new: Set[str]
+        with open(always_sync_path, 'r') as fp:
+            new = set(parse_text(fp.read()))
+
+        old = self.always_enable_sync
+        if new == old:
+            return
+
+        to_enable = new - old
+        to_disable = old - new
+
+        self.log.info('update always_enable_sync', new=new, to_enable=to_enable, to_disable=to_disable)
+
+        for peer_id in new:
+            if peer_id not in self.connected_peers:
+                continue
+            self.connected_peers[peer_id].enable_sync()
+
+        for peer_id in to_disable:
+            if peer_id not in self.connected_peers:
+                continue
+            self.connected_peers[peer_id].disable_sync()
+
+        self.always_enable_sync = new
+
+    def _check_force_sync_rotate(self) -> bool:
+        """Check if sync rotate should forcefully run now."""
+        cmd_path = self.manager.get_cmd_path()
+        if cmd_path is None:
+            return False
+
+        force_rotate_path = os.path.join(cmd_path, 'force_sync_rotate')
+        if not os.path.isfile(force_rotate_path):
+            return False
+
+        self.log.info('force sync rotate detected')
+        os.remove(force_rotate_path)
+        return True
+
+    def _calculate_sync_rotate(self) -> _SyncRotateInfo:
+        """Calculate new sync rotation."""
+        current_enabled: Set[str] = set()
+        for peer_id, conn in self.connected_peers.items():
+            if conn.is_sync_enabled():
+                current_enabled.add(peer_id)
+
+        candidates = list(self.connected_peers.keys())
+        self.rng.shuffle(candidates)
+        selected_peers: Set[str] = set(candidates[:self.MAX_ENABLED_SYNC])
+
+        to_disable = current_enabled - selected_peers
+        to_enable = selected_peers - current_enabled
+
+        # Do not disable peers in the `always_enable_sync`.
+        to_disable.difference_update(self.always_enable_sync)
+
+        return _SyncRotateInfo(
+            candidates=candidates,
+            old=current_enabled,
+            new=selected_peers,
+            to_disable=to_disable,
+            to_enable=to_enable,
+        )
+
+    def _sync_rotate_if_needed(self, *, force: bool = False) -> None:
+        """Rotate peers who we are syncing from."""
+        if not force:
+            force = self._check_force_sync_rotate()
+
+        now = self.reactor.seconds()
+        dt = now - self._last_sync_rotate
+        if not force and dt < self.SYNC_UPDATE_INTERVAL:
+            return
+        self._last_sync_rotate = now
+
+        info = self._calculate_sync_rotate()
+
+        self.log.info(
+            'sync rotate',
+            candidates=len(info.candidates),
+            old=info.old,
+            new=info.new,
+            to_enable=info.to_enable,
+            to_disable=info.to_disable,
+        )
+
+        for peer_id in info.to_disable:
+            self.connected_peers[peer_id].disable_sync()
+
+        for peer_id in info.to_enable:
+            self.connected_peers[peer_id].enable_sync()

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -134,7 +134,7 @@ class HathorProtocol:
         self.state: Optional[BaseState] = None
 
         # Default rate limit
-        self.ratelimit: RateLimiter = RateLimiter()
+        self.ratelimit: RateLimiter = RateLimiter(self.reactor)
         # self.ratelimit.set_limit(self.RateLimitKeys.GLOBAL, 120, 60)
 
         # Connection string of the peer
@@ -359,6 +359,27 @@ class HathorProtocol:
         """ Executed when an ERROR command is received.
         """
         self.log.warn('remote error', payload=payload)
+
+    def is_sync_enabled(self) -> bool:
+        """Return true if sync is enabled for this connection."""
+        if not self.is_state(self.PeerState.READY):
+            return False
+        assert isinstance(self.state, ReadyState)
+        return self.state.sync_manager.is_sync_enabled()
+
+    def enable_sync(self) -> None:
+        """Enable sync for this connection."""
+        assert self.is_state(self.PeerState.READY)
+        assert isinstance(self.state, ReadyState)
+        self.log.info('enable sync')
+        self.state.sync_manager.enable_sync()
+
+    def disable_sync(self) -> None:
+        """Disable sync for this connection."""
+        assert self.is_state(self.PeerState.READY)
+        assert isinstance(self.state, ReadyState)
+        self.log.info('disable sync')
+        self.state.sync_manager.disable_sync()
 
 
 class HathorLineReceiver(LineReceiver, HathorProtocol):

--- a/hathor/p2p/rate_limiter.py
+++ b/hathor/p2p/rate_limiter.py
@@ -40,7 +40,7 @@ class RateLimiter:
             reactor = twisted_reactor
         self.reactor = reactor
 
-    def set_limit(self, key: str, max_hits: int, window_seconds: int) -> None:
+    def set_limit(self, key: str, max_hits: int, window_seconds: float) -> None:
         """ Set a limit to a given key, e.g., `max_hits = 10` and
         `window_seconds = 60` means at most 10 hits per minute.
 

--- a/hathor/p2p/sync_manager.py
+++ b/hathor/p2p/sync_manager.py
@@ -54,3 +54,15 @@ class SyncManager(ABC):
     def is_errored(self) -> bool:
         """Whether the manager entered an error state"""
         raise NotImplementedError
+
+    def is_sync_enabled(self) -> bool:
+        """Return true if the sync is enabled."""
+        raise NotImplementedError
+
+    def enable_sync(self) -> None:
+        """Enable sync."""
+        raise NotImplementedError
+
+    def disable_sync(self) -> None:
+        """Disable sync."""
+        raise NotImplementedError

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -24,6 +24,7 @@ from structlog import get_logger
 
 from hathor.conf import HathorSettings
 from hathor.indexes import IndexesManager, MemoryIndexesManager
+from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import PubSubManager
 from hathor.transaction.base_transaction import BaseTransaction
 from hathor.transaction.block import Block
@@ -34,6 +35,7 @@ from hathor.transaction.transaction_metadata import TransactionMetadata
 from hathor.util import not_none
 
 settings = HathorSettings()
+cpu = get_cpu_profiler()
 
 # these are the timestamp values to be used when resetting them, 1 is used for the node instead of 0, so it can be
 # greater, that way if both are reset (which also happens on a database that never run this implementation before) we
@@ -552,6 +554,7 @@ class TransactionStorage(ABC):
 
         return highest_height
 
+    @cpu.profiler('get_merkle_tree')
     def get_merkle_tree(self, timestamp: int) -> Tuple[bytes, List[bytes]]:
         """ Generate a hash to check whether the DAG is the same at that timestamp.
 

--- a/tests/p2p/test_cmds.py
+++ b/tests/p2p/test_cmds.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+from tests import unittest
+from tests.simulation.base import SimulatorTestCase
+
+
+class BaseRandomSimulatorTestCase(SimulatorTestCase):
+    def test_cmd_p2p_max_enabled_sync(self):
+        manager = self.create_peer()
+        connections = manager.connections
+        connections._sync_rotate_if_needed = MagicMock()
+        self.assertEqual(connections._sync_rotate_if_needed.call_count, 0)
+
+        connections._execute_cmds([('p2p.max_enabled_sync', ['10'])])
+        self.assertEqual(connections._sync_rotate_if_needed.call_count, 1)
+        self.assertEqual(connections.MAX_ENABLED_SYNC, 10)
+
+        connections._execute_cmds([('p2p.max_enabled_sync', ['10'])])
+        self.assertEqual(connections._sync_rotate_if_needed.call_count, 1)
+        self.assertEqual(connections.MAX_ENABLED_SYNC, 10)
+
+        connections._execute_cmds([('p2p.max_enabled_sync', ['5'])])
+        self.assertEqual(connections._sync_rotate_if_needed.call_count, 2)
+        self.assertEqual(connections.MAX_ENABLED_SYNC, 5)
+
+    def test_cmd_global_rate_limiter_send_tips(self):
+        manager = self.create_peer()
+        connections = manager.connections
+
+        connections._execute_cmds([('p2p.rate_limiter.global.send_tips', ['10', '4'])])
+        limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(limit, (10, 4))
+
+        connections._execute_cmds([('p2p.rate_limiter.global.send_tips', ['15', '5'])])
+        limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(limit, (15, 5))
+
+        connections._execute_cmds([('p2p.rate_limiter.global.send_tips', ['0', '0'])])
+        limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(limit, None)
+
+        # Invalid value.
+        connections._execute_cmds([('p2p.rate_limiter.global.send_tips', ['1.5', '2'])])
+        limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(limit, None)
+
+        # Invalid value.
+        connections._execute_cmds([('p2p.rate_limiter.global.send_tips', ['1', '2a'])])
+        limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(limit, None)
+
+    def test_files(self):
+        manager = self.create_peer()
+        connections = manager.connections
+        connections._sync_rotate_if_needed = MagicMock()
+        self.assertEqual(connections._sync_rotate_if_needed.call_count, 0)
+
+        with tempfile.TemporaryDirectory() as dir_path:
+            content = [
+                'p2p.rate_limiter.global.send_tips 50 4',
+                'p2p.max_enabled_sync 0',
+            ]
+            fp = open(os.path.join(dir_path, 'p2p_params.txt'), 'w')
+            fp.write('\n'.join(content))
+            fp.close()
+
+            content = [
+                'peer-id-1',
+                'peer-id-2',
+            ]
+            fp = open(os.path.join(dir_path, 'always_enable_sync.txt'), 'w')
+            fp.write('\n'.join(content))
+            fp.close()
+
+            fp = open(os.path.join(dir_path, 'force_sync_rotate'), 'w')
+            fp.close()
+
+            manager.set_cmd_path(dir_path)
+            connections.sync_update()
+
+        limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(limit, (50, 4))
+        self.assertEqual(connections.MAX_ENABLED_SYNC, 0)
+        self.assertEqual(connections.always_enable_sync, {'peer-id-1', 'peer-id-2'})
+        self.assertEqual(connections._sync_rotate_if_needed.call_count, 2)
+
+
+class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, BaseRandomSimulatorTestCase):
+    __test__ = True
+
+
+class SyncV2RandomSimulatorTestCase(unittest.SyncV2Params, BaseRandomSimulatorTestCase):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeRandomSimulatorTestCase(unittest.SyncBridgeParams, SyncV2RandomSimulatorTestCase):
+    __test__ = True

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -460,7 +460,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
     def test_downloader_disconnect(self):
         """ This is related to test_downloader_retry_reorder, but it basically tests the change in behavior instead.
 
-        When a peer disconnects it should be immediately remvoed from the tx-detail's connections list.
+        When a peer disconnects it should be immediately removed from the tx-detail's connections list.
         """
         self._downloader_bug_setup()
 

--- a/tests/p2p/test_sync_enabled.py
+++ b/tests/p2p/test_sync_enabled.py
@@ -1,0 +1,75 @@
+from hathor.simulator import FakeConnection
+from hathor.simulator.trigger import StopAfterNMinedBlocks
+from tests import unittest
+from tests.simulation.base import SimulatorTestCase
+
+
+class BaseRandomSimulatorTestCase(SimulatorTestCase):
+    def test_new_node_disabled(self):
+        manager1 = self.create_peer()
+        manager1.allow_mining_without_peers()
+
+        miner1 = self.simulator.create_miner(manager1, hashpower=10e6)
+        miner1.start()
+        trigger = StopAfterNMinedBlocks(miner1, quantity=20)
+        self.simulator.run(3600, trigger=trigger)
+
+        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=3 / 60., hashpower=1e6, ignore_no_funds=True)
+        gen_tx1.start()
+        self.simulator.run(3600)
+
+        for _ in range(20):
+            print()
+
+        manager2 = self.create_peer()
+        manager2.connections.MAX_ENABLED_SYNC = 0
+        conn12 = FakeConnection(manager1, manager2, latency=0.05)
+        self.simulator.add_connection(conn12)
+
+        self.assertFalse(conn12._proto2.is_sync_enabled())
+        v2 = list(manager2.tx_storage.get_all_transactions())
+        self.assertEqual(3, len(v2))
+
+        self.simulator.run(3600)
+
+        v1 = list(manager1.tx_storage.get_all_transactions())
+        self.assertGreater(len(v1), 3)
+
+        self.assertFalse(conn12._proto2.is_sync_enabled())
+        v2 = list(manager2.tx_storage.get_all_transactions())
+        self.assertEqual(3, len(v2))
+
+    def test_sync_rotate(self):
+        manager1 = self.create_peer()
+        manager1.connections.MAX_ENABLED_SYNC = 3
+        other_managers = [self.create_peer() for _ in range(15)]
+
+        connections = []
+        for other in other_managers:
+            conn = FakeConnection(manager1, other, latency=0.05)
+            connections.append(conn)
+            self.simulator.add_connection(conn)
+
+        self.simulator.run(600)
+
+        enabled = set(conn for conn in connections if conn.proto1.is_sync_enabled())
+        self.assertTrue(len(enabled), 3)
+
+        manager1.connections._sync_rotate_if_needed(force=True)
+        enabled2 = set(conn for conn in connections if conn.proto1.is_sync_enabled())
+        self.assertTrue(len(enabled2), 3)
+        # Chance of false positive: 1/comb(20, 3) = 0.0008771929824561404
+        self.assertNotEqual(enabled, enabled2)
+
+
+class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, BaseRandomSimulatorTestCase):
+    __test__ = True
+
+
+class SyncV2RandomSimulatorTestCase(unittest.SyncV2Params, BaseRandomSimulatorTestCase):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeRandomSimulatorTestCase(unittest.SyncBridgeParams, SyncV2RandomSimulatorTestCase):
+    __test__ = True

--- a/tests/p2p/test_sync_rate_limiter.py
+++ b/tests/p2p/test_sync_rate_limiter.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+from hathor.simulator import FakeConnection
+from hathor.simulator.trigger import StopAfterNMinedBlocks
+from tests import unittest
+from tests.simulation.base import SimulatorTestCase
+
+
+class BaseRandomSimulatorTestCase(SimulatorTestCase):
+    def test_sync_rate_limiter(self):
+        manager1 = self.create_peer()
+
+        miner1 = self.simulator.create_miner(manager1, hashpower=10e6)
+        miner1.start()
+        trigger = StopAfterNMinedBlocks(miner1, quantity=20)
+        self.simulator.run(3600, trigger=trigger)
+
+        manager2 = self.create_peer()
+        manager2.connections.MAX_ENABLED_SYNC = 0
+        conn12 = FakeConnection(manager1, manager2, latency=0.05)
+        self.simulator.add_connection(conn12)
+        self.simulator.run(3600)
+
+        manager2.connections.enable_rate_limiter(8, 2)
+
+        connected_peers2 = list(manager2.connections.connected_peers.values())
+        self.assertEqual(1, len(connected_peers2))
+        protocol2 = connected_peers2[0]
+        sync2 = protocol2.state.sync_manager
+        sync2._send_tips = MagicMock()
+
+        for i in range(100):
+            sync2.send_tips()
+            self.assertEqual(sync2._send_tips.call_count, min(i + 1, 8))
+        self.assertEqual(sync2._send_tips.call_count, 8)
+
+        sync2.send_tips()
+        self.assertEqual(sync2._send_tips.call_count, 8)
+
+        self.simulator._clock.advance(2000)
+        self.assertTrue(sync2._send_tips.call_count, 16)
+
+
+class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, BaseRandomSimulatorTestCase):
+    __test__ = True
+
+
+class SyncV2RandomSimulatorTestCase(unittest.SyncV2Params, BaseRandomSimulatorTestCase):
+    __test__ = True
+
+
+# sync-bridge should behave like sync-v2
+class SyncBridgeRandomSimulatorTestCase(unittest.SyncBridgeParams, SyncV2RandomSimulatorTestCase):
+    __test__ = True

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -9,7 +9,7 @@ from structlog import get_logger
 from twisted.internet.task import Clock
 from twisted.trial import unittest
 
-from hathor.builder import Builder
+from hathor.builder import BuildArtifacts, Builder
 from hathor.conf import HathorSettings
 from hathor.daa import TestMode, _set_test_mode
 from hathor.p2p.peer_id import PeerId
@@ -74,6 +74,13 @@ class TestBuilder(Builder):
     def __init__(self) -> None:
         super().__init__()
         self.set_network('testnet')
+
+    def build(self) -> BuildArtifacts:
+        artifacts = super().build()
+        # We disable rate limiter by default for tests because most tests were designed
+        # to run without rate limits. You can enable it in your unittest if you need.
+        artifacts.manager.connections.disable_rate_limiter()
+        return artifacts
 
     def _get_peer_id(self) -> PeerId:
         if self._peer_id is not None:


### PR DESCRIPTION
The reasoning behind this change is described in https://github.com/HathorNetwork/on-call-incidents/issues/109#issuecomment-1535409697

Acceptance Criteria:

- Limit the number of syncs that can happen simultaneously
  - Ability to configure that number via `HathorSettings`
- Rotate the group of peers that are syncing every 10 minutes
- Connections should not be changed. Only whether the connected peer is syncing or not.
- Set a group of peers to always run the sync
- Create a `cmd_path`, a place to put files to communicate with the full node.
    - Use `force_sync_rotate` file to force a sync rotation.
    - Use `always_enable_sync.txt` file to set peers to always have sync enabled.
- Add a global rate limiter to the number of calls per second to `NodeSyncTimestamp.send_tips()`.