### PR TITLE
tests: Skip flaky event tests

### DIFF
--- a/tests/event/test_simulation.py
+++ b/tests/event/test_simulation.py
@@ -15,6 +15,8 @@
 from typing import List
 from unittest.mock import Mock
 
+import pytest
+
 from hathor.event.model.base_event import BaseEvent
 from hathor.event.model.event_data import EmptyData, ReorgData, SpentOutput, TxData, TxInput, TxMetadata, TxOutput
 from hathor.event.model.event_type import EventType
@@ -194,6 +196,7 @@ class TestEventSimulation(TestCase):
 
         _assert_equal_events(actual_events, expected_events)
 
+    @pytest.mark.skip(reason='broken?')
     def test_single_chain_blocks_and_transactions(self):
         simulator = Simulator(seed=SIMULATOR_SEED)
         simulator.start()
@@ -294,6 +297,7 @@ class TestEventSimulation(TestCase):
 
         _assert_equal_events(actual_events, expected_events)
 
+    @pytest.mark.skip(reason='broken?')
     def test_reorg(self):
         simulator = Simulator(seed=SIMULATOR_SEED)
         simulator.start()


### PR DESCRIPTION
These flaky event tests have been failing a lot recently. So I think it's best to skip them for now while they are fixed in another PR.

## Acceptance criteria

1. Skip flaky event tests.