### PR TITLE
fix(p2p): Fix v1.1 not enforcing whitelist

### DIFF
--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -21,7 +21,6 @@ from hathor.conf import HathorSettings
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.states.base import BaseState
-from hathor.p2p.sync_version import SyncVersion
 from hathor.util import json_dumps, json_loads
 
 if TYPE_CHECKING:
@@ -156,8 +155,8 @@ class PeerIdState(BaseState):
 
         # when ENABLE_PEER_WHITELIST is set, we check if we're on sync-v1 to block non-whitelisted peers
         if settings.ENABLE_PEER_WHITELIST:
-            protocol_is_v1 = self.protocol.sync_version is SyncVersion.V1
-            if protocol_is_v1 and not peer_is_whitelisted:
+            assert self.protocol.sync_version is not None
+            if self.protocol.sync_version.is_v1() and not peer_is_whitelisted:
                 return True
 
         # otherwise we block non-whitelisted peers when on "whitelist-only mode"

--- a/hathor/p2p/sync_version.py
+++ b/hathor/p2p/sync_version.py
@@ -47,6 +47,10 @@ class SyncVersion(Enum):
         else:
             raise ValueError('value is either invalid for this enum or not implemented')
 
+    def is_v1(self) -> bool:
+        """Return True for V1 and V1_1."""
+        return self.get_priority() < 20
+
     # XXX: total_ordering decorator will implement the other methods: __le__, __gt__, and __ge__
     def __lt__(self, other):
         """Used to sort versions by considering the value on get_priority."""

--- a/tests/p2p/test_whitelist.py
+++ b/tests/p2p/test_whitelist.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from hathor.conf import HathorSettings
+from hathor.p2p.sync_version import SyncVersion
+from hathor.simulator import FakeConnection
+from tests import unittest
+
+settings = HathorSettings()
+
+
+class WhitelistTestCase(unittest.SyncV1Params, unittest.TestCase):
+    @patch('hathor.p2p.states.peer_id.settings', new=settings._replace(ENABLE_PEER_WHITELIST=True))
+    def test_sync_v11_whitelist_no_no(self):
+        network = 'testnet'
+
+        manager1 = self.create_peer(network)
+        self.assertEqual(set(manager1.connections._sync_factories.keys()), {SyncVersion.V1_1})
+
+        manager2 = self.create_peer(network)
+        self.assertEqual(set(manager2.connections._sync_factories.keys()), {SyncVersion.V1_1})
+
+        conn = FakeConnection(manager1, manager2)
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertFalse(conn.tr2.disconnecting)
+
+        # Run the p2p protocol.
+        for _ in range(100):
+            conn.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        self.assertTrue(conn.tr1.disconnecting)
+        self.assertTrue(conn.tr2.disconnecting)
+
+    @patch('hathor.p2p.states.peer_id.settings', new=settings._replace(ENABLE_PEER_WHITELIST=True))
+    def test_sync_v11_whitelist_yes_no(self):
+        network = 'testnet'
+
+        manager1 = self.create_peer(network)
+        self.assertEqual(set(manager1.connections._sync_factories.keys()), {SyncVersion.V1_1})
+
+        manager2 = self.create_peer(network)
+        self.assertEqual(set(manager2.connections._sync_factories.keys()), {SyncVersion.V1_1})
+
+        manager1.peers_whitelist.append(manager2.my_peer.id)
+
+        conn = FakeConnection(manager1, manager2)
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertFalse(conn.tr2.disconnecting)
+
+        # Run the p2p protocol.
+        for _ in range(100):
+            conn.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertTrue(conn.tr2.disconnecting)
+
+    @patch('hathor.p2p.states.peer_id.settings', new=settings._replace(ENABLE_PEER_WHITELIST=True))
+    def test_sync_v11_whitelist_yes_yes(self):
+        network = 'testnet'
+
+        manager1 = self.create_peer(network)
+        self.assertEqual(set(manager1.connections._sync_factories.keys()), {SyncVersion.V1_1})
+
+        manager2 = self.create_peer(network)
+        self.assertEqual(set(manager2.connections._sync_factories.keys()), {SyncVersion.V1_1})
+
+        manager1.peers_whitelist.append(manager2.my_peer.id)
+        manager2.peers_whitelist.append(manager1.my_peer.id)
+
+        conn = FakeConnection(manager1, manager2)
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertFalse(conn.tr2.disconnecting)
+
+        # Run the p2p protocol.
+        for _ in range(100):
+            conn.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertFalse(conn.tr2.disconnecting)


### PR DESCRIPTION
### Acceptance criteria

1) Consider `SyncVersion.v1_1` as v1.