### PR TITLE
refactor: remove deprecated typing uses and add custom linter script

### DIFF
--- a/extras/custom_checks.sh
+++ b/extras/custom_checks.sh
@@ -71,10 +71,20 @@ function check_do_not_use_builtin_random_in_tests() {
 	return 0
 }
 
+function check_deprecated_typing() {
+	if grep -R '\<typing .*\<import .*\<\(Tuple\|List\|Dict\|Set\|FrozenSet\|AbstractSet\|DefaultDict\|OrderedDict\)\>' "${SOURCE_DIRS[@]}"; then
+		echo 'do not use typing.List/Tuple/Dict/... for type annotations use builtin list/tuple/dict/... instead'
+		echo 'for more info check the PEP 585 doc: https://peps.python.org/pep-0585/'
+		return 1
+	fi
+	return 0
+}
+
 # List of functions to be executed
 checks=(
 	check_version_match
 	check_do_not_use_builtin_random_in_tests
+	check_deprecated_typing
 )
 
 # Initialize a variable to track if any check fails

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import Extra
 
@@ -32,8 +32,8 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     dns: Optional[str]
     peer: Optional[str]
     sysctl: Optional[str]
-    listen: List[str]
-    bootstrap: Optional[List[str]]
+    listen: list[str]
+    bootstrap: Optional[list[str]]
     status: Optional[int]
     stratum: Optional[int]
     data: Optional[str]
@@ -68,5 +68,5 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     x_localhost_only: bool
     x_rocksdb_indexes: bool
     x_enable_event_queue: bool
-    peer_id_blacklist: List[str]
+    peer_id_blacklist: list[str]
     config_yaml: Optional[str]

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Set
-
 from structlog import get_logger
 
 from hathor.conf import HathorSettings
@@ -57,7 +55,7 @@ class ConsensusAlgorithm:
     b0 will not be propagated to the voided_by of b1, b2, and b3.
     """
 
-    def __init__(self, soft_voided_tx_ids: Set[bytes], pubsub: PubSubManager) -> None:
+    def __init__(self, soft_voided_tx_ids: set[bytes], pubsub: PubSubManager) -> None:
         self.log = logger.new()
         self._pubsub = pubsub
         self.soft_voided_tx_ids = frozenset(soft_voided_tx_ids)
@@ -147,7 +145,7 @@ class ConsensusAlgorithm:
         if context.reorg_common_block is not None:
             context.pubsub.publish(HathorEvents.REORG_FINISHED)
 
-    def filter_out_soft_voided_entries(self, tx: BaseTransaction, voided_by: Set[bytes]) -> Set[bytes]:
+    def filter_out_soft_voided_entries(self, tx: BaseTransaction, voided_by: set[bytes]) -> set[bytes]:
         if not (self.soft_voided_tx_ids & voided_by):
             return voided_by
         ret = set()
@@ -163,7 +161,7 @@ class ConsensusAlgorithm:
             assert tx.storage is not None
             tx3 = tx.storage.get_transaction(h)
             tx3_meta = tx3.get_metadata()
-            tx3_voided_by: Set[bytes] = tx3_meta.voided_by or set()
+            tx3_voided_by: set[bytes] = tx3_meta.voided_by or set()
             if not (self.soft_voided_tx_ids & tx3_voided_by):
                 ret.add(h)
         return ret

--- a/hathor/consensus/context.py
+++ b/hathor/consensus/context.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Set
+from typing import TYPE_CHECKING, Optional
 
 from structlog import get_logger
 
@@ -41,7 +41,7 @@ class ConsensusAlgorithmContext:
     pubsub: PubSubManager
     block_algorithm: 'BlockConsensusAlgorithm'
     transaction_algorithm: 'TransactionConsensusAlgorithm'
-    txs_affected: Set[BaseTransaction]
+    txs_affected: set[BaseTransaction]
     reorg_common_block: Optional[Block]
 
     def __init__(self, consensus: 'ConsensusAlgorithm', pubsub: PubSubManager) -> None:

--- a/hathor/event/websocket/factory.py
+++ b/hathor/event/websocket/factory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Set
+from typing import Optional
 
 from autobahn.twisted.websocket import WebSocketServerFactory
 from structlog import get_logger
@@ -42,7 +42,7 @@ class EventWebsocketFactory(WebSocketServerFactory):
         self.log = logger.new()
         self._reactor = reactor
         self._event_storage = event_storage
-        self._connections: Set[EventWebsocketProtocol] = set()
+        self._connections: set[EventWebsocketProtocol] = set()
 
         latest_event = self._event_storage.get_last_event()
 

--- a/hathor/indexes/memory_mempool_tips_index.py
+++ b/hathor/indexes/memory_mempool_tips_index.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional, Set
+from typing import Iterable, Optional
 
 from structlog import get_logger
 
@@ -22,7 +22,7 @@ logger = get_logger()
 
 
 class MemoryMempoolTipsIndex(ByteCollectionMempoolTipsIndex):
-    _index: Set[bytes]
+    _index: set[bytes]
 
     def __init__(self):
         self.log = logger.new()

--- a/hathor/indexes/memory_tx_group_index.py
+++ b/hathor/indexes/memory_tx_group_index.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Iterable, Set, Sized, TypeVar
+from typing import Iterable, Sized, TypeVar
 
 from structlog import get_logger
 
@@ -31,7 +31,7 @@ class MemoryTxGroupIndex(TxGroupIndex[KT]):
     """Memory implementation of the TxGroupIndex. This class is abstract and cannot be used directly.
     """
 
-    index: defaultdict[KT, Set[bytes]]
+    index: defaultdict[KT, set[bytes]]
 
     def __init__(self) -> None:
         self.force_clear()

--- a/hathor/indexes/mempool_tips_index.py
+++ b/hathor/indexes/mempool_tips_index.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 from collections.abc import Collection
-from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Set, cast
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional, cast
 
 import structlog
 
@@ -70,7 +70,7 @@ class MempoolTipsIndex(BaseIndex):
 
     # originally tx_storage.get_mempool_tips_index
     @abstractmethod
-    def get(self) -> Set[bytes]:
+    def get(self) -> set[bytes]:
         """
         Get the set of mempool tips indexed.
 
@@ -107,8 +107,8 @@ class ByteCollectionMempoolTipsIndex(MempoolTipsIndex):
         assert tx.hash is not None
         assert tx.storage is not None
         tx_meta = tx.get_metadata()
-        to_remove: Set[bytes] = set()
-        to_remove_parents: Set[bytes] = set()
+        to_remove: set[bytes] = set()
+        to_remove_parents: set[bytes] = set()
         tx_storage = tx.storage
         for tip_tx in self.iter(tx_storage):
             assert tip_tx.hash is not None
@@ -194,5 +194,5 @@ class ByteCollectionMempoolTipsIndex(MempoolTipsIndex):
             else:
                 yield tx
 
-    def get(self) -> Set[bytes]:
+    def get(self) -> set[bytes]:
         return set(iter(self._index))

--- a/hathor/indexes/tips_index.py
+++ b/hathor/indexes/tips_index.py
@@ -14,7 +14,6 @@
 
 from abc import abstractmethod
 from enum import Enum
-from typing import Set
 
 from intervaltree import Interval
 from structlog import get_logger
@@ -88,5 +87,5 @@ class TipsIndex(BaseIndex):
         raise NotImplementedError
 
     @abstractmethod
-    def __getitem__(self, index: float) -> Set[Interval]:
+    def __getitem__(self, index: float) -> set[Interval]:
         raise NotImplementedError

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from typing import Any, Iterator, Optional, Set
+from typing import Any, Iterator, Optional
 
 from twisted.internet import threads
 
@@ -29,8 +29,8 @@ class TransactionCacheStorage(BaseTransactionStorage):
     """Caching storage to be used 'on top' of other storages.
     """
 
-    cache: 'OrderedDict[bytes, BaseTransaction]'
-    dirty_txs: Set[bytes]
+    cache: OrderedDict[bytes, BaseTransaction]
+    dirty_txs: set[bytes]
 
     def __init__(self, store: 'BaseTransactionStorage', reactor: Reactor, interval: int = 5,
                  capacity: int = 10000, *, indexes: Optional[IndexesManager], _clone_if_needed: bool = False):
@@ -63,7 +63,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
         self._clone_if_needed = _clone_if_needed
         self.cache = OrderedDict()
         # dirty_txs has the txs that have been modified but are not persisted yet
-        self.dirty_txs = set()  # Set[bytes(hash)]
+        self.dirty_txs = set()
         self.stats = dict(hit=0, miss=0)
 
         # we need to use only one weakref dict, so we must first initialize super, and then
@@ -120,7 +120,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
             deferred.addErrback(self._err_flush_thread)
             self.flush_deferred = deferred
 
-    def _cb_flush_thread(self, flushed_txs: Set[bytes]) -> None:
+    def _cb_flush_thread(self, flushed_txs: set[bytes]) -> None:
         self.reactor.callLater(self.interval, self._start_flush_thread)
         self.flush_deferred = None
 
@@ -129,7 +129,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
         self.reactor.callLater(self.interval, self._start_flush_thread)
         self.flush_deferred = None
 
-    def _flush_to_storage(self, dirty_txs_copy: Set[bytes]) -> None:
+    def _flush_to_storage(self, dirty_txs_copy: set[bytes]) -> None:
         """Write dirty pages to disk."""
         for tx_hash in dirty_txs_copy:
             # a dirty tx might be removed from self.cache outside this thread: if _update_cache is called
@@ -155,7 +155,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
         # call super which adds to index if needed
         super().save_transaction(tx, only_metadata=only_metadata)
 
-    def get_all_genesis(self) -> Set[BaseTransaction]:
+    def get_all_genesis(self) -> set[BaseTransaction]:
         return self.store.get_all_genesis()
 
     def _save_transaction(self, tx: BaseTransaction, *, only_metadata: bool = False) -> None:

--- a/hathor/websocket/protocol.py
+++ b/hathor/websocket/protocol.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Set, Union
+from typing import TYPE_CHECKING, Union
 
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from structlog import get_logger
@@ -33,7 +33,7 @@ class HathorAdminWebsocketProtocol(WebSocketServerProtocol):
     def __init__(self, factory: 'HathorAdminWebsocketFactory') -> None:
         self.log = logger.new()
         self.factory = factory
-        self.subscribed_to: Set[str] = set()
+        self.subscribed_to: set[str] = set()
         super().__init__()
 
     def onConnect(self, request):


### PR DESCRIPTION
### Motivation

I noticed some uses of `typing.Set` in the code, even after we removing those, because there's no linter it's very easy to forget we can use `set` instead.

### Acceptance Criteria

- add custom linter script to check for deprecated uses of typing

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 