### PR TITLE
feat(sysctl): Validate types before calling setter

### DIFF
--- a/hathor/sysctl/protocol.py
+++ b/hathor/sysctl/protocol.py
@@ -15,6 +15,7 @@
 import json
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
 from twisted.protocols.basic import LineReceiver
 
 from hathor.sysctl.exception import SysctlEntryNotFound, SysctlException, SysctlReadOnlyEntry, SysctlWriteOnlyEntry
@@ -64,6 +65,8 @@ class SysctlProtocol(LineReceiver):
         except SysctlReadOnlyEntry:
             self.sendError(f'cannot write to {path}')
         except SysctlException as e:
+            self.sendError(str(e))
+        except ValidationError as e:
             self.sendError(str(e))
         except TypeError as e:
             self.sendError(str(e))

--- a/hathor/sysctl/sysctl.py
+++ b/hathor/sysctl/sysctl.py
@@ -14,6 +14,8 @@
 
 from typing import Any, Callable, Dict, Iterator, NamedTuple, Optional, Tuple
 
+from pydantic import validate_arguments
+
 from hathor.sysctl.exception import SysctlEntryNotFound, SysctlReadOnlyEntry, SysctlWriteOnlyEntry
 
 Getter = Callable[[], Any]
@@ -40,6 +42,8 @@ class Sysctl:
     def register(self, path: str, getter: Optional[Getter], setter: Optional[Setter]) -> None:
         """Register a new parameter for sysctl."""
         assert path not in self._commands
+        if setter is not None:
+            setter = validate_arguments(setter)
         self._commands[path] = SysctlCommand(
             getter=getter,
             setter=setter,

--- a/tests/sysctl/test_sysctl.py
+++ b/tests/sysctl/test_sysctl.py
@@ -1,5 +1,5 @@
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from twisted.test import proto_helpers
 
@@ -11,6 +11,8 @@ from tests import unittest
 
 
 class SysctlTest(unittest.TestCase):
+    # We need this patch because pydantic.validate_arguments fails when it gets a mock function.
+    @patch('hathor.sysctl.sysctl.validate_arguments', new=lambda x: x)
     def setUp(self) -> None:
         super().setUp()
 
@@ -23,7 +25,7 @@ class SysctlTest(unittest.TestCase):
         net.register(
             'readonly',
             MagicMock(return_value=0.25),  # float
-            None
+            None,
         )
         net.register(
             'rate_limit',


### PR DESCRIPTION
### Acceptance criteria

1) Validate date types before calling setter. This is important to prevent sending a `str` where the setter expects and `int`, for instance.