### PR TITLE
refactor: implement typed RunNodeArgs

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -17,12 +17,12 @@ import json
 import os
 import platform
 import sys
-from argparse import Namespace
-from typing import Optional
+from typing import Any, Optional
 
 from structlog import get_logger
 from twisted.internet.posixbase import PosixReactorBase
 
+from hathor.cli.run_node import RunNodeArgs
 from hathor.consensus import ConsensusAlgorithm
 from hathor.event import EventManager
 from hathor.exception import BuilderError
@@ -44,15 +44,16 @@ class CliBuilder:
 
     TODO Refactor to use Builder. It could even be ported to a Builder.from_args classmethod.
     """
-    def __init__(self) -> None:
+    def __init__(self, args: RunNodeArgs) -> None:
         self.log = logger.new()
+        self._args = args
 
     def check_or_raise(self, condition: bool, message: str) -> None:
         """Will exit printing `message` if `condition` is False."""
         if not condition:
             raise BuilderError(message)
 
-    def create_manager(self, reactor: PosixReactorBase, args: Namespace) -> HathorManager:
+    def create_manager(self, reactor: PosixReactorBase) -> HathorManager:
         import hathor
         from hathor.conf import HathorSettings
         from hathor.conf.get_settings import get_settings_source
@@ -79,7 +80,7 @@ class CliBuilder:
         self.log = logger.new()
         self.reactor = reactor
 
-        peer_id = self.create_peer_id(args)
+        peer_id = self.create_peer_id()
 
         python = f'{platform.python_version()}-{platform.python_implementation()}'
 
@@ -100,61 +101,62 @@ class CliBuilder:
         self.rocksdb_storage: Optional[RocksDBStorage] = None
         self.event_ws_factory: Optional[EventWebsocketFactory] = None
 
-        if args.memory_storage:
-            self.check_or_raise(not args.data, '--data should not be used with --memory-storage')
+        if self._args.memory_storage:
+            self.check_or_raise(not self._args.data, '--data should not be used with --memory-storage')
             # if using MemoryStorage, no need to have cache
             indexes = MemoryIndexesManager()
             tx_storage = TransactionMemoryStorage(indexes)
             event_storage = EventMemoryStorage()
-            self.check_or_raise(not args.x_rocksdb_indexes, 'RocksDB indexes require RocksDB data')
+            self.check_or_raise(not self._args.x_rocksdb_indexes, 'RocksDB indexes require RocksDB data')
             self.log.info('with storage', storage_class=type(tx_storage).__name__)
         else:
-            self.check_or_raise(args.data, '--data is expected')
-            if args.rocksdb_storage:
+            self.check_or_raise(bool(self._args.data), '--data is expected')
+            assert self._args.data is not None
+            if self._args.rocksdb_storage:
                 self.log.warn('--rocksdb-storage is now implied, no need to specify it')
-            cache_capacity = args.rocksdb_cache
-            self.rocksdb_storage = RocksDBStorage(path=args.data, cache_capacity=cache_capacity)
+            cache_capacity = self._args.rocksdb_cache
+            self.rocksdb_storage = RocksDBStorage(path=self._args.data, cache_capacity=cache_capacity)
 
             # Initialize indexes manager.
-            if args.memory_indexes:
+            if self._args.memory_indexes:
                 indexes = MemoryIndexesManager()
             else:
                 indexes = RocksDBIndexesManager(self.rocksdb_storage)
 
             kwargs = {}
-            if not args.cache:
+            if not self._args.cache:
                 # We should only pass indexes if cache is disabled. Otherwise,
                 # only TransactionCacheStorage should have indexes.
                 kwargs['indexes'] = indexes
             tx_storage = TransactionRocksDBStorage(self.rocksdb_storage, **kwargs)
             event_storage = EventRocksDBStorage(self.rocksdb_storage)
 
-        self.log.info('with storage', storage_class=type(tx_storage).__name__, path=args.data)
-        if args.cache:
-            self.check_or_raise(not args.memory_storage, '--cache should not be used with --memory-storage')
+        self.log.info('with storage', storage_class=type(tx_storage).__name__, path=self._args.data)
+        if self._args.cache:
+            self.check_or_raise(not self._args.memory_storage, '--cache should not be used with --memory-storage')
             tx_storage = TransactionCacheStorage(tx_storage, reactor, indexes=indexes)
-            if args.cache_size:
-                tx_storage.capacity = args.cache_size
-            if args.cache_interval:
-                tx_storage.interval = args.cache_interval
+            if self._args.cache_size:
+                tx_storage.capacity = self._args.cache_size
+            if self._args.cache_interval:
+                tx_storage.interval = self._args.cache_interval
             self.log.info('with cache', capacity=tx_storage.capacity, interval=tx_storage.interval)
         self.tx_storage = tx_storage
         self.log.info('with indexes', indexes_class=type(tx_storage.indexes).__name__)
 
         self.wallet = None
-        if args.wallet:
-            self.wallet = self.create_wallet(args)
-            self.log.info('with wallet', wallet=self.wallet, path=args.data)
+        if self._args.wallet:
+            self.wallet = self.create_wallet()
+            self.log.info('with wallet', wallet=self.wallet, path=self._args.data)
 
-        hostname = self.get_hostname(args)
+        hostname = self.get_hostname()
         network = settings.NETWORK_NAME
-        enable_sync_v1 = args.x_enable_legacy_sync_v1_0
-        enable_sync_v1_1 = not args.x_sync_v2_only
-        enable_sync_v2 = args.x_sync_v2_only or args.x_sync_bridge
+        enable_sync_v1 = self._args.x_enable_legacy_sync_v1_0
+        enable_sync_v1_1 = not self._args.x_sync_v2_only
+        enable_sync_v2 = self._args.x_sync_v2_only or self._args.x_sync_bridge
 
         pubsub = PubSubManager(reactor)
 
-        if args.x_enable_event_queue:
+        if self._args.x_enable_event_queue:
             self.event_ws_factory = EventWebsocketFactory(reactor, event_storage)
 
         event_manager = EventManager(
@@ -164,24 +166,26 @@ class CliBuilder:
             reactor=reactor
         )
 
-        if args.wallet_index and tx_storage.indexes is not None:
+        if self._args.wallet_index and tx_storage.indexes is not None:
             self.log.debug('enable wallet indexes')
             self.enable_wallet_index(tx_storage.indexes, pubsub)
 
-        if args.utxo_index and tx_storage.indexes is not None:
+        if self._args.utxo_index and tx_storage.indexes is not None:
             self.log.debug('enable utxo index')
             tx_storage.indexes.enable_utxo_index()
 
         full_verification = False
-        if args.x_full_verification:
-            self.check_or_raise(not args.x_enable_event_queue, '--x-full-verification cannot be used with '
-                                                               '--x-enable-event-queue')
+        if self._args.x_full_verification:
+            self.check_or_raise(
+                not self._args.x_enable_event_queue,
+                '--x-full-verification cannot be used with --x-enable-event-queue'
+            )
             full_verification = True
 
         soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
         consensus_algorithm = ConsensusAlgorithm(soft_voided_tx_ids, pubsub=pubsub)
 
-        if args.x_enable_event_queue:
+        if self._args.x_enable_event_queue:
             self.log.info('--x-enable-event-queue flag provided. '
                           'The events detected by the full node will be stored and can be retrieved by clients')
 
@@ -210,59 +214,59 @@ class CliBuilder:
             event_manager=event_manager,
             wallet=self.wallet,
             checkpoints=settings.CHECKPOINTS,
-            environment_info=get_environment_info(args=str(args), peer_id=peer_id.id),
+            environment_info=get_environment_info(args=str(self._args), peer_id=peer_id.id),
             full_verification=full_verification,
-            enable_event_queue=args.x_enable_event_queue
+            enable_event_queue=self._args.x_enable_event_queue
         )
 
         p2p_manager.set_manager(self.manager)
 
-        if args.stratum:
+        if self._args.stratum:
             stratum_factory = StratumFactory(self.manager)
             self.manager.stratum_factory = stratum_factory
             self.manager.metrics.stratum_factory = stratum_factory
 
-        if args.data:
-            self.manager.set_cmd_path(args.data)
+        if self._args.data:
+            self.manager.set_cmd_path(self._args.data)
 
-        if args.allow_mining_without_peers:
+        if self._args.allow_mining_without_peers:
             self.manager.allow_mining_without_peers()
 
-        if args.x_localhost_only:
+        if self._args.x_localhost_only:
             self.manager.connections.localhost_only = True
 
         dns_hosts = []
         if settings.BOOTSTRAP_DNS:
             dns_hosts.extend(settings.BOOTSTRAP_DNS)
 
-        if args.dns:
-            dns_hosts.extend(args.dns)
+        if self._args.dns:
+            dns_hosts.extend(self._args.dns)
 
         if dns_hosts:
             self.manager.add_peer_discovery(DNSPeerDiscovery(dns_hosts))
 
-        if args.bootstrap:
-            self.manager.add_peer_discovery(BootstrapPeerDiscovery(args.bootstrap))
+        if self._args.bootstrap:
+            self.manager.add_peer_discovery(BootstrapPeerDiscovery(self._args.bootstrap))
 
-        if args.test_mode_tx_weight:
+        if self._args.test_mode_tx_weight:
             _set_test_mode(TestMode.TEST_TX_WEIGHT)
             if self.wallet:
                 self.wallet.test_mode = True
 
-        if args.x_rocksdb_indexes:
+        if self._args.x_rocksdb_indexes:
             self.log.warn('--x-rocksdb-indexes is now the default, no need to specify it')
-            if args.memory_indexes:
+            if self._args.memory_indexes:
                 raise BuilderError('You cannot use --memory-indexes and --x-rocksdb-indexes.')
 
-        if args.memory_indexes and args.memory_storage:
+        if self._args.memory_indexes and self._args.memory_storage:
             self.log.warn('--memory-indexes is implied for memory storage or JSON storage')
 
-        for description in args.listen:
+        for description in self._args.listen:
             self.manager.add_listen_address(description)
 
-        if args.peer_id_blacklist:
-            self.log.info('with peer id blacklist', blacklist=args.peer_id_blacklist)
-            add_peer_id_blacklist(args.peer_id_blacklist)
+        if self._args.peer_id_blacklist:
+            self.log.info('with peer id blacklist', blacklist=self._args.peer_id_blacklist)
+            add_peer_id_blacklist(self._args.peer_id_blacklist)
 
         return self.manager
 
@@ -271,13 +275,13 @@ class CliBuilder:
         indexes.enable_address_index(pubsub)
         indexes.enable_tokens_index()
 
-    def get_hostname(self, args: Namespace) -> str:
-        if args.hostname and args.auto_hostname:
+    def get_hostname(self) -> Optional[str]:
+        if self._args.hostname and self._args.auto_hostname:
             print('You cannot use --hostname and --auto-hostname together.')
             sys.exit(-1)
 
-        if not args.auto_hostname:
-            hostname = args.hostname
+        if not self._args.auto_hostname:
+            hostname = self._args.hostname
         else:
             print('Trying to discover your hostname...')
             hostname = discover_hostname()
@@ -288,38 +292,38 @@ class CliBuilder:
             print('Hostname discovered and set to {}'.format(hostname))
         return hostname
 
-    def create_peer_id(self, args: Namespace) -> PeerId:
-        if not args.peer:
+    def create_peer_id(self) -> PeerId:
+        if not self._args.peer:
             peer_id = PeerId()
         else:
-            data = json.load(open(args.peer, 'r'))
+            data = json.load(open(self._args.peer, 'r'))
             peer_id = PeerId.create_from_json(data)
         return peer_id
 
-    def create_wallet(self, args: Namespace) -> BaseWallet:
-        if args.wallet == 'hd':
-            kwargs = {
-                'words': args.words,
+    def create_wallet(self) -> BaseWallet:
+        if self._args.wallet == 'hd':
+            kwargs: dict[str, Any] = {
+                'words': self._args.words,
             }
 
-            if args.passphrase:
+            if self._args.passphrase:
                 wallet_passphrase = getpass.getpass(prompt='HD Wallet passphrase:')
                 kwargs['passphrase'] = wallet_passphrase.encode()
 
-            if args.data:
-                kwargs['directory'] = args.data
+            if self._args.data:
+                kwargs['directory'] = self._args.data
 
             return HDWallet(**kwargs)
-        elif args.wallet == 'keypair':
+        elif self._args.wallet == 'keypair':
             print('Using KeyPairWallet')
-            if args.data:
-                wallet = Wallet(directory=args.data)
+            if self._args.data:
+                wallet = Wallet(directory=self._args.data)
             else:
                 wallet = Wallet()
 
             wallet.flush_to_disk_interval = 5  # seconds
 
-            if args.unlock_wallet:
+            if self._args.unlock_wallet:
                 wallet_passwd = getpass.getpass(prompt='Wallet password:')
                 wallet.unlock(wallet_passwd.encode())
 

--- a/hathor/cli/db_import.py
+++ b/hathor/cli/db_import.py
@@ -15,7 +15,7 @@
 import io
 import struct
 import sys
-from argparse import ArgumentParser, FileType, Namespace
+from argparse import ArgumentParser, FileType
 from typing import TYPE_CHECKING, Iterator
 
 from hathor.cli.db_export import MAGIC_HEADER
@@ -26,10 +26,10 @@ if TYPE_CHECKING:
 
 
 class DbImport(RunNode):
-    def start_manager(self, args: Namespace) -> None:
+    def start_manager(self) -> None:
         pass
 
-    def register_signal_handlers(self, args: Namespace) -> None:
+    def register_signal_handlers(self) -> None:
         pass
 
     @classmethod
@@ -39,11 +39,11 @@ class DbImport(RunNode):
                             help='Save the export to this file')
         return parser
 
-    def prepare(self, args: Namespace, *, register_resources: bool = True) -> None:
-        super().prepare(args, register_resources=False)
+    def prepare(self, *, register_resources: bool = True) -> None:
+        super().prepare(register_resources=False)
 
         # allocating io.BufferedReader here so we "own" it
-        self.in_file = io.BufferedReader(args.import_file)
+        self.in_file = io.BufferedReader(self._args.import_file)
 
     def run(self) -> None:
         from hathor.util import tx_progress

--- a/hathor/cli/quick_test.py
+++ b/hathor/cli/quick_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 
 from hathor.cli.run_node import RunNode
 
@@ -25,9 +25,9 @@ class QuickTest(RunNode):
         parser.add_argument('--no-wait', action='store_true', help='If set will not wait for a new tx before exiting')
         return parser
 
-    def prepare(self, args: Namespace, *, register_resources: bool = True) -> None:
-        super().prepare(args, register_resources=False)
-        self._no_wait = args.no_wait
+    def prepare(self, *, register_resources: bool = True) -> None:
+        super().prepare(register_resources=False)
+        self._no_wait = self._args.no_wait
 
         self.log.info('patching on_new_tx to quit on success')
         orig_on_new_tx = self.manager.on_new_tx

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -20,6 +20,7 @@ from typing import Any, Callable
 from pydantic import ValidationError
 from structlog import get_logger
 
+from hathor.cli.run_node_args import RunNodeArgs
 from hathor.conf import TESTNET_SETTINGS_FILEPATH, HathorSettings
 from hathor.exception import PreInitializationError
 
@@ -28,7 +29,7 @@ logger = get_logger()
 
 
 class RunNode:
-    UNSAFE_ARGUMENTS: list[tuple[str, Callable[[Namespace], bool]]] = [
+    UNSAFE_ARGUMENTS: list[tuple[str, Callable[[RunNodeArgs], bool]]] = [
         ('--test-mode-tx-weight', lambda args: bool(args.test_mode_tx_weight)),
         ('--enable-crash-api', lambda args: bool(args.enable_crash_api)),
         ('--x-sync-bridge', lambda args: bool(args.x_sync_bridge)),
@@ -38,6 +39,10 @@ class RunNode:
 
     @classmethod
     def create_parser(cls) -> ArgumentParser:
+        """
+        Create a new parser with the run_node CLI arguments.
+        Arguments must also be added to hathor.cli.run_node_args.RunNodeArgs
+        """
         from hathor.cli.util import create_parser
         parser = create_parser()
 
@@ -109,12 +114,12 @@ class RunNode:
         parser.add_argument('--config-yaml', type=str, help='Configuration yaml filepath')
         return parser
 
-    def prepare(self, args: Namespace, *, register_resources: bool = True) -> None:
+    def prepare(self, *, register_resources: bool = True) -> None:
         from setproctitle import setproctitle
-        setproctitle('{}hathor-core'.format(args.procname_prefix))
+        setproctitle('{}hathor-core'.format(self._args.procname_prefix))
 
-        if args.recursion_limit:
-            sys.setrecursionlimit(args.recursion_limit)
+        if self._args.recursion_limit:
+            sys.setrecursionlimit(self._args.recursion_limit)
         else:
             sys.setrecursionlimit(5000)
 
@@ -125,7 +130,7 @@ class RunNode:
                 print('Maximum number of open file descriptors is too low. Minimum required is 256.')
                 sys.exit(-2)
 
-        self.check_unsafe_arguments(args)
+        self.check_unsafe_arguments()
         self.check_python_version()
 
         from hathor.util import reactor
@@ -133,19 +138,19 @@ class RunNode:
 
         from hathor.builder import CliBuilder, ResourcesBuilder
         from hathor.exception import BuilderError
-        builder = CliBuilder()
+        builder = CliBuilder(self._args)
         try:
-            self.manager = builder.create_manager(reactor, args)
+            self.manager = builder.create_manager(reactor)
         except BuilderError as err:
             self.log.error(str(err))
             sys.exit(2)
 
         self.tx_storage = self.manager.tx_storage
         self.wallet = self.manager.wallet
-        self.start_manager(args)
+        self.start_manager()
 
-        if args.stratum:
-            self.reactor.listenTCP(args.stratum, self.manager.stratum_factory)
+        if self._args.stratum:
+            self.reactor.listenTCP(self._args.stratum, self.manager.stratum_factory)
 
         from hathor.conf import HathorSettings
         from hathor.feature_activation.feature_service import FeatureService
@@ -154,10 +159,10 @@ class RunNode:
         feature_service = FeatureService(feature_settings=settings.FEATURE_ACTIVATION)
 
         if register_resources:
-            resources_builder = ResourcesBuilder(self.manager, builder.event_ws_factory, feature_service)
-            status_server = resources_builder.build(args)
-            if args.status:
-                self.reactor.listenTCP(args.status, status_server)
+            resources_builder = ResourcesBuilder(self.manager, self._args, builder.event_ws_factory, feature_service)
+            status_server = resources_builder.build()
+            if self._args.status:
+                self.reactor.listenTCP(self._args.status, status_server)
 
         from hathor.builder.builder import BuildArtifacts
         self.artifacts = BuildArtifacts(
@@ -177,11 +182,11 @@ class RunNode:
             feature_service=feature_service
         )
 
-    def start_sentry_if_possible(self, args: Namespace) -> None:
+    def start_sentry_if_possible(self) -> None:
         """Start Sentry integration if possible."""
-        if not args.sentry_dsn:
+        if not self._args.sentry_dsn:
             return
-        self.log.info('Starting Sentry', dsn=args.sentry_dsn)
+        self.log.info('Starting Sentry', dsn=self._args.sentry_dsn)
         try:
             import sentry_sdk
             from structlog_sentry import SentryProcessor  # noqa: F401
@@ -193,21 +198,21 @@ class RunNode:
         from hathor.conf import HathorSettings
         settings = HathorSettings()
         sentry_sdk.init(
-            dsn=args.sentry_dsn,
+            dsn=self._args.sentry_dsn,
             release=hathor.__version__,
             environment=settings.NETWORK_NAME,
         )
 
-    def start_manager(self, args: Namespace) -> None:
-        self.start_sentry_if_possible(args)
+    def start_manager(self) -> None:
+        self.start_sentry_if_possible()
         self.manager.start()
 
-    def register_signal_handlers(self, args: Namespace) -> None:
+    def register_signal_handlers(self) -> None:
         """Register signal handlers."""
         import signal
         sigusr1 = getattr(signal, 'SIGUSR1', None)
         if sigusr1 is not None:
-            # USR1 is avaiable in this OS.
+            # USR1 is available in this OS.
             signal.signal(sigusr1, self.signal_usr1_handler)
 
     def signal_usr1_handler(self, sig: int, frame: Any) -> None:
@@ -216,13 +221,13 @@ class RunNode:
         if self.manager and self.manager.connections:
             self.manager.connections.disconnect_all_peers(force=True)
 
-    def check_unsafe_arguments(self, args: Namespace) -> None:
+    def check_unsafe_arguments(self) -> None:
         unsafe_args_found = []
         for arg_cmdline, arg_test_fn in self.UNSAFE_ARGUMENTS:
-            if arg_test_fn(args):
+            if arg_test_fn(self._args):
                 unsafe_args_found.append(arg_cmdline)
 
-        if args.unsafe_mode is None:
+        if self._args.unsafe_mode is None:
             if unsafe_args_found:
                 message = [
                     'You need to enable --unsafe-mode to run with these arguments.',
@@ -255,9 +260,9 @@ class RunNode:
             from hathor.conf import HathorSettings
             settings = HathorSettings()
 
-            if args.unsafe_mode != settings.NETWORK_NAME:
+            if self._args.unsafe_mode != settings.NETWORK_NAME:
                 message.extend([
-                    f'Unsafe mode enabled for wrong network ({args.unsafe_mode} != {settings.NETWORK_NAME}).',
+                    f'Unsafe mode enabled for wrong network ({self._args.unsafe_mode} != {settings.NETWORK_NAME}).',
                     '',
                 ])
                 fail = True
@@ -322,12 +327,15 @@ class RunNode:
         if argv is None:
             import sys
             argv = sys.argv[1:]
-        self.parser = self.create_parser()
-        args = self.parse_args(argv)
 
-        if args.config_yaml:
-            os.environ['HATHOR_CONFIG_YAML'] = args.config_yaml
-        elif args.testnet:
+        self.parser = self.create_parser()
+        raw_args = self.parse_args(argv)
+
+        self._args = RunNodeArgs.parse_obj(vars(raw_args))
+
+        if self._args.config_yaml:
+            os.environ['HATHOR_CONFIG_YAML'] = self._args.config_yaml
+        elif self._args.testnet:
             os.environ['HATHOR_CONFIG_YAML'] = TESTNET_SETTINGS_FILEPATH
 
         try:
@@ -337,10 +345,10 @@ class RunNode:
                 'An error was found while trying to initialize HathorSettings. See above for details.'
             ) from e
 
-        self.prepare(args)
-        self.register_signal_handlers(args)
-        if args.sysctl:
-            self.init_sysctl(args.sysctl)
+        self.prepare()
+        self.register_signal_handlers()
+        if self._args.sysctl:
+            self.init_sysctl(self._args.sysctl)
 
     def init_sysctl(self, description: str) -> None:
         """Initialize sysctl and listen for connections.

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -1,0 +1,72 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List, Optional
+
+from pydantic import Extra
+
+from hathor.utils.pydantic import BaseModel
+
+
+class RunNodeArgs(BaseModel, extra=Extra.allow):
+    """
+    Class that represents the CLI arguments used by the run_node command.
+    Arguments must also be added to hathor.cli.run_node.RunNode.create_parser.
+    """
+    hostname: Optional[str]
+    auto_hostname: bool
+    unsafe_mode: Optional[str]
+    testnet: bool
+    test_mode_tx_weight: bool
+    dns: Optional[str]
+    peer: Optional[str]
+    sysctl: Optional[str]
+    listen: List[str]
+    bootstrap: Optional[List[str]]
+    status: Optional[int]
+    stratum: Optional[int]
+    data: Optional[str]
+    rocksdb_storage: bool
+    memory_storage: bool
+    memory_indexes: bool
+    rocksdb_cache: Optional[int]
+    wallet: Optional[str]
+    wallet_enable_api: bool
+    words: Optional[str]
+    passphrase: bool
+    unlock_wallet: bool
+    wallet_index: bool
+    utxo_index: bool
+    prometheus: bool
+    prometheus_prefix: str
+    cache: bool
+    cache_size: Optional[int]
+    cache_interval: Optional[int]
+    recursion_limit: Optional[int]
+    allow_mining_without_peers: bool
+    x_full_verification: bool
+    procname_prefix: str
+    allow_non_standard_script: bool
+    max_output_script_size: Optional[int]
+    sentry_dsn: Optional[str]
+    enable_debug_api: bool
+    enable_crash_api: bool
+    x_enable_legacy_sync_v1_0: bool
+    x_sync_bridge: bool
+    x_sync_v2_only: bool
+    x_localhost_only: bool
+    x_rocksdb_indexes: bool
+    x_enable_event_queue: bool
+    peer_id_blacklist: List[str]
+    config_yaml: Optional[str]

--- a/hathor/cli/shell.py
+++ b/hathor/cli/shell.py
@@ -28,18 +28,18 @@ def get_ipython(extra_args: list[Any], imported_objects: dict[str, Any]) -> Call
 
 
 class Shell(RunNode):
-    def start_manager(self, args: Namespace) -> None:
+    def start_manager(self) -> None:
         pass
 
-    def register_signal_handlers(self, args: Namespace) -> None:
+    def register_signal_handlers(self) -> None:
         pass
 
-    def prepare(self, args: Namespace, *, register_resources: bool = True) -> None:
-        super().prepare(args, register_resources=False)
+    def prepare(self, *, register_resources: bool = True) -> None:
+        super().prepare(register_resources=False)
 
         imported_objects: dict[str, Any] = {}
         imported_objects['tx_storage'] = self.tx_storage
-        if args.wallet:
+        if self._args.wallet:
             imported_objects['wallet'] = self.wallet
         imported_objects['manager'] = self.manager
         self.shell = get_ipython(self.extra_args, imported_objects)

--- a/tests/cli/test_db_export.py
+++ b/tests/cli/test_db_export.py
@@ -1,0 +1,12 @@
+import os
+
+from hathor.cli.db_export import DbExport
+from tests import unittest
+
+
+class TestDbExport(unittest.TestCase):
+    def test_db_export(self):
+        tmp_dir = self.mkdtemp()
+        tmp_file = os.path.join(tmp_dir, 'test_file')
+        db_export = DbExport(argv=['--memory-storage', '--export-file', tmp_file])
+        assert db_export is not None

--- a/tests/cli/test_db_import.py
+++ b/tests/cli/test_db_import.py
@@ -1,0 +1,11 @@
+import tempfile
+
+from hathor.cli.db_import import DbImport
+from tests import unittest
+
+
+class TestDbImport(unittest.TestCase):
+    def test_db_import(self):
+        _, tmp_file = tempfile.mkstemp()
+        db_import = DbImport(argv=['--memory-storage', '--import-file', tmp_file])
+        assert db_import is not None

--- a/tests/cli/test_quick_test.py
+++ b/tests/cli/test_quick_test.py
@@ -1,0 +1,17 @@
+from hathor.cli.quick_test import QuickTest
+from tests import unittest
+
+
+class TestQuickTest(unittest.TestCase):
+    def test_quick_test(self):
+        class CustomQuickTest(QuickTest):
+            def start_manager(self) -> None:
+                pass
+
+            def register_signal_handlers(self) -> None:
+                pass
+
+        quick_test = CustomQuickTest(argv=['--memory-storage', '--no-wait'])
+        assert quick_test is not None
+
+        self.clean_pending(required_to_quiesce=False)

--- a/tests/cli/test_run_node.py
+++ b/tests/cli/test_run_node.py
@@ -1,5 +1,3 @@
-from argparse import Namespace
-
 from hathor.cli.run_node import RunNode
 from tests import unittest
 
@@ -9,10 +7,10 @@ class RunNodeTest(unittest.TestCase):
 
     def test_memory_storage(self):
         class CustomRunNode(RunNode):
-            def start_manager(self, args: Namespace) -> None:
+            def start_manager(self) -> None:
                 pass
 
-            def register_signal_handlers(self, args: Namespace) -> None:
+            def register_signal_handlers(self) -> None:
                 pass
 
         run_node = CustomRunNode(argv=['--memory-storage'])

--- a/tests/cli/test_shell.py
+++ b/tests/cli/test_shell.py
@@ -11,7 +11,7 @@ class ShellTest(unittest.TestCase):
     # In this case we just want to go through the code to see if it's okay
 
     def test_shell_execution_memory_storage(self):
-        shell = Shell(argv=['--memory-storage'])
+        shell = Shell(argv=['--memory-storage', '--', '--extra-arg'])
         self.assertTrue(shell is not None)
 
     @pytest.mark.skipif(not HAS_ROCKSDB, reason='requires python-rocksdb')


### PR DESCRIPTION
### Acceptance Criteria

- Implement new `from_namespace()` utils function to instantiate typed CLI args from `argparse.Namespace`
- Implement new `RunNodeArgs` named tuple to provide typed `run_node` CLI args
