### PR TITLE
refactor(settings): make HathorSettings always return the same instance

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -55,7 +55,7 @@ class CliBuilder:
     def create_manager(self, reactor: PosixReactorBase, args: Namespace) -> HathorManager:
         import hathor
         from hathor.conf import HathorSettings
-        from hathor.conf.get_settings import get_settings_filepath, get_settings_module
+        from hathor.conf.get_settings import get_settings_source
         from hathor.daa import TestMode, _set_test_mode
         from hathor.event.storage import EventMemoryStorage, EventRocksDBStorage, EventStorage
         from hathor.event.websocket.factory import EventWebsocketFactory
@@ -74,8 +74,7 @@ class CliBuilder:
         settings = HathorSettings()
 
         # only used for logging its location
-        settings_module = get_settings_module()
-        settings_source = settings_module.__file__ if settings_module is not None else get_settings_filepath()
+        settings_source = get_settings_source()
 
         self.log = logger.new()
         self.reactor = reactor


### PR DESCRIPTION
This wasn't _exactly_ the case before this commit. On one side when using the deprecated module settings the same module would always be loaded, and the same `SETTINGS` property would be accessed, but reloading the module (or at least leaving that up to importlib) unnecessary. On the new YAML system the file is reloaded everytime, this is also unnecessary.

This commit will make it the last HathorSettings instantiated will be returned, as long as the source is the same, otherwise an exception is raised.

There is a little small caveat that is fixed in this commit is that in the YAML file could in theory be altered between different calls to HathorSettings, which would lead to different content being loaded silently. What happens now is that the first time it is loaded is what is used for every call, any change in the file won't have any effect.

## Acceptance Criteria

- always return the same `hathor.conf.HathorSettings` instance when calling `hathor.conf.get_settings.HathorSettings`
- replace `get_settings_module` with `get_settings_module_path` that returns the loaded path instead of the loaded module