### PR TITLE
feat(wallet): Add BaseWallet.get_balance_per_address() method

### DIFF
--- a/hathor/types.py
+++ b/hathor/types.py
@@ -17,6 +17,7 @@
 
 VertexId = bytes        # NewType('TxId', bytes)
 Address = bytes         # NewType('Address', bytes)
+AddressB58 = str
 TxOutputScript = bytes  # NewType('TxOutputScript', bytes)
 Timestamp = int         # NewType('Timestamp', int)
 TokenUid = VertexId     # NewType('TokenUid', VertexId)

--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -32,6 +32,7 @@ from hathor.transaction.base_transaction import int_to_bytes
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
 from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.transaction import Transaction
+from hathor.types import AddressB58, Amount, TokenUid
 from hathor.util import Reactor
 from hathor.wallet.exceptions import InputDuplicated, InsufficientFunds, PrivateKeyNotFound
 
@@ -134,6 +135,13 @@ class BaseWallet:
 
     def _manually_initialize(self) -> None:
         pass
+
+    def get_balance_per_address(self, token_uid: TokenUid) -> dict[AddressB58, Amount]:
+        """Return balance per address for a given token. This method ignores locks."""
+        balances: defaultdict[AddressB58, Amount] = defaultdict(Amount)
+        for utxo_info, unspent_tx in self.unspent_txs[token_uid].items():
+            balances[unspent_tx.address] += unspent_tx.value
+        return dict(balances)
 
     def start(self) -> None:
         """ Start the pubsub subscription if wallet has a pubsub

--- a/tests/wallet/test_balance_update.py
+++ b/tests/wallet/test_balance_update.py
@@ -436,6 +436,9 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # hathor balance remains the same
         self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID], hathor_balance)
 
+        balances_per_address = self.manager.wallet.get_balance_per_address(settings.HATHOR_TOKEN_UID)
+        self.assertEqual(hathor_balance.available, sum(x for x in balances_per_address.values()))
+
 
 class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMethodsTestCase):
     __test__ = True


### PR DESCRIPTION
### Motivation

Utility method to be used on tests and simulations.

### Acceptance Criteria

1. Add method `BaseWallet.get_balance_per_address()` that returns the balances grouped by addresses.
2. This method ignores locks and returns the total balance (available + locked).

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 