### PR TITLE
refactor: use None by default for height metadata

### DIFF
--- a/hathor/cli/db_export.py
+++ b/hathor/cli/db_export.py
@@ -95,6 +95,7 @@ class DbExport(RunNode):
             yield tx
 
     def run(self) -> None:
+        from hathor.transaction import Block
         from hathor.util import tx_progress
         self.log.info('export')
         self.out_file.write(MAGIC_HEADER)
@@ -112,9 +113,10 @@ class DbExport(RunNode):
             assert tx.hash is not None
             tx_meta = tx.get_metadata()
             if tx.is_block:
+                assert isinstance(tx, Block)
                 if not tx_meta.voided_by:
                     # XXX: max() shouldn't be needed, but just in case
-                    best_height = max(best_height, tx_meta.height)
+                    best_height = max(best_height, tx.get_height())
                 block_count += 1
             else:
                 tx_count += 1

--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -146,7 +146,7 @@ class BlockConsensusAlgorithm:
             # we need to check that block is not voided.
             meta = block.get_metadata()
             if not meta.voided_by:
-                storage.indexes.height.add_new(meta.height, block.hash, block.timestamp)
+                storage.indexes.height.add_new(block.get_height(), block.hash, block.timestamp)
                 storage.update_best_block_tips_cache([block.hash])
             # The following assert must be true, but it is commented out for performance reasons.
             if settings.SLOW_ASSERTS:
@@ -206,10 +206,11 @@ class BlockConsensusAlgorithm:
                     # As `update_score_and_mark_as_the_best_chain_if_possible` may affect `voided_by`,
                     # we need to check that block is not voided.
                     meta = block.get_metadata()
+                    height = block.get_height()
                     if not meta.voided_by:
-                        self.log.debug('index new winner block', height=meta.height, block=block.hash_hex)
+                        self.log.debug('index new winner block', height=height, block=block.hash_hex)
                         # We update the height cache index with the new winner chain
-                        storage.indexes.height.update_new_chain(meta.height, block)
+                        storage.indexes.height.update_new_chain(height, block)
                         storage.update_best_block_tips_cache([block.hash])
                         # It is only a re-org if common_block not in heads
                         if common_block not in heads:

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -125,10 +125,9 @@ class ConsensusAlgorithm:
         # emit the reorg started event if needed
         if context.reorg_common_block is not None:
             old_best_block = base.storage.get_transaction(best_tip)
+            assert isinstance(old_best_block, Block)
             new_best_block = base.storage.get_transaction(new_best_tip)
-            old_best_block_meta = old_best_block.get_metadata()
-            common_block_meta = context.reorg_common_block.get_metadata()
-            reorg_size = old_best_block_meta.height - common_block_meta.height
+            reorg_size = old_best_block.get_height() - context.reorg_common_block.get_height()
             assert old_best_block != new_best_block
             assert reorg_size > 0
             context.pubsub.publish(HathorEvents.REORG_STARTED, old_best_height=best_height,

--- a/hathor/daa.py
+++ b/hathor/daa.py
@@ -83,7 +83,7 @@ def calculate_next_weight(parent_block: 'Block', timestamp: int) -> float:
     from hathor.transaction import sum_weights
 
     root = parent_block
-    N = min(2 * settings.BLOCK_DIFFICULTY_N_BLOCKS, parent_block.get_metadata().height - 1)
+    N = min(2 * settings.BLOCK_DIFFICULTY_N_BLOCKS, parent_block.get_height() - 1)
     K = N // 2
     T = AVG_TIME_BETWEEN_BLOCKS
     S = 5

--- a/hathor/indexes/deps_index.py
+++ b/hathor/indexes/deps_index.py
@@ -45,7 +45,8 @@ def get_requested_from_height(tx: BaseTransaction) -> int:
     """
     assert tx.storage is not None
     if tx.is_block:
-        return tx.get_metadata().height
+        assert isinstance(tx, Block)
+        return tx.get_height()
     first_block = tx.get_metadata().first_block
     if first_block is None:
         # XXX: consensus did not run yet to update first_block, what should we do?
@@ -54,7 +55,7 @@ def get_requested_from_height(tx: BaseTransaction) -> int:
         return INF_HEIGHT
     block = tx.storage.get_transaction(first_block)
     assert isinstance(block, Block)
-    return block.get_metadata().height
+    return block.get_height()
 
 
 class DepsIndex(BaseIndex):

--- a/hathor/indexes/height_index.py
+++ b/hathor/indexes/height_index.py
@@ -57,10 +57,9 @@ class HeightIndex(BaseIndex):
             return
         assert isinstance(tx, Block)
         assert tx.hash is not None
-        tx_meta = tx.get_metadata()
-        if tx_meta.voided_by:
+        if tx.get_metadata().voided_by:
             return
-        self.add_new(tx_meta.height, tx.hash, tx.timestamp)
+        self.add_new(tx.get_height(), tx.hash, tx.timestamp)
 
     @abstractmethod
     def add_new(self, height: int, block_hash: bytes, timestamp: int) -> None:
@@ -105,7 +104,7 @@ class HeightIndex(BaseIndex):
             )
 
             side_chain_block = side_chain_block.get_block_parent()
-            new_block_height = side_chain_block.get_metadata().height
+            new_block_height = side_chain_block.get_height()
             assert new_block_height + 1 == block_height
             block_height = new_block_height
 

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -646,7 +646,8 @@ class TransactionStorage(ABC):
         heads = [self.get_transaction(h) for h in self.get_best_block_tips()]
         highest_height = 0
         for head in heads:
-            head_height = head.get_metadata().height
+            assert isinstance(head, Block)
+            head_height = head.get_height()
             if head_height > highest_height:
                 highest_height = head_height
 

--- a/hathor/transaction/transaction_metadata.py
+++ b/hathor/transaction/transaction_metadata.py
@@ -37,7 +37,7 @@ class TransactionMetadata:
     accumulated_weight: float
     score: float
     first_block: Optional[bytes]
-    height: int
+    height: Optional[int]
     validation: ValidationState
     # XXX: this is only used to defer the reward-lock verification from the transaction spending a reward to the first
     # block that confirming this transaction, it is important to always have this set to be able to distinguish an old
@@ -62,7 +62,7 @@ class TransactionMetadata:
         hash: Optional[bytes] = None,
         accumulated_weight: float = 0,
         score: float = 0,
-        height: int = 0,
+        height: Optional[int] = None,
         min_height: int = 0,
         feature_activation_bit_counts: Optional[list[int]] = None
     ) -> None:

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -520,8 +520,10 @@ def _tx_progress(iter_tx: Iterator['BaseTransaction'], *, log: 'structlog.stdlib
             log.warn('iterator was slow to yield', took_sec=dt_next)
 
         assert tx.hash is not None
-        tx_meta = tx.get_metadata()
-        h = max(h, tx_meta.height)
+        # XXX: this is only informative and made to work with either partially/fully validated blocks/transactions
+        meta = tx.get_metadata()
+        if meta.height:
+            h = max(h, meta.height)
         ts_tx = max(ts_tx, tx.timestamp)
 
         t_log = time.time()

--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -27,7 +27,7 @@ from twisted.internet.interfaces import IDelayedCall
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.pubsub import EventArguments, HathorEvents, PubSubManager
-from hathor.transaction import BaseTransaction, TxInput, TxOutput
+from hathor.transaction import BaseTransaction, Block, TxInput, TxOutput
 from hathor.transaction.base_transaction import int_to_bytes
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
 from hathor.transaction.storage import TransactionStorage
@@ -499,7 +499,8 @@ class BaseWallet:
     def can_spend_block(self, tx_storage: 'TransactionStorage', tx_id: bytes) -> bool:
         tx = tx_storage.get_transaction(tx_id)
         if tx.is_block:
-            if tx_storage.get_height_best_block() - tx.get_metadata().height < settings.REWARD_SPEND_MIN_BLOCKS:
+            assert isinstance(tx, Block)
+            if tx_storage.get_height_best_block() - tx.get_height() < settings.REWARD_SPEND_MIN_BLOCKS:
                 return False
         return True
 


### PR DESCRIPTION
## Acceptance criteria

- `height` metadata type should change from `int` to `Optional[int]`
- initial value should go from `0` to `None`
- any code accessing the `height` metadata directly should preferably use `Block.get_height` method (for both ensuring that the vertex in question is a block and asserting that it is not None)