### PR TITLE
feat(p2p): add setting to enable/disable peer whitelist for sync-v2

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -46,6 +46,10 @@ class HathorSettings(NamedTuple):
     # enable peer whitelist
     ENABLE_PEER_WHITELIST: bool = False
 
+    # weather to use the whitelist with sync-v2 peers, does not affect whether the whitelist is enabled or not, it will
+    # always be enabled for sync-v1 if it is enabled
+    USE_PEER_WHITELIST_ON_SYNC_V2: bool = True
+
     DECIMAL_PLACES: int = DECIMAL_PLACES
 
     # Genesis pre-mined tokens

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -156,8 +156,11 @@ class PeerIdState(BaseState):
         # when ENABLE_PEER_WHITELIST is set, we check if we're on sync-v1 to block non-whitelisted peers
         if settings.ENABLE_PEER_WHITELIST:
             assert self.protocol.sync_version is not None
-            if self.protocol.sync_version.is_v1() and not peer_is_whitelisted:
-                return True
+            if not peer_is_whitelisted:
+                if self.protocol.sync_version.is_v1():
+                    return True
+                elif settings.USE_PEER_WHITELIST_ON_SYNC_V2:
+                    return True
 
         # otherwise we block non-whitelisted peers when on "whitelist-only mode"
         if self.protocol.connections is not None:


### PR DESCRIPTION
### Motivation

While sync-v2 is in beta it's better to keep using the whitelist until it is stable.

### Acceptance Criteria

- Add a bool option to the settings to choose whether the peer whitelist should be considered for sync-v2 peers

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 