### PR TITLE
chore: deprecate set output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,8 @@ jobs:
               matrix = full_matrix
           else:
               matrix = reduced_matrix
-          outputs = []
-          if os.environ['GITHUB_OUTPUT']:
-            outputs.append(os.environ['GITHUB_OUTPUT'])
-          outputs.append('{name}={value}'.format(name='matrix', value=json.dumps(matrix)))
-          os.environ['GITHUB_OUTPUT'] = '\n'.join(outputs)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write('matrix={}\n'.format(json.dumps(matrix)))
   check-matrix:
     runs-on: ubuntu-latest
     needs: matrix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           outputs = []
           if os.environ['GITHUB_OUTPUT']:
             outputs.append(os.environ['GITHUB_OUTPUT'])
-          outputs.push('{name}={value}'.format(name='matrix', value=json.dumps(matrix)))
+          outputs.append('{name}={value}'.format(name='matrix', value=json.dumps(matrix)))
           os.environ['GITHUB_OUTPUT'] = '\n'.join(outputs)
   check-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,11 @@ jobs:
               matrix = full_matrix
           else:
               matrix = reduced_matrix
-          print('::set-output name=matrix::' + json.dumps(matrix))
+          outputs = []
+          if os.environ['GITHUB_OUTPUT']:
+            outputs.append(os.environ['GITHUB_OUTPUT'])
+          outputs.push('{name}={value}'.format(name='matrix', value=json.dumps(matrix)))
+          os.environ['GITHUB_OUTPUT'] = '\n'.join(outputs)
   check-matrix:
     runs-on: ubuntu-latest
     needs: matrix

--- a/extras/github/docker.py
+++ b/extras/github/docker.py
@@ -5,9 +5,9 @@ from typing import Dict
 def print_output(output: Dict):
     outputs = []
     if os.environ['GITHUB_OUTPUT']:
-        outputs.push(os.environ['GITHUB_OUTPUT'])
+        outputs.append(os.environ['GITHUB_OUTPUT'])
     for k, v in output.items():
-        outputs.push('{name}={value}'.format(name=k, value=v))
+        outputs.append('{name}={value}'.format(name=k, value=v))
     os.environ['GITHUB_OUTPUT'] += '\n'.join(outputs)
 
 def prep_base_version(environ: Dict):

--- a/extras/github/docker.py
+++ b/extras/github/docker.py
@@ -3,8 +3,12 @@ import os
 from typing import Dict
 
 def print_output(output: Dict):
-    str_output = '\n'.join(['{}={}'.format(k, v) for k, v in output.items()])
-    os.environ['GITHUB_OUTPUT'] += str_output + '\n'
+    outputs = []
+    if os.environ['GITHUB_OUTPUT']:
+        outputs.push(os.environ['GITHUB_OUTPUT'])
+    for k, v in output.items():
+        outputs.push('{name}={value}'.format(name=k, value=v))
+    os.environ['GITHUB_OUTPUT'] += '\n'.join(outputs)
 
 def prep_base_version(environ: Dict):
     GITHUB_REF = environ.get('GITHUB_REF')

--- a/extras/github/docker.py
+++ b/extras/github/docker.py
@@ -3,9 +3,8 @@ import os
 from typing import Dict
 
 def print_output(output: Dict):
-    for k, v in output.items():
-        print(f'::set-output name={k}::{v}')
-
+    str_output = '\n'.join(['{}={}'.format(k, v) for k, v in output.items()])
+    os.environ['GITHUB_OUTPUT'] += str_output + '\n'
 
 def prep_base_version(environ: Dict):
     GITHUB_REF = environ.get('GITHUB_REF')

--- a/extras/github/docker.py
+++ b/extras/github/docker.py
@@ -3,12 +3,9 @@ import os
 from typing import Dict
 
 def print_output(output: Dict):
-    outputs = []
-    if os.environ['GITHUB_OUTPUT']:
-        outputs.append(os.environ['GITHUB_OUTPUT'])
-    for k, v in output.items():
-        outputs.append('{name}={value}'.format(name=k, value=v))
-    os.environ['GITHUB_OUTPUT'] += '\n'.join(outputs)
+    outputs = ['{}={}\n'.format(k, v) for k, v in output.items()]
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+        f.writelines(outputs)
 
 def prep_base_version(environ: Dict):
     GITHUB_REF = environ.get('GITHUB_REF')


### PR DESCRIPTION
Update the soon to be deprecated `set-output` command ([reference](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))