### PR TITLE
chore(feature-activation): update feature endpoint visibility to public

### DIFF
--- a/hathor/cli/openapi_files/register.py
+++ b/hathor/cli/openapi_files/register.py
@@ -34,6 +34,7 @@ def register_resource(resource_class: ResourceClass) -> ResourceClass:
 def get_registered_resources() -> list[type[Resource]]:
     """ Returns a list with all the resources registered for the docs
     """
+    import hathor.feature_activation.resources.feature  # noqa: 401
     import hathor.p2p.resources  # noqa: 401
     import hathor.profiler.resources  # noqa: 401
     import hathor.stratum.resources  # noqa: 401

--- a/hathor/feature_activation/resources/feature.py
+++ b/hathor/feature_activation/resources/feature.py
@@ -171,7 +171,7 @@ FeatureResource.openapi = {
             ],
             'per-ip': [
                 {
-                    'rate': '3r/s',
+                    'rate': '1r/s',
                     'burst': 10,
                     'delay': 3
                 }

--- a/hathor/feature_activation/resources/feature.py
+++ b/hathor/feature_activation/resources/feature.py
@@ -160,7 +160,23 @@ class GetFeaturesResponse(Response):
 
 FeatureResource.openapi = {
     '/feature': {
-        'x-visibility': 'private',
+        'x-visibility': 'public',
+        'x-rate-limit': {
+            'global': [
+                {
+                    'rate': '50r/s',
+                    'burst': 100,
+                    'delay': 50
+                }
+            ],
+            'per-ip': [
+                {
+                    'rate': '3r/s',
+                    'burst': 10,
+                    'delay': 3
+                }
+            ]
+        },
         'get': {
             'operationId': 'feature',
             'summary': 'Feature Activation',


### PR DESCRIPTION
### Motivation

Currently, trying to access Feature Activation endpoints on our public nodes returns 403 Forbidden, like on https://node1.mainnet.hathor.network/v1a/feature. This PR updates the endpoint visibility so it can be used by the Hathor Explorer UIs.

### Acceptance Criteria

- Change `GET /feature` visibility to public and add rate limits (the same used by `GET /transaction`)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 