### PR TITLE
tests: decrease tests duration

### DIFF
--- a/hathor/simulator/miner/geometric_miner.py
+++ b/hathor/simulator/miner/geometric_miner.py
@@ -124,7 +124,7 @@ class GeometricMiner(AbstractMiner):
         will unpause the miner and pause again according to the new argument.
 
         Use this instead of the `StopAfterNMinedBlocks` trigger if you need "exactly N blocks" behavior, instead of
-        "at least N blocks". Use both to prevent the simulator from running more steps than necessary.
+        "at least N blocks".
         """
         self._blocks_before_pause = n_blocks
 

--- a/hathor/simulator/miner/geometric_miner.py
+++ b/hathor/simulator/miner/geometric_miner.py
@@ -124,7 +124,7 @@ class GeometricMiner(AbstractMiner):
         will unpause the miner and pause again according to the new argument.
 
         Use this instead of the `StopAfterNMinedBlocks` trigger if you need "exactly N blocks" behavior, instead of
-        "at least N blocks".
+        "at least N blocks". Use both to prevent the simulator from running more steps than necessary.
         """
         self._blocks_before_pause = n_blocks
 

--- a/tests/feature_activation/test_mining_simulation.py
+++ b/tests/feature_activation/test_mining_simulation.py
@@ -26,6 +26,7 @@ from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.mining.ws import MiningWebsocketFactory, MiningWebsocketProtocol
 from hathor.p2p.resources import MiningResource
+from hathor.simulator.trigger import StopAfterNMinedBlocks
 from hathor.transaction.resources import GetBlockTemplateResource
 from hathor.transaction.util import unpack, unpack_len
 from hathor.util import json_loadb
@@ -88,55 +89,55 @@ class BaseMiningSimulationTest(SimulatorTestCase):
         expected_signal_bits = 0b0000
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits]
         miner.pause_after_exactly(n_blocks=1)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=1))
         assert self._get_signal_bits_from_get_block_template(get_block_template_client) == expected_signal_bits
         assert self._get_signal_bits_from_mining(mining_client) == expected_signal_bits
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits]
 
         miner.pause_after_exactly(n_blocks=6)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=6))
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits] * 6
 
         # At height=8, NOP_FEATURE_1 is signaling, so it's enabled by the default support.
         expected_signal_bits = 0b0001
         miner.pause_after_exactly(n_blocks=1)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=1))
         assert self._get_signal_bits_from_get_block_template(get_block_template_client) == expected_signal_bits
         assert self._get_signal_bits_from_mining(mining_client) == expected_signal_bits
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits]
 
         miner.pause_after_exactly(n_blocks=3)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=3))
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits] * 3
 
         # At height=12, NOP_FEATURE_2 is signaling, enabled by the user. NOP_FEATURE_1 also continues signaling.
         expected_signal_bits = 0b0101
         miner.pause_after_exactly(n_blocks=1)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=1))
         assert self._get_signal_bits_from_get_block_template(get_block_template_client) == expected_signal_bits
         assert self._get_signal_bits_from_mining(mining_client) == expected_signal_bits
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits]
 
         miner.pause_after_exactly(n_blocks=7)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=7))
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits] * 7
 
         # At height=20, NOP_FEATURE_1 stops signaling, and NOP_FEATURE_2 continues.
         expected_signal_bits = 0b0100
         miner.pause_after_exactly(n_blocks=1)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=1))
         assert self._get_signal_bits_from_get_block_template(get_block_template_client) == expected_signal_bits
         assert self._get_signal_bits_from_mining(mining_client) == expected_signal_bits
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits]
 
         miner.pause_after_exactly(n_blocks=3)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=3))
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits] * 3
 
         # At height=24, all features have left their signaling period and therefore none are signaled.
         expected_signal_bits = 0b0000
         miner.pause_after_exactly(n_blocks=1)
-        self.simulator.run(3600)
+        self.simulator.run(3600, trigger=StopAfterNMinedBlocks(miner, quantity=1))
         assert self._get_signal_bits_from_get_block_template(get_block_template_client) == expected_signal_bits
         assert self._get_signal_bits_from_mining(mining_client) == expected_signal_bits
         assert self._get_ws_signal_bits(ws_transport) == [expected_signal_bits]


### PR DESCRIPTION
### Motivation

PR https://github.com/HathorNetwork/hathor-core/pull/753 introduced the new `pause_after_exactly()` miner simulator ability, and changed Feature Activation mining simulation tests to use it instead of the `StopAfterNMinedBlocks`, removing flakiness. Since the trigger was removed, the test running times were unnecessarily too long.

### Acceptance Criteria

- Decrease running times of Feature Activation mining simulation tests
- Increase miner hash rate to make sure enough blocks are found

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 