### PR TITLE
refactor(p2p): Build ConnectionsManager in builder

### DIFF
--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -33,22 +33,20 @@ class HathorServerFactory(protocol.ServerFactory):
     """
 
     manager: Optional[ConnectionsManager]
-    protocol: Optional[Type[MyServerProtocol]] = MyServerProtocol
+    protocol: Type[MyServerProtocol] = MyServerProtocol
 
     def __init__(
             self,
             network: str,
             my_peer: PeerId,
-            connections: Optional[ConnectionsManager] = None,
+            p2p_manager: ConnectionsManager,
             *,
-            node: 'HathorManager',
             use_ssl: bool,
     ):
         super().__init__()
         self.network = network
         self.my_peer = my_peer
-        self.connections = connections
-        self.node = node
+        self.p2p_manager = p2p_manager
         self.use_ssl = use_ssl
 
     def buildProtocol(self, addr: IAddress) -> MyServerProtocol:
@@ -56,8 +54,7 @@ class HathorServerFactory(protocol.ServerFactory):
         p = self.protocol(
             network=self.network,
             my_peer=self.my_peer,
-            connections=self.connections,
-            node=self.node,
+            p2p_manager=self.p2p_manager,
             use_ssl=self.use_ssl,
             inbound=True,
         )
@@ -69,23 +66,20 @@ class HathorClientFactory(protocol.ClientFactory):
     """ HathorClientFactory is used to generate HathorProtocol objects when we connected to another peer.
     """
 
-    manager: Optional[ConnectionsManager]
-    protocol: Optional[Type[MyClientProtocol]] = MyClientProtocol
+    protocol: Type[MyClientProtocol] = MyClientProtocol
 
     def __init__(
             self,
             network: str,
             my_peer: PeerId,
-            connections: Optional[ConnectionsManager] = None,
+            p2p_manager: ConnectionsManager,
             *,
-            node: 'HathorManager',
             use_ssl: bool,
     ):
         super().__init__()
         self.network = network
         self.my_peer = my_peer
-        self.connections = connections
-        self.node = node
+        self.p2p_manager = p2p_manager
         self.use_ssl = use_ssl
 
     def buildProtocol(self, addr: IAddress) -> MyClientProtocol:
@@ -93,8 +87,7 @@ class HathorClientFactory(protocol.ClientFactory):
         p = self.protocol(
             network=self.network,
             my_peer=self.my_peer,
-            connections=self.connections,
-            node=self.node,
+            p2p_manager=self.p2p_manager,
             use_ssl=self.use_ssl,
             inbound=False,
         )

--- a/hathor/p2p/sync_v1_1_factory.py
+++ b/hathor/p2p/sync_v1_1_factory.py
@@ -27,7 +27,14 @@ if TYPE_CHECKING:
 
 class SyncV11Factory(SyncManagerFactory):
     def __init__(self, connections: ConnectionsManager):
-        self.downloader = Downloader(connections.manager)
+        self.connections = connections
+        self._downloader: Optional[Downloader] = None
+
+    def get_downloader(self) -> Downloader:
+        if self._downloader is None:
+            assert self.connections.manager is not None
+            self._downloader = Downloader(self.connections.manager)
+        return self._downloader
 
     def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
-        return NodeSyncTimestamp(protocol, downloader=self.downloader, reactor=reactor)
+        return NodeSyncTimestamp(protocol, downloader=self.get_downloader(), reactor=reactor)

--- a/hathor/p2p/sync_v1_factory.py
+++ b/hathor/p2p/sync_v1_factory.py
@@ -27,7 +27,14 @@ if TYPE_CHECKING:
 
 class SyncV1Factory(SyncManagerFactory):
     def __init__(self, connections: ConnectionsManager):
-        self.downloader = Downloader(connections.manager)
+        self.connections = connections
+        self._downloader: Optional[Downloader] = None
+
+    def get_downloader(self) -> Downloader:
+        if self._downloader is None:
+            assert self.connections.manager is not None
+            self._downloader = Downloader(self.connections.manager)
+        return self._downloader
 
     def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
-        return NodeSyncTimestamp(protocol, downloader=self.downloader, reactor=reactor)
+        return NodeSyncTimestamp(protocol, downloader=self.get_downloader(), reactor=reactor)

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -53,8 +53,8 @@ class FakeConnection:
         self.latency = latency
         self.is_connected = True
 
-        self._proto1 = manager1.server_factory.buildProtocol(HostnameAddress(b'fake', 0))
-        self._proto2 = manager2.client_factory.buildProtocol(HostnameAddress(b'fake', 0))
+        self._proto1 = manager1.connections.server_factory.buildProtocol(HostnameAddress(b'fake', 0))
+        self._proto2 = manager2.connections.client_factory.buildProtocol(HostnameAddress(b'fake', 0))
 
         self.tr1 = HathorStringTransport(self._proto2.my_peer)
         self.tr2 = HathorStringTransport(self._proto1.my_peer)

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -50,11 +50,12 @@ class SimpleManagerInitializationTestCase(unittest.TestCase):
         manager = artifacts.manager
         del manager
 
-        # disabling both sync versions should be invalid
+        # disabling all sync versions should be invalid
         with self.assertRaises(TypeError):
             builder = TestBuilder()
             builder.set_tx_storage(self.tx_storage)
             builder.disable_sync_v1()
+            builder.disable_sync_v1_1()
             builder.disable_sync_v2()
             builder.build()
 

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -210,8 +210,7 @@ class BaseMetricsTest(unittest.TestCase):
             protocol = HathorProtocol(
                 network="testnet",
                 my_peer=my_peer,
-                connections=manager.connections,
-                node=manager,
+                p2p_manager=manager.connections,
                 use_ssl=False,
                 inbound=False
             )

--- a/tests/p2p/netfilter/test_factory.py
+++ b/tests/p2p/netfilter/test_factory.py
@@ -1,13 +1,12 @@
 from twisted.internet.address import IPv4Address
 
-from hathor.p2p.factory import HathorServerFactory
 from hathor.p2p.netfilter import get_table
 from hathor.p2p.netfilter.factory import NetfilterFactory
 from hathor.p2p.netfilter.matches import NetfilterMatchIPAddress
 from hathor.p2p.netfilter.rule import NetfilterRule
 from hathor.p2p.netfilter.targets import NetfilterReject
-from hathor.p2p.peer_id import PeerId
 from tests import unittest
+from tests.unittest import TestBuilder
 
 
 class NetfilterFactoryTest(unittest.TestCase):
@@ -18,7 +17,9 @@ class NetfilterFactoryTest(unittest.TestCase):
         rule = NetfilterRule(match, NetfilterReject())
         pre_conn.add_rule(rule)
 
-        wrapped_factory = HathorServerFactory('testnet', PeerId(), node=None, use_ssl=False)
+        builder = TestBuilder()
+        artifacts = builder.build()
+        wrapped_factory = artifacts.p2p_manager.server_factory
         factory = NetfilterFactory(connections=None, wrappedFactory=wrapped_factory)
 
         ret = factory.buildProtocol(IPv4Address('TCP', '192.168.0.1', 1234))

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -7,8 +7,8 @@ from twisted.internet.defer import inlineCallbacks
 from hathor.conf import HathorSettings
 from hathor.p2p.peer_id import InvalidPeerIdException, PeerId
 from hathor.p2p.peer_storage import PeerStorage
-from hathor.p2p.protocol import HathorProtocol
 from tests import unittest
+from tests.unittest import TestBuilder
 
 settings = HathorSettings()
 
@@ -150,8 +150,11 @@ class PeerIdTest(unittest.TestCase):
         self.assertEqual(p.retry_timestamp, 0)
 
     def test_validate_certificate(self):
+        builder = TestBuilder()
+        artifacts = builder.build()
+        protocol = artifacts.p2p_manager.server_factory.buildProtocol('127.0.0.1')
+
         peer = PeerId('testnet')
-        protocol = HathorProtocol('testnet', peer, None, node=None, use_ssl=True, inbound=True)
 
         class FakeTransport:
             def getPeerCertificate(self):
@@ -216,7 +219,7 @@ class BasePeerIdTest(unittest.TestCase):
         peer_id.entrypoints = ['tcp://127.0.0.1:40403']
 
         # we consider that we are starting the connection to the peer
-        protocol = HathorProtocol('testnet', peer_id, None, node=manager, use_ssl=True, inbound=False)
+        protocol = manager.connections.client_factory.buildProtocol('127.0.0.1')
         protocol.connection_string = 'tcp://127.0.0.1:40403'
         result = yield peer_id.validate_entrypoint(protocol)
         self.assertTrue(result)

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -268,7 +268,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
         self.assertTrue(isinstance(conn.proto1.state, PeerIdState))
         self.assertTrue(isinstance(conn.proto2.state, PeerIdState))
 
-        downloader = conn.proto2.connections._sync_factories[SyncVersion.V1_1].downloader
+        downloader = conn.proto2.connections._sync_factories[SyncVersion.V1_1].get_downloader()
 
         node_sync1 = NodeSyncTimestamp(conn.proto1, downloader, reactor=conn.proto1.node.reactor)
         node_sync1.start()
@@ -361,7 +361,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
 
         # create the peer that will experience the bug
         self.manager_bug = self.create_peer(self.network)
-        self.downloader = self.manager_bug.connections._sync_factories[SyncVersion.V1_1].downloader
+        self.downloader = self.manager_bug.connections._sync_factories[SyncVersion.V1_1].get_downloader()
         self.downloader.window_size = 1
         self.conn1 = FakeConnection(self.manager_bug, self.manager1)
         self.conn2 = FakeConnection(self.manager_bug, self.manager2)

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -71,6 +71,8 @@ class SyncBridgeParams:
 
 
 class TestBuilder(Builder):
+    __test__ = False
+
     def __init__(self) -> None:
         super().__init__()
         self.set_network('testnet')
@@ -208,9 +210,11 @@ class TestCase(unittest.TestCase):
             builder.force_memory_index()
 
         if enable_sync_v1 is True:
-            builder.enable_sync_v1()
+            # Enable Sync v1.1 (instead of v1.0)
+            builder.enable_sync_v1_1()
         elif enable_sync_v1 is False:
-            builder.disable_sync_v1()
+            # Disable Sync v1.1 (instead of v1.0)
+            builder.disable_sync_v1_1()
 
         if enable_sync_v2 is True:
             builder.enable_sync_v2()


### PR DESCRIPTION
### Acceptance criteria

1) Build `ConnectionsManager` in builders.
2) Move `ssl: bool`, `enable_sync_v1`, `enable_sync_v1_1`, and `enable_sync_v2` to `ConnectionsManager`.
3) Remove `HathorManager.server_factory` and `HathorManager.client_factory`.

### Note

There are still some network-related attributes and methods on `HathorManager`. I'll move those on a separate refactor to keep this one small for reviewers. Some attributes and methods yet-to-be moved out of `HathorManager` are:

- `listen_addresses: List[str]`
- `capabilities`
- `has_sync_version_capability()`
- `add_peer_to_whitelist()`
- `remove_peer_from_whitelist_and_disconnect()`
- `listen()`
- `do_discovery()`