### PR TITLE
refactor(p2p): rename sync *manager* to sync *agent*

### DIFF
--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -29,7 +29,7 @@ from hathor.p2p.peer_storage import PeerStorage
 from hathor.p2p.protocol import HathorProtocol
 from hathor.p2p.rate_limiter import RateLimiter
 from hathor.p2p.states.ready import ReadyState
-from hathor.p2p.sync_factory import SyncManagerFactory
+from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_version import SyncVersion
 from hathor.p2p.utils import description_to_connection_string, parse_whitelist
 from hathor.pubsub import HathorEvents, PubSubManager
@@ -83,7 +83,7 @@ class ConnectionsManager:
     connecting_peers: dict[IStreamClientEndpoint, _ConnectingPeer]
     handshaking_peers: set[HathorProtocol]
     whitelist_only: bool
-    _sync_factories: dict[SyncVersion, SyncManagerFactory]
+    _sync_factories: dict[SyncVersion, SyncAgentFactory]
 
     rate_limiter: RateLimiter
 
@@ -258,7 +258,7 @@ class ConnectionsManager:
             # XXX: this is to make it easy to simulate old behavior if we disable the sync-version capability
             return {SyncVersion.V1}
 
-    def get_sync_factory(self, sync_version: SyncVersion) -> SyncManagerFactory:
+    def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:
         """Get the sync factory for a given version, support MUST be checked beforehand or it will raise an assert."""
         assert sync_version in self._sync_factories, 'get_sync_factory must be called for a supported version'
         return self._sync_factories[sync_version]

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -363,21 +363,21 @@ class HathorProtocol:
         if not self.is_state(self.PeerState.READY):
             return False
         assert isinstance(self.state, ReadyState)
-        return self.state.sync_manager.is_sync_enabled()
+        return self.state.sync_agent.is_sync_enabled()
 
     def enable_sync(self) -> None:
         """Enable sync for this connection."""
         assert self.is_state(self.PeerState.READY)
         assert isinstance(self.state, ReadyState)
         self.log.info('enable sync')
-        self.state.sync_manager.enable_sync()
+        self.state.sync_agent.enable_sync()
 
     def disable_sync(self) -> None:
         """Disable sync for this connection."""
         assert self.is_state(self.PeerState.READY)
         assert isinstance(self.state, ReadyState)
         self.log.info('disable sync')
-        self.state.sync_manager.disable_sync()
+        self.state.sync_agent.disable_sync()
 
 
 class HathorLineReceiver(LineReceiver, HathorProtocol):

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -58,7 +58,7 @@ class StatusResource(Resource):
         for conn in self.manager.connections.iter_ready_connections():
             remote = conn.transport.getPeer()
             status = {}
-            status[conn.state.sync_manager.name] = conn.state.sync_manager.get_status()
+            status[conn.state.sync_agent.name] = conn.state.sync_agent.get_status()
             connected_peers.append({
                 'id': conn.peer.id,
                 'app_version': conn.app_version,

--- a/hathor/p2p/sync_agent.py
+++ b/hathor/p2p/sync_agent.py
@@ -19,7 +19,7 @@ from hathor.p2p.messages import ProtocolMessages
 from hathor.transaction import BaseTransaction
 
 
-class SyncManager(ABC):
+class SyncAgent(ABC):
     @abstractmethod
     def is_started(self) -> bool:
         """Whether the manager started running"""

--- a/hathor/p2p/sync_factory.py
+++ b/hathor/p2p/sync_factory.py
@@ -15,14 +15,14 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
-from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_agent import SyncAgent
 from hathor.util import Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
-class SyncManagerFactory(ABC):
+class SyncAgentFactory(ABC):
     @abstractmethod
-    def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
         pass

--- a/hathor/p2p/sync_v1/agent.py
+++ b/hathor/p2p/sync_v1/agent.py
@@ -26,7 +26,7 @@ from zope.interface import implementer
 
 from hathor.conf import HathorSettings
 from hathor.p2p.messages import GetNextPayload, GetTipsPayload, NextPayload, ProtocolMessages, TipsPayload
-from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.transaction import BaseTransaction
 from hathor.transaction.base_transaction import tx_or_block_from_bytes
@@ -172,7 +172,7 @@ class SendDataPush:
         self.priority_queue.clear()
 
 
-class NodeSyncTimestamp(SyncManager):
+class NodeSyncTimestamp(SyncAgent):
     """ An algorithm to sync the DAG between two peers using the timestamp of the transactions.
 
     This algorithm must assume that a new item may arrive while it is running. The item's timestamp

--- a/hathor/p2p/sync_v1/factory_v1_0.py
+++ b/hathor/p2p/sync_v1/factory_v1_0.py
@@ -15,8 +15,8 @@
 from typing import TYPE_CHECKING, Optional
 
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.sync_factory import SyncManagerFactory
-from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_agent import SyncAgent
+from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.util import Reactor
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
-class SyncV10Factory(SyncManagerFactory):
+class SyncV10Factory(SyncAgentFactory):
     def __init__(self, connections: ConnectionsManager):
         self.connections = connections
         self._downloader: Optional[Downloader] = None
@@ -36,5 +36,5 @@ class SyncV10Factory(SyncManagerFactory):
             self._downloader = Downloader(self.connections.manager)
         return self._downloader
 
-    def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
         return NodeSyncTimestamp(protocol, downloader=self.get_downloader(), reactor=reactor)

--- a/hathor/p2p/sync_v1/factory_v1_1.py
+++ b/hathor/p2p/sync_v1/factory_v1_1.py
@@ -15,8 +15,8 @@
 from typing import TYPE_CHECKING, Optional
 
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.sync_factory import SyncManagerFactory
-from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_agent import SyncAgent
+from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 from hathor.p2p.sync_v1.downloader import Downloader
 from hathor.util import Reactor
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
-class SyncV11Factory(SyncManagerFactory):
+class SyncV11Factory(SyncAgentFactory):
     def __init__(self, connections: ConnectionsManager):
         self.connections = connections
         self._downloader: Optional[Downloader] = None
@@ -36,5 +36,5 @@ class SyncV11Factory(SyncManagerFactory):
             self._downloader = Downloader(self.connections.manager)
         return self._downloader
 
-    def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
         return NodeSyncTimestamp(protocol, downloader=self.get_downloader(), reactor=reactor)

--- a/hathor/p2p/sync_v2/factory.py
+++ b/hathor/p2p/sync_v2/factory.py
@@ -15,8 +15,8 @@
 from typing import TYPE_CHECKING, Optional
 
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.sync_factory import SyncManagerFactory
-from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_agent import SyncAgent
+from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_v2.manager import NodeBlockSync
 from hathor.util import Reactor
 
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
-class SyncV2Factory(SyncManagerFactory):
+class SyncV2Factory(SyncAgentFactory):
     def __init__(self, connections: ConnectionsManager):
         self.connections = connections
 
-    def create_sync_manager(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncManager:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
         return NodeBlockSync(protocol, reactor=reactor)

--- a/hathor/p2p/sync_v2/manager.py
+++ b/hathor/p2p/sync_v2/manager.py
@@ -26,7 +26,7 @@ from twisted.internet.task import LoopingCall
 
 from hathor.conf import HathorSettings
 from hathor.p2p.messages import ProtocolMessages
-from hathor.p2p.sync_manager import SyncManager
+from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.sync_v2.mempool import SyncMempoolManager
 from hathor.p2p.sync_v2.streamers import DEFAULT_STREAMING_LIMIT, BlockchainStreaming, StreamEnd, TransactionsStreaming
 from hathor.transaction import BaseTransaction, Block, Transaction
@@ -53,7 +53,7 @@ class PeerState(Enum):
     SYNCING_MEMPOOL = 'syncing-mempool'
 
 
-class NodeBlockSync(SyncManager):
+class NodeBlockSync(SyncAgent):
     """ An algorithm to sync two peers based on their blockchain.
     """
     name: str = 'node-block-sync'

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -91,13 +91,13 @@ class FakeConnection:
             return False
         assert isinstance(state1, ReadyState)  # mypy can't infer this from the above
         assert isinstance(state2, ReadyState)  # mypy can't infer this from the above
-        state1_is_errored = state1.sync_manager.is_errored()
-        state2_is_errored = state2.sync_manager.is_errored()
+        state1_is_errored = state1.sync_agent.is_errored()
+        state2_is_errored = state2.sync_agent.is_errored()
         if state1_is_errored or state2_is_errored:
             self.log.debug('peer errored', peer1_errored=state1_is_errored, peer2_errored=state2_is_errored)
             return False
-        state1_is_synced = state1.sync_manager.is_synced()
-        state2_is_synced = state2.sync_manager.is_synced()
+        state1_is_synced = state1.sync_agent.is_synced()
+        state2_is_synced = state2.sync_agent.is_synced()
         if not state1_is_synced or not state2_is_synced:
             self.log.debug('peer not synced', peer1_synced=state1_is_synced, peer2_synced=state2_is_synced)
             return False
@@ -120,13 +120,13 @@ class FakeConnection:
             return True
         assert isinstance(state1, ReadyState)  # mypy can't infer this from the above
         assert isinstance(state2, ReadyState)  # mypy can't infer this from the above
-        state1_is_errored = state1.sync_manager.is_errored()
-        state2_is_errored = state2.sync_manager.is_errored()
+        state1_is_errored = state1.sync_agent.is_errored()
+        state2_is_errored = state2.sync_agent.is_errored()
         if state1_is_errored or state2_is_errored:
             self.log.debug('peer errored', peer1_errored=state1_is_errored, peer2_errored=state2_is_errored)
             return False
-        state1_is_synced = state1.sync_manager.is_synced()
-        state2_is_synced = state2.sync_manager.is_synced()
+        state1_is_synced = state1.sync_agent.is_synced()
+        state2_is_synced = state2.sync_agent.is_synced()
         if not state1_is_synced or not state2_is_synced:
             self.log.debug('peer not synced', peer1_synced=state1_is_synced, peer2_synced=state2_is_synced)
             return True

--- a/tests/p2p/test_capabilities.py
+++ b/tests/p2p/test_capabilities.py
@@ -23,8 +23,8 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
         # Even if we don't have the capability we must connect because the whitelist url conf is None
         self.assertEqual(conn._proto1.state.state_name, 'READY')
         self.assertEqual(conn._proto2.state.state_name, 'READY')
-        self.assertIsInstance(conn._proto1.state.sync_manager, NodeSyncTimestamp)
-        self.assertIsInstance(conn._proto2.state.sync_manager, NodeSyncTimestamp)
+        self.assertIsInstance(conn._proto1.state.sync_agent, NodeSyncTimestamp)
+        self.assertIsInstance(conn._proto2.state.sync_agent, NodeSyncTimestamp)
 
         manager3 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST])
         manager4 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST])
@@ -38,8 +38,8 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
 
         self.assertEqual(conn2._proto1.state.state_name, 'READY')
         self.assertEqual(conn2._proto2.state.state_name, 'READY')
-        self.assertIsInstance(conn2._proto1.state.sync_manager, NodeSyncTimestamp)
-        self.assertIsInstance(conn2._proto2.state.sync_manager, NodeSyncTimestamp)
+        self.assertIsInstance(conn2._proto1.state.sync_agent, NodeSyncTimestamp)
+        self.assertIsInstance(conn2._proto2.state.sync_agent, NodeSyncTimestamp)
 
 
 class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase):
@@ -59,8 +59,8 @@ class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase)
         # Even if we don't have the capability we must connect because the whitelist url conf is None
         self.assertEqual(conn._proto1.state.state_name, 'READY')
         self.assertEqual(conn._proto2.state.state_name, 'READY')
-        self.assertIsInstance(conn._proto1.state.sync_manager, NodeBlockSync)
-        self.assertIsInstance(conn._proto2.state.sync_manager, NodeBlockSync)
+        self.assertIsInstance(conn._proto1.state.sync_agent, NodeBlockSync)
+        self.assertIsInstance(conn._proto2.state.sync_agent, NodeBlockSync)
 
         manager3 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST,
                                                            settings.CAPABILITY_SYNC_VERSION])
@@ -76,8 +76,8 @@ class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase)
 
         self.assertEqual(conn2._proto1.state.state_name, 'READY')
         self.assertEqual(conn2._proto2.state.state_name, 'READY')
-        self.assertIsInstance(conn2._proto1.state.sync_manager, NodeBlockSync)
-        self.assertIsInstance(conn2._proto2.state.sync_manager, NodeBlockSync)
+        self.assertIsInstance(conn2._proto1.state.sync_agent, NodeBlockSync)
+        self.assertIsInstance(conn2._proto2.state.sync_agent, NodeBlockSync)
 
 
 # sync-bridge should behave like sync-v2

--- a/tests/p2p/test_split_brain.py
+++ b/tests/p2p/test_split_brain.py
@@ -92,7 +92,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
             dot2 = GraphvizVisualizer(manager2.tx_storage, include_verifications=True).dot()
             dot2.render('dot2-post')
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertSyncedProgress(node_sync)
         self.assertTipsEqual(manager1, manager2)
         self.assertConsensusEqual(manager1, manager2)

--- a/tests/p2p/test_split_brain2.py
+++ b/tests/p2p/test_split_brain2.py
@@ -67,8 +67,8 @@ class BaseHathorSyncMethodsTestCase(SimulatorTestCase):
             dot2 = GraphvizVisualizer(manager2.tx_storage, include_verifications=True).dot()
             dot2.render('dot2-post')
 
-        self.assertSyncedProgress(conn12.proto1.state.sync_manager)
-        self.assertSyncedProgress(conn12.proto2.state.sync_manager)
+        self.assertSyncedProgress(conn12.proto1.state.sync_agent)
+        self.assertSyncedProgress(conn12.proto2.state.sync_agent)
         self.assertTipsEqual(manager1, manager2)
         self.assertConsensusEqual(manager1, manager2)
         self.assertConsensusValid(manager1)

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -101,7 +101,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         conn.run_one_step()  # PEER-ID
         conn.run_one_step()  # READY
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
         self.assertTipsEqual(self.manager1, manager2)
 
@@ -119,7 +119,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
             conn.run_one_step(debug=True)
             self.clock.advance(0.1)
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
         self.assertTipsEqual(self.manager1, manager2)
         self.assertConsensusEqual(self.manager1, manager2)
@@ -139,7 +139,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
             conn.run_one_step(debug=True)
             self.clock.advance(0.1)
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
         self.assertTipsEqual(self.manager1, manager2)
         self.assertConsensusEqual(self.manager1, manager2)
@@ -167,7 +167,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # dot2 = manager2.tx_storage.graphviz(format='pdf')
         # dot2.render('dot2')
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(self.manager1.tx_storage.latest_timestamp, manager2.tx_storage.latest_timestamp)
         self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
         self.assertTipsEqual(self.manager1, manager2)
@@ -501,8 +501,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             self.clock.advance(1)
 
         # check they have the same consensus
-        node_sync1 = conn.proto1.state.sync_manager
-        node_sync2 = conn.proto2.state.sync_manager
+        node_sync1 = conn.proto1.state.sync_agent
+        node_sync2 = conn.proto2.state.sync_agent
         self.assertEqual(node_sync1.peer_height, height)
         self.assertEqual(node_sync1.synced_height, height)
         self.assertEqual(node_sync2.peer_height, height)
@@ -525,13 +525,13 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
     def test_tx_propagation_nat_peers(self):
         super().test_tx_propagation_nat_peers()
 
-        node_sync1 = self.conn1.proto1.state.sync_manager
+        node_sync1 = self.conn1.proto1.state.sync_agent
         self.assertEqual(self.manager1.tx_storage.latest_timestamp, self.manager2.tx_storage.latest_timestamp)
         self.assertEqual(node_sync1.peer_height, node_sync1.synced_height)
         self.assertEqual(node_sync1.peer_height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, self.manager2)
 
-        node_sync2 = self.conn2.proto1.state.sync_manager
+        node_sync2 = self.conn2.proto1.state.sync_agent
         self.assertEqual(self.manager2.tx_storage.latest_timestamp, self.manager3.tx_storage.latest_timestamp)
         self.assertEqual(node_sync2.peer_height, node_sync2.synced_height)
         self.assertEqual(node_sync2.peer_height, self.manager2.tx_storage.get_height_best_block())
@@ -558,7 +558,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         # dot2 = manager2.tx_storage.graphviz(format='pdf')
         # dot2.render('dot2')
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(self.manager1.tx_storage.latest_timestamp, manager2.tx_storage.latest_timestamp)
         self.assertEqual(node_sync.peer_height, node_sync.synced_height)
         self.assertEqual(node_sync.peer_height, self.manager1.tx_storage.get_height_best_block())
@@ -580,7 +580,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             conn.run_one_step(debug=True)
             self.clock.advance(1)
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(node_sync.peer_height, node_sync.synced_height)
         self.assertEqual(node_sync.peer_height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, manager2)
@@ -601,7 +601,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             conn.run_one_step(debug=True)
             self.clock.advance(1)
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(node_sync.peer_height, node_sync.synced_height)
         self.assertEqual(node_sync.peer_height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, manager2)
@@ -654,7 +654,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             self.clock.advance(0.1)
         conn.run_until_empty(1000)
 
-        # node_sync = conn.proto1.state.sync_manager
+        # node_sync = conn.proto1.state.sync_agent
         # self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
         # self.assertTipsEqual(self.manager1, manager2)
         common_height = 25 + len_reward_unlock
@@ -662,8 +662,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertEqual(self.manager1.tx_storage.get_height_best_block(), common_height)
         self.assertEqual(manager2.tx_storage.get_height_best_block(), common_height)
 
-        node_sync1 = conn.proto1.state.sync_manager
-        node_sync2 = conn.proto2.state.sync_manager
+        node_sync1 = conn.proto1.state.sync_agent
+        node_sync2 = conn.proto2.state.sync_agent
         self.assertEqual(node_sync1.peer_height, common_height)
         self.assertEqual(node_sync1.synced_height, common_height)
         self.assertEqual(node_sync2.peer_height, common_height)
@@ -712,8 +712,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertEqual(self.manager1.tx_storage.get_best_block().get_metadata().height, TOTAL_BLOCKS)
         self.assertEqual(manager2.tx_storage.get_best_block().get_metadata().height, TOTAL_BLOCKS)
 
-        node_sync1 = conn.proto1.state.sync_manager
-        node_sync2 = conn.proto2.state.sync_manager
+        node_sync1 = conn.proto1.state.sync_agent
+        node_sync2 = conn.proto2.state.sync_agent
 
         self.assertEqual(node_sync1.peer_height, TOTAL_BLOCKS)
         self.assertEqual(node_sync1.synced_height, TOTAL_BLOCKS)
@@ -737,7 +737,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             conn.run_one_step(debug=True)
             self.clock.advance(1)
 
-        node_sync = conn.proto1.state.sync_manager
+        node_sync = conn.proto1.state.sync_agent
         self.assertEqual(node_sync.synced_height, 0)
         self.assertEqual(node_sync.peer_height, 0)
 

--- a/tests/p2p/test_sync_rate_limiter.py
+++ b/tests/p2p/test_sync_rate_limiter.py
@@ -30,7 +30,7 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, SimulatorTestCase):
         connected_peers2 = list(manager2.connections.connected_peers.values())
         self.assertEqual(1, len(connected_peers2))
         protocol1 = connected_peers2[0]
-        sync2 = protocol1.state.sync_manager
+        sync2 = protocol1.state.sync_agent
         sync2._send_tips = MagicMock()
 
         for i in range(100):
@@ -62,7 +62,7 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, SimulatorTestCase):
         self.assertEqual(1, len(connected_peers2))
 
         protocol1 = connected_peers2[0]
-        sync1 = protocol1.state.sync_manager
+        sync1 = protocol1.state.sync_agent
         sync1._send_tips = Mock(wraps=sync1._send_tips)
 
         sync1.send_tips()
@@ -109,7 +109,7 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, SimulatorTestCase):
         self.assertEqual(1, len(connected_peers2))
 
         protocol1 = connected_peers2[0]
-        sync1 = protocol1.state.sync_manager
+        sync1 = protocol1.state.sync_agent
 
         sync1.send_tips()
         self.assertEqual(len(sync1._send_tips_call_later), 0)
@@ -147,7 +147,7 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, SimulatorTestCase):
         self.assertEqual(1, len(connected_peers2))
 
         protocol1 = connected_peers2[0]
-        sync1 = protocol1.state.sync_manager
+        sync1 = protocol1.state.sync_agent
 
         sync1.send_tips()
         self.assertEqual(len(sync1._send_tips_call_later), 0)

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -116,7 +116,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         self.simulator.run(60)
 
         # Run until it's synced (time out of 1h)
-        sync3 = conn13.proto2.state.sync_manager
+        sync3 = conn13.proto2.state.sync_agent
         self.simulator.run(600)
         sync3._breakpoint = True
 
@@ -221,14 +221,14 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         self.simulator.run(1)
 
         # Change manager1 default streaming and mempool limits.
-        sync1 = conn12.proto1.state.sync_manager
+        sync1 = conn12.proto1.state.sync_agent
         sync1.DEFAULT_STREAMING_LIMIT = 30
         sync1.mempool_manager.MAX_STACK_LENGTH = 30
         self.assertIsNone(sync1.blockchain_streaming)
         self.assertIsNone(sync1.transactions_streaming)
 
         # Change manager2 default streaming and mempool limits.
-        sync2 = conn12.proto2.state.sync_manager
+        sync2 = conn12.proto2.state.sync_agent
         sync2.DEFAULT_STREAMING_LIMIT = 50
         sync2.mempool_manager.MAX_STACK_LENGTH = 50
         self.assertIsNone(sync2.blockchain_streaming)


### PR DESCRIPTION
### Motivation

We've been using the term "manager" for the class that deals with the sync from the point of view of an individual connection but we've already agreed to changing it to "agent" instead. This PR finishes the transition to this term.

### Acceptance Criteria

- Use `sync_agent`/`SyncAgent*` instead of `sync_manager`/`SyncManager*` everywhere throughout the code.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 