### PR TITLE
fix(feature-activation): add signal bits to minimally valid block

### DIFF
--- a/hathor/mining/block_template.py
+++ b/hathor/mining/block_template.py
@@ -36,7 +36,7 @@ class BlockTemplate(NamedTuple):
     score: float  # metadata
     signal_bits: int  # signal bits for blocks generated from this template
 
-    def generate_minimaly_valid_block(self) -> BaseTransaction:
+    def generate_minimally_valid_block(self) -> BaseTransaction:
         """ Generates a block, without any extra information that is valid for this template. No random choices."""
         from hathor.transaction import TxOutput, TxVersion
         return TxVersion(min(self.versions)).get_cls()(
@@ -44,6 +44,7 @@ class BlockTemplate(NamedTuple):
             parents=self.parents[:] + sorted(self.parents_any)[:(3 - len(self.parents))],
             outputs=[TxOutput(self.reward, b'')],
             weight=self.weight,
+            signal_bits=self.signal_bits,
         )
 
     def generate_mining_block(self, rng: Random, merge_mined: bool = False, address: Optional[bytes] = None,
@@ -83,7 +84,7 @@ class BlockTemplate(NamedTuple):
 
     def to_dict(self) -> dict:
         return {
-            'data': self.generate_minimaly_valid_block().get_struct_without_nonce().hex(),
+            'data': self.generate_minimally_valid_block().get_struct_without_nonce().hex(),
             'versions': sorted(self.versions),
             'reward': self.reward,
             'weight': self.weight,

--- a/tests/tx/test_mining.py
+++ b/tests/tx/test_mining.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 from hathor.conf import HathorSettings
 from hathor.mining import BlockTemplate
-from hathor.transaction import sum_weights
+from hathor.transaction import Block, sum_weights
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
 from tests.utils import add_new_blocks
@@ -74,6 +76,39 @@ class BaseMiningTest(unittest.TestCase):
         ))
 
         self.assertConsensusValid(manager)
+
+    def test_minimally_valid_block(self) -> None:
+        template = BlockTemplate(
+            versions={0},
+            reward=6400,
+            weight=60,
+            timestamp_now=12345,
+            timestamp_min=12344,
+            timestamp_max=12346,
+            parents=[b'\x01', b'\x02', b'\x03'],
+            parents_any=[],
+            height=999,
+            score=100,
+            signal_bits=0b0101,
+        )
+        block = template.generate_minimally_valid_block()
+        json = block.to_json()
+        expected: dict[str, Any] = dict(
+            data='',
+            hash=None,
+            inputs=[],
+            nonce=0,
+            outputs=[dict(script='', token_data=0, value=6400)],
+            parents=['01', '02', '03'],
+            signal_bits=0b0101,
+            timestamp=12344,
+            tokens=[],
+            version=0,
+            weight=60
+        )
+
+        self.assertTrue(isinstance(block, Block))
+        self.assertEqual(json, expected)
 
 
 class SyncV1MiningTest(unittest.SyncV1Params, BaseMiningTest):


### PR DESCRIPTION
### Motivation

The `BlockTemplate.generate_minimally_valid_block()` method is not setting signal bits as it should.

### Acceptance Criteria

- Add signal bits to minimally valid block template

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 