### PR TITLE
chore(extras): script to generate list of PRs that master is ahead of rc

### DIFF
--- a/extras/gen_release_candidate_changes.py
+++ b/extras/gen_release_candidate_changes.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+This script finds all PRs that have been merged into the `master` branch but not into the `release-candidate` branch in a given GitHub repository.
+
+Usage:
+
+    ./extras/gen_release_candidate_changes.py
+
+Example output:
+
+```
+- #701
+- #697
+- #686
+```
+"""
+
+import yaml
+import os
+import requests
+
+BASE_API_URL = 'https://api.github.com'
+REPO = 'HathorNetwork/hathor-core'
+
+
+def get_gh_token():
+    config_path = os.path.expanduser('~/.config/gh/hosts.yml')
+
+    if not os.path.exists(config_path):
+        print("GitHub CLI configuration not found. Please authenticate with 'gh auth login'.")
+        exit(1)
+
+    with open(config_path, 'r') as file:
+        config = yaml.safe_load(file)
+
+    token = config['github.com']['oauth_token']
+    return token
+
+
+def get_headers(token):
+    return {'Authorization': f'token {token}'}
+
+
+def get_commits_ahead(base, compare, token):
+    response = requests.get(
+        f'{BASE_API_URL}/repos/{REPO}/compare/{base}...{compare}',
+        headers=get_headers(token)
+    )
+    data = response.json()
+    return [commit['sha'] for commit in data['commits']]
+
+
+def get_pr_for_commit(commit, token):
+    response = requests.get(
+        f'{BASE_API_URL}/repos/{REPO}/commits/{commit}/pulls',
+        headers=get_headers(token),
+        params={'state': 'all'}
+    )
+    data = response.json()
+    if data:
+        return data[0]['number']
+    return None
+
+
+def get_new_prs_in_master(token):
+    commits = get_commits_ahead('release-candidate', 'master', token)
+    prs = []
+    for commit in commits:
+        pr = get_pr_for_commit(commit, token)
+        if pr and pr not in prs:
+            prs.append(pr)
+    return prs
+
+
+if __name__ == '__main__':
+    token = get_gh_token()
+    prs = get_new_prs_in_master(token)
+    for pr in prs:
+        print(f'- #{pr}')


### PR DESCRIPTION
### Motivation

Getting the list of PRs to include in the release-candidate description was getting cumbersome and error prone.

### Acceptance Criteria

- new script in `extras` that will generate a markdown list of PRs to be used when creating a new release-candidate
- script requires `gh` to be installed and authenticated in order to use Github's API

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 