### PR TITLE
feat: add --sysctl-init-file as cli command option

### DIFF
--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 from hathor.builder import BuildArtifacts
 from hathor.sysctl import ConnectionsManagerSysctl, Sysctl, WebsocketManagerSysctl
 
@@ -23,7 +21,6 @@ class SysctlBuilder:
 
     def __init__(self, artifacts: BuildArtifacts) -> None:
         self.artifacts = artifacts
-        self.sysctl_init_file: Optional[str] = None
 
     def build(self) -> Sysctl:
         """Build the sysctl tree."""

--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from hathor.builder import BuildArtifacts
+from hathor.conf.settings import HathorSettings
 from hathor.sysctl import ConnectionsManagerSysctl, Sysctl, WebsocketManagerSysctl
+
+settings = HathorSettings
 
 
 class SysctlBuilder:
     """Builder for the sysctl tree."""
+
     def __init__(self, artifacts: BuildArtifacts) -> None:
         self.artifacts = artifacts
+        self.sysctl_init_file: Optional[str] = None
 
     def build(self) -> Sysctl:
         """Build the sysctl tree."""

--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -15,10 +15,7 @@
 from typing import Optional
 
 from hathor.builder import BuildArtifacts
-from hathor.conf.settings import HathorSettings
 from hathor.sysctl import ConnectionsManagerSysctl, Sysctl, WebsocketManagerSysctl
-
-settings = HathorSettings
 
 
 class SysctlBuilder:

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -15,7 +15,7 @@
 import os
 import sys
 from argparse import SUPPRESS, ArgumentParser, Namespace
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from pydantic import ValidationError
 from structlog import get_logger
@@ -58,6 +58,8 @@ class RunNode:
         parser.add_argument('--peer', help='json file with peer info')
         parser.add_argument('--sysctl',
                             help='Endpoint description (eg: unix:/path/sysctl.sock, tcp:5000:interface:127.0.0.1)')
+        parser.add_argument('--sysctl-init-file',
+                            help='File path to the sysctl.txt init file (eg: conf/sysctl.txt)')
         parser.add_argument('--listen', action='append', default=[],
                             help='Address to listen for new connections (eg: tcp:8000)')
         parser.add_argument('--bootstrap', action='append', help='Address to connect to (eg: tcp:127.0.0.1:8000')
@@ -371,10 +373,11 @@ class RunNode:
         self.prepare()
         self.register_signal_handlers()
         if self._args.sysctl:
-            self.init_sysctl(self._args.sysctl)
+            self.init_sysctl(
+                self._args.sysctl, self._args.sysctl_init_file)
 
-    def init_sysctl(self, description: str) -> None:
-        """Initialize sysctl and listen for connections.
+    def init_sysctl(self, description: str, sysctl_init_file: Optional[str] = None) -> None:
+        """Initialize sysctl, listen for connections and apply settings from config file if required.
 
         Examples of description:
         - tcp:5000
@@ -390,11 +393,15 @@ class RunNode:
         from hathor.builder.sysctl_builder import SysctlBuilder
         from hathor.sysctl.factory import SysctlFactory
         from hathor.sysctl.runner import SysctlRunner
+        from hathor.sysctl.init_file_loader import SysctlInitFileLoader
 
         builder = SysctlBuilder(self.artifacts)
         root = builder.build()
-
         runner = SysctlRunner(root)
+
+        init_file_loader = SysctlInitFileLoader(runner, sysctl_init_file)
+        init_file_loader.load()
+
         factory = SysctlFactory(runner)
         endpoint = serverFromString(self.reactor, description)
         endpoint.listen(factory)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -398,8 +398,9 @@ class RunNode:
         root = builder.build()
         runner = SysctlRunner(root)
 
-        init_file_loader = SysctlInitFileLoader(runner, sysctl_init_file)
-        init_file_loader.load()
+        if sysctl_init_file:
+            init_file_loader = SysctlInitFileLoader(runner, sysctl_init_file)
+            init_file_loader.load()
 
         factory = SysctlFactory(runner)
         endpoint = serverFromString(self.reactor, description)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -392,8 +392,8 @@ class RunNode:
 
         from hathor.builder.sysctl_builder import SysctlBuilder
         from hathor.sysctl.factory import SysctlFactory
-        from hathor.sysctl.runner import SysctlRunner
         from hathor.sysctl.init_file_loader import SysctlInitFileLoader
+        from hathor.sysctl.runner import SysctlRunner
 
         builder = SysctlBuilder(self.artifacts)
         root = builder.build()

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -373,8 +373,7 @@ class RunNode:
         self.prepare()
         self.register_signal_handlers()
         if self._args.sysctl:
-            self.init_sysctl(
-                self._args.sysctl, self._args.sysctl_init_file)
+            self.init_sysctl(self._args.sysctl, self._args.sysctl_init_file)
 
     def init_sysctl(self, description: str, sysctl_init_file: Optional[str] = None) -> None:
         """Initialize sysctl, listen for connections and apply settings from config file if required.

--- a/hathor/sysctl/init_file_loader.py
+++ b/hathor/sysctl/init_file_loader.py
@@ -10,6 +10,7 @@ class SysctlInitFileLoader:
         self.init_file = init_file
 
     def load(self) -> None:
+        """Read the init_file and execute each line as a syctl command in the runner."""
         with open(self.init_file, 'r', encoding='utf-8') as file:
             lines = file.readlines()
 

--- a/hathor/sysctl/init_file_loader.py
+++ b/hathor/sysctl/init_file_loader.py
@@ -1,19 +1,15 @@
-from typing import Optional
-
 from hathor.sysctl.runner import SysctlRunner
 
 
 class SysctlInitFileLoader:
-    def __init__(self, runner: SysctlRunner, init_file: Optional[str]) -> None:
+    def __init__(self, runner: SysctlRunner, init_file: str) -> None:
         assert runner
+        assert init_file
 
         self.runner = runner
         self.init_file = init_file
 
     def load(self) -> None:
-        if not self.init_file:
-            return
-
         with open(self.init_file, 'r', encoding='utf-8') as file:
             lines = file.readlines()
 

--- a/hathor/sysctl/init_file_loader.py
+++ b/hathor/sysctl/init_file_loader.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from hathor.sysctl.runner import SysctlRunner
+
+
+class SysctlInitFileLoader:
+    def __init__(self, runner: SysctlRunner, init_file: Optional[str]) -> None:
+        assert runner
+
+        self.runner = runner
+        self.init_file = init_file
+
+    def load(self) -> None:
+        if not self.init_file:
+            return
+
+        with open(self.init_file, 'r', encoding='utf-8') as file:
+            lines = file.readlines()
+
+        for line in lines:
+            self.runner.run(line.strip())

--- a/hathor/sysctl/runner.py
+++ b/hathor/sysctl/runner.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 import json
+import re
 from typing import TYPE_CHECKING, Any
 
 from hathor.sysctl.exception import SysctlRunnerException
 
 if TYPE_CHECKING:
     from hathor.sysctl.sysctl import Sysctl
+
+# - It starts with an opening square bracket [.
+# - It ends with a closing square bracket ].
+# - The elements are separated by commas and can be followed by optional whitespace.
+# - There can be zero or more elements in the array (an empty array is allowed).
+array_pattern = r'^\s*\[\s*(?:[^\[\],]+(?:\s*,\s*[^\[\],]+)*)?\s*\]\s*$'
 
 
 class SysctlRunner:
@@ -75,6 +82,10 @@ class SysctlRunner:
         """Deserialize a value sent by the client."""
         if len(value_str) == 0:
             return ()
+
+        if re.match(array_pattern, value_str):
+            return list(json.loads(value_str))
+
         parts = [x.strip() for x in value_str.split(',')]
         if len(parts) > 1:
             return tuple(json.loads(x) for x in parts)

--- a/hathor/sysctl/runner.py
+++ b/hathor/sysctl/runner.py
@@ -13,19 +13,12 @@
 # limitations under the License.
 
 import json
-import re
 from typing import TYPE_CHECKING, Any
 
 from hathor.sysctl.exception import SysctlRunnerException
 
 if TYPE_CHECKING:
     from hathor.sysctl.sysctl import Sysctl
-
-# - It starts with an opening square bracket [.
-# - It ends with a closing square bracket ].
-# - The elements are separated by commas and can be followed by optional whitespace.
-# - There can be zero or more elements in the array (an empty array is allowed).
-array_pattern = r'^\s*\[\s*(?:[^\[\],]+(?:\s*,\s*[^\[\],]+)*)?\s*\]\s*$'
 
 
 class SysctlRunner:
@@ -82,9 +75,6 @@ class SysctlRunner:
         """Deserialize a value sent by the client."""
         if len(value_str) == 0:
             return ()
-
-        if re.match(array_pattern, value_str):
-            return list(json.loads(value_str))
 
         parts = [x.strip() for x in value_str.split(',')]
         if len(parts) > 1:

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -161,7 +162,7 @@ class SysctlInitTest(unittest.TestCase):
             always_enabled_peers_file_path = str(Path(always_enabled_peers_file.name))
 
         file_content = [
-            f'p2p.always_enable_sync.readtxt="{always_enabled_peers_file_path}"'
+            f'p2p.always_enable_sync.readtxt={json.dumps(always_enabled_peers_file_path)}'
         ]
 
         # set the sysctl.txt file

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -1,0 +1,186 @@
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from hathor.builder.sysctl_builder import SysctlBuilder
+from hathor.cli.run_node import RunNode
+from hathor.sysctl.exception import SysctlRunnerException
+from hathor.sysctl.init_file_loader import SysctlInitFileLoader
+from hathor.sysctl.runner import SysctlRunner
+from tests import unittest
+
+
+class SysctlInitTest(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        super().tearDown()
+        # Removing tmpdir
+        shutil.rmtree(self.tmp_dir)
+
+    def test_sysctl_builder_fail_with_invalid_property(self):
+        file_content = [
+            'invalid.property=10',
+        ]
+
+        with tempfile.NamedTemporaryFile(
+                dir=self.tmp_dir,
+                suffix='.txt',
+                prefix='sysctl_',
+                delete=False) as sysctl_init_file:
+            sysctl_init_file.write('\n'.join(file_content).encode())
+            sysctl_init_file_path = str(Path(sysctl_init_file.name))
+
+        # prepare to register only p2p commands
+        artifacts = Mock(**{
+            'p2p_manager': Mock(),
+            'manager.metrics.websocket_factory.return_value': None
+        })
+
+        with self.assertRaises(SysctlRunnerException) as context:
+            root = SysctlBuilder(artifacts).build()
+            runner = SysctlRunner(root)
+            loader = SysctlInitFileLoader(runner, sysctl_init_file_path)
+            loader.load()
+
+        # assert message in the caught exception
+        expected_msg = 'path invalid.property not found'
+        self.assertEqual(str(context.exception), expected_msg)
+
+    def test_sysctl_builder_fail_with_invalid_value(self):
+        file_content = [
+            'p2p.rate_limit.global.send_tips=!!tuple [1,2]'
+        ]
+
+        with tempfile.NamedTemporaryFile(
+                dir=self.tmp_dir,
+                suffix='.txt',
+                prefix='sysctl_',
+                delete=False) as sysctl_init_file:
+            sysctl_init_file.write('\n'.join(file_content).encode())
+            sysctl_init_file_path = str(Path(sysctl_init_file.name))
+
+        # prepare to register only p2p commands
+        artifacts = Mock(**{
+            'p2p_manager': Mock(),
+            'manager.metrics.websocket_factory.return_value': None
+        })
+
+        with self.assertRaises(SysctlRunnerException) as context:
+            root = SysctlBuilder(artifacts).build()
+            runner = SysctlRunner(root)
+            loader = SysctlInitFileLoader(runner, sysctl_init_file_path)
+            loader.load()
+
+        # assert message in the caught exception
+        expected_msg = 'value: wrong format'
+        self.assertEqual(str(context.exception), expected_msg)
+
+    @patch('twisted.internet.endpoints.serverFromString')  # avoid open sock
+    def test_command_option_sysctl_init_file(self, mock_endpoint):
+        class CustomRunNode(RunNode):
+            def start_manager(self) -> None:
+                pass
+
+            def register_signal_handlers(self) -> None:
+                pass
+
+        expected_sysctl_dict = {
+            'p2p.max_enabled_sync': 7,
+            'p2p.rate_limit.global.send_tips': (5, 3),
+            'p2p.sync_update_interval': 17,
+            'p2p.always_enable_sync': ['peer-1', 'peer-2'],
+        }
+
+        file_content = [
+            'p2p.max_enabled_sync=7',
+            'p2p.rate_limit.global.send_tips=5,3',
+            'p2p.sync_update_interval=17',
+            'p2p.always_enable_sync=["peer-1","peer-2"]',
+        ]
+
+        with tempfile.NamedTemporaryFile(
+                dir=self.tmp_dir,
+                suffix='.txt',
+                prefix='sysctl_',
+                delete=False) as sysctl_init_file:
+            sysctl_init_file.write('\n'.join(file_content).encode())
+            sysctl_init_file_path = str(Path(sysctl_init_file.name))
+
+        run_node = CustomRunNode(argv=[
+            '--sysctl', 'tcp:8181',
+            '--sysctl-init-file', sysctl_init_file_path,  # relative to src/hathor
+            '--memory-storage',
+        ])
+        self.assertTrue(run_node is not None)
+        conn = run_node.manager.connections
+
+        curr_max_enabled_sync = conn.MAX_ENABLED_SYNC
+        self.assertEqual(
+                curr_max_enabled_sync,
+                expected_sysctl_dict['p2p.max_enabled_sync'])
+
+        curr_rate_limit_global_send_tips = conn.rate_limiter.get_limit(conn.GlobalRateLimiter.SEND_TIPS)
+        self.assertEqual(
+                curr_rate_limit_global_send_tips.max_hits,
+                expected_sysctl_dict['p2p.rate_limit.global.send_tips'][0])
+        self.assertEqual(
+                curr_rate_limit_global_send_tips.window_seconds,
+                expected_sysctl_dict['p2p.rate_limit.global.send_tips'][1])
+
+        curr_sync_update_interval = conn.lc_sync_update_interval
+        self.assertEqual(
+                curr_sync_update_interval,
+                expected_sysctl_dict['p2p.sync_update_interval'])
+
+        curr_always_enabled_sync = list(conn.always_enable_sync)
+        self.assertTrue(
+                set(curr_always_enabled_sync).issuperset(set(expected_sysctl_dict['p2p.always_enable_sync'])))
+
+        # assert always_enabled_sync when it is set with a file
+        expected_sysctl_dict = {
+            'p2p.always_enable_sync': ['peer-3', 'peer-4'],
+        }
+
+        file_content = [
+            'peer-3',
+            'peer-4',
+        ]
+
+        # set the always_enabled_sync peers file
+        with tempfile.NamedTemporaryFile(
+                dir=self.tmp_dir,
+                suffix='.txt',
+                prefix='always_enable_sync_',
+                delete=False) as always_enabled_peers_file:
+            always_enabled_peers_file.write('\n'.join(file_content).encode())
+            always_enabled_peers_file_path = str(Path(always_enabled_peers_file.name))
+
+        file_content = [
+            f'p2p.always_enable_sync.readtxt="{always_enabled_peers_file_path}"'
+        ]
+
+        # set the sysctl.txt file
+        with tempfile.NamedTemporaryFile(
+                dir=self.tmp_dir,
+                suffix='.txt',
+                prefix='sysctl_',
+                delete=False) as sysctl_init_file:
+            sysctl_init_file.write('\n'.join(file_content).encode())
+            sysctl_init_file_path = str(Path(sysctl_init_file.name))
+
+        run_node = CustomRunNode(argv=[
+            '--sysctl', 'tcp:8181',
+            '--sysctl-init-file', sysctl_init_file_path,  # relative to src/hathor
+            '--memory-storage',
+        ])
+        self.assertTrue(run_node is not None)
+        conn = run_node.manager.connections
+
+        curr_always_enabled_sync = list(conn.always_enable_sync)
+        self.assertTrue(
+                set(curr_always_enabled_sync).issuperset(set(expected_sysctl_dict['p2p.always_enable_sync'])))

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -113,14 +113,12 @@ class SysctlInitTest(unittest.TestCase):
             'p2p.max_enabled_sync': 7,
             'p2p.rate_limit.global.send_tips': (5, 3),
             'p2p.sync_update_interval': 17,
-            'p2p.always_enable_sync': ['peer-1', 'peer-2'],
         }
 
         file_content = [
             'p2p.max_enabled_sync=7',
             'p2p.rate_limit.global.send_tips=5,3',
             'p2p.sync_update_interval=17',
-            'p2p.always_enable_sync=["peer-1","peer-2"]',
         ]
 
         with tempfile.NamedTemporaryFile(
@@ -156,10 +154,6 @@ class SysctlInitTest(unittest.TestCase):
         self.assertEqual(
                 curr_sync_update_interval,
                 expected_sysctl_dict['p2p.sync_update_interval'])
-
-        curr_always_enabled_sync = list(conn.always_enable_sync)
-        self.assertTrue(
-                set(curr_always_enabled_sync).issuperset(set(expected_sysctl_dict['p2p.always_enable_sync'])))
 
         # assert always_enabled_sync when it is set with a file
         expected_sysctl_dict = {

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 from hathor.builder.sysctl_builder import SysctlBuilder
 from hathor.cli.run_node import RunNode
-from hathor.sysctl.exception import SysctlRunnerException
+from hathor.sysctl.exception import SysctlEntryNotFound, SysctlRunnerException
 from hathor.sysctl.init_file_loader import SysctlInitFileLoader
 from hathor.sysctl.runner import SysctlRunner
 from tests import unittest
@@ -41,14 +41,14 @@ class SysctlInitTest(unittest.TestCase):
             'manager.metrics.websocket_factory.return_value': None
         })
 
-        with self.assertRaises(SysctlRunnerException) as context:
+        with self.assertRaises(SysctlEntryNotFound) as context:
             root = SysctlBuilder(artifacts).build()
             runner = SysctlRunner(root)
             loader = SysctlInitFileLoader(runner, sysctl_init_file_path)
             loader.load()
 
         # assert message in the caught exception
-        expected_msg = 'path invalid.property not found'
+        expected_msg = 'invalid.property'
         self.assertEqual(str(context.exception), expected_msg)
 
     def test_sysctl_builder_fail_with_invalid_value(self):

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -81,6 +81,25 @@ class SysctlInitTest(unittest.TestCase):
         expected_msg = 'value: wrong format'
         self.assertEqual(str(context.exception), expected_msg)
 
+    def test_syctl_init_file_fail_with_empty_or_invalid_file(self):
+        # prepare to register only p2p commands
+        artifacts = Mock(**{
+            'p2p_manager': Mock(),
+            'manager.metrics.websocket_factory.return_value': None
+        })
+
+        with self.assertRaises(AssertionError):
+            root = SysctlBuilder(artifacts).build()
+            runner = SysctlRunner(root)
+            loader = SysctlInitFileLoader(runner, None)
+            loader.load()
+
+        with self.assertRaises(AssertionError):
+            root = SysctlBuilder(artifacts).build()
+            runner = SysctlRunner(root)
+            loader = SysctlInitFileLoader(runner, "")
+            loader.load()
+
     @patch('twisted.internet.endpoints.serverFromString')  # avoid open sock
     def test_command_option_sysctl_init_file(self, mock_endpoint):
         class CustomRunNode(RunNode):

--- a/tests/sysctl/test_sysctl.py
+++ b/tests/sysctl/test_sysctl.py
@@ -177,7 +177,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_get_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown')
-        self.assertEqual(b'[error] unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
 
     def test_proto_get_readonly(self) -> None:
         self.proto.lineReceived(b'net.readonly')
@@ -209,7 +209,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_set_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown=0.50')
-        self.assertEqual(b'[error] unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
 
     def test_proto_set_tuple(self) -> None:
         self.proto.lineReceived(b'net.rate_limit=8, 2')

--- a/tests/sysctl/test_sysctl.py
+++ b/tests/sysctl/test_sysctl.py
@@ -177,7 +177,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_get_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown')
-        self.assertEqual(b'[error] path net.unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
 
     def test_proto_get_readonly(self) -> None:
         self.proto.lineReceived(b'net.readonly')
@@ -185,7 +185,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_get_writeonly(self) -> None:
         self.proto.lineReceived(b'core.writeonly')
-        self.assertEqual(b'[error] cannot read from the path core.writeonly\n', self.tr.value())
+        self.assertEqual(b'[error] cannot read from core.writeonly\n', self.tr.value())
 
     ##################
     # Protocol: Set
@@ -205,11 +205,11 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_set_readonly(self) -> None:
         self.proto.lineReceived(b'net.readonly=0.50')
-        self.assertEqual(b'[error] cannot write to the path net.readonly\n', self.tr.value())
+        self.assertEqual(b'[error] cannot write to net.readonly\n', self.tr.value())
 
     def test_proto_set_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown=0.50')
-        self.assertEqual(b'[error] path net.unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
 
     def test_proto_set_tuple(self) -> None:
         self.proto.lineReceived(b'net.rate_limit=8, 2')

--- a/tests/sysctl/test_sysctl.py
+++ b/tests/sysctl/test_sysctl.py
@@ -177,7 +177,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_get_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown')
-        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] unknown not found\n', self.tr.value())
 
     def test_proto_get_readonly(self) -> None:
         self.proto.lineReceived(b'net.readonly')
@@ -209,7 +209,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_set_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown=0.50')
-        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] unknown not found\n', self.tr.value())
 
     def test_proto_set_tuple(self) -> None:
         self.proto.lineReceived(b'net.rate_limit=8, 2')

--- a/tests/sysctl/test_sysctl.py
+++ b/tests/sysctl/test_sysctl.py
@@ -177,7 +177,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_get_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown')
-        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] path net.unknown not found\n', self.tr.value())
 
     def test_proto_get_readonly(self) -> None:
         self.proto.lineReceived(b'net.readonly')
@@ -185,7 +185,7 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_get_writeonly(self) -> None:
         self.proto.lineReceived(b'core.writeonly')
-        self.assertEqual(b'[error] cannot read from core.writeonly\n', self.tr.value())
+        self.assertEqual(b'[error] cannot read from the path core.writeonly\n', self.tr.value())
 
     ##################
     # Protocol: Set
@@ -205,11 +205,11 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_set_readonly(self) -> None:
         self.proto.lineReceived(b'net.readonly=0.50')
-        self.assertEqual(b'[error] cannot write to net.readonly\n', self.tr.value())
+        self.assertEqual(b'[error] cannot write to the path net.readonly\n', self.tr.value())
 
     def test_proto_set_unknown(self) -> None:
         self.proto.lineReceived(b'net.unknown=0.50')
-        self.assertEqual(b'[error] net.unknown not found\n', self.tr.value())
+        self.assertEqual(b'[error] path net.unknown not found\n', self.tr.value())
 
     def test_proto_set_tuple(self) -> None:
         self.proto.lineReceived(b'net.rate_limit=8, 2')


### PR DESCRIPTION
### Acceptance criteria
- Add `--sysctl-init-file` CLI command option that should use the sysctl subsystem to configure the node.
- The configuration file is a txt file with a simple key value pair scheme.

Closes:
- https://github.com/HathorNetwork/hathor-core/issues/684
- https://github.com/HathorNetwork/hathor-core/issues/685
