### PR TITLE
chore: add peer connecting event

### DIFF
--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -173,6 +173,7 @@ class Metrics:
         """
         events = [
             HathorEvents.NETWORK_NEW_TX_ACCEPTED,
+            HathorEvents.NETWORK_PEER_CONNECTING,
             HathorEvents.NETWORK_PEER_READY,
             HathorEvents.NETWORK_PEER_CONNECTED,
             HathorEvents.NETWORK_PEER_DISCONNECTED,
@@ -196,6 +197,7 @@ class Metrics:
                 self.transactions = self.tx_storage.get_tx_count()
         elif key in (
             HathorEvents.NETWORK_PEER_READY,
+            HathorEvents.NETWORK_PEER_CONNECTING,
             HathorEvents.NETWORK_PEER_CONNECTED,
             HathorEvents.NETWORK_PEER_DISCONNECTED,
             HathorEvents.NETWORK_PEER_CONNECTION_FAILED

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -572,6 +572,11 @@ class ConnectionsManager:
         deferred.addCallback(self._connect_to_callback, peer, endpoint, connection_string, peer_id)
         deferred.addErrback(self.on_connection_failure, peer, endpoint)
         self.log.info('connect to ', endpoint=description, peer=str(peer))
+        self.pubsub.publish(
+            HathorEvents.NETWORK_PEER_CONNECTING,
+            peer=peer,
+            peers_count=self._get_peers_count()
+        )
 
     def listen(self, description: str, use_ssl: Optional[bool] = None) -> IStreamServerEndpoint:
         """ Start to listen to new connection according to the description.

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -30,6 +30,10 @@ class HathorEvents(Enum):
             Triggered when a new tx/block is accepted in the network
             Publishes a tx/block object
 
+        NETWORK_PEER_CONNECTING:
+            Triggered when a peer starts connecting to the network
+            Publishes the peer id and the peers count
+
         NETWORK_PEER_CONNECTION_FAILURE:
             Triggered when a peer connection to the network fails
             Publishes the peer id and the peers count
@@ -90,6 +94,8 @@ class HathorEvents(Enum):
     """
     MANAGER_ON_START = 'manager:on_start'
     MANAGER_ON_STOP = 'manager:on_stop'
+
+    NETWORK_PEER_CONNECTING = 'network:peer_connecting'
 
     NETWORK_PEER_CONNECTION_FAILED = 'network:peer_connection_failed'
 


### PR DESCRIPTION
### Motivation

This PR is in preparation for PubSub changes in https://github.com/HathorNetwork/hathor-core/pull/694. The current implementation of the `test_p2p_network_events()` test,

https://github.com/HathorNetwork/hathor-core/blob/0dd129d904d9ad0625dec2c226b927b7b7ecd38d/tests/others/test_metrics.py#L68-L69

Tries to start a connection, which fails because the reactor used in tests (`Clock`) doesn't support TCP connections. This fail is expected and triggers the emission of the PubSub `NETWORK_PEER_CONNECTION_FAILURE` event, which is what triggers the `Metrics` update, making the test work.

In #694, the `Clock` is getting changed to a `MemoryReactorClock`, which does support TCP connections (but doesn't complete them), so the `NETWORK_PEER_CONNECTION_FAILURE` is not triggered.

We add an almost effectless new `NETWORK_PEER_CONNECTING` event that gets triggered when the peers starts connecting, so the `Metrics` update is still triggered.

### Acceptance Criteria

- Create new `HathorEvents.NETWORK_PEER_CONNECTING` event
  - Emit the event when a peer starts connecting to the p2p manager
  - Subscribe to the event and handle it in `Metrics`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 