### PR TITLE
fix: do not include newline in the BUILD_VERSION file

### DIFF
--- a/extras/github/docker.py
+++ b/extras/github/docker.py
@@ -160,7 +160,7 @@ def overwrite_version(base_version: str):
     with open('BUILD_VERSION', 'w') as file:
         if base_version.startswith('v'):
             base_version = base_version[1:]
-        file.write(base_version + '\n')
+        file.write(base_version)
 
 
 if __name__ == '__main__':

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -40,7 +40,7 @@ def _get_build_version() -> Optional[str]:
         return None
 
     with open(BUILD_VERSION_FILE_PATH, 'r') as f:
-        build_version = f.readline()
+        build_version = f.readline().strip()
         match = re.match(BUILD_VERSION_REGEX, build_version)
 
         if match:

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -58,6 +58,11 @@ class BaseVersionTest(_BaseResourceTest._ResourceTest):
                 build_version_file.write('nightly-a4b3f9c2')
             self.assertEqual(_get_version(), 'nightly-a4b3f9c2')
 
+            # BUILD_VERSION with white spaces
+            with open(file_path, 'w') as build_version_file:
+                build_version_file.write('  ' + BASE_VERSION + '-rc.1  ')
+            self.assertEqual(_get_version(), BASE_VERSION + '-rc.1')
+
             # Invalid BUILD_VERSION files
             git_head = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
 


### PR DESCRIPTION
### Acceptance Criteria

- We should not include a `\n` on the generated BUILD_VERSION file