### PR TITLE
feat(feature-activation): bit count optimization

### DIFF
--- a/hathor/conf/unittests.py
+++ b/hathor/conf/unittests.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from hathor.conf.settings import HathorSettings
+from hathor.feature_activation.settings import Settings as FeatureActivationSettings
 
 SETTINGS = HathorSettings(
     P2PKH_VERSION_BYTE=b'\x28',
@@ -34,4 +35,9 @@ SETTINGS = HathorSettings(
     REWARD_SPEND_MIN_BLOCKS=10,
     SLOW_ASSERTS=True,
     MAX_TX_WEIGHT_DIFF_ACTIVATION=0.0,
+    FEATURE_ACTIVATION=FeatureActivationSettings(
+        evaluation_interval=4,
+        max_signal_bits=4,
+        default_threshold=3
+    )
 )

--- a/hathor/conf/unittests.yml
+++ b/hathor/conf/unittests.yml
@@ -17,3 +17,8 @@ GENESIS_TX2_HASH: 33e14cb555a96967841dcbe0f95e9eab5810481d01de8f4f73afb8cce365e8
 REWARD_SPEND_MIN_BLOCKS: 10
 SLOW_ASSERTS: true
 MAX_TX_WEIGHT_DIFF_ACTIVATION: 0.0
+
+FEATURE_ACTIVATION:
+  evaluation_interval: 4
+  max_signal_bits: 4
+  default_threshold: 3

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -301,11 +301,21 @@ class BaseTransaction(ABC):
     def calculate_min_height(self) -> int:
         raise NotImplementedError
 
-    @abstractmethod
     def calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
         """
         Calculates the feature_activation_bit_counts metadata attribute.
-        Must only be calculated by Blocks, and return None otherwise.
+        It's only calculated by Blocks, and returns None otherwise.
+        """
+        if not self.is_block:
+            return None
+
+        return self._calculate_feature_activation_bit_counts()
+
+    @abstractmethod
+    def _calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
+        """
+        Calculates the feature_activation_bit_counts metadata attribute.
+        Must only be implemented by Blocks.
         """
         raise NotImplementedError
 

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -113,7 +113,7 @@ class Block(BaseTransaction):
         return max((self.storage.get_transaction(tx).get_metadata().min_height for tx in self.get_tx_parents()),
                    default=0)
 
-    def calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
+    def _calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
         """
         Calculates the feature_activation_bit_counts metadata attribute, which is a list of feature activation bit
         counts.

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -113,7 +113,7 @@ class Block(BaseTransaction):
         return max((self.storage.get_transaction(tx).get_metadata().min_height for tx in self.get_tx_parents()),
                    default=0)
 
-    def _calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
+    def calculate_feature_activation_bit_counts(self) -> list[int]:
         """
         Calculates the feature_activation_bit_counts metadata attribute, which is a list of feature activation bit
         counts.

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import base64
+from itertools import starmap, zip_longest
+from operator import add
 from struct import pack
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -31,6 +33,7 @@ from hathor.transaction.exceptions import (
     WeightError,
 )
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
+from hathor.utils.int import get_bit_list
 
 if TYPE_CHECKING:
     from hathor.transaction.storage import TransactionStorage  # noqa: F401
@@ -109,6 +112,35 @@ class Block(BaseTransaction):
         # maximum min-height of any parent tx
         return max((self.storage.get_transaction(tx).get_metadata().min_height for tx in self.get_tx_parents()),
                    default=0)
+
+    def calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
+        """
+        Calculates the feature_activation_bit_counts metadata attribute, which is a list of feature activation bit
+        counts.
+
+        Each list index corresponds to a bit position, and its respective value is the rolling count of active bits
+        from the previous boundary block up to this block, including it. LSB is on the left.
+        """
+        previous_counts = self._get_previous_feature_activation_bit_counts()
+        bit_list = self._get_feature_activation_bit_list()
+
+        count_and_bit_pairs = zip_longest(previous_counts, bit_list, fillvalue=0)
+        updated_counts = starmap(add, count_and_bit_pairs)
+
+        return list(updated_counts)
+
+    def _get_previous_feature_activation_bit_counts(self) -> list[int]:
+        """
+        Returns the feature_activation_bit_counts metadata attribute from the parent block,
+        or no previous counts if this is a boundary block.
+        """
+        evaluation_interval = settings.FEATURE_ACTIVATION.evaluation_interval
+        is_boundary_block = self.calculate_height() % evaluation_interval == 0
+
+        if is_boundary_block:
+            return []
+
+        return self.get_parent_feature_activation_bit_counts()
 
     def get_next_block_best_chain_hash(self) -> Optional[bytes]:
         """Return the hash of the next (child/left-to-right) block in the best blockchain.
@@ -354,13 +386,26 @@ class Block(BaseTransaction):
         """Returns the block's height."""
         return self.get_metadata().height
 
-    def get_feature_activation_bits(self) -> int:
-        """Returns the feature activation bits from the signal bits."""
+    def get_parent_feature_activation_bit_counts(self) -> list[int]:
+        """Returns the parent block's feature_activation_bit_counts metadata attribute."""
+        parent_metadata = self.get_block_parent().get_metadata()
+        assert parent_metadata.feature_activation_bit_counts is not None, 'Blocks must always have this attribute set.'
+
+        return parent_metadata.feature_activation_bit_counts
+
+    def _get_feature_activation_bit_list(self) -> list[int]:
+        """
+        Extracts feature activation bits from the signal bits, as a list where each index corresponds to the bit
+        position. LSB is on the left.
+        """
         assert self.signal_bits <= 0xFF, 'signal_bits must be one byte at most'
 
         bitmask = self._get_feature_activation_bitmask()
+        bits = self.signal_bits & bitmask
 
-        return self.signal_bits & bitmask
+        bit_list = get_bit_list(bits, min_size=settings.FEATURE_ACTIVATION.max_signal_bits)
+
+        return bit_list
 
     @classmethod
     def _get_feature_activation_bitmask(cls) -> int:

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -140,6 +140,10 @@ class Transaction(BaseTransaction):
             self._calculate_my_min_height(),
         )
 
+    def calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
+        """Returns None, as Transactions do not have the feature_activation_bit_counts metadata attribute."""
+        return None
+
     def _calculate_inherited_min_height(self) -> int:
         """ Calculates min height inherited from any input or parent"""
         assert self.storage is not None

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -140,10 +140,6 @@ class Transaction(BaseTransaction):
             self._calculate_my_min_height(),
         )
 
-    def _calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
-        """Not implemented, as Transactions do not have the feature_activation_bit_counts metadata attribute."""
-        raise NotImplementedError
-
     def _calculate_inherited_min_height(self) -> int:
         """ Calculates min height inherited from any input or parent"""
         assert self.storage is not None

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -140,9 +140,9 @@ class Transaction(BaseTransaction):
             self._calculate_my_min_height(),
         )
 
-    def calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
-        """Returns None, as Transactions do not have the feature_activation_bit_counts metadata attribute."""
-        return None
+    def _calculate_feature_activation_bit_counts(self) -> Optional[list[int]]:
+        """Not implemented, as Transactions do not have the feature_activation_bit_counts metadata attribute."""
+        raise NotImplementedError
 
     def _calculate_inherited_min_height(self) -> int:
         """ Calculates min height inherited from any input or parent"""

--- a/hathor/utils/int.py
+++ b/hathor/utils/int.py
@@ -41,9 +41,14 @@ def get_bit_list(n: int, min_size: Optional[int] = None) -> list[int]:
     [0, 1, 0, 1, 0, 0, 1, 1, 1, 0]
     """
     assert n >= 0
+    bits = []
 
-    shifts = range(n.bit_length())
-    bits = [n >> shift & 1 for shift in shifts]
-    padding_zeroes = [] if min_size is None else [0] * (min_size - len(bits))
+    while n > 0:
+        bits.append(n & 1)
+        n >>= 1
 
-    return bits + padding_zeroes
+    if min_size is not None:
+        while len(bits) < min_size:
+            bits.append(0)
+
+    return bits

--- a/hathor/utils/int.py
+++ b/hathor/utils/int.py
@@ -1,0 +1,49 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional
+
+
+def get_bit_list(n: int, min_size: Optional[int] = None) -> list[int]:
+    """
+    Returns a list of bits corresponding to a non-negative number, with LSB on the left.
+
+    Args:
+        n: the number
+        min_size: if set, pads the returned list with zeroes until it reaches min_size
+
+    >>> get_bit_list(0b0)
+    []
+    >>> get_bit_list(0b1)
+    [1]
+    >>> get_bit_list(0b10)
+    [0, 1]
+    >>> get_bit_list(0b111001010)
+    [0, 1, 0, 1, 0, 0, 1, 1, 1]
+    >>> get_bit_list(0b0, min_size=4)
+    [0, 0, 0, 0]
+    >>> get_bit_list(0b1, min_size=3)
+    [1, 0, 0]
+    >>> get_bit_list(0b10, min_size=1)
+    [0, 1]
+    >>> get_bit_list(0b111001010, min_size=10)
+    [0, 1, 0, 1, 0, 0, 1, 1, 1, 0]
+    """
+    assert n >= 0
+
+    shifts = range(n.bit_length())
+    bits = [n >> shift & 1 for shift in shifts]
+    padding_zeroes = [] if min_size is None else [0] * (min_size - len(bits))
+
+    return bits + padding_zeroes

--- a/tests/resources/transaction/test_mining.py
+++ b/tests/resources/transaction/test_mining.py
@@ -39,6 +39,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'height': 1,
                 'min_height': 0,
                 'first_block': None,
+                'feature_activation_bit_counts': [0, 0, 0, 0]
             },
             'tokens': [],
             'data': '',
@@ -70,6 +71,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'height': 1,
                 'min_height': 0,
                 'first_block': None,
+                'feature_activation_bit_counts': [0, 0, 0, 0]
             },
             'tokens': [],
             'data': '',

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -16,8 +16,84 @@ from unittest.mock import Mock
 
 import pytest
 
-from hathor.transaction import Block, TransactionMetadata
+from hathor.conf import HathorSettings
+from hathor.transaction import Block, Transaction, TransactionMetadata
+from hathor.transaction.genesis import BLOCK_GENESIS, TX_GENESIS1, TX_GENESIS2
 from hathor.transaction.storage import TransactionStorage
+
+
+@pytest.mark.parametrize('transaction', [TX_GENESIS1, TX_GENESIS2, Transaction()])
+def test_calculate_feature_activation_bit_counts_transaction(transaction: Transaction) -> None:
+    result = transaction.calculate_feature_activation_bit_counts()
+
+    assert result is None
+
+
+def test_calculate_feature_activation_bit_counts_genesis():
+    result = BLOCK_GENESIS.calculate_feature_activation_bit_counts()
+
+    assert result == [0, 0, 0, 0]
+
+
+@pytest.fixture
+def block_mocks() -> list[Block]:
+    blocks: list[Block] = []
+    feature_activation_bits = [
+        0b0000,  # 0: boundary block
+        0b1010,
+        0b1110,
+        0b1110,
+
+        0b0011,  # 4: boundary block
+        0b0111,
+        0b1111,
+        0b0101,
+
+        0b0000,  # 8: boundary block
+        0b0000,
+    ]
+
+    for i, bits in enumerate(feature_activation_bits):
+        settings = HathorSettings()
+        genesis_hash = settings.GENESIS_BLOCK_HASH
+        block_hash = genesis_hash if i == 0 else b'some_hash'
+
+        storage = Mock(spec_set=TransactionStorage)
+        storage.get_metadata = Mock(return_value=None)
+
+        block = Block(hash=block_hash, storage=storage, signal_bits=bits)
+        blocks.append(block)
+
+        get_block_parent_mock = Mock(return_value=blocks[i - 1])
+        setattr(block, 'get_block_parent', get_block_parent_mock)
+
+    return blocks
+
+
+@pytest.mark.parametrize(
+    ['block_height', 'expected_counts'],
+    [
+        (0, [0, 0, 0, 0]),
+        (1, [0, 1, 0, 1]),
+        (2, [0, 2, 1, 2]),
+        (3, [0, 3, 2, 3]),
+        (4, [1, 1, 0, 0]),
+        (5, [2, 2, 1, 0]),
+        (6, [3, 3, 2, 1]),
+        (7, [4, 3, 3, 1]),
+        (8, [0, 0, 0, 0]),
+        (9, [0, 0, 0, 0]),
+    ]
+)
+def test_calculate_feature_activation_bit_counts(
+    block_mocks: list[Block],
+    block_height: int,
+    expected_counts: list[int]
+) -> None:
+    block = block_mocks[block_height]
+    result = block.calculate_feature_activation_bit_counts()
+
+    assert result == expected_counts
 
 
 def test_get_height():
@@ -34,18 +110,19 @@ def test_get_height():
 
 
 @pytest.mark.parametrize(
-    ['signal_bits', 'expected_bits'],
+    ['signal_bits', 'expected_bit_list'],
     [
-        (0x00, 0),
-        (0x01, 1),
-        (0xF1, 1),
-        (0x06, 6),
-        (0xF6, 6),
-        (0x0F, 0xF),
-        (0xFF, 0xF),
+        (0x00, [0, 0, 0, 0]),  # 0
+        (0x01, [1, 0, 0, 0]),  # 1
+        (0xF1, [1, 0, 0, 0]),  # 1
+        (0x07, [1, 1, 1, 0]),  # 7
+        (0xF7, [1, 1, 1, 0]),  # 7
+        (0x0F, [1, 1, 1, 1]),  # 0xF
+        (0xFF, [1, 1, 1, 1]),  # 0xF
     ]
 )
-def test_get_feature_activation_bits(signal_bits: int, expected_bits: int) -> None:
+def test_get_feature_activation_bit_list(signal_bits: int, expected_bit_list: list[int]) -> None:
     block = Block(signal_bits=signal_bits)
+    result = block._get_feature_activation_bit_list()
 
-    assert block.get_feature_activation_bits() == expected_bits
+    assert result == expected_bit_list

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -17,16 +17,9 @@ from unittest.mock import Mock
 import pytest
 
 from hathor.conf import HathorSettings
-from hathor.transaction import Block, Transaction, TransactionMetadata
-from hathor.transaction.genesis import BLOCK_GENESIS, TX_GENESIS1, TX_GENESIS2
+from hathor.transaction import Block, TransactionMetadata
+from hathor.transaction.genesis import BLOCK_GENESIS
 from hathor.transaction.storage import TransactionStorage
-
-
-@pytest.mark.parametrize('transaction', [TX_GENESIS1, TX_GENESIS2, Transaction()])
-def test_calculate_feature_activation_bit_counts_transaction(transaction: Transaction) -> None:
-    result = transaction.calculate_feature_activation_bit_counts()
-
-    assert result is None
 
 
 def test_calculate_feature_activation_bit_counts_genesis():


### PR DESCRIPTION
Implements the suggestion in https://github.com/HathorNetwork/hathor-core/pull/613#discussion_r1205747507

### Acceptance Criteria

- Implement new `get_bit_list()` utils function
- Create new `TransactionMetadata.feature_activation_bit_counts` attribute
- Implement new `BaseTransaction.calculate_feature_activation_bit_counts()` abstract method and concrete implementations on `Block` and `Transaction`
- Add `feature_activation_bit_counts` to `BaseTransaction.get_metadata()` and `BaseTransaction.update_initial_metadata()`
- Update `FeatureService` to use the `feature_activation_bit_counts` metadata attribute instead of calculating the bit count itself