### PR TITLE
feat(ws): Change default configuration of WS_MAX_SUBS_ADDRS_CONN and WS_MAX_SUBS_ADDRS_EMPTY to infinite

### DIFF
--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from hathor.builder import BuildArtifacts
-from hathor.sysctl import ConnectionsManagerSysctl, Sysctl
+from hathor.sysctl import ConnectionsManagerSysctl, Sysctl, WebsocketManagerSysctl
 
 
 class SysctlBuilder:
@@ -25,4 +25,9 @@ class SysctlBuilder:
         """Build the sysctl tree."""
         root = Sysctl()
         root.put_child('p2p', ConnectionsManagerSysctl(self.artifacts.p2p_manager))
+
+        ws_factory = self.artifacts.manager.metrics.websocket_factory
+        if ws_factory is not None:
+            root.put_child('ws', WebsocketManagerSysctl(ws_factory))
+
         return root

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -230,10 +230,10 @@ class HathorSettings(NamedTuple):
     PUSHTX_MAX_OUTPUT_SCRIPT_SIZE: int = 256
 
     # Maximum number of subscribed addresses per websocket connection
-    WS_MAX_SUBS_ADDRS_CONN: int = 200000
+    WS_MAX_SUBS_ADDRS_CONN: Optional[int] = None
 
     # Maximum number of subscribed addresses that do not have any outputs (also per websocket connection)
-    WS_MAX_SUBS_ADDRS_EMPTY: int = 100
+    WS_MAX_SUBS_ADDRS_EMPTY: Optional[int] = None
 
     # Whether miners are assumed to mine txs by default
     STRATUM_MINE_TXS_DEFAULT: bool = True

--- a/hathor/sysctl/p2p/manager.py
+++ b/hathor/sysctl/p2p/manager.py
@@ -69,13 +69,9 @@ class ConnectionsManagerSysctl(Sysctl):
             self.set_always_enable_sync_readtxt,
         )
 
-    #############
-
     def set_force_sync_rotate(self) -> None:
         """Force a sync rotate."""
         self.connections._sync_rotate_if_needed(force=True)
-
-    #############
 
     def get_global_send_tips_rate_limit(self) -> Tuple[int, float]:
         """Return the global rate limiter for SEND_TIPS."""
@@ -97,8 +93,6 @@ class ConnectionsManagerSysctl(Sysctl):
             raise SysctlException('window_seconds must be >= 0')
         self.connections.enable_rate_limiter(max_hits, window_seconds)
 
-    #############
-
     def get_lc_sync_update_interval(self) -> float:
         """Return the interval to rotate sync (in seconds)."""
         return self.connections.lc_sync_update_interval
@@ -111,8 +105,6 @@ class ConnectionsManagerSysctl(Sysctl):
         if self.connections.lc_sync_update.running:
             self.connections.lc_sync_update.stop()
             self.connections.lc_sync_update.start(self.connections.lc_sync_update_interval, now=False)
-
-    #############
 
     def get_always_enable_sync(self) -> List[str]:
         """Return the list of sync-always-enabled peers."""
@@ -130,8 +122,6 @@ class ConnectionsManagerSysctl(Sysctl):
         with open(file_path, 'r') as fp:
             values = parse_text(fp.read())
         self.connections.set_always_enable_sync(values)
-
-    #############
 
     def get_max_enabled_sync(self) -> int:
         """Return the maximum number of peers running sync simultaneously."""

--- a/hathor/sysctl/websocket/__init__.py
+++ b/hathor/sysctl/websocket/__init__.py
@@ -11,13 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from hathor.sysctl.p2p.manager import ConnectionsManagerSysctl
-from hathor.sysctl.sysctl import Sysctl
-from hathor.sysctl.websocket.manager import WebsocketManagerSysctl
-
-__all__ = [
-    'Sysctl',
-    'ConnectionsManagerSysctl',
-    'WebsocketManagerSysctl',
-]

--- a/hathor/sysctl/websocket/manager.py
+++ b/hathor/sysctl/websocket/manager.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathor.sysctl.exception import SysctlException
+from hathor.sysctl.sysctl import Sysctl
+from hathor.websocket.factory import HathorAdminWebsocketFactory
+
+
+class WebsocketManagerSysctl(Sysctl):
+    def __init__(self, factory: HathorAdminWebsocketFactory) -> None:
+        super().__init__()
+        self.factory = factory
+
+        self.register(
+            'max_subs_addrs_conn',
+            self.get_max_subs_addrs_conn,
+            self.set_max_subs_addrs_conn,
+        )
+        self.register(
+            'max_subs_addrs_empty',
+            self.get_max_subs_addrs_empty,
+            self.set_max_subs_addrs_empty,
+        )
+
+    def get_max_subs_addrs_conn(self) -> int:
+        """Return the maximum number of subscribed addresses per websocket connection.
+        Note: -1 means unlimited"""
+        value = self.factory.max_subs_addrs_conn
+        if value is None:
+            return -1
+        return value
+
+    def set_max_subs_addrs_conn(self, value: int) -> None:
+        """Change the maximum number of subscribed addresses per websocket connection.
+        Use -1 for unlimited"""
+        if value == -1:
+            self.factory.max_subs_addrs_conn = None
+            return
+        if value < 0:
+            raise SysctlException('value must be >= 0 or -1')
+        self.factory.max_subs_addrs_conn = value
+
+    def get_max_subs_addrs_empty(self) -> int:
+        """Return the maximum number of subscribed addresses that do not have any outputs per websocket connection.
+        Note: -1 means unlimited"""
+        value = self.factory.max_subs_addrs_empty
+        if value is None:
+            return -1
+        return value
+
+    def set_max_subs_addrs_empty(self, value: int) -> None:
+        """Change the maximum number of subscribed addresses that do not have any outputs per websocket connection.
+        Use -1 for unlimited"""
+        if value == -1:
+            self.factory.max_subs_addrs_empty = None
+            return
+        if value < 0:
+            raise SysctlException('value must be >= 0 or -1')
+        self.factory.max_subs_addrs_empty = value

--- a/tests/sysctl/test_websocket.py
+++ b/tests/sysctl/test_websocket.py
@@ -1,0 +1,44 @@
+from hathor.sysctl import WebsocketManagerSysctl
+from hathor.sysctl.exception import SysctlException
+from hathor.websocket.factory import HathorAdminWebsocketFactory
+from tests import unittest
+
+
+class WebsocketSysctlTestCase(unittest.TestCase):
+    def test_max_subs_addrs_conn(self):
+        ws_factory = HathorAdminWebsocketFactory()
+        sysctl = WebsocketManagerSysctl(ws_factory)
+
+        sysctl.set('max_subs_addrs_conn', 10)
+        self.assertEqual(ws_factory.max_subs_addrs_conn, 10)
+        self.assertEqual(sysctl.get('max_subs_addrs_conn'), 10)
+
+        sysctl.set('max_subs_addrs_conn', 0)
+        self.assertEqual(ws_factory.max_subs_addrs_conn, 0)
+        self.assertEqual(sysctl.get('max_subs_addrs_conn'), 0)
+
+        sysctl.set('max_subs_addrs_conn', -1)
+        self.assertIsNone(ws_factory.max_subs_addrs_conn)
+        self.assertEqual(sysctl.get('max_subs_addrs_conn'), -1)
+
+        with self.assertRaises(SysctlException):
+            sysctl.set('max_subs_addrs_conn', -2)
+
+    def test_max_subs_addrs_empty(self):
+        ws_factory = HathorAdminWebsocketFactory()
+        sysctl = WebsocketManagerSysctl(ws_factory)
+
+        sysctl.set('max_subs_addrs_empty', 10)
+        self.assertEqual(ws_factory.max_subs_addrs_empty, 10)
+        self.assertEqual(sysctl.get('max_subs_addrs_empty'), 10)
+
+        sysctl.set('max_subs_addrs_empty', 0)
+        self.assertEqual(ws_factory.max_subs_addrs_empty, 0)
+        self.assertEqual(sysctl.get('max_subs_addrs_empty'), 0)
+
+        sysctl.set('max_subs_addrs_empty', -1)
+        self.assertIsNone(ws_factory.max_subs_addrs_empty)
+        self.assertEqual(sysctl.get('max_subs_addrs_empty'), -1)
+
+        with self.assertRaises(SysctlException):
+            sysctl.set('max_subs_addrs_empty', -2)


### PR DESCRIPTION
### Acceptance criteria

1) Change `settings.WS_MAX_SUBS_ADDRS_CONN` default value to `None`, which means unlimited.
2) Change `settings.WS_MAX_SUBS_ADDRS_EMPTY` default value to `None`, which means unlimited.
3) Create sysctl command `ws.max_subs_addrs_conn`.
4) Create sysctl command `ws.max_subs_addrs_empty`.