### PR TITLE
chore: improve pubsub

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -20,7 +20,6 @@ import sys
 from typing import Any, Optional
 
 from structlog import get_logger
-from twisted.internet.posixbase import PosixReactorBase
 
 from hathor.cli.run_node import RunNodeArgs
 from hathor.consensus import ConsensusAlgorithm
@@ -35,7 +34,7 @@ from hathor.p2p.peer_id import PeerId
 from hathor.p2p.utils import discover_hostname
 from hathor.pubsub import PubSubManager
 from hathor.stratum import StratumFactory
-from hathor.util import Random
+from hathor.util import Random, Reactor
 from hathor.wallet import BaseWallet, HDWallet, Wallet
 
 logger = get_logger()
@@ -55,7 +54,7 @@ class CliBuilder:
         if not condition:
             raise BuilderError(message)
 
-    def create_manager(self, reactor: PosixReactorBase) -> HathorManager:
+    def create_manager(self, reactor: Reactor) -> HathorManager:
         import hathor
         from hathor.conf import HathorSettings
         from hathor.conf.get_settings import get_settings_source

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -156,6 +156,7 @@ class RunNode:
         self.start_manager()
 
         if self._args.stratum:
+            assert self.manager.stratum_factory is not None
             self.reactor.listenTCP(self._args.stratum, self.manager.stratum_factory)
 
         from hathor.conf import HathorSettings
@@ -170,6 +171,7 @@ class RunNode:
             )
             status_server = resources_builder.build()
             if self._args.status:
+                assert status_server is not None
                 self.reactor.listenTCP(self._args.status, status_server)
 
         from hathor.builder.builder import BuildArtifacts

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -111,7 +111,7 @@ class ConsensusAlgorithm:
                           prev_block_tip=best_tip.hex(), new_block_tip=new_best_tip.hex())
             # XXX: this method will mark as INVALID all transactions in the mempool that became invalid because of a
             #      reward lock
-            to_remove = storage.compute_transactions_that_became_invalid()
+            to_remove = storage.compute_transactions_that_became_invalid(new_best_height)
             if to_remove:
                 self.log.warn('some transactions on the mempool became invalid and will be removed',
                               count=len(to_remove))

--- a/hathor/p2p/sync_v1/agent.py
+++ b/hathor/p2p/sync_v1/agent.py
@@ -31,7 +31,8 @@ from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.transaction import BaseTransaction
 from hathor.transaction.base_transaction import tx_or_block_from_bytes
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
-from hathor.util import Reactor, json_dumps, json_loads, verified_cast
+from hathor.util import Reactor, json_dumps, json_loads
+from hathor.utils.zope import asserted_cast
 
 settings = HathorSettings()
 logger = get_logger()
@@ -60,8 +61,8 @@ class SendDataPush:
         self.node_sync = node_sync
         self.protocol: 'HathorProtocol' = node_sync.protocol
         assert self.protocol.transport is not None
-        self.consumer = verified_cast(IConsumer, self.protocol.transport)
-
+        consumer = asserted_cast(IConsumer, self.protocol.transport)
+        self.consumer = consumer
         self.is_running: bool = False
         self.is_producing: bool = False
 

--- a/hathor/p2p/sync_v2/streamers.py
+++ b/hathor/p2p/sync_v2/streamers.py
@@ -21,7 +21,7 @@ from zope.interface import implementer
 
 from hathor.transaction import BaseTransaction, Block, Transaction
 from hathor.transaction.storage.traversal import BFSOrderWalk
-from hathor.util import verified_cast
+from hathor.utils.zope import asserted_cast
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
@@ -60,7 +60,8 @@ class _StreamingBase:
         self.node_sync = node_sync
         self.protocol: 'HathorProtocol' = node_sync.protocol
         assert self.protocol.transport is not None
-        self.consumer = verified_cast(IConsumer, self.protocol.transport)
+        consumer = asserted_cast(IConsumer, self.protocol.transport)
+        self.consumer = consumer
 
         self.counter = 0
         self.limit = limit

--- a/hathor/reactor/reactor.py
+++ b/hathor/reactor/reactor.py
@@ -1,0 +1,31 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import cast
+
+from twisted.internet import reactor as twisted_reactor
+from twisted.internet.interfaces import IReactorCore, IReactorTCP, IReactorTime
+from zope.interface.verify import verifyObject
+
+from hathor.reactor.reactor_protocol import ReactorProtocol
+
+assert verifyObject(IReactorTime, twisted_reactor) is True
+assert verifyObject(IReactorCore, twisted_reactor) is True
+assert verifyObject(IReactorTCP, twisted_reactor) is True
+
+"""
+This variable is the global reactor that should be imported to use the Twisted reactor.
+It's cast to ReactorProtocol, our own type that stubs the necessary Twisted zope interfaces, to aid typing.
+"""
+reactor = cast(ReactorProtocol, twisted_reactor)

--- a/hathor/reactor/reactor_core_protocol.py
+++ b/hathor/reactor/reactor_core_protocol.py
@@ -1,0 +1,74 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, Callable, Optional, Protocol, Sequence
+
+from twisted.internet.interfaces import IReactorCore
+from zope.interface import implementer
+
+if TYPE_CHECKING:
+    from twisted.internet.defer import Deferred
+
+
+@implementer(IReactorCore)
+class ReactorCoreProtocol(Protocol):
+    """
+    A Python protocol that stubs Twisted's IReactorCore interface.
+    """
+
+    running: bool
+
+    @abstractmethod
+    def resolve(self, name: str, timeout: Sequence[int]) -> 'Deferred[str]':
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def stop(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def crash(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def iterate(self, delay: float) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def fireSystemEvent(self, eventType: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def addSystemEventTrigger(
+        self,
+        phase: str,
+        eventType: str,
+        callable: Callable[..., Any],
+        *args: object,
+        **kwargs: object,
+    ) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def removeSystemEventTrigger(self, triggerID: Any) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def callWhenRunning(self, callable: Callable[..., Any], *args: object, **kwargs: object) -> Optional[Any]:
+        raise NotImplementedError

--- a/hathor/reactor/reactor_protocol.py
+++ b/hathor/reactor/reactor_protocol.py
@@ -1,0 +1,31 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Protocol
+
+from hathor.reactor.reactor_core_protocol import ReactorCoreProtocol
+from hathor.reactor.reactor_tcp_protocol import ReactorTCPProtocol
+from hathor.reactor.reactor_time_protocol import ReactorTimeProtocol
+
+
+class ReactorProtocol(
+    ReactorCoreProtocol,
+    ReactorTimeProtocol,
+    ReactorTCPProtocol,
+    Protocol,
+):
+    """
+    A Python protocol that represents the intersection of Twisted's IReactorCore+IReactorTime+IReactorTCP interfaces.
+    """
+    pass

--- a/hathor/reactor/reactor_tcp_protocol.py
+++ b/hathor/reactor/reactor_tcp_protocol.py
@@ -1,0 +1,51 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Optional, Protocol
+
+from twisted.internet.interfaces import IReactorTCP
+from zope.interface import implementer
+
+if TYPE_CHECKING:
+    from twisted.internet.interfaces import IConnector, IListeningPort
+    from twisted.internet.protocol import ClientFactory, ServerFactory
+
+
+@implementer(IReactorTCP)
+class ReactorTCPProtocol(Protocol):
+    """
+    A Python protocol that stubs Twisted's IReactorTCP interface.
+    """
+
+    @abstractmethod
+    def listenTCP(
+        self,
+        port: int,
+        factory: 'ServerFactory',
+        backlog: int = 0,
+        interface: str = ''
+    ) -> 'IListeningPort':
+        raise NotImplementedError
+
+    @abstractmethod
+    def connectTCP(
+        self,
+        host: str,
+        port: int,
+        factory: 'ClientFactory',
+        timeout: float,
+        bindAddress: Optional[tuple[str, int]],
+    ) -> 'IConnector':
+        raise NotImplementedError

--- a/hathor/reactor/reactor_time_protocol.py
+++ b/hathor/reactor/reactor_time_protocol.py
@@ -1,0 +1,41 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, Callable, Protocol, Sequence
+
+from twisted.internet.interfaces import IReactorTime
+from zope.interface import implementer
+
+if TYPE_CHECKING:
+    from twisted.internet.interfaces import IDelayedCall
+
+
+@implementer(IReactorTime)
+class ReactorTimeProtocol(Protocol):
+    """
+    A Python protocol that stubs Twisted's IReactorTime interface.
+    """
+
+    @abstractmethod
+    def seconds(self) -> float:
+        raise NotImplementedError
+
+    @abstractmethod
+    def callLater(self, delay: float, callable: Callable[..., Any], *args: object, **kwargs: object) -> 'IDelayedCall':
+        raise NotImplementedError
+
+    @abstractmethod
+    def getDelayedCalls(self) -> Sequence['IDelayedCall']:
+        raise NotImplementedError

--- a/hathor/simulator/clock.py
+++ b/hathor/simulator/clock.py
@@ -94,3 +94,10 @@ class MemoryReactorHeapClock(MemoryReactor, HeapClock):
     def __init__(self):
         MemoryReactor.__init__(self)
         HeapClock.__init__(self)
+
+    def run(self):
+        """
+        We have to override MemoryReactor.run() because the original Twisted implementation weirdly calls stop() inside
+        run(), and we need the reactor running during our tests.
+        """
+        self.running = True

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -25,7 +25,7 @@ from hathor.conf import HathorSettings
 from hathor.daa import TestMode, _set_test_mode
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
-from hathor.simulator.clock import HeapClock
+from hathor.simulator.clock import HeapClock, MemoryReactorHeapClock
 from hathor.simulator.miner.geometric_miner import GeometricMiner
 from hathor.simulator.tx_generator import RandomTransactionGenerator
 from hathor.transaction.genesis import _get_genesis_transactions_unsafe
@@ -118,7 +118,7 @@ class Simulator:
         self.rng = Random(self.seed)
         self.settings = HathorSettings()
         self._network = 'testnet'
-        self._clock = HeapClock()
+        self._clock = MemoryReactorHeapClock()
         self._peers: OrderedDict[str, HathorManager] = OrderedDict()
         self._connections: list['FakeConnection'] = []
         self._started = False
@@ -178,6 +178,7 @@ class Simulator:
             .build()
 
         artifacts.manager.start()
+        self._clock.run()
         self.run_to_completion()
 
         # Don't use it anywhere else. It is unsafe to generate mnemonic words like this.

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -29,7 +29,7 @@ from structlog import get_logger
 from twisted.internet import task
 from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IAddress, IDelayedCall
-from twisted.internet.protocol import Factory, connectionDone
+from twisted.internet.protocol import ServerFactory, connectionDone
 from twisted.protocols.basic import LineReceiver
 from twisted.python.failure import Failure
 
@@ -717,7 +717,7 @@ class StratumProtocol(JSONRPC):
         )
 
 
-class StratumFactory(Factory):
+class StratumFactory(ServerFactory):
     """
     Twisted factory of server Hathor Stratum protocols.
     Interfaces with nodes to keep mining jobs up to date and to submit successful ones.

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -459,18 +459,19 @@ class TransactionStorage(ABC):
     def remove_transaction(self, tx: BaseTransaction) -> None:
         """Remove the tx.
 
-        :param tx: Trasaction to be removed
+        :param tx: Transaction to be removed
         """
         if self.indexes is not None:
             self.del_from_indexes(tx, remove_all=True, relax_assert=True)
 
     def remove_transactions(self, txs: list[BaseTransaction]) -> None:
-        """Will remove all of the transactions on the list from the database.
+        """Will remove all the transactions on the list from the database.
 
         Special notes:
 
         - will refuse and raise an error when removing all transactions would leave dangling transactions, that is,
-          transactions without existing parent
+          transactions without existing parent. That is, it expects the `txs` list to include all children of deleted
+          txs, from both the confirmation and funds DAGs
         - inputs's spent_outputs should not have any of the transactions being removed as spending transactions,
           this method will update and save those transaction's metadata
         - parent's children metadata will be updated to reflect the removals
@@ -486,6 +487,8 @@ class TransactionStorage(ABC):
             for parent in set(tx.parents) - txset:
                 parents_to_update[parent].append(tx.hash)
             dangling_children.update(set(tx_meta.children) - txset)
+            for spending_txs in tx_meta.spent_outputs.values():
+                dangling_children.update(set(spending_txs) - txset)
             for tx_input in tx.inputs:
                 spent_tx = tx.get_spent_tx(tx_input)
                 spent_tx_meta = spent_tx.get_metadata()
@@ -1067,13 +1070,18 @@ class TransactionStorage(ABC):
         else:
             yield from self.iter_mempool_from_tx_tips()
 
-    def compute_transactions_that_became_invalid(self) -> list[BaseTransaction]:
-        """ This method will look for transactions in the mempool that have became invalid due to the reward lock.
+    def compute_transactions_that_became_invalid(self, new_best_height: int) -> list[BaseTransaction]:
+        """ This method will look for transactions in the mempool that have become invalid due to the reward lock.
+        It compares each tx's `min_height` to the `new_best_height`, accounting for the fact that the tx can be
+        confirmed by the next block.
         """
         from hathor.transaction.validation_state import ValidationState
         to_remove: list[BaseTransaction] = []
         for tx in self.iter_mempool_from_best_index():
-            if tx.is_spent_reward_locked():
+            tx_min_height = tx.get_metadata().min_height
+            assert tx_min_height is not None
+            # We use +1 here because a tx is valid if it can be confirmed by the next block
+            if new_best_height + 1 < tx_min_height:
                 tx.set_validation(ValidationState.INVALID)
                 to_remove.append(tx)
         return to_remove

--- a/hathor/transaction/transaction_metadata.py
+++ b/hathor/transaction/transaction_metadata.py
@@ -44,7 +44,7 @@ class TransactionMetadata:
     # XXX: this is only used to defer the reward-lock verification from the transaction spending a reward to the first
     # block that confirming this transaction, it is important to always have this set to be able to distinguish an old
     # metadata (that does not have this calculated, from a tx with a new format that does have this calculated)
-    min_height: int
+    min_height: Optional[int]
 
     # A list of feature activation bit counts. Must only be used by Blocks, is None otherwise.
     # Each list index corresponds to a bit position, and its respective value is the rolling count of active bits from
@@ -68,7 +68,7 @@ class TransactionMetadata:
         accumulated_weight: float = 0,
         score: float = 0,
         height: Optional[int] = None,
-        min_height: int = 0,
+        min_height: Optional[int] = None,
         feature_activation_bit_counts: Optional[list[int]] = None
     ) -> None:
         from hathor.transaction.genesis import is_genesis
@@ -276,7 +276,7 @@ class TransactionMetadata:
         meta.accumulated_weight = data['accumulated_weight']
         meta.score = data.get('score', 0)
         meta.height = data.get('height', 0)  # XXX: should we calculate the height if it's not defined?
-        meta.min_height = data.get('min_height', 0)
+        meta.min_height = data.get('min_height')
         meta.feature_activation_bit_counts = data.get('feature_activation_bit_counts', [])
 
         feature_states_raw = data.get('feature_states')

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -22,44 +22,33 @@ import warnings
 from collections import OrderedDict
 from contextlib import AbstractContextManager
 from dataclasses import asdict, dataclass
-from enum import Enum
 from functools import partial, wraps
 from random import Random as PyRandom
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional, Sequence, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional, Sequence, TypeVar, cast
 
 from structlog import get_logger
-from twisted.internet import reactor as twisted_reactor
-from twisted.internet.base import ReactorBase
-from twisted.internet.posixbase import PosixReactorBase
-from twisted.python.threadable import isInIOThread
-from zope.interface import Interface
-from zope.interface.verify import verifyObject
 
 import hathor
 from hathor.conf import HathorSettings
+from hathor.reactor.reactor import reactor as hathor_reactor
+from hathor.reactor.reactor_protocol import ReactorProtocol
 from hathor.types import TokenUid
 
 if TYPE_CHECKING:
     import structlog
 
-    from hathor.simulator.clock import HeapClock
     from hathor.transaction.base_transaction import BaseTransaction
 
-# Reactor = IReactorTime
-# XXX: Ideally we would want to be able to express Reactor as IReactorTime+IReactorCore, which is what everyone using
-#      this type annotation needs, however it is not possible to express this. In practice most classes that implement
-#      these interfaces use ReactorBase as base, however that is not the case for MemoryReactorClock, which inherits
-#      IReactorTime from Clock and IReactorCore from MemoryReactor. For the lack of a better approach, a union of these
-#      types is enough for most of our uses. If we end up having to use a different reactor that does not use those
-#      bases but implement IReactorTime+IReactorCore, we could add it to the Union below
-Reactor = Union[ReactorBase, 'HeapClock']
-reactor = cast(PosixReactorBase, twisted_reactor)
+# TODO: Those reexports are kept for retro-compatibility, but users could import them directly and then we can remove
+#  them from this file.
+Reactor = ReactorProtocol
+reactor = hathor_reactor
+
 logger = get_logger()
 settings = HathorSettings()
 
 
 T = TypeVar('T')
-Z = TypeVar('Z', bound=Interface)
 
 
 def practically_equal(a: dict[Any, Any], b: dict[Any, Any]) -> bool:
@@ -110,28 +99,6 @@ def skip_warning(func: Callable[..., Any]) -> Callable[..., Any]:
         return partial(f, getattr(func, '__self__'))
     else:
         return f
-
-
-class ReactorThread(Enum):
-    MAIN_THREAD = 'MAIN_THREAD'
-    NOT_MAIN_THREAD = 'NOT_MAIN_THREAD'
-    NOT_RUNNING = 'NOT_RUNNING'
-
-    @classmethod
-    def get_current_thread(cls, reactor: Reactor) -> 'ReactorThread':
-        """ Returns if the code is being run on the reactor thread, if it's running already.
-        """
-        running = getattr(reactor, 'running', None)
-        if running is not None:
-            if running:
-                return cls.MAIN_THREAD if isInIOThread() else cls.NOT_MAIN_THREAD
-            else:
-                # if reactor is not running yet, there's no threading
-                return cls.NOT_RUNNING
-        else:
-            # on tests, we use Clock instead of a real Reactor, so there's
-            # no threading. We consider that the reactor is running
-            return cls.MAIN_THREAD
 
 
 def abbrev(data: bytes, max_len: int = 256, gap: bytes = b' [...] ') -> bytes:
@@ -417,11 +384,6 @@ def skip_n(it: Iterator[_T], n: int) -> Iterator[_T]:
         except StopIteration:
             return it
     return it
-
-
-def verified_cast(interface_class: type[Z], obj: Any) -> Z:
-    verifyObject(interface_class, obj)
-    return obj
 
 
 _DT_ITER_NEXT_WARN = 3  # time in seconds to warn when `next(iter_tx)` takes too long

--- a/hathor/utils/zope.py
+++ b/hathor/utils/zope.py
@@ -1,0 +1,45 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any, Optional, TypeVar, cast
+
+from zope.interface import Interface
+from zope.interface.exceptions import Invalid
+from zope.interface.verify import verifyObject
+
+T = TypeVar('T', bound=Interface)
+
+
+def verified_cast(interface_class: type[T], obj: Any) -> Optional[T]:
+    """
+    Receive a zope interface and an object, and return a cast to this interface if the object implements it.
+    Return None otherwise.
+    """
+    try:
+        if verifyObject(interface_class, obj):
+            return cast(T, obj)
+    except Invalid:
+        pass
+
+    return None
+
+
+def asserted_cast(interface_class: type[T], obj: Any) -> T:
+    """
+    Receive a zope interface and an object, and return a cast to this interface if the object implements it.
+    Raise and AssertionError otherwise.
+    """
+    result = verified_cast(interface_class, obj)
+    assert result is not None
+    return result

--- a/tests/event/websocket/test_factory.py
+++ b/tests/event/websocket/test_factory.py
@@ -20,7 +20,7 @@ from hathor.event.storage import EventMemoryStorage
 from hathor.event.websocket.factory import EventWebsocketFactory
 from hathor.event.websocket.protocol import EventWebsocketProtocol
 from hathor.event.websocket.response import EventResponse, InvalidRequestType
-from hathor.simulator.clock import HeapClock
+from hathor.simulator.clock import MemoryReactorHeapClock
 from tests.utils import EventMocker
 
 
@@ -109,7 +109,7 @@ def test_broadcast_multiple_events_multiple_connections():
 )
 def test_send_next_event_to_connection(next_expected_event_id: int, can_receive_event: bool) -> None:
     n_starting_events = 10
-    clock = HeapClock()
+    clock = MemoryReactorHeapClock()
     factory = _get_factory(n_starting_events, clock)
     connection = Mock(spec_set=EventWebsocketProtocol)
     connection.send_event_response = Mock()
@@ -137,7 +137,10 @@ def test_send_next_event_to_connection(next_expected_event_id: int, can_receive_
     connection.send_event_response.assert_has_calls(calls)
 
 
-def _get_factory(n_starting_events: int = 0, clock: HeapClock = HeapClock()) -> EventWebsocketFactory:
+def _get_factory(
+    n_starting_events: int = 0,
+    clock: MemoryReactorHeapClock = MemoryReactorHeapClock()
+) -> EventWebsocketFactory:
     event_storage = EventMemoryStorage()
 
     for event_id in range(n_starting_events):

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -74,7 +74,7 @@ class BaseMetricsTest(unittest.TestCase):
         self.assertEquals(manager.metrics.known_peers, 3)
         self.assertEquals(manager.metrics.connected_peers, 2)
         self.assertEquals(manager.metrics.handshaking_peers, 1)
-        self.assertEquals(manager.metrics.connecting_peers, 0)
+        self.assertEquals(manager.metrics.connecting_peers, 1)
 
         manager.metrics.stop()
 

--- a/tests/p2p/test_connections.py
+++ b/tests/p2p/test_connections.py
@@ -23,6 +23,6 @@ class ConnectionsTest(unittest.TestCase):
         endpoint = 'tcp://127.0.0.1:8005'
         manager.connections.connect_to(endpoint, use_ssl=True)
 
-        self.assertNotIn(endpoint, manager.connections.iter_not_ready_endpoints())
+        self.assertIn(endpoint, manager.connections.iter_not_ready_endpoints())
         self.assertNotIn(endpoint, manager.connections.iter_ready_connections())
         self.assertNotIn(endpoint, manager.connections.iter_all_connections())

--- a/tests/test_memory_reactor_clock.py
+++ b/tests/test_memory_reactor_clock.py
@@ -1,0 +1,24 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from twisted.internet.testing import MemoryReactorClock
+
+
+class TestMemoryReactorClock(MemoryReactorClock):
+    def run(self):
+        """
+        We have to override MemoryReactor.run() because the original Twisted implementation weirdly calls stop() inside
+        run(), and we need the reactor running during our tests.
+        """
+        self.running = True

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -7,7 +7,6 @@ from typing import Iterator, Optional
 from unittest import main as ut_main
 
 from structlog import get_logger
-from twisted.internet.task import Clock
 from twisted.trial import unittest
 
 from hathor.builder import BuildArtifacts, Builder
@@ -19,6 +18,7 @@ from hathor.simulator.clock import MemoryReactorHeapClock
 from hathor.transaction import BaseTransaction
 from hathor.util import Random, Reactor, reactor
 from hathor.wallet import HDWallet, Wallet
+from tests.test_memory_reactor_clock import TestMemoryReactorClock
 
 logger = get_logger()
 main = ut_main
@@ -105,8 +105,7 @@ class TestCase(unittest.TestCase):
     def setUp(self):
         _set_test_mode(TestMode.TEST_ALL_WEIGHT)
         self.tmpdirs = []
-        # XXX: changing this clock to a MemoryReactorClock will break a lot of tests
-        self.clock = Clock()
+        self.clock = TestMemoryReactorClock()
         self.clock.advance(time.time())
         self.log = logger.new()
         self.reset_peer_id_pool()
@@ -174,6 +173,7 @@ class TestCase(unittest.TestCase):
 
         if start_manager:
             manager.start()
+            self.clock.run()
             self.run_to_completion()
 
         return manager


### PR DESCRIPTION
### Motivation

This PR resolves https://github.com/HathorNetwork/hathor-core/issues/552. There are 3 goals:

1. Improve typing of code using Twisted reactors
2. Change tests to use a `MemoryReactorClock` instead of a `Clock`, so it's compatible with the reactor used in production (that is, it implements the `IReactorCore`, `IReactorTime`, and `IReactorTCP` Twisted interfaces. `Clock` only implements `IReactorTime`)
3. Remove PubSub support for reactors that don't implement `IReactorCore`

This was done by leveraging [Python protocols](https://peps.python.org/pep-0544/) to represent an intersection of Twisted interfaces, which allows us to better represent the reactor type. By doing this, we were able to change tests to use a reactor that is more similar to the one used in production, as previously we were using a `Clock`, that behaved differently than the production reactor during full node initialization. This also allows for simplifying `PubSub`, as it had a specifc implementation for dealing with `Clock`.

### Acceptance Criteria

- Create new `ReactorCoreProtocol`, `ReactorTimeProtocol`, and `ReactorTCPProtocol` classes stubbing the respective Twisted interfaces, `IReactorCore`, `IReactorTime`, and `IReactorTCP`
- Create new `ReactorProtocol` that implements the 3 protocols above, effectively creating a type that represents an intersection of Twisted interfaces, and cast the Twisted reactor to that protocol (this resolves a `XXX` comment in `hathor/util.py`)
- Update `PubSub` to improve its code, also removing support for "non-running" reactors (`Clock`)
- Remove the `ReactorThread` enum as it's not used anymore
- Change the `Clock` to `MemoryReactorClock` in tests (this resolves a `XXX` comment)
- Change `HeapClock` to `MemoryReactorHeapClock` on simulator
- Improve `verified_cast()` utils function and move it to its own file

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 