### PR TITLE
fix(tests): make simulator test not flaky on sync-v2

### DIFF
--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -101,6 +101,16 @@ class FakeConnection:
         if not state1_is_synced or not state2_is_synced:
             self.log.debug('peer not synced', peer1_synced=state1_is_synced, peer2_synced=state2_is_synced)
             return False
+        [best_block_info1] = state1.protocol.node.tx_storage.get_n_height_tips(1)
+        [best_block_info2] = state2.protocol.node.tx_storage.get_n_height_tips(1)
+        if best_block_info1.id != best_block_info2.id:
+            self.log.debug('best block is different')
+            return False
+        tips1 = {i.data for i in state1.protocol.node.tx_storage.get_tx_tips()}
+        tips2 = {i.data for i in state2.protocol.node.tx_storage.get_tx_tips()}
+        if tips1 != tips2:
+            self.log.debug('tx tips are different')
+            return False
         return True
 
     def can_step(self) -> bool:

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -44,7 +44,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         self.simulator.add_connection(conn12)
         self.simulator.run(60)
 
-        miner2 = self.simulator.create_miner(manager2, hashpower=100e6)
+        miner2 = self.simulator.create_miner(manager2, hashpower=10e9)
         miner2.start()
         self.simulator.run(120)
 
@@ -57,7 +57,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         gen_tx1.stop()
         gen_tx2.stop()
 
-        self.assertTrue(self.simulator.run(600, trigger=StopWhenSynced(conn12)))
+        self.assertTrue(self.simulator.run(3000, trigger=StopWhenSynced(conn12)))
 
         self.assertTrue(conn12.is_connected)
         self.assertTipsEqual(manager1, manager2)


### PR DESCRIPTION
### Motivation

This test became very flaky after the latest changes on sync-v2.

### Acceptance Criteria

- The test should avoid building two chains with the same score 

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 