### PR TITLE
refactor: move get settings [part 1]

### DIFF
--- a/hathor/conf/get_settings.py
+++ b/hathor/conf/get_settings.py
@@ -33,6 +33,10 @@ class _SettingsMetadata(NamedTuple):
 _settings_singleton: Optional[_SettingsMetadata] = None
 
 
+def get_settings() -> Settings:
+    return HathorSettings()
+
+
 def HathorSettings() -> Settings:
     """
     Returns the configuration named tuple.

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -24,7 +24,7 @@ from structlog import get_logger
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.task import LoopingCall
 
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.sync_v2.mempool import SyncMempoolManager
@@ -39,7 +39,6 @@ from hathor.util import Reactor, collect_n
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
-settings = HathorSettings()
 logger = get_logger()
 
 MAX_GET_TRANSACTIONS_BFS_LEN: int = 8
@@ -66,6 +65,7 @@ class NodeBlockSync(SyncAgent):
         :param reactor: Reactor to schedule later calls. (default=twisted.internet.reactor)
         :type reactor: Reactor
         """
+        self._settings = get_settings()
         self.protocol = protocol
         self.manager = protocol.node
         self.tx_storage = protocol.node.tx_storage
@@ -85,7 +85,7 @@ class NodeBlockSync(SyncAgent):
 
         # Extra
         self._blk_size = 0
-        self._blk_end_hash = settings.GENESIS_BLOCK_HASH
+        self._blk_end_hash = self._settings.GENESIS_BLOCK_HASH
         self._blk_max_quantity = 0
 
         # indicates whether we're receiving a stream from the peer
@@ -319,7 +319,7 @@ class NodeBlockSync(SyncAgent):
         # Start with the last received block and find the best block full validated in its chain
         block = self._last_received_block
         if block is None:
-            block = cast(Block, self.tx_storage.get_genesis(settings.GENESIS_BLOCK_HASH))
+            block = cast(Block, self.tx_storage.get_genesis(self._settings.GENESIS_BLOCK_HASH))
         else:
             with self.tx_storage.allow_partially_validated_context():
                 while not block.get_metadata().validation.is_valid():

--- a/hathor/p2p/utils.py
+++ b/hathor/p2p/utils.py
@@ -28,12 +28,10 @@ from cryptography.x509.oid import NameOID
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.interfaces import IAddress
 
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.indexes.height_index import HeightInfo
 from hathor.p2p.peer_discovery import DNSPeerDiscovery
 from hathor.transaction.genesis import GENESIS_HASH
-
-settings = HathorSettings()
 
 
 def discover_hostname() -> Optional[str]:
@@ -83,6 +81,7 @@ def get_genesis_short_hash() -> str:
 def get_settings_hello_dict() -> dict[str, Any]:
     """ Return a dict of settings values that must be validated in the hello state
     """
+    settings = get_settings()
     settings_dict = {}
     for key in settings.P2P_SETTINGS_HASH_FIELDS:
         value = getattr(settings, key)

--- a/hathor/prometheus.py
+++ b/hathor/prometheus.py
@@ -18,13 +18,11 @@ from typing import TYPE_CHECKING
 from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
 from twisted.internet.task import LoopingCall
 
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.util import reactor
 
 if TYPE_CHECKING:
     from hathor.metrics import Metrics
-
-settings = HathorSettings()
 
 # Define prometheus metrics and it's explanation
 METRIC_INFO = {
@@ -79,6 +77,7 @@ class PrometheusMetricsExporter:
         :param filename: Name of the prometheus file (must end in .prom)
         :type filename: str
         """
+        self._settings = get_settings()
         self.metrics = metrics
         self.metrics_prefix = metrics_prefix
 
@@ -99,7 +98,7 @@ class PrometheusMetricsExporter:
         self.running: bool = False
 
         # Interval in which the write data method will be called (in seconds)
-        self.call_interval: int = settings.PROMETHEUS_WRITE_INTERVAL
+        self.call_interval: int = self._settings.PROMETHEUS_WRITE_INTERVAL
 
         # A timer to periodically write data to prometheus
         self._lc_write_data = LoopingCall(self._write_data)

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -20,13 +20,10 @@ from structlog import get_logger
 from twisted.internet.address import HostnameAddress
 from twisted.internet.testing import StringTransport
 
-from hathor.conf import HathorSettings
-
 if TYPE_CHECKING:
     from hathor.manager import HathorManager
     from hathor.p2p.peer_id import PeerId
 
-settings = HathorSettings()
 logger = get_logger()
 
 

--- a/hathor/simulator/miner/geometric_miner.py
+++ b/hathor/simulator/miner/geometric_miner.py
@@ -15,7 +15,7 @@
 import math
 from typing import TYPE_CHECKING, Optional
 
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.manager import HathorEvents
 from hathor.simulator.miner.abstract_miner import AbstractMiner
 from hathor.util import Random
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
     from hathor.manager import HathorManager
     from hathor.pubsub import EventArguments
     from hathor.transaction import Block
-
-settings = HathorSettings()
 
 
 class GeometricMiner(AbstractMiner):
@@ -46,6 +44,7 @@ class GeometricMiner(AbstractMiner):
             blocks than values provided, 0 is used.
         """
         super().__init__(manager, rng)
+        self._settings = get_settings()
 
         self._hashpower = hashpower
         self._signal_bits = signal_bits or []
@@ -107,9 +106,9 @@ class GeometricMiner(AbstractMiner):
         else:
             dt = 60
 
-        if dt > settings.WEIGHT_DECAY_ACTIVATE_DISTANCE:
+        if dt > self._settings.WEIGHT_DECAY_ACTIVATE_DISTANCE:
             self._block = None
-            dt = settings.WEIGHT_DECAY_ACTIVATE_DISTANCE
+            dt = self._settings.WEIGHT_DECAY_ACTIVATE_DISTANCE
 
         if self._delayed_call and self._delayed_call.active():
             self._delayed_call.cancel()

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -21,7 +21,7 @@ from mnemonic import Mnemonic
 from structlog import get_logger
 
 from hathor.builder import BuildArtifacts, Builder
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.daa import TestMode, _set_test_mode
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
@@ -116,7 +116,7 @@ class Simulator:
             seed = secrets.randbits(64)
         self.seed = seed
         self.rng = Random(self.seed)
-        self.settings = HathorSettings()
+        self.settings = get_settings()
         self._network = 'testnet'
         self._clock = MemoryReactorHeapClock()
         self._peers: OrderedDict[str, HathorManager] = OrderedDict()

--- a/hathor/simulator/tx_generator.py
+++ b/hathor/simulator/tx_generator.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from structlog import get_logger
 
 from hathor import daa
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.transaction.exceptions import RewardLocked
 from hathor.util import Random
 from hathor.wallet.exceptions import InsufficientFunds
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from hathor.manager import HathorManager
     from hathor.transaction import Transaction
 
-settings = HathorSettings()
 logger = get_logger()
 
 
@@ -45,6 +44,7 @@ class RandomTransactionGenerator:
         :param: rate: Number of transactions per second
         :param: hashpower: Number of hashes per second
         """
+        self._settings = get_settings()
         self.manager = manager
 
         # List of addresses to send tokens. If this list is empty, tokens will be sent to an address
@@ -101,7 +101,7 @@ class RandomTransactionGenerator:
     def new_tx_step1(self):
         """ Generate a new transaction and schedule the mining part of the transaction.
         """
-        balance = self.manager.wallet.balance[settings.HATHOR_TOKEN_UID]
+        balance = self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID]
         if balance.available == 0 and self.ignore_no_funds:
             self.delayedcall = self.clock.callLater(0, self.schedule_next_transaction)
             return

--- a/hathor/transaction/__init__.py
+++ b/hathor/transaction/__init__.py
@@ -14,8 +14,6 @@
 
 from hathor.transaction.aux_pow import BitcoinAuxPow
 from hathor.transaction.base_transaction import (
-    MAX_NUM_INPUTS,
-    MAX_NUM_OUTPUTS,
     MAX_OUTPUT_VALUE,
     BaseTransaction,
     TxInput,
@@ -38,8 +36,6 @@ __all__ = [
     'TxInput',
     'TxOutput',
     'TxVersion',
-    'MAX_NUM_INPUTS',
-    'MAX_NUM_OUTPUTS',
     'MAX_OUTPUT_VALUE',
     'sum_weights',
 ]

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -15,14 +15,11 @@
 from struct import error as StructError, pack
 from typing import Any, Optional
 
-from hathor.conf import HathorSettings
 from hathor.transaction.base_transaction import TxInput, TxOutput, TxVersion
 from hathor.transaction.exceptions import InvalidToken, TransactionDataError
 from hathor.transaction.storage import TransactionStorage  # noqa: F401
 from hathor.transaction.transaction import TokenInfo, Transaction
 from hathor.transaction.util import VerboseCallback, clean_token_string, int_to_bytes, unpack, unpack_len
-
-settings = HathorSettings()
 
 # Signal bits (B), version (B), inputs len (B), outputs len (B)
 _FUNDS_FORMAT_STRING = '!BBBB'
@@ -259,15 +256,15 @@ class TokenCreationTransaction(Transaction):
         """
         name_len = len(self.token_name)
         symbol_len = len(self.token_symbol)
-        if name_len == 0 or name_len > settings.MAX_LENGTH_TOKEN_NAME:
+        if name_len == 0 or name_len > self._settings.MAX_LENGTH_TOKEN_NAME:
             raise TransactionDataError('Invalid token name length ({})'.format(name_len))
-        if symbol_len == 0 or symbol_len > settings.MAX_LENGTH_TOKEN_SYMBOL:
+        if symbol_len == 0 or symbol_len > self._settings.MAX_LENGTH_TOKEN_SYMBOL:
             raise TransactionDataError('Invalid token symbol length ({})'.format(symbol_len))
 
         # Can't create token with hathor name or symbol
-        if clean_token_string(self.token_name) == clean_token_string(settings.HATHOR_TOKEN_NAME):
+        if clean_token_string(self.token_name) == clean_token_string(self._settings.HATHOR_TOKEN_NAME):
             raise TransactionDataError('Invalid token name ({})'.format(self.token_name))
-        if clean_token_string(self.token_symbol) == clean_token_string(settings.HATHOR_TOKEN_SYMBOL):
+        if clean_token_string(self.token_symbol) == clean_token_string(self._settings.HATHOR_TOKEN_SYMBOL):
             raise TransactionDataError('Invalid token symbol ({})'.format(self.token_symbol))
 
 

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -19,10 +19,9 @@ from typing import TYPE_CHECKING, Any, Iterator, NamedTuple, Optional
 
 from hathor import daa
 from hathor.checkpoint import Checkpoint
-from hathor.conf import HathorSettings
 from hathor.exception import InvalidNewTransaction
 from hathor.profiler import get_cpu_profiler
-from hathor.transaction import MAX_NUM_INPUTS, BaseTransaction, Block, TxInput, TxOutput, TxVersion
+from hathor.transaction import BaseTransaction, Block, TxInput, TxOutput, TxVersion
 from hathor.transaction.base_transaction import TX_HASH_SIZE
 from hathor.transaction.exceptions import (
     ConflictingInputs,
@@ -48,7 +47,6 @@ from hathor.util import not_none
 if TYPE_CHECKING:
     from hathor.transaction.storage import TransactionStorage  # noqa: F401
 
-settings = HathorSettings()
 cpu = get_cpu_profiler()
 
 # Signal bits (B), version (B), token uids len (B) and inputs len (B), outputs len (B).
@@ -155,7 +153,7 @@ class Transaction(BaseTransaction):
         """ Calculates min height derived from own spent block rewards"""
         min_height = 0
         for blk in self.iter_spent_rewards():
-            min_height = max(min_height, blk.get_height() + settings.REWARD_SPEND_MIN_BLOCKS + 1)
+            min_height = max(min_height, blk.get_height() + self._settings.REWARD_SPEND_MIN_BLOCKS + 1)
         return min_height
 
     def get_funds_fields_from_struct(self, buf: bytes, *, verbose: VerboseCallback = None) -> bytes:
@@ -278,7 +276,7 @@ class Transaction(BaseTransaction):
         :return: the token uid
         """
         if index == 0:
-            return settings.HATHOR_TOKEN_UID
+            return self._settings.HATHOR_TOKEN_UID
         return self.tokens[index - 1]
 
     def to_json(self, decode_script: bool = False, include_metadata: bool = False) -> dict[str, Any]:
@@ -322,11 +320,11 @@ class Transaction(BaseTransaction):
     def verify_weight(self) -> None:
         """Validate minimum tx difficulty."""
         min_tx_weight = daa.minimum_tx_weight(self)
-        max_tx_weight = min_tx_weight + settings.MAX_TX_WEIGHT_DIFF
-        if self.weight < min_tx_weight - settings.WEIGHT_TOL:
+        max_tx_weight = min_tx_weight + self._settings.MAX_TX_WEIGHT_DIFF
+        if self.weight < min_tx_weight - self._settings.WEIGHT_TOL:
             raise WeightError(f'Invalid new tx {self.hash_hex}: weight ({self.weight}) is '
                               f'smaller than the minimum weight ({min_tx_weight})')
-        elif min_tx_weight > settings.MAX_TX_WEIGHT_DIFF_ACTIVATION and self.weight > max_tx_weight:
+        elif min_tx_weight > self._settings.MAX_TX_WEIGHT_DIFF_ACTIVATION and self.weight > max_tx_weight:
             raise WeightError(f'Invalid new tx {self.hash_hex}: weight ({self.weight}) is '
                               f'greater than the maximum allowed ({max_tx_weight})')
 
@@ -375,7 +373,7 @@ class Transaction(BaseTransaction):
 
     def verify_number_of_inputs(self) -> None:
         """Verify number of inputs is in a valid range"""
-        if len(self.inputs) > MAX_NUM_INPUTS:
+        if len(self.inputs) > self._settings.MAX_NUM_INPUTS:
             raise TooManyInputs('Maximum number of inputs exceeded')
 
         if len(self.inputs) == 0:
@@ -399,7 +397,7 @@ class Transaction(BaseTransaction):
                     tx_input.tx_id.hex(), tx_input.index))
             n_txops += get_sigops_count(tx_input.data, spent_tx.outputs[tx_input.index].script)
 
-        if n_txops > settings.MAX_TX_SIGOPS_INPUT:
+        if n_txops > self._settings.MAX_TX_SIGOPS_INPUT:
             raise TooManySigOps(
                 'TX[{}]: Max number of sigops for inputs exceeded ({})'.format(self.hash_hex, n_txops))
 
@@ -424,7 +422,7 @@ class Transaction(BaseTransaction):
         # add HTR to token dict due to tx melting tokens: there might be an HTR output without any
         # input or authority. If we don't add it, an error will be raised when iterating through
         # the outputs of such tx (error: 'no token creation and no inputs for token 00')
-        token_dict[settings.HATHOR_TOKEN_UID] = TokenInfo(0, False, False)
+        token_dict[self._settings.HATHOR_TOKEN_UID] = TokenInfo(0, False, False)
 
         for tx_input in self.inputs:
             spent_tx = self.get_spent_tx(tx_input)
@@ -486,7 +484,7 @@ class Transaction(BaseTransaction):
         withdraw = 0
         deposit = 0
         for token_uid, token_info in token_dict.items():
-            if token_uid == settings.HATHOR_TOKEN_UID:
+            if token_uid == self._settings.HATHOR_TOKEN_UID:
                 continue
 
             if token_info.amount == 0:
@@ -507,7 +505,7 @@ class Transaction(BaseTransaction):
 
         # check whether the deposit/withdraw amount is correct
         htr_expected_amount = withdraw - deposit
-        htr_info = token_dict[settings.HATHOR_TOKEN_UID]
+        htr_info = token_dict[self._settings.HATHOR_TOKEN_UID]
         if htr_info.amount != htr_expected_amount:
             raise InputOutputMismatch('HTR balance is different than expected. (amount={}, expected={})'.format(
                 htr_info.amount,
@@ -541,9 +539,9 @@ class Transaction(BaseTransaction):
 
         spent_outputs: set[tuple[VertexId, int]] = set()
         for input_tx in self.inputs:
-            if len(input_tx.data) > settings.MAX_INPUT_DATA_SIZE:
+            if len(input_tx.data) > self._settings.MAX_INPUT_DATA_SIZE:
                 raise InvalidInputDataSize('size: {} and max-size: {}'.format(
-                    len(input_tx.data), settings.MAX_INPUT_DATA_SIZE
+                    len(input_tx.data), self._settings.MAX_INPUT_DATA_SIZE
                 ))
 
             try:
@@ -610,7 +608,7 @@ class Transaction(BaseTransaction):
         assert isinstance(best_height, int)
         spent_height = block.get_height()
         spend_blocks = best_height - spent_height
-        needed_height = settings.REWARD_SPEND_MIN_BLOCKS - spend_blocks
+        needed_height = self._settings.REWARD_SPEND_MIN_BLOCKS - spend_blocks
         return max(needed_height, 0)
 
     def verify_script(self, input_tx: TxInput, spent_tx: BaseTransaction) -> None:

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -3,10 +3,9 @@ import hashlib
 from math import isinf, isnan
 
 from hathor import daa
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address, get_address_from_public_key, get_private_key_from_bytes
 from hathor.daa import TestMode, _set_test_mode
-from hathor.transaction import MAX_NUM_INPUTS, MAX_NUM_OUTPUTS, MAX_OUTPUT_VALUE, Block, Transaction, TxInput, TxOutput
+from hathor.transaction import MAX_OUTPUT_VALUE, Block, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import (
     BlockWithInputs,
     ConflictingInputs,
@@ -40,8 +39,6 @@ from tests.utils import (
     create_script_with_sigops,
     get_genesis_key,
 )
-
-settings = HathorSettings()
 
 
 class BaseTransactionTest(unittest.TestCase):
@@ -129,7 +126,7 @@ class BaseTransactionTest(unittest.TestCase):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
 
         _input = TxInput(random_bytes, 0, random_bytes)
-        inputs = [_input] * (MAX_NUM_INPUTS + 1)
+        inputs = [_input] * (self._settings.MAX_NUM_INPUTS + 1)
 
         tx = Transaction(inputs=inputs, storage=self.tx_storage)
 
@@ -146,7 +143,7 @@ class BaseTransactionTest(unittest.TestCase):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
 
         output = TxOutput(1, random_bytes)
-        outputs = [output] * (MAX_NUM_OUTPUTS + 1)
+        outputs = [output] * (self._settings.MAX_NUM_OUTPUTS + 1)
 
         tx = Transaction(outputs=outputs, storage=self.tx_storage)
 
@@ -351,7 +348,6 @@ class BaseTransactionTest(unittest.TestCase):
         b.verify_aux_pow()
 
     def test_block_outputs(self):
-        from hathor.transaction import MAX_NUM_OUTPUTS
         from hathor.transaction.exceptions import TooManyOutputs
 
         # a block should have no more than MAX_NUM_OUTPUTS outputs
@@ -359,7 +355,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         address = get_address_from_public_key(self.genesis_public_key)
         output_script = P2PKH.create_output_script(address)
-        tx_outputs = [TxOutput(100, output_script)] * (MAX_NUM_OUTPUTS + 1)
+        tx_outputs = [TxOutput(100, output_script)] * (self._settings.MAX_NUM_OUTPUTS + 1)
 
         block = Block(
             nonce=100,
@@ -535,7 +531,7 @@ class BaseTransactionTest(unittest.TestCase):
         tx = Transaction(weight=1, inputs=inputs, outputs=outputs, parents=parents,
                          storage=self.tx_storage, timestamp=self.last_block.timestamp + 1)
         tx.weight = daa.minimum_tx_weight(tx)
-        tx.weight += settings.MAX_TX_WEIGHT_DIFF + 0.1
+        tx.weight += self._settings.MAX_TX_WEIGHT_DIFF + 0.1
         tx.update_hash()
         with self.assertRaises(WeightError):
             tx.verify_weight()
@@ -656,7 +652,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         # 4. propagate block from the future
         block = manager.generate_mining_block()
-        block.timestamp = int(self.clock.seconds()) + settings.MAX_FUTURE_TIMESTAMP_ALLOWED + 100
+        block.timestamp = int(self.clock.seconds()) + self._settings.MAX_FUTURE_TIMESTAMP_ALLOWED + 100
         block.resolve(update_time=False)
         self.assertFalse(manager.propagate_tx(block))
 
@@ -709,7 +705,7 @@ class BaseTransactionTest(unittest.TestCase):
         # Validate maximum distance between blocks
         block = blocks[0]
         block2 = blocks[1]
-        block2.timestamp = block.timestamp + settings.MAX_DISTANCE_BETWEEN_BLOCKS
+        block2.timestamp = block.timestamp + self._settings.MAX_DISTANCE_BETWEEN_BLOCKS
         block2.verify_parents()
         block2.timestamp += 1
         with self.assertRaises(TimestampError):
@@ -886,7 +882,7 @@ class BaseTransactionTest(unittest.TestCase):
         _input = TxInput(genesis_block.hash, 0, b'')
 
         value = genesis_block.outputs[0].value
-        script = b'*' * (settings.MAX_OUTPUT_SCRIPT_SIZE + offset)
+        script = b'*' * (self._settings.MAX_OUTPUT_SCRIPT_SIZE + offset)
         _output = TxOutput(value, script)
 
         tx = Transaction(inputs=[_input], outputs=[_output], storage=self.tx_storage)
@@ -902,7 +898,7 @@ class BaseTransactionTest(unittest.TestCase):
 
     def _test_txin_data_limit(self, offset):
         genesis_block = self.genesis_blocks[0]
-        data = b'*' * (settings.MAX_INPUT_DATA_SIZE + offset)
+        data = b'*' * (self._settings.MAX_INPUT_DATA_SIZE + offset)
         _input = TxInput(genesis_block.hash, 0, data)
 
         value = genesis_block.outputs[0].value
@@ -1037,7 +1033,7 @@ class BaseTransactionTest(unittest.TestCase):
         value = genesis_block.outputs[0].value - 1
         _input = TxInput(genesis_block.hash, 0, b'')
 
-        hscript = create_script_with_sigops(settings.MAX_TX_SIGOPS_OUTPUT + 1)
+        hscript = create_script_with_sigops(self._settings.MAX_TX_SIGOPS_OUTPUT + 1)
         output1 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output1], storage=self.tx_storage)
         tx.update_hash()
@@ -1051,7 +1047,7 @@ class BaseTransactionTest(unittest.TestCase):
         _input = TxInput(genesis_block.hash, 0, b'')
         num_outputs = 5
 
-        hscript = create_script_with_sigops((settings.MAX_TX_SIGOPS_OUTPUT + num_outputs) // num_outputs)
+        hscript = create_script_with_sigops((self._settings.MAX_TX_SIGOPS_OUTPUT + num_outputs) // num_outputs)
         output2 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output2]*num_outputs, storage=self.tx_storage)
         tx.update_hash()
@@ -1063,7 +1059,7 @@ class BaseTransactionTest(unittest.TestCase):
         value = genesis_block.outputs[0].value - 1
         _input = TxInput(genesis_block.hash, 0, b'')
 
-        hscript = create_script_with_sigops(settings.MAX_TX_SIGOPS_OUTPUT - 1)
+        hscript = create_script_with_sigops(self._settings.MAX_TX_SIGOPS_OUTPUT - 1)
         output3 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output3], storage=self.tx_storage)
         tx.update_hash()
@@ -1075,7 +1071,7 @@ class BaseTransactionTest(unittest.TestCase):
         _input = TxInput(genesis_block.hash, 0, b'')
         num_outputs = 5
 
-        hscript = create_script_with_sigops((settings.MAX_TX_SIGOPS_OUTPUT - 1) // num_outputs)
+        hscript = create_script_with_sigops((self._settings.MAX_TX_SIGOPS_OUTPUT - 1) // num_outputs)
         output4 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output4]*num_outputs, storage=self.tx_storage)
         tx.update_hash()
@@ -1088,7 +1084,7 @@ class BaseTransactionTest(unittest.TestCase):
         script = P2PKH.create_output_script(address)
         _output = TxOutput(value, script)
 
-        hscript = create_script_with_sigops(settings.MAX_TX_SIGOPS_INPUT + 1)
+        hscript = create_script_with_sigops(self._settings.MAX_TX_SIGOPS_INPUT + 1)
         input1 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input1], outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
@@ -1103,7 +1099,7 @@ class BaseTransactionTest(unittest.TestCase):
         _output = TxOutput(value, script)
         num_inputs = 5
 
-        hscript = create_script_with_sigops((settings.MAX_TX_SIGOPS_INPUT + num_inputs) // num_inputs)
+        hscript = create_script_with_sigops((self._settings.MAX_TX_SIGOPS_INPUT + num_inputs) // num_inputs)
         input2 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input2]*num_inputs, outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
@@ -1117,7 +1113,7 @@ class BaseTransactionTest(unittest.TestCase):
         script = P2PKH.create_output_script(address)
         _output = TxOutput(value, script)
 
-        hscript = create_script_with_sigops(settings.MAX_TX_SIGOPS_INPUT - 1)
+        hscript = create_script_with_sigops(self._settings.MAX_TX_SIGOPS_INPUT - 1)
         input3 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input3], outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
@@ -1131,7 +1127,7 @@ class BaseTransactionTest(unittest.TestCase):
         _output = TxOutput(value, script)
         num_inputs = 5
 
-        hscript = create_script_with_sigops((settings.MAX_TX_SIGOPS_INPUT - 1) // num_inputs)
+        hscript = create_script_with_sigops((self._settings.MAX_TX_SIGOPS_INPUT - 1) // num_inputs)
         input4 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input4]*num_inputs, outputs=[_output], storage=self.tx_storage)
         tx.update_hash()

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -11,6 +11,7 @@ from twisted.trial import unittest
 
 from hathor.builder import BuildArtifacts, Builder
 from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_settings
 from hathor.daa import TestMode, _set_test_mode
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.sync_version import SyncVersion
@@ -113,6 +114,7 @@ class TestCase(unittest.TestCase):
         self.log.debug('set seed', seed=self.seed)
         self.rng = Random(self.seed)
         self._pending_cleanups = []
+        self._settings = get_settings()
 
     def tearDown(self):
         self.clean_tmpdirs()


### PR DESCRIPTION
### Motivation

This PR is the first on of a series of PRs focused on improving settings handling in the project, aiming to remove "global settings" that often cause importing order problems and limit varying settings for tests.

Those improvements will be made in two phases:

1. Renaming the `HathorSettings()` function to `get_settings()` and removing all invocations from module-level, moving them to inside functions/methods. This will be done incrementally in multiple PRs, and this PR is part 1 of that.
2. Changing all usages of settings to use injection instead of direct access.

Eventually the objective is that `get_settings()` is only called once in the whole system, and then injected as arguments on all objects/functions that need it.

In this PR, changes are very simple, code is mostly just renamed and the function call is moved. No logic should be changed. The only exceptions are changes to conform to linters and such.

### Acceptance Criteria

- Create new `get_settings()` function that is just a forward of `HathorSettings()`. This is just so we can do an "incremental rename" without having to touch all code that uses `HathorSettings()` at once. When it's done, `HathorSettings()` will be removed.
- Remove some usages of `HathorSettings()` from the module level and move it to inside functions/methods
  - For functions, the function just calls the new `get_settings()`
  - For classes we set `self._settings = get_settings()` in the class' `__init__()`, and update all methods to use that new attribute

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 