### PR TITLE
feat(events): reset event queue command

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -22,6 +22,7 @@ from hathor.conf import HathorSettings
 from hathor.conf.settings import HathorSettings as HathorSettingsType
 from hathor.consensus import ConsensusAlgorithm
 from hathor.event import EventManager
+from hathor.event.model.EventQueueOptions import EventQueueOptions
 from hathor.event.storage import EventMemoryStorage, EventRocksDBStorage, EventStorage
 from hathor.event.websocket import EventWebsocketFactory
 from hathor.indexes import IndexesManager
@@ -83,7 +84,7 @@ class Builder:
 
         self._event_manager: Optional[EventManager] = None
         self._event_ws_factory: Optional[EventWebsocketFactory] = None
-        self._enable_event_queue: Optional[bool] = None
+        self._event_queue_options: Optional[EventQueueOptions] = None
 
         self._rocksdb_path: Optional[str] = None
         self._rocksdb_storage: Optional[RocksDBStorage] = None
@@ -158,8 +159,8 @@ class Builder:
         if self._full_verification is not None:
             kwargs['full_verification'] = self._full_verification
 
-        if self._enable_event_queue is not None:
-            kwargs['enable_event_queue'] = self._enable_event_queue
+        if self._event_queue_options is not None:
+            kwargs['event_queue_options'] = self._event_queue_options
 
         manager = HathorManager(
             reactor,
@@ -387,7 +388,7 @@ class Builder:
 
     def enable_event_manager(self, *, event_ws_factory: EventWebsocketFactory) -> 'Builder':
         self.check_if_can_modify()
-        self._enable_event_queue = True
+        self._event_queue_options = EventQueueOptions(enable=True)
         self._event_ws_factory = event_ws_factory
         return self
 

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -28,6 +28,7 @@ from twisted.web.resource import Resource
 
 from hathor.consensus import ConsensusAlgorithm
 from hathor.event import EventManager
+from hathor.event.model.EventQueueOptions import EventQueueOptions
 from hathor.event.resources.event import EventResource
 from hathor.exception import BuilderError
 from hathor.indexes import IndexesManager
@@ -170,6 +171,11 @@ class CliBuilder:
         soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
         consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=pubsub)
 
+        event_queue_options = EventQueueOptions(
+            enable=bool(args.x_enable_event_queue),
+            reset=bool(args.x_reset_event_queue)
+        )
+
         self.manager = HathorManager(
             reactor,
             pubsub=pubsub,
@@ -187,7 +193,7 @@ class CliBuilder:
             consensus_algorithm=consensus_algorithm,
             environment_info=get_environment_info(args=str(args), peer_id=peer_id.id),
             full_verification=full_verification,
-            enable_event_queue=bool(args.x_enable_event_queue)
+            event_queue_options=event_queue_options
         )
 
         if args.allow_mining_without_peers:

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -171,6 +171,14 @@ class CliBuilder:
         soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
         consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=pubsub)
 
+        if args.x_enable_event_queue:
+            if not settings.ENABLE_EVENT_QUEUE_FEATURE:
+                self.log.error('The event queue feature is not available yet')
+                sys.exit(-1)
+
+            self.log.info('--x-enable-event-queue flag provided. '
+                          'The events detected by the full node will be stored and can be retrieved by clients')
+
         event_queue_options = EventQueueOptions(
             enable=bool(args.x_enable_event_queue),
             reset=bool(args.x_reset_event_queue)
@@ -229,15 +237,6 @@ class CliBuilder:
 
         if args.memory_indexes and args.memory_storage:
             self.log.warn('--memory-indexes is implied for memory storage or JSON storage')
-
-        if args.x_enable_event_queue:
-            if not settings.ENABLE_EVENT_QUEUE_FEATURE:
-                self.log.error('The event queue feature is not available yet')
-                sys.exit(-1)
-
-            self.manager.enable_event_queue = True
-            self.log.info('--x-enable-event-queue flag provided. '
-                          'The events detected by the full node will be stored and can be retrieved by clients')
 
         for description in args.listen:
             self.manager.add_listen_address(description)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -96,6 +96,7 @@ class RunNode:
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
         parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')
+        parser.add_argument('--x-reset-event-queue', action='store_true', help='Reset the event queue')
         parser.add_argument('--peer-id-blacklist', action='extend', default=[], nargs='+', type=str,
                             help='Peer IDs to forbid connection')
         return parser

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -83,7 +83,7 @@ class EventManager:
         self._previous_node_state = self._event_storage.get_node_state()
 
         if self._should_reload_events():
-            self._event_storage.clear_events()
+            self._event_storage.reset_events()
         else:
             self._last_event = self._event_storage.get_last_event()
             self._last_existing_group_id = self._event_storage.get_last_group_id()
@@ -217,6 +217,10 @@ class EventManager:
 
     def _should_reload_events(self) -> bool:
         return self._previous_node_state in [None, NodeState.LOAD]
+
+    def reset_all(self) -> None:
+        """Reset all data."""
+        self._event_storage.reset_all()
 
     def get_event_queue_state(self) -> bool:
         """Get whether the event queue feature is enabled from the storage"""

--- a/hathor/event/model/EventQueueOptions.py
+++ b/hathor/event/model/EventQueueOptions.py
@@ -1,0 +1,20 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.utils.pydantic import BaseModel
+
+
+class EventQueueOptions(BaseModel):
+    enable: bool = False
+    reset: bool = False

--- a/hathor/event/model/event_data.py
+++ b/hathor/event/model/event_data.py
@@ -88,7 +88,7 @@ class EmptyData(BaseEventData):
 
 class TxData(BaseEventData, extra=Extra.ignore):
     hash: str
-    nonce: int
+    nonce: Optional[int] = None
     timestamp: int
     version: int
     weight: float
@@ -100,6 +100,7 @@ class TxData(BaseEventData, extra=Extra.ignore):
     token_name: Optional[str]
     token_symbol: Optional[str]
     metadata: 'TxMetadata'
+    aux_pow: Optional[str] = None
 
     @classmethod
     def from_event_arguments(cls, args: EventArguments) -> 'TxData':

--- a/hathor/event/storage/event_storage.py
+++ b/hathor/event/storage/event_storage.py
@@ -46,8 +46,13 @@ class EventStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def clear_events(self) -> None:
-        """Clear all stored events and related metadata."""
+    def reset_events(self) -> None:
+        """Reset stored events and related metadata."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def reset_all(self) -> None:
+        """Reset all data."""
         raise NotImplementedError
 
     @abstractmethod

--- a/hathor/event/storage/memory_storage.py
+++ b/hathor/event/storage/memory_storage.py
@@ -58,10 +58,15 @@ class EventMemoryStorage(EventStorage):
             yield self._events[key]
             key += 1
 
-    def clear_events(self) -> None:
+    def reset_events(self) -> None:
         self._events = []
         self._last_event = None
         self._last_group_id = None
+
+    def reset_all(self) -> None:
+        self.reset_events()
+        self._node_state = None
+        self._event_queue_enabled = False
 
     def save_node_state(self, state: NodeState) -> None:
         self._node_state = state

--- a/hathor/event/storage/rocksdb_storage.py
+++ b/hathor/event/storage/rocksdb_storage.py
@@ -91,7 +91,7 @@ class EventRocksDBStorage(EventStorage):
     def get_last_group_id(self) -> Optional[int]:
         return self._last_group_id
 
-    def clear_events(self) -> None:
+    def reset_events(self) -> None:
         self._last_event = None
         self._last_group_id = None
 
@@ -99,6 +99,11 @@ class EventRocksDBStorage(EventStorage):
         self._db.drop_column_family(self._cf_event)
 
         self._cf_event = self._rocksdb_storage.get_or_create_column_family(_CF_NAME_EVENT)
+
+    def reset_all(self) -> None:
+        self.reset_events()
+        self._db.delete((self._cf_meta, _KEY_NODE_STATE))
+        self._db.delete((self._cf_meta, _KEY_EVENT_QUEUE_ENABLED))
 
     def save_node_state(self, state: NodeState) -> None:
         self._db.put((self._cf_meta, _KEY_NODE_STATE), int_to_bytes(state.value, 8))

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -4,6 +4,7 @@ import pytest
 
 from hathor.builder import CliBuilder
 from hathor.event import EventManager
+from hathor.event.model.EventQueueOptions import EventQueueOptions
 from hathor.event.storage import EventMemoryStorage, EventRocksDBStorage
 from hathor.event.websocket import EventWebsocketFactory
 from hathor.exception import BuilderError
@@ -55,7 +56,7 @@ class BuilderTestCase(unittest.TestCase):
         self.assertNotIn(SyncVersion.V2, manager.connections._sync_factories)
         self.assertFalse(self.builder._build_prometheus)
         self.assertFalse(self.builder._build_status)
-        self.assertFalse(manager._enable_event_queue)
+        self.assertEqual(EventQueueOptions(enable=False, reset=False), manager._event_queue_options)
 
     @pytest.mark.skipif(not HAS_ROCKSDB, reason='requires python-rocksdb')
     def test_cache_storage(self):
@@ -152,6 +153,7 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsInstance(manager._event_manager, EventManager)
         self.assertIsInstance(manager._event_manager._event_storage, EventRocksDBStorage)
         self.assertIsInstance(manager._event_manager._event_ws_factory, EventWebsocketFactory)
+        self.assertEqual(EventQueueOptions(enable=True, reset=False), manager._event_queue_options)
 
     def test_event_queue_with_memory_storage(self):
         manager = self._build(['--x-enable-event-queue', '--memory-storage'])
@@ -159,7 +161,16 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsInstance(manager._event_manager, EventManager)
         self.assertIsInstance(manager._event_manager._event_storage, EventMemoryStorage)
         self.assertIsInstance(manager._event_manager._event_ws_factory, EventWebsocketFactory)
+        self.assertEqual(EventQueueOptions(enable=True, reset=False), manager._event_queue_options)
 
     def test_event_queue_with_full_verification(self):
         args = ['--x-enable-event-queue', '--memory-storage', '--x-full-verification']
         self._build_with_error(args, '--x-full-verification cannot be used with --x-enable-event-queue')
+
+    def test_reset_event_queue(self):
+        manager = self._build(['--x-reset-event-queue', '--memory-storage'])
+        self.assertEqual(EventQueueOptions(enable=False, reset=True), manager._event_queue_options)
+
+    def test_reset_and_enable_event_queue(self):
+        manager = self._build(['--x-reset-event-queue', '--x-enable-event-queue', '--memory-storage'])
+        self.assertEqual(EventQueueOptions(enable=True, reset=True), manager._event_queue_options)


### PR DESCRIPTION
### Acceptance Criteria

- Implement `--x-reset-event-queue` CLI flag to reset the event queue, allowing the start of a full node without the event feature after it was previously enabled
- Implement ability to reset all `EventStorage` data
- Fix support for merged mining block

Closes #580 
