### PR TITLE
tests(feature-activation): implement reorg test

### DIFF
--- a/hathor/feature_activation/feature_service.py
+++ b/hathor/feature_activation/feature_service.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from hathor.feature_activation.feature import Feature
-from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.model.feature_description import FeatureDescription
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
@@ -76,7 +75,10 @@ class FeatureService:
     ) -> FeatureState:
         """Returns the new feature state based on the new block, the criteria, and the previous state."""
         height = boundary_block.get_height()
-        criteria = self._get_criteria(feature=feature)
+        criteria = self._feature_settings.features.get(feature)
+
+        if not criteria:
+            return FeatureState.DEFINED
 
         assert not boundary_block.is_genesis, 'cannot calculate new state for genesis'
         assert height % self._feature_settings.evaluation_interval == 0, (
@@ -123,15 +125,6 @@ class FeatureService:
             return FeatureState.FAILED
 
         raise ValueError(f'Unknown previous state: {previous_state}')
-
-    def _get_criteria(self, *, feature: Feature) -> Criteria:
-        """Get the Criteria defined for a specific Feature."""
-        criteria = self._feature_settings.features.get(feature)
-
-        if not criteria:
-            raise ValueError(f"Criteria not defined for feature '{feature}'.")
-
-        return criteria
 
     def get_bits_description(self, *, block: Block) -> dict[Feature, FeatureDescription]:
         """Returns the criteria definition and feature state for all features at a certain block."""

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -823,7 +823,7 @@ class HathorManager:
     def generate_mining_block(self, timestamp: Optional[int] = None,
                               parent_block_hash: Optional[VertexId] = None,
                               data: bytes = b'', address: Optional[Address] = None,
-                              merge_mined: bool = False) -> Union[Block, MergeMinedBlock]:
+                              merge_mined: bool = False, signal_bits: int = 0) -> Union[Block, MergeMinedBlock]:
         """ Generates a block ready to be mined. The block includes new issued tokens,
         parents, and the weight.
 
@@ -840,6 +840,7 @@ class HathorManager:
             merge_mined=merge_mined,
             address=address or None,  # XXX: because we allow b'' for explicit empty output script
             data=data,
+            signal_bits=signal_bits
         )
         return block
 

--- a/hathor/mining/block_template.py
+++ b/hathor/mining/block_template.py
@@ -48,7 +48,7 @@ class BlockTemplate(NamedTuple):
     def generate_mining_block(self, rng: Random, merge_mined: bool = False, address: Optional[bytes] = None,
                               timestamp: Optional[int] = None, data: Optional[bytes] = None,
                               storage: Optional[TransactionStorage] = None, include_metadata: bool = False,
-                              ) -> Union[Block, MergeMinedBlock]:
+                              signal_bits: int = 0) -> Union[Block, MergeMinedBlock]:
         """ Generates a block by filling the template with the given options and random parents (if multiple choices).
 
         Note that if a timestamp is given it will be coerced into the [timestamp_min, timestamp_max] range.
@@ -64,7 +64,7 @@ class BlockTemplate(NamedTuple):
         tx_outputs = [TxOutput(self.reward, output_script)]
         cls: Union[type['Block'], type['MergeMinedBlock']] = MergeMinedBlock if merge_mined else Block
         block = cls(outputs=tx_outputs, parents=parents, timestamp=block_timestamp,
-                    data=data or b'', storage=storage, weight=self.weight)
+                    data=data or b'', storage=storage, weight=self.weight, signal_bits=signal_bits)
         if include_metadata:
             block._metadata = TransactionMetadata(height=self.height, score=self.score)
         block.get_metadata(use_storage=False)
@@ -124,9 +124,10 @@ class BlockTemplates(list[BlockTemplate]):
     def generate_mining_block(self, rng: Random, merge_mined: bool = False, address: Optional[bytes] = None,
                               timestamp: Optional[int] = None, data: Optional[bytes] = None,
                               storage: Optional[TransactionStorage] = None, include_metadata: bool = False,
-                              ) -> Union[Block, MergeMinedBlock]:
+                              signal_bits: int = 0) -> Union[Block, MergeMinedBlock]:
         """ Randomly choose a template and use that for generating a block, see BlockTemplate.generate_mining_block"""
         return self.choose_random_template(rng).generate_mining_block(rng, merge_mined=merge_mined, address=address,
                                                                       timestamp=timestamp, data=data,
                                                                       storage=storage or self.storage,
-                                                                      include_metadata=include_metadata)
+                                                                      include_metadata=include_metadata,
+                                                                      signal_bits=signal_bits)

--- a/tests/feature_activation/test_feature_service.py
+++ b/tests/feature_activation/test_feature_service.py
@@ -446,10 +446,9 @@ def test_get_state_from_failed(block_mocks: list[Block], tx_storage: Transaction
 def test_get_state_undefined_feature(block_mocks: list[Block], service: FeatureService) -> None:
     block = block_mocks[10]
 
-    with pytest.raises(ValueError) as e:
-        service.get_state(block=block, feature=Feature.NOP_FEATURE_1)
+    result = service.get_state(block=block, feature=Feature.NOP_FEATURE_1)
 
-    assert str(e.value) == f"Criteria not defined for feature '{Feature.NOP_FEATURE_1}'."
+    assert result == FeatureState.DEFINED
 
 
 def test_get_bits_description(tx_storage: TransactionStorage) -> None:


### PR DESCRIPTION
### Acceptance Criteria

- Add `signal_bits` to block templates
- Add `signal_bits` arg to miner simulator
- Change rule where an error would be raised if trying to retrieve a feature that is only defined in another network
- Add feature activation reorg test

Resolves #631 