### PR TITLE
tests: Do not update time by default on BaseTransaction.resolve()

### DIFF
--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -723,7 +723,7 @@ class BaseTransaction(ABC):
                     len(output.script), settings.MAX_OUTPUT_SCRIPT_SIZE
                 ))
 
-    def resolve(self, update_time: bool = True) -> bool:
+    def resolve(self, update_time: bool = False) -> bool:
         """Run a CPU mining looking for the nonce that solves the proof-of-work
 
         The `self.weight` must be set before calling this method.


### PR DESCRIPTION
I noticed that many flaky tests fail with a "future transaction" exception, possibly caused by the `BaseTransaction.resolve()`. As this is used only for testing, we can safely change its behavior.

### Acceptance criteria

1. Stop updating time by default on `BaseTransaction.resolve()`.