### PR TITLE
refactor: Add common Hathor types

### DIFF
--- a/hathor/types.py
+++ b/hathor/types.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# XXX There is a lot of refactor to be done before we can use `NewType`.
+#     So, let's skip using NewType until everything is refactored.
+
+VertexId = bytes            # NewType('TxId', bytes)
+Address = bytes         # NewType('Address', bytes)
+TxOutputScript = bytes  # NewType('TxOutputScript', bytes)
+Timestamp = int         # NewType('Timestamp', int)
+TokenUid = VertexId     # NewType('TokenUid', VertexId)
+Amount = int            # NewType('Amount', int)

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -53,6 +53,7 @@ from zope.interface.verify import verifyObject
 
 import hathor
 from hathor.conf import HathorSettings
+from hathor.types import TokenUid
 
 if TYPE_CHECKING:
     import structlog
@@ -735,7 +736,7 @@ class manualgc(AbstractContextManager):
             gc.enable()
 
 
-def is_token_uid_valid(token_uid: bytes) -> bool:
+def is_token_uid_valid(token_uid: TokenUid) -> bool:
     """ Checks whether a byte sequence can be a valid token UID.
 
     >>> is_token_uid_valid(bytes.fromhex('00'))


### PR DESCRIPTION
## Acceptance criteria

1. Create the common Hathor types: `TxId`, `Address`, `TxOutputScript`, `Timestamp`, `TokenUid`, and `Amount`.
2. Refactor `hathor.manager`, `hathor.transaction.base_transaction`, and `hathor.transaction.transaction` as the initial refactor.