### PR TITLE
feat(sysctl): Add helper command

### DIFF
--- a/hathor/sysctl/sysctl.py
+++ b/hathor/sysctl/sysctl.py
@@ -102,3 +102,10 @@ class Sysctl:
                 continue
             value = cmd.getter()
             yield (self.path_join(prefix, path), value)
+
+    def get_all_paths(self, prefix: str = '') -> Iterator[str]:
+        """Return all available paths."""
+        for path, child in self._children.items():
+            yield from child.get_all_paths(self.path_join(prefix, path))
+        for path, cmd in self._commands.items():
+            yield self.path_join(prefix, path)


### PR DESCRIPTION
### Acceptance criteria

1) Add `!help` command, which shows all commands available.
2) Add `!help [cmd]` command, which shows a help message for the command.

### Example

```
!help
p2p.always_enable_sync
p2p.always_enable_sync.readtxt
p2p.force_sync_rotate
p2p.max_enabled_sync
p2p.rate_limit.global.send_tips
p2p.sync_update_interval
!help p2p.always_enable_sync
getter() -> List[str]:
    Return the list of sync-always-enabled peers.

setter(values: List[str]) -> None:
    Change the list of sync-always-enabled peers.
!help p2p.rate_limit.global.send_tips
getter() -> Tuple[int, float]:
    Return the global rate limiter for SEND_TIPS.

setter(max_hits: int, window_seconds: float) -> None:
    Change the global rate limiter for SEND_TIPS.

    The rate limiter is disabled when `window_seconds == 0`.
```