### PR TITLE
feat(indexes): add get_n_height_tips method to height index

### DIFF
--- a/hathor/indexes/height_index.py
+++ b/hathor/indexes/height_index.py
@@ -19,6 +19,7 @@ from hathor.indexes.base_index import BaseIndex
 from hathor.indexes.scope import Scope
 from hathor.transaction import BaseTransaction, Block
 from hathor.transaction.genesis import BLOCK_GENESIS
+from hathor.types import VertexId
 from hathor.util import not_none
 
 SCOPE = Scope(
@@ -32,6 +33,12 @@ class IndexEntry(NamedTuple):
     """Helper named tuple that implementations can use."""
     hash: bytes
     timestamp: int
+
+
+class HeightInfo(NamedTuple):
+    """Used by a few methods to represent a (height, hash) tuple."""
+    height: int
+    id: VertexId
 
 
 BLOCK_GENESIS_ENTRY: IndexEntry = IndexEntry(not_none(BLOCK_GENESIS.hash), BLOCK_GENESIS.timestamp)
@@ -84,8 +91,16 @@ class HeightIndex(BaseIndex):
         raise NotImplementedError
 
     @abstractmethod
-    def get_height_tip(self) -> tuple[int, bytes]:
+    def get_height_tip(self) -> HeightInfo:
         """ Return the best block height and hash, it returns the genesis when there is no other block
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_n_height_tips(self, n_blocks: int) -> list[HeightInfo]:
+        """ Return the n best block height and hash list, it returns the genesis when there is no other block
+
+        The returned list starts at the highest block and goes down in reverse height order.
         """
         raise NotImplementedError
 

--- a/hathor/indexes/memory_height_index.py
+++ b/hathor/indexes/memory_height_index.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from hathor.indexes.height_index import BLOCK_GENESIS_ENTRY, HeightIndex, IndexEntry
+from hathor.indexes.height_index import BLOCK_GENESIS_ENTRY, HeightIndex, HeightInfo, IndexEntry
 
 
 class MemoryHeightIndex(HeightIndex):
@@ -68,6 +68,15 @@ class MemoryHeightIndex(HeightIndex):
     def get_tip(self) -> bytes:
         return self._index[-1].hash
 
-    def get_height_tip(self) -> tuple[int, bytes]:
+    def get_height_tip(self) -> HeightInfo:
         height = len(self._index) - 1
-        return height, self._index[height].hash
+        return HeightInfo(height, self._index[height].hash)
+
+    def get_n_height_tips(self, n_blocks: int) -> list[HeightInfo]:
+        if n_blocks < 1:
+            raise ValueError('n_blocks must be a positive, non-zero, integer')
+        # highest height that is included, will be the first element
+        h_high = len(self._index) - 1
+        # lowest height that is not included, -1 if it reaches the genesis
+        h_low = max(h_high - n_blocks, -1)
+        return [HeightInfo(h, self._index[h].hash) for h in range(h_high, h_low, -1)]

--- a/hathor/indexes/rocksdb_height_index.py
+++ b/hathor/indexes/rocksdb_height_index.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from structlog import get_logger
 
 from hathor.conf import HathorSettings
-from hathor.indexes.height_index import BLOCK_GENESIS_ENTRY, HeightIndex, IndexEntry
+from hathor.indexes.height_index import BLOCK_GENESIS_ENTRY, HeightIndex, HeightInfo, IndexEntry
 from hathor.indexes.rocksdb_utils import RocksDBIndexUtils
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -141,11 +141,28 @@ class RocksDBHeightIndex(HeightIndex, RocksDBIndexUtils):
         assert value is not None  # must never be empty, at least genesis has been added
         return self._from_value(value).hash
 
-    def get_height_tip(self) -> tuple[int, bytes]:
+    def get_height_tip(self) -> HeightInfo:
         it = self._db.iteritems(self._cf)
         it.seek_to_last()
         (_, key), value = it.get()
         assert key is not None and value is not None  # must never be empty, at least genesis has been added
         height = self._from_key(key)
         entry = self._from_value(value)
-        return height, entry.hash
+        return HeightInfo(height, entry.hash)
+
+    def get_n_height_tips(self, n_blocks: int) -> list[HeightInfo]:
+        if n_blocks < 1:
+            raise ValueError('n_blocks must be a positive, non-zero, integer')
+        info_list: list[HeightInfo] = []
+        # we need to iterate in reverse order
+        it: Any = reversed(self._db.iteritems(self._cf))  # XXX: mypy doesn't know what reversed does to this iterator
+        it.seek_to_last()
+        for (_, key), value in it:
+            # stop when we have enough elements, otherwise the iterator will stop naturally when it reaches the genesis
+            if len(info_list) == n_blocks:
+                break
+            assert key is not None and value is not None  # must never be empty, at least genesis has been added
+            height = self._from_key(key)
+            entry = self._from_value(value)
+            info_list.append(HeightInfo(height, entry.hash))
+        return info_list


### PR DESCRIPTION
### Motivation

PR #686 needs this method

### Acceptance Criteria

- Add new method to the height index that allows getting a list of blocks starting from the tip

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 