### PR TITLE
chore: add deprecation warning for Python 3.9

### DIFF
--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -310,11 +310,14 @@ class RunNode:
                 sys.exit(-1)
 
     def check_python_version(self) -> None:
-        MIN_VER = (3, 8)
-        RECOMMENDED_VER = (3, 9)
+        # comments to help grep's
+        MIN_VER = (3, 9)  # Python-3.9
+        MIN_STABLE = (3, 10)  # Python-3.10
+        RECOMMENDED_VER = (3, 10)  # Python-3.10
         cur = sys.version_info
-        min_pretty = '.'.join(map(str, MIN_VER))
         cur_pretty = '.'.join(map(str, cur))
+        min_pretty = '.'.join(map(str, MIN_VER))
+        min_stable_pretty = '.'.join(map(str, MIN_STABLE))
         recommended_pretty = '.'.join(map(str, RECOMMENDED_VER))
         if cur < MIN_VER:
             self.log.critical('\n'.join([
@@ -327,6 +330,17 @@ class RunNode:
                 '',
             ]))
             sys.exit(-1)
+        elif cur < MIN_STABLE:
+            self.log.warning('\n'.join([
+                '',
+                '********************************************************',
+                f'The detected Python version {cur_pretty} is deprecated and support for it will be removed in the'
+                ' next release.',
+                f'The minimum supported Python version will be {min_stable_pretty}',
+                f'The recommended Python version is {recommended_pretty}',
+                '********************************************************',
+                '',
+            ]))
 
     def __init__(self, *, argv=None):
         self.log = logger.new()


### PR DESCRIPTION
### Motivation

We want to remove support for Python 3.9 on hathor-core v0.57.0

### Acceptance Criteria

- Print warning message when using Python-3.9, but do not alter any behavior.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 