### PR TITLE
fix(test): regression after sync-v2 command was removed

### DIFF
--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -429,8 +429,8 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
         self.assertAndStepConn(self.conn, b'^RELAY')
         self.assertIsConnected()
         missing_tx = '00000000228dfcd5dec1c9c6263f6430a5b4316bb9e3decb9441a6414bfd8697'
-        payload = {'child': missing_tx, 'last_block': settings.GENESIS_BLOCK_HASH.hex()}
-        yield self._send_cmd(self.conn.proto1, 'GET-BLOCK-TXS', json_dumps(payload))
+        payload = {'until_first_block': missing_tx, 'start_from': [settings.GENESIS_BLOCK_HASH.hex()]}
+        yield self._send_cmd(self.conn.proto1, 'GET-TRANSACTIONS-BFS', json_dumps(payload))
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'NOT-FOUND')
         self.conn.run_one_step()
 


### PR DESCRIPTION
### Motivation

The CI broke because a test was not passing after sync-v2 was merged.

### Acceptance Criteria

- The `GET-BLOCK-TXS` command was removed, adapt test to use `GET-TRANSACTIONS-BFS` instead

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 