### PR TITLE
refactor: move simulator utils functions

### DIFF
--- a/extras/custom_checks.sh
+++ b/extras/custom_checks.sh
@@ -80,11 +80,21 @@ function check_deprecated_typing() {
 	return 0
 }
 
+function check_do_not_import_tests_in_hathor() {
+	if grep -R '\<.*import .*tests.*\>\|\<.*from .*tests.* import\>' "hathor"; then
+		echo 'do not import test definitions in the hathor module'
+		echo 'move them from tests to hathor instead'
+		return 1
+	fi
+	return 0
+}
+
 # List of functions to be executed
 checks=(
 	check_version_match
 	check_do_not_use_builtin_random_in_tests
 	check_deprecated_typing
+	check_do_not_import_tests_in_hathor
 )
 
 # Initialize a variable to track if any check fails

--- a/hathor/cli/events_simulator/scenario.py
+++ b/hathor/cli/events_simulator/scenario.py
@@ -44,14 +44,14 @@ def simulate_only_load(simulator: 'Simulator', _manager: 'HathorManager') -> Non
 
 
 def simulate_single_chain_one_block(simulator: 'Simulator', manager: 'HathorManager') -> None:
-    from tests.utils import add_new_blocks
+    from hathor.simulator.utils import add_new_blocks
     add_new_blocks(manager, 1)
     simulator.run(60)
 
 
 def simulate_single_chain_blocks_and_transactions(simulator: 'Simulator', manager: 'HathorManager') -> None:
     from hathor.conf.get_settings import get_settings
-    from tests.utils import add_new_blocks, gen_new_tx
+    from hathor.simulator.utils import add_new_blocks, gen_new_tx
 
     settings = get_settings()
     assert manager.wallet is not None
@@ -78,7 +78,7 @@ def simulate_single_chain_blocks_and_transactions(simulator: 'Simulator', manage
 
 def simulate_reorg(simulator: 'Simulator', manager: 'HathorManager') -> None:
     from hathor.simulator import FakeConnection
-    from tests.utils import add_new_blocks
+    from hathor.simulator.utils import add_new_blocks
 
     builder = simulator.get_default_builder()
     manager2 = simulator.create_peer(builder)

--- a/hathor/simulator/tx_generator.py
+++ b/hathor/simulator/tx_generator.py
@@ -18,10 +18,10 @@ from typing import TYPE_CHECKING
 from structlog import get_logger
 
 from hathor.conf.get_settings import get_settings
+from hathor.simulator.utils import NoCandidatesError, gen_new_double_spending, gen_new_tx
 from hathor.transaction.exceptions import RewardLocked
 from hathor.util import Random
 from hathor.wallet.exceptions import InsufficientFunds
-from tests.utils import NoCandidatesError, gen_new_double_spending, gen_new_tx
 
 if TYPE_CHECKING:
     from hathor.manager import HathorManager

--- a/hathor/simulator/utils.py
+++ b/hathor/simulator/utils.py
@@ -1,0 +1,183 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional, cast
+
+from hathor.crypto.util import decode_address
+from hathor.manager import HathorManager
+from hathor.transaction import Block, Transaction
+from hathor.types import Address, VertexId
+
+
+def gen_new_tx(manager: HathorManager, address: str, value: int, verify: bool = True) -> Transaction:
+    """
+    Generate and return a new transaction.
+
+    Args:
+        manager: the HathorManager to generate the transaction for
+        address: an address for the transaction's output
+        value: a value for the transaction's output
+        verify: whether to verify the generated transaction
+
+    Returns: the generated transaction.
+    """
+    from hathor.transaction import Transaction
+    from hathor.wallet.base_wallet import WalletOutputInfo
+
+    outputs = []
+    outputs.append(WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None))
+
+    assert manager.wallet is not None
+    tx = manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, manager.tx_storage)
+    tx.storage = manager.tx_storage
+
+    max_ts_spent_tx = max(tx.get_spent_tx(txin).timestamp for txin in tx.inputs)
+    tx.timestamp = max(max_ts_spent_tx + 1, int(manager.reactor.seconds()))
+
+    tx.weight = 1
+    tx.parents = manager.get_new_tx_parents(tx.timestamp)
+    manager.cpu_mining_service.resolve(tx)
+    if verify:
+        manager.verification_service.verify(tx)
+    return tx
+
+
+def add_new_blocks(
+    manager: HathorManager,
+    num_blocks: int,
+    advance_clock: Optional[int] = None,
+    *,
+    parent_block_hash: Optional[VertexId] = None,
+    block_data: bytes = b'',
+    weight: Optional[float] = None,
+    address: Optional[Address] = None,
+    signal_bits: int | None = None,
+) -> list[Block]:
+    """ Create, resolve and propagate some blocks
+
+        :param manager: Manager object to handle the creation
+        :type manager: :py:class:`hathor.manager.HathorManager`
+
+        :param num_blocks: Quantity of blocks to be created
+        :type num_blocks: int
+
+        :return: Blocks created
+        :rtype: list[Block]
+    """
+    blocks = []
+    for _ in range(num_blocks):
+        blocks.append(
+            add_new_block(manager, advance_clock, parent_block_hash=parent_block_hash,
+                          data=block_data, weight=weight, address=address, signal_bits=signal_bits)
+        )
+        if parent_block_hash:
+            parent_block_hash = blocks[-1].hash
+    return blocks
+
+
+def add_new_block(
+    manager: HathorManager,
+    advance_clock: Optional[int] = None,
+    *,
+    parent_block_hash: Optional[VertexId] = None,
+    data: bytes = b'',
+    weight: Optional[float] = None,
+    address: Optional[Address] = None,
+    propagate: bool = True,
+    signal_bits: int | None = None,
+) -> Block:
+    """ Create, resolve and propagate a new block
+
+        :param manager: Manager object to handle the creation
+        :type manager: :py:class:`hathor.manager.HathorManager`
+
+        :return: Block created
+        :rtype: :py:class:`hathor.transaction.block.Block`
+    """
+    block = manager.generate_mining_block(parent_block_hash=parent_block_hash, data=data, address=address)
+    if weight is not None:
+        block.weight = weight
+    if signal_bits is not None:
+        block.signal_bits = signal_bits
+    manager.cpu_mining_service.resolve(block)
+    manager.verification_service.validate_full(block)
+    if propagate:
+        manager.propagate_tx(block, fails_silently=False)
+    if advance_clock:
+        assert hasattr(manager.reactor, 'advance')
+        manager.reactor.advance(advance_clock)
+    return block
+
+
+class NoCandidatesError(Exception):
+    pass
+
+
+def gen_new_double_spending(manager: HathorManager, *, use_same_parents: bool = False,
+                            tx: Optional[Transaction] = None, weight: float = 1) -> Transaction:
+    """
+    Generate and return a double spending transaction.
+
+    Args:
+        manager: the HathorManager to generate the transaction for
+        use_same_parents: whether to use the same parents as the original transaction
+        tx: the original transaction do double spend
+        weight: the new transaction's weight
+
+    Returns: the double spending transaction.
+    """
+    if tx is None:
+        tx_candidates = manager.get_new_tx_parents()
+        genesis = manager.tx_storage.get_all_genesis()
+        genesis_txs = [tx for tx in genesis if not tx.is_block]
+        # XXX: it isn't possible to double-spend a genesis transaction, thus we remove it from tx_candidates
+        for genesis_tx in genesis_txs:
+            if genesis_tx.hash in tx_candidates:
+                tx_candidates.remove(genesis_tx.hash)
+        if not tx_candidates:
+            raise NoCandidatesError()
+        # assert tx_candidates, 'Must not be empty, otherwise test was wrongly set up'
+        tx_hash = manager.rng.choice(tx_candidates)
+        tx = cast(Transaction, manager.tx_storage.get_transaction(tx_hash))
+
+    txin = manager.rng.choice(tx.inputs)
+
+    from hathor.transaction.scripts import P2PKH, parse_address_script
+    spent_tx = tx.get_spent_tx(txin)
+    spent_txout = spent_tx.outputs[txin.index]
+    p2pkh = parse_address_script(spent_txout.script)
+    assert isinstance(p2pkh, P2PKH)
+
+    from hathor.wallet.base_wallet import WalletInputInfo, WalletOutputInfo
+    value = spent_txout.value
+    wallet = manager.wallet
+    assert wallet is not None
+    private_key = wallet.get_private_key(p2pkh.address)
+    inputs = [WalletInputInfo(tx_id=txin.tx_id, index=txin.index, private_key=private_key)]
+
+    address = wallet.get_unused_address(mark_as_used=True)
+    outputs = [WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None)]
+
+    tx2 = wallet.prepare_transaction(Transaction, inputs, outputs)
+    tx2.storage = manager.tx_storage
+    tx2.weight = weight
+    tx2.timestamp = max(tx.timestamp + 1, int(manager.reactor.seconds()))
+
+    if use_same_parents:
+        tx2.parents = list(tx.parents)
+    else:
+        tx2.parents = manager.get_new_tx_parents(tx2.timestamp)
+
+    manager.cpu_mining_service.resolve(tx2)
+    return tx2

--- a/tests/cli/test_multisig_signature.py
+++ b/tests/cli/test_multisig_signature.py
@@ -9,9 +9,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from structlog.testing import capture_logs
 
 from hathor.cli.multisig_signature import create_parser, execute
+from hathor.simulator.utils import add_new_blocks
 from hathor.wallet import Wallet
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_transactions
 
 
 class BaseSignatureTest(unittest.TestCase):

--- a/tests/cli/test_multisig_spend.py
+++ b/tests/cli/test_multisig_spend.py
@@ -6,12 +6,13 @@ from structlog.testing import capture_logs
 from hathor.cli.multisig_spend import create_parser, execute
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import create_output_script
 from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 settings = HathorSettings()
 

--- a/tests/cli/test_twin_tx.py
+++ b/tests/cli/test_twin_tx.py
@@ -6,12 +6,12 @@ from structlog.testing import capture_logs
 
 from hathor.cli.twin_tx import create_parser, execute
 from hathor.conf import HathorSettings
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TransactionMetadata
 from hathor.util import json_loadb
 from tests import unittest
 from tests.utils import (
     add_blocks_unlock_reward,
-    add_new_blocks,
     add_new_transactions,
     execute_mining,
     execute_tx_gen,

--- a/tests/consensus/test_consensus.py
+++ b/tests/consensus/test_consensus.py
@@ -1,16 +1,10 @@
 from unittest.mock import MagicMock
 
 from hathor.conf import HathorSettings
+from hathor.simulator.utils import add_new_block, add_new_blocks, gen_new_tx
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
-from tests.utils import (
-    add_blocks_unlock_reward,
-    add_new_block,
-    add_new_blocks,
-    add_new_double_spending,
-    add_new_transactions,
-    gen_new_tx,
-)
+from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
 
 settings = HathorSettings()
 

--- a/tests/consensus/test_consensus2.py
+++ b/tests/consensus/test_consensus2.py
@@ -1,7 +1,8 @@
 from hathor.graphviz import GraphvizVisualizer
+from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import add_custom_tx, gen_new_tx
+from tests.utils import add_custom_tx
 
 
 class BaseConsensusSimulatorTestCase(SimulatorTestCase):

--- a/tests/consensus/test_consensus3.py
+++ b/tests/consensus/test_consensus3.py
@@ -1,7 +1,8 @@
 import pytest
 
+from hathor.simulator.utils import add_new_block, add_new_blocks
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_block, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 
 class DoubleSpendingTestCase(unittest.TestCase):

--- a/tests/consensus/test_soft_voided.py
+++ b/tests/consensus/test_soft_voided.py
@@ -2,9 +2,10 @@ from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterNTransactions
+from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import add_custom_tx, gen_new_tx
+from tests.utils import add_custom_tx
 
 settings = HathorSettings()
 

--- a/tests/consensus/test_soft_voided2.py
+++ b/tests/consensus/test_soft_voided2.py
@@ -1,9 +1,10 @@
 from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import Simulator
+from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import BURN_ADDRESS, add_custom_tx, gen_new_tx
+from tests.utils import BURN_ADDRESS, add_custom_tx
 
 settings = HathorSettings()
 

--- a/tests/consensus/test_soft_voided3.py
+++ b/tests/consensus/test_soft_voided3.py
@@ -2,9 +2,10 @@ from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterNTransactions
+from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import add_custom_tx, gen_custom_tx, gen_new_tx
+from tests.utils import add_custom_tx, gen_custom_tx
 
 settings = HathorSettings()
 

--- a/tests/consensus/test_soft_voided4.py
+++ b/tests/consensus/test_soft_voided4.py
@@ -2,9 +2,10 @@ from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterNTransactions
+from hathor.simulator.utils import gen_new_double_spending
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import add_custom_tx, gen_new_double_spending
+from tests.utils import add_custom_tx
 
 settings = HathorSettings()
 

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -1,8 +1,9 @@
 from hathor.conf import HathorSettings
 from hathor.event.model.event_type import EventType
 from hathor.event.storage import EventMemoryStorage
+from hathor.simulator.utils import add_new_blocks
 from tests import unittest
-from tests.utils import BURN_ADDRESS, add_new_blocks, get_genesis_key
+from tests.utils import BURN_ADDRESS, get_genesis_key
 
 settings = HathorSettings()
 

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -2,17 +2,12 @@ from typing import Iterator
 
 from hathor.conf import HathorSettings
 from hathor.pubsub import PubSubManager
+from hathor.simulator.utils import add_new_block, add_new_blocks
 from hathor.transaction import BaseTransaction
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
 from tests.unittest import TestBuilder
-from tests.utils import (
-    add_blocks_unlock_reward,
-    add_new_block,
-    add_new_blocks,
-    add_new_double_spending,
-    add_new_transactions,
-)
+from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
 
 settings = HathorSettings()
 

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -7,10 +7,11 @@ from hathor.p2p.manager import PeerConnectionsMetrics
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.protocol import HathorProtocol
 from hathor.pubsub import HathorEvents
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.storage import TransactionCacheStorage, TransactionMemoryStorage
 from hathor.wallet import Wallet
 from tests import unittest
-from tests.utils import HAS_ROCKSDB, add_new_blocks
+from tests.utils import HAS_ROCKSDB
 
 
 class BaseMetricsTest(unittest.TestCase):

--- a/tests/p2p/test_double_spending.py
+++ b/tests/p2p/test_double_spending.py
@@ -1,6 +1,7 @@
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_tx
+from tests.utils import add_blocks_unlock_reward, add_new_tx
 
 
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):

--- a/tests/p2p/test_split_brain.py
+++ b/tests/p2p/test_split_brain.py
@@ -4,9 +4,10 @@ from mnemonic import Mnemonic
 from hathor.daa import TestMode
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection
+from hathor.simulator.utils import add_new_block
 from hathor.wallet import HDWallet
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_block, add_new_double_spending, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
 
 
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):

--- a/tests/p2p/test_twin_tx.py
+++ b/tests/p2p/test_twin_tx.py
@@ -1,8 +1,9 @@
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletOutputInfo
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_double_spending
+from tests.utils import add_blocks_unlock_reward, add_new_double_spending
 
 
 class BaseTwinTransactionTestCase(unittest.TestCase):

--- a/tests/resources/test_mining_info.py
+++ b/tests/resources/test_mining_info.py
@@ -2,9 +2,9 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.p2p.resources import MiningInfoResource
+from hathor.simulator.utils import add_new_blocks
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_new_blocks
 
 settings = HathorSettings()
 

--- a/tests/resources/transaction/test_block_at_height.py
+++ b/tests/resources/transaction/test_block_at_height.py
@@ -1,9 +1,9 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import BlockAtHeightResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_new_blocks
 
 
 class BaseBlockAtHeightTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/transaction/test_create_tx.py
+++ b/tests/resources/transaction/test_create_tx.py
@@ -3,12 +3,13 @@ import base64
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.daa import TestMode
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.transaction.resources import CreateTxResource
 from hathor.transaction.scripts import P2PKH, create_base_script
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_tx
+from tests.utils import add_blocks_unlock_reward, add_new_tx
 
 
 class BaseTransactionTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/transaction/test_graphviz.py
+++ b/tests/resources/transaction/test_graphviz.py
@@ -1,10 +1,11 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.transaction.resources import GraphvizFullResource, GraphvizNeighboursResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, TestDummyRequest, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_transactions
 
 
 class BaseGraphvizTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/transaction/test_mempool.py
+++ b/tests/resources/transaction/test_mempool.py
@@ -1,10 +1,11 @@
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import MempoolResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_transactions
 
 settings = HathorSettings()
 

--- a/tests/resources/transaction/test_pushtx.py
+++ b/tests/resources/transaction/test_pushtx.py
@@ -4,14 +4,16 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput
 from hathor.transaction.resources import PushTxResource
 from hathor.transaction.scripts import P2PKH, parse_address_script
+from hathor.util import not_none
 from hathor.wallet.base_wallet import WalletInputInfo, WalletOutputInfo
 from hathor.wallet.resources import SendTokensResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_tx_with_data_script, create_tokens
+from tests.utils import add_blocks_unlock_reward, add_tx_with_data_script, create_tokens
 
 settings = HathorSettings()
 
@@ -101,7 +103,7 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
 
         # invalid transaction, without forcing
         tx.timestamp = 5
-        tx.inputs = [TxInput(blocks[1].hash, 0, b'')]
+        tx.inputs = [TxInput(not_none(blocks[1].hash), 0, b'')]
         script_type_out = parse_address_script(blocks[1].outputs[0].script)
         assert script_type_out is not None
         private_key = self.manager.wallet.get_private_key(script_type_out.address)

--- a/tests/resources/transaction/test_transaction_confirmation.py
+++ b/tests/resources/transaction/test_transaction_confirmation.py
@@ -1,9 +1,10 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import TransactionAccWeightResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_transactions
 
 
 class BaseTransactionTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/transaction/test_tx.py
+++ b/tests/resources/transaction/test_tx.py
@@ -1,12 +1,13 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.transaction.resources import TransactionResource
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.validation_state import ValidationState
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_transactions
 
 
 class BaseTransactionTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/transaction/test_utxo_search.py
+++ b/tests/resources/transaction/test_utxo_search.py
@@ -2,10 +2,11 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import UtxoSearchResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 settings = HathorSettings()
 

--- a/tests/resources/wallet/test_nano_contract.py
+++ b/tests/resources/wallet/test_nano_contract.py
@@ -1,5 +1,6 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.transaction.resources import DecodeTxResource, PushTxResource
 from hathor.util import json_loadb
@@ -11,7 +12,7 @@ from hathor.wallet.resources.nano_contracts import (
 )
 from tests import unittest
 from tests.resources.base_resource import StubSite, TestDummyRequest, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 
 class BaseNanoContractsTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/wallet/test_search_address.py
+++ b/tests/resources/wallet/test_search_address.py
@@ -2,11 +2,12 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.scripts import parse_address_script
 from hathor.wallet.resources.thin_wallet import AddressBalanceResource, AddressSearchResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, create_tokens
+from tests.utils import add_blocks_unlock_reward, create_tokens
 
 settings = HathorSettings()
 

--- a/tests/resources/wallet/test_send_tokens.py
+++ b/tests/resources/wallet/test_send_tokens.py
@@ -5,10 +5,11 @@ from twisted.internet.defer import inlineCallbacks
 from hathor.daa import TestMode
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.p2p.resources import MiningResource
+from hathor.simulator.utils import add_new_blocks
 from hathor.wallet.resources import BalanceResource, HistoryResource, SendTokensResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, TestDummyRequest, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, resolve_block_bytes
+from tests.utils import add_blocks_unlock_reward, resolve_block_bytes
 
 
 class BaseSendTokensTest(_BaseResourceTest._ResourceTest):

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -4,6 +4,7 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
 from hathor.wallet.resources.thin_wallet import (
@@ -14,7 +15,7 @@ from hathor.wallet.resources.thin_wallet import (
 )
 from tests import unittest
 from tests.resources.base_resource import StubSite, TestDummyRequest, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_tx, create_tokens
+from tests.utils import add_blocks_unlock_reward, add_new_tx, create_tokens
 
 settings = HathorSettings()
 

--- a/tests/tx/test_accumulated_weight.py
+++ b/tests/tx/test_accumulated_weight.py
@@ -1,7 +1,8 @@
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import sum_weights
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions
+from tests.utils import add_blocks_unlock_reward, add_new_transactions
 
 
 class BaseAccumulatedWeightTestCase(unittest.TestCase):

--- a/tests/tx/test_blockchain.py
+++ b/tests/tx/test_blockchain.py
@@ -2,10 +2,11 @@ from itertools import chain
 
 from hathor.conf import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import sum_weights
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
-from tests.utils import add_new_blocks, add_new_transactions
+from tests.utils import add_new_transactions
 
 settings = HathorSettings()
 

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -1,8 +1,9 @@
 from hathor.daa import TestMode
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TransactionMetadata
 from hathor.transaction.storage import TransactionCacheStorage
 from tests import unittest
-from tests.utils import add_new_blocks, add_new_transactions
+from tests.utils import add_new_transactions
 
 CACHE_SIZE = 5
 

--- a/tests/tx/test_indexes.py
+++ b/tests/tx/test_indexes.py
@@ -3,21 +3,13 @@ import pytest
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.graphviz import GraphvizVisualizer
+from hathor.simulator.utils import add_new_block, add_new_blocks, gen_new_tx
 from hathor.storage.rocksdb_storage import RocksDBStorage
 from hathor.transaction import Transaction
-from hathor.util import iwindows
+from hathor.util import iwindows, not_none
 from hathor.wallet import Wallet
 from tests import unittest
-from tests.utils import (
-    HAS_ROCKSDB,
-    add_blocks_unlock_reward,
-    add_custom_tx,
-    add_new_block,
-    add_new_blocks,
-    add_new_tx,
-    gen_new_tx,
-    get_genesis_key,
-)
+from tests.utils import HAS_ROCKSDB, add_blocks_unlock_reward, add_custom_tx, add_new_tx, get_genesis_key
 
 settings = HathorSettings()
 
@@ -933,7 +925,7 @@ class SyncV2MemoryIndexesTest(unittest.SyncV2Params, BaseMemoryIndexesTest):
         # XXX: this test makes use of the internals of the memory deps-index implementation
         deps_index: MemoryDepsIndex = self.manager.tx_storage.indexes.deps
 
-        address = self.get_address(0)
+        address = not_none(self.get_address(0))
         value = 500
         tx = gen_new_tx(self.manager, address, value)
 
@@ -981,7 +973,7 @@ class SyncV2RocksDBIndexesTest(unittest.SyncV2Params, BaseRocksDBIndexesTest):
         # XXX: this test makes use of the internals of the rocksdb deps-index implementation
         deps_index: RocksDBDepsIndex = self.manager.tx_storage.indexes.deps
 
-        address = self.get_address(0)
+        address = not_none(self.get_address(0))
         value = 500
         tx = gen_new_tx(self.manager, address, value)
 

--- a/tests/tx/test_indexes4.py
+++ b/tests/tx/test_indexes4.py
@@ -1,9 +1,10 @@
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks, gen_new_tx
 from hathor.transaction import Transaction
 from hathor.transaction.storage import TransactionMemoryStorage
 from hathor.wallet.base_wallet import WalletOutputInfo
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, gen_new_tx
+from tests.utils import add_blocks_unlock_reward
 
 
 class BaseSimulatorIndexesTestCase(unittest.TestCase):

--- a/tests/tx/test_mining.py
+++ b/tests/tx/test_mining.py
@@ -2,10 +2,10 @@ from typing import Any
 
 from hathor.conf import HathorSettings
 from hathor.mining import BlockTemplate
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Block, sum_weights
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
-from tests.utils import add_new_blocks
 
 settings = HathorSettings()
 

--- a/tests/tx/test_multisig.py
+++ b/tests/tx/test_multisig.py
@@ -2,13 +2,14 @@ import base58
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address, get_private_key_from_bytes, get_public_key_bytes_compressed
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import ScriptError
 from hathor.transaction.scripts import P2PKH, MultiSig, create_output_script, parse_address_script, script_eval
 from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 settings = HathorSettings()
 

--- a/tests/tx/test_prometheus.py
+++ b/tests/tx/test_prometheus.py
@@ -6,8 +6,9 @@ import tempfile
 import pytest
 
 from hathor.prometheus import PrometheusMetricsExporter
+from hathor.simulator.utils import add_new_blocks
 from tests import unittest
-from tests.utils import add_new_blocks, add_new_transactions
+from tests.utils import add_new_transactions
 
 
 class BasePrometheusTest(unittest.TestCase):

--- a/tests/tx/test_reward_lock.py
+++ b/tests/tx/test_reward_lock.py
@@ -2,13 +2,14 @@ import pytest
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import get_address_from_public_key
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import RewardLocked
 from hathor.transaction.scripts import P2PKH
 from hathor.transaction.storage import TransactionMemoryStorage
 from hathor.wallet import Wallet
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, get_genesis_key
+from tests.utils import add_blocks_unlock_reward, get_genesis_key
 
 settings = HathorSettings()
 

--- a/tests/tx/test_timelock.py
+++ b/tests/tx/test_timelock.py
@@ -1,10 +1,11 @@
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 settings = HathorSettings()
 

--- a/tests/tx/test_tips.py
+++ b/tests/tx/test_tips.py
@@ -1,12 +1,7 @@
+from hathor.simulator.utils import add_new_block, add_new_blocks
 from hathor.transaction import Transaction
 from tests import unittest
-from tests.utils import (
-    add_blocks_unlock_reward,
-    add_new_block,
-    add_new_blocks,
-    add_new_double_spending,
-    add_new_transactions,
-)
+from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
 
 
 class BaseTipsTestCase(unittest.TestCase):

--- a/tests/tx/test_traversal.py
+++ b/tests/tx/test_traversal.py
@@ -1,8 +1,9 @@
 from math import inf
 
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.storage.traversal import BFSOrderWalk, BFSTimestampWalk, DFSWalk
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, add_new_transactions, add_new_tx
+from tests.utils import add_blocks_unlock_reward, add_new_transactions, add_new_tx
 
 
 class _TraversalTestCase(unittest.TestCase):

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -4,6 +4,7 @@ from math import isinf, isnan
 
 from hathor.crypto.util import decode_address, get_address_from_public_key, get_private_key_from_bytes
 from hathor.daa import TestMode
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import MAX_OUTPUT_VALUE, Block, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import (
     BlockWithInputs,
@@ -31,13 +32,7 @@ from hathor.transaction.util import int_to_bytes
 from hathor.transaction.validation_state import ValidationState
 from hathor.wallet import Wallet
 from tests import unittest
-from tests.utils import (
-    add_blocks_unlock_reward,
-    add_new_blocks,
-    add_new_transactions,
-    create_script_with_sigops,
-    get_genesis_key,
-)
+from tests.utils import add_blocks_unlock_reward, add_new_transactions, create_script_with_sigops, get_genesis_key
 
 
 class BaseTransactionTest(unittest.TestCase):

--- a/tests/tx/test_tx_serialization.py
+++ b/tests/tx/test_tx_serialization.py
@@ -1,8 +1,9 @@
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletOutputInfo
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 
 class _SerializationTest(unittest.TestCase):

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -10,6 +10,7 @@ from twisted.trial import unittest
 
 from hathor.conf import HathorSettings
 from hathor.daa import TestMode
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
@@ -19,7 +20,6 @@ from tests.utils import (
     BURN_ADDRESS,
     HAS_ROCKSDB,
     add_blocks_unlock_reward,
-    add_new_blocks,
     add_new_transactions,
     add_new_tx,
     create_tokens,

--- a/tests/wallet/test_balance_update.py
+++ b/tests/wallet/test_balance_update.py
@@ -1,11 +1,12 @@
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH
 from hathor.wallet.base_wallet import SpentTx, UnspentTx, WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import PrivateKeyNotFound
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks, create_tokens
+from tests.utils import add_blocks_unlock_reward, create_tokens
 
 settings = HathorSettings()
 

--- a/tests/wallet/test_index.py
+++ b/tests/wallet/test_index.py
@@ -1,8 +1,9 @@
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletOutputInfo
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_blocks
+from tests.utils import add_blocks_unlock_reward
 
 
 class BaseWalletIndexTest(unittest.TestCase):

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -6,13 +6,14 @@ from cryptography.hazmat.primitives import serialization
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address, get_address_b58_from_public_key, get_private_key_bytes
+from hathor.simulator.utils import add_new_block
 from hathor.transaction import Transaction, TxInput
 from hathor.wallet import Wallet
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds, InvalidAddress, OutOfUnusedAddresses, WalletLocked
 from hathor.wallet.keypair import KeyPair
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_block, create_tokens, get_genesis_key
+from tests.utils import add_blocks_unlock_reward, create_tokens, get_genesis_key
 
 settings = HathorSettings()
 

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -1,11 +1,12 @@
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
+from hathor.simulator.utils import add_new_block
 from hathor.transaction import Transaction
 from hathor.wallet import HDWallet
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds
 from tests import unittest
-from tests.utils import add_blocks_unlock_reward, add_new_block
+from tests.utils import add_blocks_unlock_reward
 
 settings = HathorSettings()
 


### PR DESCRIPTION
### Motivation

The events simulator CLI tool was using some functions defined in the `tests` module, which is not copied to the Docker image. To make the tool available via Docker, those functions must be moved to another module.

### Acceptance Criteria

- Move functions from `tests` module to `utils/simulator` module
- Update imports
- Add custom check to make sure `tests` are not imported in `hathor`
- Small changes to fix linter issues with added typings

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 