### PR TITLE
fix(sync-v2): compare to local bytes broke in some cases

### DIFF
--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -514,7 +514,9 @@ class TransactionStorage(ABC):
     def compare_bytes_with_local_tx(self, tx: BaseTransaction) -> bool:
         """Compare byte-per-byte `tx` with the local transaction."""
         assert tx.hash is not None
-        local_tx = self.get_transaction(tx.hash)
+        # XXX: we have to accept any scope because we only want to know what bytes we have stored
+        with tx_allow_context(self, allow_scope=TxAllowScope.ALL):
+            local_tx = self.get_transaction(tx.hash)
         local_tx_bytes = bytes(local_tx)
         tx_bytes = bytes(tx)
         if tx_bytes == local_tx_bytes:

--- a/hathor/transaction/storage/tx_allow_scope.py
+++ b/hathor/transaction/storage/tx_allow_scope.py
@@ -35,6 +35,7 @@ class TxAllowScope(Flag):
     VALID = auto()
     PARTIAL = auto()
     INVALID = auto()
+    ALL = VALID | PARTIAL | INVALID
 
     def is_allowed(self, tx: BaseTransaction) -> bool:
         """True means it is allowed to be used in the storage (as argument or as return), False means not allowed."""


### PR DESCRIPTION
### Motivation

When testing sync-v2 on v0.55.0, one of the nodes got stuck in a particular situation logging this exception:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/hathor/p2p/sync_v2/manager.py", line 746, in handle_blocks
    self.on_new_tx(blk, propagate_to_peers=False, quiet=True)
  File "/usr/local/lib/python3.10/site-packages/hathor/p2p/sync_v2/manager.py", line 1137, in on_new_tx
    if not self.manager.on_new_tx(tx):
  File "/usr/local/lib/python3.10/site-packages/hathor/profiler/cpu.py", line 207, in _wrapper
    ret = fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/hathor/manager.py", line 949, in on_new_tx
    self.tx_storage.compare_bytes_with_local_tx(tx)
  File "/usr/local/lib/python3.10/site-packages/hathor/transaction/storage/transaction_storage.py", line 517, in compare_bytes_with_local_tx
    local_tx = self.get_transaction(tx.hash)
  File "/usr/local/lib/python3.10/site-packages/hathor/transaction/storage/transaction_storage.py", line 569, in get_transaction
    self.post_get_validation(tx)
  File "/usr/local/lib/python3.10/site-packages/hathor/transaction/storage/transaction_storage.py", line 437, in post_get_validation
    self._validate_transaction_in_scope(tx)
  File "/usr/local/lib/python3.10/site-packages/hathor/transaction/storage/transaction_storage.py", line 451, in _validate_transaction_in_scope
    raise TransactionNotInAllowedScopeError(tx.hash_hex, self.get_allow_scope().name, tx_meta.validation.name)
hathor.transaction.storage.exceptions.TransactionNotInAllowedScopeError: ('00000000000000020737994b34fdd7f402641657e297d8bb364367bf3f775f08', 'VALID', 'BASIC')
```

It is not entirely clear what lead to the situation, but it is very possible that it is a normal case that can happen naturally depending on the timing of connections being closed and/or the node restarting. In any case the failure itself should not happen, at the higher level `compare_bytes_with_local_tx` was called and it failed because of the validation state of the transaction, but the method shouldn't depend on that.

### Acceptance Criteria

- Make `compare_bytes_with_local_tx` work regardless of the validation state of the transaction
- Have tests that cover it

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 