### PR TITLE
feat(sync): boilerplate for sync-v1.1 protocol

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -144,7 +144,8 @@ class Builder:
         kwargs: Dict[str, Any] = {}
 
         if self._enable_sync_v1 is not None:
-            kwargs['enable_sync_v1'] = self._enable_sync_v1
+            # XXX: the interface of the Builder was kept using v1 instead of v1_1 to minimize the changes needed
+            kwargs['enable_sync_v1_1'] = self._enable_sync_v1
 
         if self._enable_sync_v2 is not None:
             kwargs['enable_sync_v2'] = self._enable_sync_v2

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -138,7 +138,8 @@ class CliBuilder:
 
         hostname = self.get_hostname(args)
         network = settings.NETWORK_NAME
-        enable_sync_v1 = not args.x_sync_v2_only
+        enable_sync_v1 = args.x_enable_legacy_sync_v1_0
+        enable_sync_v1_1 = not args.x_sync_v2_only
         enable_sync_v2 = args.x_sync_v2_only or args.x_sync_bridge
 
         pubsub = PubSubManager(reactor)
@@ -188,6 +189,7 @@ class CliBuilder:
             ssl=True,
             checkpoints=settings.CHECKPOINTS,
             enable_sync_v1=enable_sync_v1,
+            enable_sync_v1_1=enable_sync_v1_1,
             enable_sync_v2=enable_sync_v2,
             consensus_algorithm=consensus_algorithm,
             environment_info=get_environment_info(args=str(args), peer_id=peer_id.id),

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -88,6 +88,8 @@ class RunNode:
         parser.add_argument('--sentry-dsn', help='Sentry DSN')
         parser.add_argument('--enable-debug-api', action='store_true', help='Enable _debug/* endpoints')
         parser.add_argument('--enable-crash-api', action='store_true', help='Enable _crash/* endpoints')
+        parser.add_argument('--x-enable-legacy-sync-v1_0', action='store_true', help='Enable sync-v1.0, will not '
+                            'disable sync-v1.1')
         v2args = parser.add_mutually_exclusive_group()
         v2args.add_argument('--x-sync-bridge', action='store_true',
                             help='Enable support for running both sync protocols. DO NOT ENABLE, IT WILL BREAK.')

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -95,7 +95,8 @@ class HathorManager:
                  event_manager: Optional[EventManager] = None,
                  stratum_port: Optional[int] = None,
                  ssl: bool = True,
-                 enable_sync_v1: bool = True,
+                 enable_sync_v1: bool = False,
+                 enable_sync_v1_1: bool = True,
                  enable_sync_v2: bool = False,
                  capabilities: Optional[List[str]] = None,
                  checkpoints: Optional[List[Checkpoint]] = None,
@@ -121,7 +122,7 @@ class HathorManager:
         from hathor.p2p.factory import HathorClientFactory, HathorServerFactory
         from hathor.p2p.manager import ConnectionsManager
 
-        if not (enable_sync_v1 or enable_sync_v2):
+        if not (enable_sync_v1 or enable_sync_v1_1 or enable_sync_v2):
             raise TypeError(f'{type(self).__name__}() at least one sync version is required')
 
         self._enable_sync_v1 = enable_sync_v1
@@ -190,7 +191,8 @@ class HathorManager:
         self.client_factory = HathorClientFactory(self.network, self.my_peer, node=self, use_ssl=ssl)
         self.connections = ConnectionsManager(self.reactor, self.my_peer, self.server_factory, self.client_factory,
                                               self.pubsub, self, ssl, whitelist_only=False, rng=self.rng,
-                                              enable_sync_v1=enable_sync_v1, enable_sync_v2=enable_sync_v2)
+                                              enable_sync_v1=enable_sync_v1, enable_sync_v2=enable_sync_v2,
+                                              enable_sync_v1_1=enable_sync_v1_1)
 
         self.metrics = Metrics(
             pubsub=self.pubsub,

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -102,10 +102,12 @@ class ConnectionsManager:
 
     def __init__(self, reactor: Reactor, my_peer: PeerId, server_factory: 'HathorServerFactory',
                  client_factory: 'HathorClientFactory', pubsub: PubSubManager, manager: 'HathorManager',
-                 ssl: bool, rng: Random, whitelist_only: bool, enable_sync_v1: bool, enable_sync_v2: bool) -> None:
+                 ssl: bool, rng: Random, whitelist_only: bool, enable_sync_v1: bool, enable_sync_v2: bool,
+                 enable_sync_v1_1: bool) -> None:
+        from hathor.p2p.sync_v1_1_factory import SyncV11Factory
         from hathor.p2p.sync_v1_factory import SyncV1Factory
 
-        if not (enable_sync_v1 or enable_sync_v2):
+        if not (enable_sync_v1 or enable_sync_v1_1 or enable_sync_v2):
             raise TypeError(f'{type(self).__name__}() at least one sync version is required')
 
         self.log = logger.new()
@@ -182,6 +184,8 @@ class ConnectionsManager:
         self._sync_factories = {}
         if enable_sync_v1:
             self._sync_factories[SyncVersion.V1] = SyncV1Factory(self)
+        if enable_sync_v1_1:
+            self._sync_factories[SyncVersion.V1_1] = SyncV11Factory(self)
         if enable_sync_v2:
             self._sync_factories[SyncVersion.V2] = SyncV1Factory(self)
 

--- a/hathor/p2p/sync_v1_1_factory.py
+++ b/hathor/p2p/sync_v1_1_factory.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Optional
+
+from hathor.p2p.downloader import Downloader
+from hathor.p2p.manager import ConnectionsManager
+from hathor.p2p.node_sync import NodeSyncTimestamp
+from hathor.p2p.sync_factory import SyncManagerFactory
+from hathor.p2p.sync_manager import SyncManager
+from hathor.util import Reactor
+
+if TYPE_CHECKING:
+    from hathor.p2p.protocol import HathorProtocol
+
+
+class SyncV11Factory(SyncManagerFactory):
+    def __init__(self, connections: ConnectionsManager):
+        self.downloader = Downloader(connections.manager)
+
+    def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
+        return NodeSyncTimestamp(protocol, downloader=self.downloader, reactor=reactor)

--- a/hathor/p2p/sync_version.py
+++ b/hathor/p2p/sync_version.py
@@ -23,6 +23,7 @@ class SyncVersion(Enum):
     #      example, peers using `v2-fake` (which just uses sync-v1) will not connect to peers using `v2-alpha`, and so
     #      on.
     V1 = 'v1'
+    V1_1 = 'v1.1'
     V2 = 'v2-fake'  # uses sync-v1 to mock sync-v2
 
     def __str__(self):
@@ -39,6 +40,8 @@ class SyncVersion(Enum):
         if self is SyncVersion.V1:
             # low priority
             return 10
+        elif self is SyncVersion.V1_1:
+            return 11
         elif self is SyncVersion.V2:
             return 20
         else:

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -51,7 +51,8 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsInstance(manager.tx_storage.indexes, RocksDBIndexesManager)
         self.assertIsNone(manager.wallet)
         self.assertEqual('unittests', manager.network)
-        self.assertIn(SyncVersion.V1, manager.connections._sync_factories)
+        self.assertNotIn(SyncVersion.V1, manager.connections._sync_factories)
+        self.assertIn(SyncVersion.V1_1, manager.connections._sync_factories)
         self.assertNotIn(SyncVersion.V2, manager.connections._sync_factories)
         self.assertFalse(self.builder._build_prometheus)
         self.assertFalse(self.builder._build_status)
@@ -95,13 +96,21 @@ class BuilderTestCase(unittest.TestCase):
     def test_memory_storage_with_rocksdb_indexes(self):
         self._build_with_error(['--memory-storage', '--x-rocksdb-indexes'], 'RocksDB indexes require RocksDB data')
 
+    def test_sync_v1_0_legacy(self):
+        manager = self._build(['--memory-storage', '--x-enable-legacy-sync-v1_0'])
+        self.assertIn(SyncVersion.V1, manager.connections._sync_factories)
+        self.assertIn(SyncVersion.V1_1, manager.connections._sync_factories)
+        self.assertNotIn(SyncVersion.V2, manager.connections._sync_factories)
+
     def test_sync_bridge(self):
         manager = self._build(['--memory-storage', '--x-sync-bridge'])
-        self.assertIn(SyncVersion.V1, manager.connections._sync_factories)
+        self.assertNotIn(SyncVersion.V1, manager.connections._sync_factories)
+        self.assertIn(SyncVersion.V1_1, manager.connections._sync_factories)
         self.assertIn(SyncVersion.V2, manager.connections._sync_factories)
 
     def test_sync_v2_only(self):
         manager = self._build(['--memory-storage', '--x-sync-v2-only'])
+        self.assertNotIn(SyncVersion.V1_1, manager.connections._sync_factories)
         self.assertNotIn(SyncVersion.V1, manager.connections._sync_factories)
         self.assertIn(SyncVersion.V2, manager.connections._sync_factories)
 

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -268,7 +268,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
         self.assertTrue(isinstance(conn.proto1.state, PeerIdState))
         self.assertTrue(isinstance(conn.proto2.state, PeerIdState))
 
-        downloader = conn.proto2.connections._sync_factories[SyncVersion.V1].downloader
+        downloader = conn.proto2.connections._sync_factories[SyncVersion.V1_1].downloader
 
         node_sync1 = NodeSyncTimestamp(conn.proto1, downloader, reactor=conn.proto1.node.reactor)
         node_sync1.start()
@@ -361,7 +361,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
 
         # create the peer that will experience the bug
         self.manager_bug = self.create_peer(self.network)
-        self.downloader = self.manager_bug.connections._sync_factories[SyncVersion.V1].downloader
+        self.downloader = self.manager_bug.connections._sync_factories[SyncVersion.V1_1].downloader
         self.downloader.window_size = 1
         self.conn1 = FakeConnection(self.manager_bug, self.manager1)
         self.conn2 = FakeConnection(self.manager_bug, self.manager2)

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -235,9 +235,11 @@ class TestCase(unittest.TestCase):
         else:
             assert SyncVersion.V2 not in manager.connections._sync_factories
         if enable_sync_v1:
-            assert SyncVersion.V1 in manager.connections._sync_factories
+            assert SyncVersion.V1 not in manager.connections._sync_factories
+            assert SyncVersion.V1_1 in manager.connections._sync_factories
         else:
             assert SyncVersion.V1 not in manager.connections._sync_factories
+            assert SyncVersion.V1_1 not in manager.connections._sync_factories
 
         manager.avg_time_between_blocks = 0.0001
 


### PR DESCRIPTION
This is a complimentary PR to #581 

The reasoning is to create a barrier between peers using the new sync code. The protocol and implementation are backwards compatible, but a barrier helps ensure that peers that are only running sync-v1.1 (not the bridge peer running both versions) will almost certainly (unless someone is intentionally spoofing the sync version) connect to other peers running sync-v1.1, and that should be of great help to #581

## Acceptance Criteria

- add a new sync-v1.1 version marker that will use the same class as sync-v1.0 (which was just sync-v1 before)
- disable sync-v1.0 by default, requiring the use of a cli param to enable it
- enable sync-v1.1 whenever sync-v1.0 would be enabled before
- builder will keep referencing a single sync-v1 version, which will only enable sync-v1.1 and not sync-v1.0, this is because the class used is exactly the same and there's no need to make the tests aware of this difference