### PR TITLE
fix(storage): incorrect validation store when using cache storage

### DIFF
--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -21,6 +21,7 @@ from hathor.indexes import IndexesManager
 from hathor.transaction import BaseTransaction
 from hathor.transaction.storage.migrations import MigrationState
 from hathor.transaction.storage.transaction_storage import BaseTransactionStorage
+from hathor.transaction.storage.tx_allow_scope import TxAllowScope
 from hathor.util import Reactor
 
 
@@ -69,6 +70,14 @@ class TransactionCacheStorage(BaseTransactionStorage):
         # attribute the same weakref for both.
         super().__init__(indexes=indexes)
         self._tx_weakref = store._tx_weakref
+        # XXX: just to make sure this isn't being used anywhere, setters/getters should be used instead
+        del self._allow_scope
+
+    def set_allow_scope(self, allow_scope: TxAllowScope) -> None:
+        self.store._allow_scope = allow_scope
+
+    def get_allow_scope(self) -> TxAllowScope:
+        return self.store._allow_scope
 
     def set_capacity(self, capacity: int) -> None:
         """Change the max number of items in cache."""

--- a/hathor/transaction/storage/tx_allow_scope.py
+++ b/hathor/transaction/storage/tx_allow_scope.py
@@ -57,9 +57,9 @@ def tx_allow_context(tx_storage: 'TransactionStorage', *, allow_scope: TxAllowSc
     """This is used to wrap the storage with a temporary allow-scope that is reverted when the context exits"""
     from hathor.transaction.storage import TransactionStorage
     assert isinstance(tx_storage, TransactionStorage)
-    previous_allow_scope = tx_storage.allow_scope
+    previous_allow_scope = tx_storage.get_allow_scope()
     try:
-        tx_storage.allow_scope = allow_scope
+        tx_storage.set_allow_scope(allow_scope)
         yield
     finally:
-        tx_storage.allow_scope = previous_allow_scope
+        tx_storage.set_allow_scope(previous_allow_scope)


### PR DESCRIPTION
## Acceptance criteria

- Refactor `TransactionStorage.allow_scope` to use getters/setters and have the actual value private;
- Make `TransactionCacheStorage` override the getters/setters so the external storage and internal storage have the same scope.