### PR TITLE
feat(feature-activation): implement signal_bits field in txs

### DIFF
--- a/hathor/client.py
+++ b/hathor/client.py
@@ -392,8 +392,7 @@ def create_tx_from_dict(data: Dict[str, Any], update_hash: bool = False,
     if storage:
         data['storage'] = storage
 
-    _, tx_version = TxVersion.extract_from_bytes(data['version'])
-    cls = tx_version.get_cls()
+    cls = TxVersion(data['version']).get_cls()
     metadata = data.pop('metadata', None)
     tx = cls(**data)
     if update_hash:

--- a/hathor/client.py
+++ b/hathor/client.py
@@ -392,7 +392,8 @@ def create_tx_from_dict(data: Dict[str, Any], update_hash: bool = False,
     if storage:
         data['storage'] = storage
 
-    cls = TxVersion(data['version']).get_cls()
+    version = data['version'] & 0xFF
+    cls = TxVersion(version).get_cls()
     metadata = data.pop('metadata', None)
     tx = cls(**data)
     if update_hash:

--- a/hathor/client.py
+++ b/hathor/client.py
@@ -392,8 +392,8 @@ def create_tx_from_dict(data: Dict[str, Any], update_hash: bool = False,
     if storage:
         data['storage'] = storage
 
-    version = data['version'] & 0xFF
-    cls = TxVersion(version).get_cls()
+    _, tx_version = TxVersion.extract_from_bytes(data['version'])
+    cls = tx_version.get_cls()
     metadata = data.pop('metadata', None)
     tx = cls(**data)
     if update_hash:

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -121,8 +121,8 @@ class TxVersion(IntEnum):
         """
         Takes a 2-byte number and returns signal bits and a TxVersion from it.
 
-        Signal bits, extracted from the first byte, carry information about Feature Activation
-        bits and also extra bits reserved for future use, depending on the configuration.
+        Signal bits, extracted from the first byte, carry extra information that
+        may be interpreted differently by each subclass of BaseTransaction.
 
         Args:
             value: a 2-byte number
@@ -170,8 +170,10 @@ class BaseTransaction(ABC):
 
     _metadata: Optional[TransactionMetadata]
 
-    # The first byte extracted from the version field. Carries information about Feature Activation
-    # bits and also extra bits reserved for future use, depending on the configuration.
+    # Bits extracted from the first byte of the version field. They carry extra information that may be interpreted
+    # differently by each subclass of BaseTransaction.
+    # Currently only the Block subclass uses it, carrying information about Feature Activation bits and also extra
+    # bits reserved for future use, depending on the configuration.
     signal_bits: int
 
     def __init__(self,

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -81,6 +81,9 @@ _TX_PARENTS_BLOCKS = 0
 _BLOCK_PARENTS_TXS = 2
 _BLOCK_PARENTS_BLOCKS = 1
 
+# The int value of one byte
+_ONE_BYTE = 0xFF
+
 
 def sum_weights(w1: float, w2: float) -> float:
     return aux_calc_weight(w1, w2, 1)
@@ -112,28 +115,9 @@ class TxVersion(IntEnum):
     @classmethod
     def _missing_(cls, value: Any) -> None:
         assert isinstance(value, int), f"Value '{value}' must be an integer"
-        assert value <= 0xFF, f'Value {hex(value)} must not be larger than one byte'
+        assert value <= _ONE_BYTE, f'Value {hex(value)} must not be larger than one byte'
 
         raise ValueError(f'Invalid version: {value}')
-
-    @classmethod
-    def extract_from_bytes(cls, value: int) -> Tuple[int, 'TxVersion']:
-        """
-        Takes a 2-byte number and returns signal bits and a TxVersion from it.
-
-        Signal bits, extracted from the first byte, carry extra information that
-        may be interpreted differently by each subclass of BaseTransaction.
-
-        Args:
-            value: a 2-byte number
-
-        Returns: a tuple in the format (signal_bits, tx_version)
-        """
-        assert value <= 0xFFFF, f'Value {hex(value)} must not be larger than two bytes'
-
-        signal_bits, version = int_to_bytes(value, 2)
-
-        return signal_bits, TxVersion(version)
 
     def get_cls(self) -> Type['BaseTransaction']:
         from hathor.transaction.block import Block
@@ -179,6 +163,7 @@ class BaseTransaction(ABC):
     def __init__(self,
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
+                 signal_bits: int = 0,
                  version: int = TxVersion.REGULAR_BLOCK,
                  weight: float = 0,
                  inputs: Optional[List['TxInput']] = None,
@@ -189,14 +174,19 @@ class BaseTransaction(ABC):
         """
             Nonce: nonce used for the proof-of-work
             Timestamp: moment of creation
+            Signal bits: bits used to carry extra information that may be interpreted differently by each subclass
             Version: version when it was created
             Weight: different for transactions and blocks
             Outputs: all outputs that are being created
             Parents: transactions you are confirming (2 transactions and 1 block - in case of a block only)
         """
+        assert signal_bits <= _ONE_BYTE, f'signal_bits {hex(signal_bits)} must not be larger than one byte'
+        assert version <= _ONE_BYTE, f'version {hex(version)} must not be larger than one byte'
+
         self.nonce = nonce
         self.timestamp = timestamp or int(time.time())
-        self.signal_bits, self.version = TxVersion.extract_from_bytes(version)
+        self.signal_bits = signal_bits
+        self.version = version
         self.weight = weight
         self.inputs = inputs or []
         self.outputs = outputs or []

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -67,9 +67,8 @@ TX_HASH_SIZE = 32   # 256 bits, 32 bytes
 # H = unsigned short (2 bytes), d = double(8), f = float(4), I = unsigned int (4),
 # Q = unsigned long long int (64), B = unsigned char (1 byte)
 
-# Version (H), inputs len (B), and outputs len (B), token uids len (B).
-# H = unsigned short (2 bytes)
-_SIGHASH_ALL_FORMAT_STRING = '!HBBB'
+# Signal bits (B), version (B), inputs len (B), and outputs len (B), token uids len (B).
+_SIGHASH_ALL_FORMAT_STRING = '!BBBBB'
 
 # Weight (d), timestamp (I), and parents len (B)
 _GRAPH_FORMAT_STRING = '!dIB'
@@ -111,14 +110,11 @@ class TxVersion(IntEnum):
     MERGE_MINED_BLOCK = 3
 
     @classmethod
-    def _missing_(cls, value: Any) -> 'TxVersion':
-        # version's first byte is reserved for future use, so we'll ignore it
-        assert isinstance(value, int)
-        version = value & 0xFF
-        if version == value:
-            # Prevent infinite recursion when starting TxVerion with wrong version
-            raise ValueError('Invalid version.')
-        return cls(version)
+    def _missing_(cls, value: Any) -> None:
+        assert isinstance(value, int), f"Value '{value}' must be an integer"
+        assert value <= 0xFF, f'Value {hex(value)} must not be larger than one byte'
+
+        raise ValueError(f'Invalid version: {value}')
 
     def get_cls(self) -> Type['BaseTransaction']:
         from hathor.transaction.block import Block
@@ -173,9 +169,12 @@ class BaseTransaction(ABC):
             Outputs: all outputs that are being created
             Parents: transactions you are confirming (2 transactions and 1 block - in case of a block only)
         """
+        assert version <= 0xFFFF, f'Version {hex(version)} must not be larger than two bytes'
+
         self.nonce = nonce
         self.timestamp = timestamp or int(time.time())
-        self.version = version
+        self.signal_bits = (version >> 8) & 0xFF
+        self.version = version & 0xFF
         self.weight = weight
         self.inputs = inputs or []
         self.outputs = outputs or []
@@ -1354,8 +1353,8 @@ def tx_or_block_from_bytes(data: bytes,
                            storage: Optional['TransactionStorage'] = None) -> BaseTransaction:
     """ Creates the correct tx subclass from a sequence of bytes
     """
-    # version field takes up the first 2 bytes
-    version = int.from_bytes(data[0:2], 'big')
+    # version field takes up the second byte only
+    version = data[1]
     try:
         tx_version = TxVersion(version)
         cls = tx_version.get_cls()

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -38,11 +38,11 @@ if TYPE_CHECKING:
 settings = HathorSettings()
 cpu = get_cpu_profiler()
 
-# Version (H), outputs len (B)
-_FUNDS_FORMAT_STRING = '!HB'
+# Signal bits (B), version (B), outputs len (B)
+_FUNDS_FORMAT_STRING = '!BBB'
 
-# Version (H), inputs len (B) and outputs len (B)
-_SIGHASH_ALL_FORMAT_STRING = '!HBB'
+# Signal bits (B), version (B), inputs len (B) and outputs len (B)
+_SIGHASH_ALL_FORMAT_STRING = '!BBBB'
 
 
 class Block(BaseTransaction):
@@ -165,8 +165,9 @@ class Block(BaseTransaction):
 
         :raises ValueError: when the sequence of bytes is incorect
         """
-        (self.version, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
+        (self.signal_bits, self.version, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
         if verbose:
+            verbose('signal_bits', self.signal_bits)
             verbose('version', self.version)
             verbose('outputs_len', outputs_len)
 
@@ -202,7 +203,7 @@ class Block(BaseTransaction):
         :return: funds data serialization of the block
         :rtype: bytes
         """
-        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.version, len(self.outputs))
+        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.signal_bits, self.version, len(self.outputs))
 
         for tx_output in self.outputs:
             struct_bytes += bytes(tx_output)

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -51,6 +51,7 @@ class Block(BaseTransaction):
     def __init__(self,
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
+                 signal_bits: int = 0,
                  version: int = TxVersion.REGULAR_BLOCK,
                  weight: float = 0,
                  outputs: Optional[List[TxOutput]] = None,
@@ -58,7 +59,7 @@ class Block(BaseTransaction):
                  hash: Optional[bytes] = None,
                  data: bytes = b'',
                  storage: Optional['TransactionStorage'] = None) -> None:
-        super().__init__(nonce=nonce, timestamp=timestamp, version=version, weight=weight,
+        super().__init__(nonce=nonce, timestamp=timestamp, signal_bits=signal_bits, version=version, weight=weight,
                          outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
         self.data = data
 

--- a/hathor/transaction/merge_mined_block.py
+++ b/hathor/transaction/merge_mined_block.py
@@ -27,6 +27,7 @@ class MergeMinedBlock(Block):
     def __init__(self,
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
+                 signal_bits: int = 0,
                  version: int = TxVersion.MERGE_MINED_BLOCK,
                  weight: float = 0,
                  outputs: Optional[List[TxOutput]] = None,
@@ -35,8 +36,8 @@ class MergeMinedBlock(Block):
                  data: bytes = b'',
                  aux_pow: Optional[BitcoinAuxPow] = None,
                  storage: Optional['TransactionStorage'] = None) -> None:
-        super().__init__(nonce=nonce, timestamp=timestamp, version=version, weight=weight, data=data,
-                         outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
+        super().__init__(nonce=nonce, timestamp=timestamp, signal_bits=signal_bits, version=version, weight=weight,
+                         data=data, outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
         self.aux_pow = aux_pow
 
     def _get_formatted_fields_dict(self, short: bool = True) -> Dict[str, str]:

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -24,11 +24,11 @@ from hathor.transaction.util import VerboseCallback, clean_token_string, int_to_
 
 settings = HathorSettings()
 
-# Version (H), inputs len (B), outputs len (B)
-_FUNDS_FORMAT_STRING = '!HBB'
+# Signal bits (B), version (B), inputs len (B), outputs len (B)
+_FUNDS_FORMAT_STRING = '!BBBB'
 
-# Version (H), inputs len (B), outputs len (B)
-_SIGHASH_ALL_FORMAT_STRING = '!HBB'
+# Signal bist (B), version (B), inputs len (B), outputs len (B)
+_SIGHASH_ALL_FORMAT_STRING = '!BBBB'
 
 # used when (de)serializing token information
 # version 1 expects only token name and symbol
@@ -85,8 +85,9 @@ class TokenCreationTransaction(Transaction):
 
         :raises ValueError: when the sequence of bytes is incorect
         """
-        (self.version, inputs_len, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
+        (self.signal_bits, self.version, inputs_len, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
         if verbose:
+            verbose('signal_bits', self.signal_bits)
             verbose('version', self.version)
             verbose('inputs_len', inputs_len)
             verbose('outputs_len', outputs_len)
@@ -110,7 +111,13 @@ class TokenCreationTransaction(Transaction):
         :return: funds data serialization of the transaction
         :rtype: bytes
         """
-        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.version, len(self.inputs), len(self.outputs))
+        struct_bytes = pack(
+            _FUNDS_FORMAT_STRING,
+            self.signal_bits,
+            self.version,
+            len(self.inputs),
+            len(self.outputs)
+        )
 
         tx_inputs = []
         for tx_input in self.inputs:
@@ -135,7 +142,13 @@ class TokenCreationTransaction(Transaction):
         if self._sighash_cache:
             return self._sighash_cache
 
-        struct_bytes = pack(_SIGHASH_ALL_FORMAT_STRING, self.version, len(self.inputs), len(self.outputs))
+        struct_bytes = pack(
+            _SIGHASH_ALL_FORMAT_STRING,
+            self.signal_bits,
+            self.version,
+            len(self.inputs),
+            len(self.outputs)
+        )
 
         tx_inputs = []
         for tx_input in self.inputs:

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -39,6 +39,7 @@ class TokenCreationTransaction(Transaction):
     def __init__(self,
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
+                 signal_bits: int = 0,
                  version: int = TxVersion.TOKEN_CREATION_TRANSACTION,
                  weight: float = 0,
                  inputs: Optional[List[TxInput]] = None,
@@ -48,8 +49,8 @@ class TokenCreationTransaction(Transaction):
                  token_name: str = '',
                  token_symbol: str = '',
                  storage: Optional['TransactionStorage'] = None) -> None:
-        super().__init__(nonce=nonce, timestamp=timestamp, version=version, weight=weight, inputs=inputs,
-                         outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
+        super().__init__(nonce=nonce, timestamp=timestamp, signal_bits=signal_bits, version=version, weight=weight,
+                         inputs=inputs, outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
         self.token_name = token_name
         self.token_symbol = token_symbol
         # for this special tx, its own hash is used as the created token uid. We're artificially

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -74,6 +74,7 @@ class Transaction(BaseTransaction):
     def __init__(self,
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
+                 signal_bits: int = 0,
                  version: int = TxVersion.REGULAR_TRANSACTION,
                  weight: float = 0,
                  inputs: Optional[List[TxInput]] = None,
@@ -86,8 +87,8 @@ class Transaction(BaseTransaction):
             Creating new init just to make sure inputs will always be empty array
             Inputs: all inputs that are being used (empty in case of a block)
         """
-        super().__init__(nonce=nonce, timestamp=timestamp, version=version, weight=weight, inputs=inputs
-                         or [], outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
+        super().__init__(nonce=nonce, timestamp=timestamp, signal_bits=signal_bits, version=version, weight=weight,
+                         inputs=inputs or [], outputs=outputs or [], parents=parents or [], hash=hash, storage=storage)
         self.tokens = tokens or []
         self._sighash_cache: Optional[bytes] = None
         self._sighash_data_cache: Optional[bytes] = None

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -853,6 +853,23 @@ class BaseTransactionTest(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), 'Value 0x100 must not be larger than one byte')
 
+        # test invalid version
+        with self.assertRaises(ValueError) as cm:
+            TxVersion(10)
+
+        self.assertEqual(str(cm.exception), 'Invalid version: 10')
+
+        # test TxVersion.extract_from_bytes
+        with self.assertRaises(AssertionError) as cm:
+            TxVersion.extract_from_bytes(0x54321)
+
+        self.assertEqual(str(cm.exception), 'Value 0x54321 must not be larger than two bytes')
+
+        signal_bits, tx_version = TxVersion.extract_from_bytes(0x4303)
+
+        self.assertEqual(signal_bits, 0x43)
+        self.assertEqual(tx_version, TxVersion.MERGE_MINED_BLOCK)
+
         # test get the correct class
         version = TxVersion(0x00)
         self.assertEqual(version.get_cls(), Block)
@@ -867,12 +884,6 @@ class BaseTransactionTest(unittest.TestCase):
         block2 = block.clone()
         self.assertEqual(block.signal_bits, block2.signal_bits)
         self.assertEqual(block.version, block2.version)
-
-        # test invalid version init
-        with self.assertRaises(AssertionError) as cm:
-            Block(version=0x10000)
-
-        self.assertEqual(str(cm.exception), 'Version 0x10000 must not be larger than two bytes')
 
     def test_output_sum_ignore_authority(self):
         # sum of tx outputs should ignore authority outputs

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -20,7 +20,7 @@ class _BaseTest:
             tx = cls.create_from_struct(self.tx_bytes, verbose=verbose)
             tx.verify_without_storage()
 
-            key, version = v[0]
+            key, version = v[1]
             self.assertEqual(key, 'version')
 
             tx_version = TxVersion(version)


### PR DESCRIPTION
### Acceptance Criteria

- Change `TxVersion` enum so it fails instantiation for values larger than one byte, instead of ignoring it.
- Create new `signal_bits` attribute in `BaseTransaction`, derived from the first byte of the `version` field.

**ATTENTION**: this PR touches important parts of the code