### PR TITLE
feat(feature-activation): block features endpoint

### DIFF
--- a/hathor/feature_activation/model/criteria.py
+++ b/hathor/feature_activation/model/criteria.py
@@ -78,20 +78,6 @@ class Criteria(BaseModel, validate_all=True):
             signal_support_by_default=self.signal_support_by_default
         )
 
-    def to_validated(self, evaluation_interval: int, max_signal_bits: int) -> 'ValidatedCriteria':
-        """Create a validated version of self, including attribute validations that have external dependencies."""
-        return ValidatedCriteria(
-            evaluation_interval=evaluation_interval,
-            max_signal_bits=max_signal_bits,
-            bit=self.bit,
-            start_height=self.start_height,
-            timeout_height=self.timeout_height,
-            threshold=self.threshold,
-            minimum_activation_height=self.minimum_activation_height,
-            lock_in_on_timeout=self.lock_in_on_timeout,
-            version=self.version,
-        )
-
     def get_threshold(self, feature_settings: 'FeatureSettings') -> int:
         """Returns the configured threshold, or the default threshold if it is None."""
         return self.threshold if self.threshold is not None else feature_settings.default_threshold

--- a/hathor/feature_activation/model/criteria.py
+++ b/hathor/feature_activation/model/criteria.py
@@ -80,12 +80,17 @@ class Criteria(BaseModel, validate_all=True):
 
     def to_validated(self, evaluation_interval: int, max_signal_bits: int) -> 'ValidatedCriteria':
         """Create a validated version of self, including attribute validations that have external dependencies."""
-        attributes: dict[str, Any] = self.dict() | dict(
+        return ValidatedCriteria(
             evaluation_interval=evaluation_interval,
-            max_signal_bits=max_signal_bits
+            max_signal_bits=max_signal_bits,
+            bit=self.bit,
+            start_height=self.start_height,
+            timeout_height=self.timeout_height,
+            threshold=self.threshold,
+            minimum_activation_height=self.minimum_activation_height,
+            lock_in_on_timeout=self.lock_in_on_timeout,
+            version=self.version,
         )
-
-        return ValidatedCriteria(**attributes)
 
     def get_threshold(self, feature_settings: 'FeatureSettings') -> int:
         """Returns the configured threshold, or the default threshold if it is None."""

--- a/hathor/feature_activation/model/criteria.py
+++ b/hathor/feature_activation/model/criteria.py
@@ -78,6 +78,15 @@ class Criteria(BaseModel, validate_all=True):
             signal_support_by_default=self.signal_support_by_default
         )
 
+    def to_validated(self, evaluation_interval: int, max_signal_bits: int) -> 'ValidatedCriteria':
+        """Create a validated version of self, including attribute validations that have external dependencies."""
+        attributes: dict[str, Any] = self.dict() | dict(
+            evaluation_interval=evaluation_interval,
+            max_signal_bits=max_signal_bits
+        )
+
+        return ValidatedCriteria(**attributes)
+
     def get_threshold(self, feature_settings: 'FeatureSettings') -> int:
         """Returns the configured threshold, or the default threshold if it is None."""
         return self.threshold if self.threshold is not None else feature_settings.default_threshold

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -440,3 +440,9 @@ class Block(BaseTransaction):
         metadata.feature_states = feature_states
 
         self.storage.save_transaction(self, only_metadata=True)
+
+    def get_feature_activation_bit_value(self, bit: int) -> int:
+        """Get the feature activation bit value for a specific bit position."""
+        bit_list = self._get_feature_activation_bit_list()
+
+        return bit_list[bit]

--- a/hathor/utils/api.py
+++ b/hathor/utils/api.py
@@ -11,8 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import cgi
-from typing import Union
+from typing import Type, TypeVar, Union
 
 from pydantic import Field, ValidationError, validator
 from twisted.web.http import Request
@@ -20,6 +21,8 @@ from twisted.web.http import Request
 from hathor.api_util import get_args
 from hathor.utils.list import single_or_none
 from hathor.utils.pydantic import BaseModel
+
+T = TypeVar('T', bound='QueryParams')
 
 
 class QueryParams(BaseModel):
@@ -31,7 +34,7 @@ class QueryParams(BaseModel):
     _list_to_single_item_validator = validator('*', pre=True, allow_reuse=True)(single_or_none)
 
     @classmethod
-    def from_request(cls, request: Request) -> Union['QueryParams', 'ErrorResponse']:
+    def from_request(cls: Type[T], request: Request) -> Union[T, 'ErrorResponse']:
         """Creates an instance from a Twisted Request."""
         encoding = 'utf8'
 

--- a/tests/resources/feature/test_feature.py
+++ b/tests/resources/feature/test_feature.py
@@ -19,6 +19,7 @@ import pytest
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.criteria import Criteria
+from hathor.feature_activation.model.feature_description import FeatureDescription
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.resources.feature import FeatureResource
 from hathor.feature_activation.settings import Settings as FeatureSettings
@@ -29,37 +30,45 @@ from tests.resources.base_resource import StubSite
 
 @pytest.fixture
 def web():
-    best_block = Mock(spec_set=Block)
-    best_block.get_feature_activation_bit_counts = Mock(return_value=[0, 1, 0, 0])
-    best_block.hash_hex = 'some_hash'
-    best_block.get_height = Mock(return_value=123)
+    block_mock = Mock(wraps=Block(), spec_set=Block)
+    block_mock.get_feature_activation_bit_counts = Mock(return_value=[0, 1, 0, 0])
+    block_mock.hash_hex = 'some_hash'
+    block_mock.get_height = Mock(return_value=123)
 
     tx_storage = Mock(spec_set=TransactionStorage)
-    tx_storage.get_best_block = Mock(return_value=best_block)
+    tx_storage.get_best_block = Mock(return_value=block_mock)
+    tx_storage.get_transaction = Mock(return_value=block_mock)
 
     def get_state(*, block: Block, feature: Feature) -> FeatureState:
         return FeatureState.ACTIVE if feature is Feature.NOP_FEATURE_1 else FeatureState.STARTED
 
+    nop_feature_1_criteria = Criteria(
+        bit=0,
+        start_height=0,
+        timeout_height=100,
+        version='0.1.0'
+    )
+    nop_feature_2_criteria = Criteria(
+        bit=1,
+        start_height=200,
+        threshold=2,
+        timeout_height=300,
+        version='0.2.0'
+    )
+
     feature_service = Mock(spec_set=FeatureService)
     feature_service.get_state = Mock(side_effect=get_state)
+    feature_service.get_bits_description = Mock(return_value={
+        Feature.NOP_FEATURE_1: FeatureDescription(state=FeatureState.DEFINED, criteria=nop_feature_1_criteria),
+        Feature.NOP_FEATURE_2: FeatureDescription(state=FeatureState.LOCKED_IN, criteria=nop_feature_2_criteria),
+    })
 
     feature_settings = FeatureSettings(
         evaluation_interval=4,
         default_threshold=3,
         features={
-            Feature.NOP_FEATURE_1: Criteria(
-                bit=0,
-                start_height=0,
-                timeout_height=100,
-                version='0.1.0'
-            ),
-            Feature.NOP_FEATURE_2: Criteria(
-                bit=1,
-                start_height=200,
-                threshold=2,
-                timeout_height=300,
-                version='0.2.0'
-            )
+            Feature.NOP_FEATURE_1: nop_feature_1_criteria,
+            Feature.NOP_FEATURE_2: nop_feature_2_criteria
         }
     )
 
@@ -101,6 +110,18 @@ def test_get_features(web):
                 lock_in_on_timeout=False,
                 version='0.2.0'
             )
+        ]
+    )
+
+    assert result == expected
+
+
+def test_get_block_features(web):
+    response = web.get('feature', args={b'block': b'1234'})
+    result = response.result.json_value()
+    expected = dict(
+        signal_bits=[
+            dict(bit=1, signal=0, feature="NOP_FEATURE_2", feature_state="LOCKED_IN")
         ]
     )
 

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -119,3 +119,12 @@ def test_get_feature_activation_bit_list(signal_bits: int, expected_bit_list: li
     result = block._get_feature_activation_bit_list()
 
     assert result == expected_bit_list
+
+
+def test_get_feature_activation_bit_value() -> None:
+    block = Block(signal_bits=0b0000_0100)
+
+    assert block.get_feature_activation_bit_value(0) == 0
+    assert block.get_feature_activation_bit_value(1) == 0
+    assert block.get_feature_activation_bit_value(2) == 1
+    assert block.get_feature_activation_bit_value(3) == 0


### PR DESCRIPTION
### Motivation

Implement a missing Feature Activation endpoint that will be required to implement the Explorer UIs described in [this RFC](https://github.com/HathorNetwork/rfcs/pull/60).

### Acceptance Criteria

- Add support for `block` parameter on the `GET /feature` endpoint, returning feature information for a specific block
- Add `Block.get_feature_activation_bit_value()` method
- Improve typing of `QueryParams.from_request()` method

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 