### PR TITLE
feat: add safeguards for partially validated transactions [part 2/2]

### DIFF
--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -70,6 +70,8 @@ class ConsensusAlgorithm:
 
     @cpu.profiler(key=lambda self, base: 'consensus!{}'.format(base.hash.hex()))
     def update(self, base: BaseTransaction) -> None:
+        assert base.storage is not None
+        assert base.storage.is_only_valid_allowed()
         try:
             self._unsafe_update(base)
         except Exception:
@@ -107,11 +109,16 @@ class ConsensusAlgorithm:
         if new_best_height < best_height:
             self.log.warn('height decreased, re-checking mempool', prev_height=best_height, new_height=new_best_height,
                           prev_block_tip=best_tip.hex(), new_block_tip=new_best_tip.hex())
-            to_remove = storage.get_transactions_that_became_invalid()
+            # XXX: this method will mark as INVALID all transactions in the mempool that became invalid because of a
+            #      reward lock
+            to_remove = storage.compute_transactions_that_became_invalid()
             if to_remove:
                 self.log.warn('some transactions on the mempool became invalid and will be removed',
                               count=len(to_remove))
-                storage.remove_transactions(to_remove)
+                # XXX: because transactions in `to_remove` are marked as invalid, we need this context to be able to
+                #      remove them
+                with storage.allow_invalid_context():
+                    storage.remove_transactions(to_remove)
                 for tx_removed in to_remove:
                     context.pubsub.publish(HathorEvents.CONSENSUS_TX_REMOVED, tx_hash=tx_removed.hash)
 

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from typing import Any, Optional, Set
+from typing import Any, Iterator, Optional, Set
 
 from twisted.internet import threads
 
@@ -208,9 +208,11 @@ class TransactionCacheStorage(BaseTransactionStorage):
         assert tx is not None
         return tx
 
-    def get_all_transactions(self):
+    def _get_all_transactions(self) -> Iterator[BaseTransaction]:
         self._flush_to_storage(self.dirty_txs.copy())
-        for tx in self.store.get_all_transactions():
+        # XXX: explicitly use _get_all_transaction instead of get_all_transactions because there will already be a
+        #      TransactionCacheStorage.get_all_transactions outer method
+        for tx in self.store._get_all_transactions():
             tx.storage = self
             self._save_to_weakref(tx)
             yield tx

--- a/hathor/transaction/storage/exceptions.py
+++ b/hathor/transaction/storage/exceptions.py
@@ -41,3 +41,7 @@ class PartialMigrationError(HathorError):
 
 class OutOfOrderMigrationError(HathorError):
     """A migration was run before another that was before it"""
+
+
+class TransactionNotInAllowedScopeError(TransactionDoesNotExist):
+    """You are trying to get a transaction that is not allowed in the current scope, treated as non-existent"""

--- a/hathor/transaction/storage/memory_storage.py
+++ b/hathor/transaction/storage/memory_storage.py
@@ -90,7 +90,7 @@ class TransactionMemoryStorage(BaseTransactionStorage):
         else:
             raise TransactionDoesNotExist(hash_bytes.hex())
 
-    def get_all_transactions(self, *, include_partial: bool = False) -> Iterator[BaseTransaction]:
+    def _get_all_transactions(self) -> Iterator[BaseTransaction]:
         for tx in self.transactions.values():
             tx = self._clone(tx)
             if tx.hash in self.metadata:

--- a/hathor/transaction/storage/rocksdb_storage.py
+++ b/hathor/transaction/storage/rocksdb_storage.py
@@ -122,6 +122,7 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
         if not tx:
             raise TransactionDoesNotExist(hash_bytes.hex())
 
+        assert tx._metadata is not None
         assert tx.hash == hash_bytes
 
         self._save_to_weakref(tx)
@@ -146,7 +147,7 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
             self._save_to_weakref(tx)
         return tx
 
-    def get_all_transactions(self, *, include_partial: bool = False) -> Iterator['BaseTransaction']:
+    def _get_all_transactions(self) -> Iterator['BaseTransaction']:
         tx: Optional['BaseTransaction']
 
         items = self._db.iteritems(self._cf_tx)
@@ -163,10 +164,6 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
                 tx = self._get_tx(hash_bytes, tx_data)
 
             assert tx is not None
-            if not include_partial:
-                assert tx._metadata is not None
-                if not tx._metadata.validation.is_fully_connected():
-                    continue
             yield tx
 
     def is_empty(self) -> bool:

--- a/hathor/transaction/storage/tx_allow_scope.py
+++ b/hathor/transaction/storage/tx_allow_scope.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from enum import Flag, auto
+from typing import TYPE_CHECKING, Generator
+
+from hathor.conf import HathorSettings
+from hathor.transaction.base_transaction import BaseTransaction
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage import TransactionStorage  # noqa: F401
+
+
+settings = HathorSettings()
+
+
+class TxAllowScope(Flag):
+    """ This enum is used internally to mark which "type" of transactions to allow the database to read/write
+
+    In this context "type" it means validation level, the supported "types" are enumerated in this class and for the
+    purpose of filtering it can be any combination of the supported types.
+    """
+    VALID = auto()
+    PARTIAL = auto()
+    INVALID = auto()
+
+    def is_allowed(self, tx: BaseTransaction) -> bool:
+        """True means it is allowed to be used in the storage (as argument or as return), False means not allowed."""
+        tx_meta = tx.get_metadata()
+        # XXX: partial/invalid/fully_connected never overlap and cover all possible validation states
+        #      see hathor.transaction.transaction_metadata.ValidationState for more details
+        validation = tx_meta.validation
+        if validation.is_partial() and TxAllowScope.PARTIAL not in self:
+            return False
+        if validation.is_invalid() and TxAllowScope.INVALID not in self:
+            return False
+        # XXX: not allowing valid transactions is really specific, should we allow it?
+        if validation.is_fully_connected() and TxAllowScope.VALID not in self:
+            return False
+        return True
+
+
+@contextmanager
+def tx_allow_context(tx_storage: 'TransactionStorage', *, allow_scope: TxAllowScope) -> Generator[None, None, None]:
+    """This is used to wrap the storage with a temporary allow-scope that is reverted when the context exits"""
+    from hathor.transaction.storage import TransactionStorage
+    assert isinstance(tx_storage, TransactionStorage)
+    previous_allow_scope = tx_storage.allow_scope
+    try:
+        tx_storage.allow_scope = allow_scope
+        yield
+    finally:
+        tx_storage.allow_scope = previous_allow_scope

--- a/hathor/transaction/transaction_metadata.py
+++ b/hathor/transaction/transaction_metadata.py
@@ -69,7 +69,7 @@ class ValidationState(IntEnum):
 
     def is_valid(self) -> bool:
         """Short-hand property."""
-        return self in {ValidationState.FULL, ValidationState.CHECKPOINT}
+        return self in {ValidationState.FULL, ValidationState.CHECKPOINT, ValidationState.CHECKPOINT_FULL}
 
     def is_checkpoint(self) -> bool:
         """Short-hand property."""
@@ -78,6 +78,10 @@ class ValidationState(IntEnum):
     def is_fully_connected(self) -> bool:
         """Short-hand property."""
         return self in {ValidationState.FULL, ValidationState.CHECKPOINT_FULL}
+
+    def is_partial(self) -> bool:
+        """Short-hand property."""
+        return self in {ValidationState.INITIAL, ValidationState.BASIC, ValidationState.CHECKPOINT}
 
     def is_invalid(self) -> bool:
         """Short-hand property."""

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -25,12 +25,12 @@ class ModifiedTransactionMemoryStorage(TransactionMemoryStorage):
     def set_first_tx(self, tx: BaseTransaction) -> None:
         self._first_tx = tx
 
-    def get_all_transactions(self, *, include_partial: bool = False) -> Iterator[BaseTransaction]:
+    def _get_all_transactions(self) -> Iterator[BaseTransaction]:
         skip_hash = None
         if self._first_tx:
             yield self._first_tx
             skip_hash = self._first_tx.hash
-        for tx in super().get_all_transactions(include_partial=include_partial):
+        for tx in super()._get_all_transactions():
             if tx.hash != skip_hash:
                 yield tx
 

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -226,17 +226,165 @@ class BaseTransactionStorageTest(unittest.TestCase):
     def test_pre_save_validation_invalid_tx_1(self):
         self.tx.get_metadata().validation = ValidationState.BASIC
         with self.assertRaises(AssertionError):
-            self.validate_save(self.tx)
+            # XXX: avoid using validate_save because an exception could be raised for other reasons
+            self.tx_storage.save_transaction(self.tx)
 
     def test_pre_save_validation_invalid_tx_2(self):
         self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
         with self.assertRaises(AssertionError):
-            self.validate_save(self.tx)
+            with self.tx_storage.allow_partially_validated_context():
+                # XXX: avoid using validate_save because an exception could be raised for other reasons
+                self.tx_storage.save_transaction(self.tx)
 
     def test_pre_save_validation_success(self):
         self.tx.get_metadata().validation = ValidationState.BASIC
         self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        with self.tx_storage.allow_partially_validated_context():
+            # XXX: it's good to use validate_save now since we don't expect any exceptions to be raised
+            self.validate_save(self.tx)
+
+    def test_allow_scope_get_all_transactions(self):
+        self.tx.get_metadata().validation = ValidationState.BASIC
+        self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        with self.tx_storage.allow_partially_validated_context():
+            self.tx_storage.save_transaction(self.tx)
+        only_valid_txs = list(self.tx_storage.get_all_transactions())
+        self.assertNotIn(self.tx, only_valid_txs)
+        with self.tx_storage.allow_partially_validated_context():
+            txs_that_may_be_partial = list(self.tx_storage.get_all_transactions())
+            self.assertIn(self.tx, txs_that_may_be_partial)
+
+    def test_allow_scope_topological_sort_dfs(self):
+        self.tx.get_metadata().validation = ValidationState.BASIC
+        self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        with self.tx_storage.allow_partially_validated_context():
+            self.tx_storage.save_transaction(self.tx)
+        only_valid_txs = list(self.tx_storage._topological_sort_dfs())
+        self.assertNotIn(self.tx, only_valid_txs)
+        with self.tx_storage.allow_partially_validated_context():
+            txs_that_may_be_partial = list(self.tx_storage._topological_sort_dfs())
+            self.assertIn(self.tx, txs_that_may_be_partial)
+
+    def test_allow_partially_validated_context(self):
+        from hathor.transaction.storage.exceptions import TransactionNotInAllowedScopeError
+        self.tx.get_metadata().validation = ValidationState.BASIC
+        self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+        # should fail because it is out of the allowed scope
+        with self.assertRaises(TransactionNotInAllowedScopeError):
+            # XXX: avoid using validate_save because an exception could be raised for other reasons
+            self.tx_storage.save_transaction(self.tx)
+        # should succeed because a custom scope is being used
+        with self.tx_storage.allow_partially_validated_context():
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+            self.assertFalse(self.tx_storage.is_invalid_allowed())
+            self.validate_save(self.tx)
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+        # should fail because it is out of the allowed scope
+        with self.assertRaises(TransactionNotInAllowedScopeError):
+            self.tx_storage.get_transaction(self.tx.hash)
+        # should return None since TransactionNotInAllowedScopeError inherits TransactionDoesNotExist
+        self.assertIsNone(self.tx_storage.get_metadata(self.tx.hash))
+        # should succeed because a custom scope is being used
+        with self.tx_storage.allow_partially_validated_context():
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+            self.assertFalse(self.tx_storage.is_invalid_allowed())
+            self.tx_storage.get_transaction(self.tx.hash)
+            self.assertIsNotNone(self.tx_storage.get_metadata(self.tx.hash))
+
+    def test_allow_invalid_context(self):
+        from hathor.transaction.storage.exceptions import TransactionNotInAllowedScopeError
         self.validate_save(self.tx)
+        self.tx.get_metadata().validation = ValidationState.INVALID
+        # XXX: should this apply to invalid too? note that we never save invalid transactions so using the
+        #      PARTIALLY_VALIDATED_ID marker is artificial just for testing
+        self.tx.get_metadata().add_voided_by(settings.PARTIALLY_VALIDATED_ID)
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+        # should fail because it is out of the allowed scope
+        with self.assertRaises(TransactionNotInAllowedScopeError):
+            # XXX: avoid using validate_save because an exception could be raised for other reasons
+            self.tx_storage.save_transaction(self.tx)
+        # should succeed because a custom scope is being used
+        with self.tx_storage.allow_invalid_context():
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+            self.assertTrue(self.tx_storage.is_invalid_allowed())
+            self.validate_save(self.tx)
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+        # should fail because it is out of the allowed scope
+        with self.assertRaises(TransactionNotInAllowedScopeError):
+            self.tx_storage.get_transaction(self.tx.hash)
+        # should return None since TransactionNotInAllowedScopeError inherits TransactionDoesNotExist
+        self.assertIsNone(self.tx_storage.get_metadata(self.tx.hash))
+        # should succeed because a custom scope is being used
+        with self.tx_storage.allow_invalid_context():
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+            self.assertTrue(self.tx_storage.is_invalid_allowed())
+            self.tx_storage.get_transaction(self.tx.hash)
+            self.assertIsNotNone(self.tx_storage.get_metadata(self.tx.hash))
+
+    def test_allow_scope_context_composing(self):
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+        with self.tx_storage.allow_invalid_context():
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+            self.assertTrue(self.tx_storage.is_invalid_allowed())
+            with self.tx_storage.allow_partially_validated_context():
+                self.assertFalse(self.tx_storage.is_only_valid_allowed())
+                self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+                self.assertTrue(self.tx_storage.is_invalid_allowed())
+                with self.tx_storage.allow_only_valid_context():
+                    self.assertTrue(self.tx_storage.is_only_valid_allowed())
+                    self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+                    self.assertFalse(self.tx_storage.is_invalid_allowed())
+                self.assertFalse(self.tx_storage.is_only_valid_allowed())
+                self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+                self.assertTrue(self.tx_storage.is_invalid_allowed())
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+            self.assertTrue(self.tx_storage.is_invalid_allowed())
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+
+    def test_allow_scope_context_stacking(self):
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
+        with self.tx_storage.allow_partially_validated_context():
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+            self.assertFalse(self.tx_storage.is_invalid_allowed())
+            with self.tx_storage.allow_partially_validated_context():
+                self.assertFalse(self.tx_storage.is_only_valid_allowed())
+                self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+                self.assertFalse(self.tx_storage.is_invalid_allowed())
+                with self.tx_storage.allow_partially_validated_context():
+                    self.assertFalse(self.tx_storage.is_only_valid_allowed())
+                    self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+                    self.assertFalse(self.tx_storage.is_invalid_allowed())
+                self.assertFalse(self.tx_storage.is_only_valid_allowed())
+                self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+                self.assertFalse(self.tx_storage.is_invalid_allowed())
+            self.assertFalse(self.tx_storage.is_only_valid_allowed())
+            self.assertTrue(self.tx_storage.is_partially_validated_allowed())
+            self.assertFalse(self.tx_storage.is_invalid_allowed())
+        self.assertTrue(self.tx_storage.is_only_valid_allowed())
+        self.assertFalse(self.tx_storage.is_partially_validated_allowed())
+        self.assertFalse(self.tx_storage.is_invalid_allowed())
 
     def test_save_token_creation_tx(self):
         tx = create_tokens(self.manager, propagate=False)

--- a/tests/tx/test_validation_states.py
+++ b/tests/tx/test_validation_states.py
@@ -1,0 +1,102 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.transaction.transaction_metadata import ValidationState
+
+
+def test_validation_states_list_unchanged():
+    # XXX: if these change there are some code that make certain assumptions that should be reviewd, in particular:
+    # - hathor.transaction.storage.transaction_storage.tx_allow_scope.TxAllowScope.is_allowed
+    assert list(ValidationState), [
+        ValidationState.INITIAL,
+        ValidationState.BASIC,
+        ValidationState.CHECKPOINT,
+        ValidationState.FULL,
+        ValidationState.CHECKPOINT_FULL,
+        ValidationState.INVALID,
+    ]
+
+
+def test_validation_states_properties():
+    # ValidationState.INITIAL
+    assert ValidationState.INITIAL.is_initial() is True
+    assert ValidationState.INITIAL.is_at_least_basic() is False
+    assert ValidationState.INITIAL.is_valid() is False
+    assert ValidationState.INITIAL.is_checkpoint() is False
+    assert ValidationState.INITIAL.is_fully_connected() is False
+    assert ValidationState.INITIAL.is_partial() is True
+    assert ValidationState.INITIAL.is_invalid() is False
+    assert ValidationState.INITIAL.is_final() is False
+    # ValidationState.BASIC
+    assert ValidationState.BASIC.is_initial() is False
+    assert ValidationState.BASIC.is_at_least_basic() is True
+    assert ValidationState.BASIC.is_valid() is False
+    assert ValidationState.BASIC.is_checkpoint() is False
+    assert ValidationState.BASIC.is_fully_connected() is False
+    assert ValidationState.BASIC.is_partial() is True
+    assert ValidationState.BASIC.is_invalid() is False
+    assert ValidationState.BASIC.is_final() is False
+    # ValidationState.CHECKPOINT
+    assert ValidationState.CHECKPOINT.is_initial() is False
+    assert ValidationState.CHECKPOINT.is_at_least_basic() is True
+    assert ValidationState.CHECKPOINT.is_valid() is True
+    assert ValidationState.CHECKPOINT.is_checkpoint() is True
+    assert ValidationState.CHECKPOINT.is_fully_connected() is False
+    assert ValidationState.CHECKPOINT.is_partial() is True
+    assert ValidationState.CHECKPOINT.is_invalid() is False
+    assert ValidationState.CHECKPOINT.is_final() is False
+    # ValidationState.FULL
+    assert ValidationState.FULL.is_initial() is False
+    assert ValidationState.FULL.is_at_least_basic() is True
+    assert ValidationState.FULL.is_valid() is True
+    assert ValidationState.FULL.is_checkpoint() is False
+    assert ValidationState.FULL.is_fully_connected() is True
+    assert ValidationState.FULL.is_partial() is False
+    assert ValidationState.FULL.is_invalid() is False
+    assert ValidationState.FULL.is_final() is True
+    # ValidationState.CHECKPOINT_FULL
+    assert ValidationState.CHECKPOINT_FULL.is_initial() is False
+    assert ValidationState.CHECKPOINT_FULL.is_at_least_basic() is True
+    assert ValidationState.CHECKPOINT_FULL.is_valid() is True
+    assert ValidationState.CHECKPOINT_FULL.is_checkpoint() is True
+    assert ValidationState.CHECKPOINT_FULL.is_fully_connected() is True
+    assert ValidationState.CHECKPOINT_FULL.is_partial() is False
+    assert ValidationState.CHECKPOINT_FULL.is_invalid() is False
+    assert ValidationState.CHECKPOINT_FULL.is_final() is True
+    # ValidationState.INVALID
+    assert ValidationState.INVALID.is_initial() is False
+    assert ValidationState.INVALID.is_at_least_basic() is False
+    assert ValidationState.INVALID.is_valid() is False
+    assert ValidationState.INVALID.is_checkpoint() is False
+    assert ValidationState.INVALID.is_fully_connected() is False
+    assert ValidationState.INVALID.is_partial() is False
+    assert ValidationState.INVALID.is_invalid() is True
+    assert ValidationState.INVALID.is_final() is True
+
+
+def test_validation_states_partition_properties():
+    # these set of properties must not overlap and must cover all states:
+    # - is_partial
+    # - is_fully_connected
+    # - is_invalid
+    # this means that:
+    # - for each state at most one of these properties must be true
+    # - for each state at least one of these properties must be true
+    properties = [
+        ValidationState.is_partial,
+        ValidationState.is_fully_connected,
+        ValidationState.is_invalid,
+    ]
+    for state in ValidationState:
+        assert sum(int(prop(state)) for prop in properties) == 1


### PR DESCRIPTION
This change was split out from #577. The main objective is to be able to do this:

```python
tx.set_validation(ValidationState.BASIC)  # this is a partially validated transaction
tx_storage.save_transaction(tx)  # this fails with an assertion error
with stx_storage.allow_partially_validated_context():
    tx_storage.save_transaction(tx)  # but this succeeds
tx_storage.get_transaction(tx.hash)  # this also fails, but with an error that inherits from "not found"
with stx_storage.allow_partially_validated_context():
    tx_storage.get_transaction(tx.hash)  # but this succeeds
```

This change is only exists to reduce the scope where the storage APIs accept reading/writing partially validated transactions so that the changes needed by sync-v2 can have a very reduced an limited impact on the rest of the node. The previous iteration of this protection was made using a `allow_partially_validated: bool` argument on most APIs, that ended up being not only verbose, but more error prone and needed to carry this `allow_partially_validated` in a lot of places that shouldn't have to know about that.

## Acceptance Criteria

- TransactionStorage must have a scope that dictates which validation level on accept at save/get methods
- TransactionStorage must have methods that return contextmanagers which temporarily modify that scope