### PR TITLE
fix: consensus-fail-id marker should not be treated as a tx-id

### DIFF
--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -153,6 +153,8 @@ class ConsensusAlgorithm:
         for h in voided_by:
             if h == settings.SOFT_VOIDED_ID:
                 continue
+            if h == settings.CONSENSUS_FAIL_ID:
+                continue
             if h == tx.hash:
                 continue
             if h in self.soft_voided_tx_ids:


### PR DESCRIPTION
### Motivation

Bugfix triggered from artificial case.

### Acceptance Criteria

- When a tx's voided-by includes a consensus-fail-id marker, the marker should not be treated as a tx-id.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 