### PR TITLE
refactor(sync): move sync-v1 files to a separate module

### DIFF
--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -98,8 +98,8 @@ class ConnectionsManager:
                  enable_sync_v1: bool,
                  enable_sync_v2: bool,
                  enable_sync_v1_1: bool) -> None:
-        from hathor.p2p.sync_v1_1_factory import SyncV11Factory
-        from hathor.p2p.sync_v1_factory import SyncV1Factory
+        from hathor.p2p.sync_v1.factory_v1_0 import SyncV10Factory
+        from hathor.p2p.sync_v1.factory_v1_1 import SyncV11Factory
 
         if not (enable_sync_v1 or enable_sync_v1_1 or enable_sync_v2):
             raise TypeError(f'{type(self).__name__}() at least one sync version is required')
@@ -181,11 +181,11 @@ class ConnectionsManager:
         # sync-manager factories
         self._sync_factories = {}
         if enable_sync_v1:
-            self._sync_factories[SyncVersion.V1] = SyncV1Factory(self)
+            self._sync_factories[SyncVersion.V1] = SyncV10Factory(self)
         if enable_sync_v1_1:
             self._sync_factories[SyncVersion.V1_1] = SyncV11Factory(self)
         if enable_sync_v2:
-            self._sync_factories[SyncVersion.V2] = SyncV1Factory(self)
+            self._sync_factories[SyncVersion.V2] = SyncV10Factory(self)
 
     def set_manager(self, manager: 'HathorManager') -> None:
         """Set the manager. This method must be called before start()."""

--- a/hathor/p2p/sync_v1/agent.py
+++ b/hathor/p2p/sync_v1/agent.py
@@ -25,9 +25,9 @@ from twisted.internet.interfaces import IConsumer, IDelayedCall, IPushProducer
 from zope.interface import implementer
 
 from hathor.conf import HathorSettings
-from hathor.p2p.downloader import Downloader
 from hathor.p2p.messages import GetNextPayload, GetTipsPayload, NextPayload, ProtocolMessages, TipsPayload
 from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.transaction import BaseTransaction
 from hathor.transaction.base_transaction import tx_or_block_from_bytes
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist

--- a/hathor/p2p/sync_v1/downloader.py
+++ b/hathor/p2p/sync_v1/downloader.py
@@ -27,7 +27,7 @@ settings = HathorSettings()
 
 if TYPE_CHECKING:
     from hathor.manager import HathorManager
-    from hathor.p2p.node_sync import NodeSyncTimestamp
+    from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
     from hathor.transaction import BaseTransaction
 
 logger = get_logger()

--- a/hathor/p2p/sync_v1/factory_v1_0.py
+++ b/hathor/p2p/sync_v1/factory_v1_0.py
@@ -14,18 +14,18 @@
 
 from typing import TYPE_CHECKING, Optional
 
-from hathor.p2p.downloader import Downloader
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.node_sync import NodeSyncTimestamp
 from hathor.p2p.sync_factory import SyncManagerFactory
 from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
+from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.util import Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
-class SyncV11Factory(SyncManagerFactory):
+class SyncV10Factory(SyncManagerFactory):
     def __init__(self, connections: ConnectionsManager):
         self.connections = connections
         self._downloader: Optional[Downloader] = None

--- a/hathor/p2p/sync_v1/factory_v1_1.py
+++ b/hathor/p2p/sync_v1/factory_v1_1.py
@@ -14,18 +14,18 @@
 
 from typing import TYPE_CHECKING, Optional
 
-from hathor.p2p.downloader import Downloader
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.node_sync import NodeSyncTimestamp
 from hathor.p2p.sync_factory import SyncManagerFactory
 from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
+from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.util import Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
-class SyncV1Factory(SyncManagerFactory):
+class SyncV11Factory(SyncManagerFactory):
     def __init__(self, connections: ConnectionsManager):
         self.connections = connections
         self._downloader: Optional[Downloader] = None

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -253,7 +253,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
     __test__ = True
 
     def test_downloader(self):
-        from hathor.p2p.node_sync import NodeSyncTimestamp
+        from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 
         blocks = self._add_new_blocks(3)
 


### PR DESCRIPTION
## Acceptance criteria

- move all modules related to sync-v1 into `hathor.p2p.sync_v1`
- do not change anything else