### PR TITLE
refactor(verification): move vertex verification to its own service

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -41,6 +41,7 @@ from hathor.transaction.storage import (
     TransactionStorage,
 )
 from hathor.util import Random, Reactor, get_environment_info
+from hathor.verification.verification_service import VerificationService
 from hathor.wallet import BaseWallet, Wallet
 
 logger = get_logger()
@@ -101,6 +102,8 @@ class Builder:
         self._feature_service: Optional[FeatureService] = None
         self._bit_signaling_service: Optional[BitSignalingService] = None
 
+        self._verification_service: Optional[VerificationService] = None
+
         self._rocksdb_path: Optional[str] = None
         self._rocksdb_storage: Optional[RocksDBStorage] = None
         self._rocksdb_cache_capacity: Optional[int] = None
@@ -157,6 +160,7 @@ class Builder:
         tx_storage = self._get_or_create_tx_storage(indexes)
         feature_service = self._get_or_create_feature_service(tx_storage)
         bit_signaling_service = self._get_or_create_bit_signaling_service(tx_storage)
+        verification_service = self._get_or_create_verification_service()
 
         if self._enable_address_index:
             indexes.enable_address_index(pubsub)
@@ -191,6 +195,7 @@ class Builder:
             environment_info=get_environment_info(self._cmdline, peer_id.id),
             feature_service=feature_service,
             bit_signaling_service=bit_signaling_service,
+            verification_service=verification_service,
             **kwargs
         )
 
@@ -424,6 +429,12 @@ class Builder:
 
         return self._bit_signaling_service
 
+    def _get_or_create_verification_service(self) -> VerificationService:
+        if self._verification_service is None:
+            self._verification_service = VerificationService()
+
+        return self._verification_service
+
     def use_memory(self) -> 'Builder':
         self.check_if_can_modify()
         self._storage_type = StorageType.MEMORY
@@ -514,6 +525,11 @@ class Builder:
     def set_event_storage(self, event_storage: EventStorage) -> 'Builder':
         self.check_if_can_modify()
         self._event_storage = event_storage
+        return self
+
+    def set_verification_service(self, verification_service: VerificationService) -> 'Builder':
+        self.check_if_can_modify()
+        self._verification_service = verification_service
         return self
 
     def set_reactor(self, reactor: Reactor) -> 'Builder':

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -35,6 +35,7 @@ from hathor.p2p.utils import discover_hostname
 from hathor.pubsub import PubSubManager
 from hathor.stratum import StratumFactory
 from hathor.util import Random, Reactor
+from hathor.verification.verification_service import VerificationService
 from hathor.wallet import BaseWallet, HDWallet, Wallet
 
 logger = get_logger()
@@ -202,6 +203,8 @@ class CliBuilder:
             not_support_features=self._args.signal_not_support
         )
 
+        verification_service = VerificationService()
+
         p2p_manager = ConnectionsManager(
             reactor,
             network=network,
@@ -231,7 +234,8 @@ class CliBuilder:
             full_verification=full_verification,
             enable_event_queue=self._args.x_enable_event_queue,
             feature_service=self.feature_service,
-            bit_signaling_service=bit_signaling_service
+            bit_signaling_service=bit_signaling_service,
+            verification_service=verification_service,
         )
 
         p2p_manager.set_manager(self.manager)

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -1154,7 +1154,7 @@ class NodeBlockSync(SyncAgent):
                 if isinstance(tx, Block) and not tx.has_basic_block_parent():
                     self.log.warn('on_new_tx(): block parent needs to be at least basic-valid', tx=tx.hash_hex)
                     return False
-                if not tx.validate_basic():
+                if not self.manager.verification_service.validate_basic(tx):
                     self.log.warn('on_new_tx(): basic validation failed', tx=tx.hash_hex)
                     return False
 

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -321,12 +321,6 @@ class Block(BaseTransaction):
             return False
         return metadata.validation.is_at_least_basic()
 
-    def verify_basic(self, skip_block_weight_verification: bool = False) -> None:
-        """Partially run validations, the ones that need parents/inputs are skipped."""
-        if not skip_block_weight_verification:
-            self.verify_weight()
-        self.verify_reward()
-
     def verify_checkpoint(self, checkpoints: list[Checkpoint]) -> None:
         assert self.hash is not None
         assert self.storage is not None
@@ -395,27 +389,6 @@ class Block(BaseTransaction):
     def get_base_hash(self) -> bytes:
         from hathor.merged_mining.bitcoin import sha256d_hash
         return sha256d_hash(self.get_header_without_nonce())
-
-    @cpu.profiler(key=lambda self: 'block-verify!{}'.format(self.hash.hex()))
-    def verify(self, reject_locked_reward: bool = True) -> None:
-        """
-            (1) confirms at least two pending transactions and references last block
-            (2) solves the pow with the correct weight (done in HathorManager)
-            (3) creates the correct amount of tokens in the output (done in HathorManager)
-            (4) all parents must exist and have timestamp smaller than ours
-            (5) data field must contain at most BLOCK_DATA_MAX_SIZE bytes
-        """
-        # TODO Should we validate a limit of outputs?
-        if self.is_genesis:
-            # TODO do genesis validation
-            return
-
-        self.verify_without_storage()
-
-        # (1) and (4)
-        self.verify_parents()
-
-        self.verify_height()
 
     def get_height(self) -> int:
         """Returns the block's height."""

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -220,14 +220,6 @@ class TokenCreationTransaction(Transaction):
         json['tokens'] = []
         return json
 
-    def verify(self, reject_locked_reward: bool = True) -> None:
-        """ Run all validations as regular transactions plus validation on token info.
-
-        We also overload verify_sum to make some different checks
-        """
-        super().verify(reject_locked_reward=reject_locked_reward)
-        self.verify_token_info()
-
     def verify_sum(self) -> None:
         """ Besides all checks made on regular transactions, a few extra ones are made:
         - only HTR tokens on the inputs;

--- a/hathor/verification/block_verification.py
+++ b/hathor/verification/block_verification.py
@@ -1,0 +1,47 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.profiler import get_cpu_profiler
+from hathor.transaction import Block
+
+cpu = get_cpu_profiler()
+
+
+def verify_basic(block: Block, *, skip_block_weight_verification: bool = False) -> None:
+    """Partially run validations, the ones that need parents/inputs are skipped."""
+    if not skip_block_weight_verification:
+        block.verify_weight()
+    block.verify_reward()
+
+
+@cpu.profiler(key=lambda block: 'block-verify!{}'.format(block.hash.hex()))
+def verify(block: Block) -> None:
+    """
+        (1) confirms at least two pending transactions and references last block
+        (2) solves the pow with the correct weight (done in HathorManager)
+        (3) creates the correct amount of tokens in the output (done in HathorManager)
+        (4) all parents must exist and have timestamp smaller than ours
+        (5) data field must contain at most BLOCK_DATA_MAX_SIZE bytes
+    """
+    # TODO Should we validate a limit of outputs?
+    if block.is_genesis:
+        # TODO do genesis validation
+        return
+
+    block.verify_without_storage()
+
+    # (1) and (4)
+    block.verify_parents()
+
+    block.verify_height()

--- a/hathor/verification/token_creation_transaction_verification.py
+++ b/hathor/verification/token_creation_transaction_verification.py
@@ -1,0 +1,25 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.verification import transaction_verification
+
+
+def verify(tx: TokenCreationTransaction, *, reject_locked_reward: bool = True) -> None:
+    """ Run all validations as regular transactions plus validation on token info.
+
+    We also overload verify_sum to make some different checks
+    """
+    transaction_verification.verify(tx, reject_locked_reward=reject_locked_reward)
+    tx.verify_token_info()

--- a/hathor/verification/transaction_verification.py
+++ b/hathor/verification/transaction_verification.py
@@ -1,0 +1,53 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.profiler import get_cpu_profiler
+from hathor.transaction import Transaction
+
+cpu = get_cpu_profiler()
+
+
+def verify_basic(transaction: Transaction) -> None:
+    """Partially run validations, the ones that need parents/inputs are skipped."""
+    if transaction.is_genesis:
+        # TODO do genesis validation?
+        return
+    transaction.verify_parents_basic()
+    transaction.verify_weight()
+    transaction.verify_without_storage()
+
+
+@cpu.profiler(key=lambda tx: 'tx-verify!{}'.format(tx.hash.hex()))
+def verify(tx: Transaction, *, reject_locked_reward: bool = True) -> None:
+    """ Common verification for all transactions:
+       (i) number of inputs is at most 256
+      (ii) number of outputs is at most 256
+     (iii) confirms at least two pending transactions
+      (iv) solves the pow (we verify weight is correct in HathorManager)
+       (v) validates signature of inputs
+      (vi) validates public key and output (of the inputs) addresses
+     (vii) validate that both parents are valid
+    (viii) validate input's timestamps
+      (ix) validate inputs and outputs sum
+    """
+    if tx.is_genesis:
+        # TODO do genesis validation
+        return
+    tx.verify_without_storage()
+    tx.verify_sigops_input()
+    tx.verify_inputs()  # need to run verify_inputs first to check if all inputs exist
+    tx.verify_parents()
+    tx.verify_sum()
+    if reject_locked_reward:
+        tx.verify_reward_locked()

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -1,0 +1,112 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.transaction import BaseTransaction, Block, Transaction, TxVersion
+from hathor.transaction.exceptions import TxValidationError
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.validation_state import ValidationState
+from hathor.verification import block_verification, token_creation_transaction_verification, transaction_verification
+
+
+class VerificationService:
+    __slots__ = ()
+
+    def validate_basic(self, vertex: BaseTransaction, *, skip_block_weight_verification: bool = False) -> bool:
+        """ Run basic validations (all that are possible without dependencies) and update the validation state.
+
+        If no exception is raised, the ValidationState will end up as `BASIC` and return `True`.
+        """
+        self.verify_basic(vertex, skip_block_weight_verification=skip_block_weight_verification)
+        vertex.set_validation(ValidationState.BASIC)
+
+        return True
+
+    def validate_full(
+        self,
+        vertex: BaseTransaction,
+        *,
+        skip_block_weight_verification: bool = False,
+        sync_checkpoints: bool = False,
+        reject_locked_reward: bool = True
+    ) -> bool:
+        """ Run full validations (these need access to all dependencies) and update the validation state.
+
+        If no exception is raised, the ValidationState will end up as `FULL` or `CHECKPOINT_FULL` and return `True`.
+        """
+        from hathor.transaction.transaction_metadata import ValidationState
+
+        meta = vertex.get_metadata()
+
+        # skip full validation when it is a checkpoint
+        if meta.validation.is_checkpoint():
+            vertex.set_validation(ValidationState.CHECKPOINT_FULL)
+            return True
+
+        # XXX: in some cases it might be possible that this transaction is verified by a checkpoint but we went
+        #      directly into trying a full validation so we should check it here to make sure the validation states
+        #      ends up being CHECKPOINT_FULL instead of FULL
+        if not meta.validation.is_at_least_basic():
+            # run basic validation if we haven't already
+            self.verify_basic(vertex, skip_block_weight_verification=skip_block_weight_verification)
+
+        self.verify(vertex, reject_locked_reward=reject_locked_reward)
+        validation = ValidationState.CHECKPOINT_FULL if sync_checkpoints else ValidationState.FULL
+        vertex.set_validation(validation)
+        return True
+
+    def verify_basic(self, vertex: BaseTransaction, *, skip_block_weight_verification: bool = False) -> None:
+        """Basic verifications (the ones without access to dependencies: parents+inputs). Raises on error.
+
+        Used by `self.validate_basic`. Should not modify the validation state."""
+        match vertex.version:
+            case TxVersion.REGULAR_BLOCK | TxVersion.MERGE_MINED_BLOCK:
+                assert isinstance(vertex, Block)
+                block_verification.verify_basic(vertex, skip_block_weight_verification=skip_block_weight_verification)
+            case TxVersion.REGULAR_TRANSACTION | TxVersion.TOKEN_CREATION_TRANSACTION:
+                assert isinstance(vertex, Transaction)
+                transaction_verification.verify_basic(vertex)
+            case _:
+                raise NotImplementedError
+
+    def verify(self, vertex: BaseTransaction, *, reject_locked_reward: bool = True) -> None:
+        """Run all verifications. Raises on error.
+
+        Used by `self.validate_full`. Should not modify the validation state."""
+        match vertex.version:
+            case TxVersion.REGULAR_BLOCK | TxVersion.MERGE_MINED_BLOCK:
+                assert isinstance(vertex, Block)
+                block_verification.verify(vertex)
+            case TxVersion.REGULAR_TRANSACTION:
+                assert isinstance(vertex, Transaction)
+                transaction_verification.verify(vertex, reject_locked_reward=reject_locked_reward)
+            case TxVersion.TOKEN_CREATION_TRANSACTION:
+                assert isinstance(vertex, TokenCreationTransaction)
+                token_creation_transaction_verification.verify(vertex, reject_locked_reward=reject_locked_reward)
+            case _:
+                raise NotImplementedError
+
+    def validate_vertex_error(self, vertex: BaseTransaction) -> tuple[bool, str]:
+        """ Verify if tx is valid and return success and possible error message
+
+            :return: Success if tx is valid and possible error message, if not
+            :rtype: tuple[bool, str]
+        """
+        success = True
+        message = ''
+        try:
+            self.verify(vertex)
+        except TxValidationError as e:
+            success = False
+            message = str(e)
+        return success, message

--- a/hathor/wallet/resources/send_tokens.py
+++ b/hathor/wallet/resources/send_tokens.py
@@ -128,7 +128,7 @@ class SendTokensResource(Resource):
             weight = minimum_tx_weight(tx)
         tx.weight = weight
         tx.resolve()
-        tx.verify()
+        self.manager.verification_service.verify(tx)
         return tx
 
     def _cb_tx_resolve(self, tx, request):

--- a/hathor/wallet/resources/thin_wallet/send_tokens.py
+++ b/hathor/wallet/resources/thin_wallet/send_tokens.py
@@ -212,7 +212,7 @@ class SendTokensResource(Resource):
     def _stratum_thread_verify(self, context: _Context) -> _Context:
         """ Method to verify the transaction that runs in a separated thread
         """
-        context.tx.verify()
+        self.manager.verification_service.verify(context.tx)
         return context
 
     def _stratum_timeout(self, result: Failure, timeout: int, *, context: _Context) -> None:
@@ -264,7 +264,7 @@ class SendTokensResource(Resource):
         if context.should_stop_mining_thread:
             raise CancelledError()
         context.tx.update_hash()
-        context.tx.verify()
+        self.manager.verification_service.verify(context.tx)
         return context
 
     def _cb_tx_resolve(self, context: _Context) -> None:

--- a/tests/consensus/test_consensus.py
+++ b/tests/consensus/test_consensus.py
@@ -83,7 +83,7 @@ class BaseConsensusTestCase(unittest.TestCase):
         b0 = tb0.generate_mining_block(manager.rng, storage=manager.tx_storage)
         b0.weight = 10
         b0.resolve()
-        b0.verify()
+        manager.verification_service.verify(b0)
         manager.propagate_tx(b0, fails_silently=False)
 
         b1 = add_new_block(manager, advance_clock=15)
@@ -145,7 +145,7 @@ class BaseConsensusTestCase(unittest.TestCase):
         b0 = manager.generate_mining_block()
         b0.parents = [blocks[-1].hash, conflicting_tx.hash, conflicting_tx.parents[0]]
         b0.resolve()
-        b0.verify()
+        manager.verification_service.verify(b0)
         manager.propagate_tx(b0, fails_silently=False)
 
         b1 = add_new_block(manager, advance_clock=15)
@@ -201,7 +201,7 @@ class BaseConsensusTestCase(unittest.TestCase):
         b0 = tb0.generate_mining_block(manager.rng, storage=manager.tx_storage)
         b0.weight = 10
         b0.resolve()
-        b0.verify()
+        manager.verification_service.verify(b0)
         manager.propagate_tx(b0, fails_silently=False)
 
         b1 = add_new_block(manager, advance_clock=15)
@@ -255,7 +255,7 @@ class BaseConsensusTestCase(unittest.TestCase):
         b0.parents = [b0.parents[0], conflicting_tx.hash, conflicting_tx.parents[0]]
         b0.weight = 10
         b0.resolve()
-        b0.verify()
+        manager.verification_service.verify(b0)
         manager.propagate_tx(b0, fails_silently=False)
 
         b1 = add_new_block(manager, advance_clock=15)

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -40,7 +40,7 @@ class BaseEventReorgTest(unittest.TestCase):
         b0 = tb0.generate_mining_block(self.manager.rng, storage=self.manager.tx_storage, address=BURN_ADDRESS)
         b0.weight = 10
         b0.resolve()
-        b0.verify()
+        self.manager.verification_service.verify(b0)
         self.manager.propagate_tx(b0, fails_silently=False)
         self.log.debug('reorg block propagated')
         self.run_to_completion()

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -44,7 +44,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         tx.weight = 10
         tx.parents = self.manager1.get_new_tx_parents()
         tx.resolve()
-        tx.verify()
+        self.manager1.verification_service.verify(tx)
         self.manager1.propagate_tx(tx)
         self.clock.advance(10)
         return tx
@@ -61,7 +61,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
     def _add_new_block(self, propagate=True):
         block = self.manager1.generate_mining_block()
         self.assertTrue(block.resolve())
-        block.verify()
+        self.manager1.verification_service.verify(block)
         self.manager1.on_new_tx(block, propagate_to_peers=propagate)
         self.clock.advance(10)
         return block

--- a/tests/p2p/test_sync_mempool.py
+++ b/tests/p2p/test_sync_mempool.py
@@ -32,7 +32,7 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
         tx.weight = 10
         tx.parents = self.manager1.get_new_tx_parents()
         tx.resolve()
-        tx.verify()
+        self.manager1.verification_service.verify(tx)
         self.manager1.propagate_tx(tx)
         self.clock.advance(10)
         return tx
@@ -49,7 +49,7 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
     def _add_new_block(self, propagate=True):
         block = self.manager1.generate_mining_block()
         self.assertTrue(block.resolve())
-        block.verify()
+        self.manager1.verification_service.verify(block)
         self.manager1.on_new_tx(block, propagate_to_peers=propagate)
         self.clock.advance(10)
         return block

--- a/tests/tx/test_blockchain.py
+++ b/tests/tx/test_blockchain.py
@@ -115,7 +115,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
         fork_block1 = manager.generate_mining_block()
         fork_block1.parents = [fork_block1.parents[0]] + fork_block1.parents[:0:-1]
         fork_block1.resolve()
-        fork_block1.verify()
+        manager.verification_service.verify(fork_block1)
 
         # Mine 8 blocks in a row
         blocks = add_new_blocks(manager, 8, advance_clock=15)
@@ -167,7 +167,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
         # This block belongs to case (iv).
         fork_block3 = manager.generate_mining_block(parent_block_hash=fork_block1.hash)
         fork_block3.resolve()
-        fork_block3.verify()
+        manager.verification_service.verify(fork_block3)
         self.assertTrue(manager.propagate_tx(fork_block3))
         fork_meta3 = fork_block3.get_metadata()
         self.assertEqual(fork_meta3.voided_by, {fork_block3.hash})
@@ -237,7 +237,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
         # Propagate a block connected to the voided chain, case (iii).
         fork_block2 = manager.generate_mining_block(parent_block_hash=sidechain[-1].hash)
         fork_block2.resolve()
-        fork_block2.verify()
+        manager.verification_service.verify(fork_block2)
         self.assertTrue(manager.propagate_tx(fork_block2))
         sidechain.append(fork_block2)
 
@@ -285,7 +285,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
         # Propagate a block connected to the side chain, case (v).
         fork_block3 = manager.generate_mining_block(parent_block_hash=fork_block2.hash)
         fork_block3.resolve()
-        fork_block3.verify()
+        manager.verification_service.verify(fork_block3)
         self.assertTrue(manager.propagate_tx(fork_block3))
         sidechain.append(fork_block3)
 
@@ -311,7 +311,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
         fork_block4 = manager.generate_mining_block(parent_block_hash=sidechain3[-1].hash)
         fork_block4.weight = 10
         fork_block4.resolve()
-        fork_block4.verify()
+        manager.verification_service.verify(fork_block4)
         self.assertTrue(manager.propagate_tx(fork_block4))
         sidechain3.append(fork_block4)
 

--- a/tests/tx/test_indexes.py
+++ b/tests/tx/test_indexes.py
@@ -439,7 +439,7 @@ class BaseIndexesTest(unittest.TestCase):
         block2.timestamp = block1.timestamp
         block2.weight = 1.2
         block2.resolve()
-        block2.validate_full()
+        self.manager.verification_service.validate_full(block2)
         self.manager.propagate_tx(block2, fails_silently=False)
         self.graphviz.labels[block2.hash] = 'block2'
 

--- a/tests/tx/test_reward_lock.py
+++ b/tests/tx/test_reward_lock.py
@@ -73,7 +73,7 @@ class BaseTransactionTest(unittest.TestCase):
             tx = self._spend_reward_tx(self.manager, reward_block)
             self.assertEqual(tx.get_metadata().min_height, unlock_height)
             with self.assertRaises(RewardLocked):
-                tx.verify()
+                self.manager.verification_service.verify(tx)
             add_new_blocks(self.manager, 1, advance_clock=1)
 
         # now it should be spendable
@@ -127,7 +127,7 @@ class BaseTransactionTest(unittest.TestCase):
         tx = self._spend_reward_tx(self.manager, reward_block)
         self.assertEqual(tx.get_metadata().min_height, unlock_height)
         with self.assertRaises(RewardLocked):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
         with self.assertRaises(InvalidNewTransaction):
             self.assertTrue(self.manager.on_new_tx(tx, fails_silently=False))
 
@@ -161,12 +161,12 @@ class BaseTransactionTest(unittest.TestCase):
         b0 = tb0.generate_mining_block(self.manager.rng, storage=self.manager.tx_storage)
         b0.weight = 10
         b0.resolve()
-        b0.verify()
+        self.manager.verification_service.verify(b0)
         self.manager.propagate_tx(b0, fails_silently=False)
 
         # now the new tx should not pass verification considering the reward lock
         with self.assertRaises(RewardLocked):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # the transaction should have been removed from the mempool
         self.assertNotIn(tx, self.manager.tx_storage.iter_mempool_from_best_index())
@@ -190,7 +190,7 @@ class BaseTransactionTest(unittest.TestCase):
         tx.resolve()
         self.assertEqual(tx.get_metadata().min_height, unlock_height)
         with self.assertRaises(RewardLocked):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
 
 class SyncV1TransactionTest(unittest.SyncV1Params, BaseTransactionTest):

--- a/tests/tx/test_tips.py
+++ b/tests/tx/test_tips.py
@@ -70,7 +70,7 @@ class BaseTipsTestCase(unittest.TestCase):
         new_block = add_new_block(self.manager, propagate=False)
         new_block.parents = [new_block.parents[0], tx1.hash, tx3.hash]
         new_block.resolve()
-        new_block.verify()
+        self.manager.verification_service.verify(new_block)
         self.manager.propagate_tx(new_block, fails_silently=False)
 
         self.manager.reactor.advance(10)

--- a/tests/tx/test_tokens.py
+++ b/tests/tx/test_tokens.py
@@ -54,7 +54,7 @@ class BaseTokenTest(unittest.TestCase):
 
         block.resolve()
         with self.assertRaises(BlockWithTokensError):
-            block.verify()
+            self.manager.verification_service.verify(block)
 
     def test_tx_token_outputs(self):
         genesis_block = self.genesis_blocks[0]
@@ -74,7 +74,7 @@ class BaseTokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx.resolve()
         with self.assertRaises(InvalidToken):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # with 1 token uid in list
         tx.tokens = [bytes.fromhex('0023be91834c973d6a6ddd1a0ae411807b7c8ef2a015afb5177ee64b666ce602')]
@@ -84,7 +84,7 @@ class BaseTokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx.resolve()
         with self.assertRaises(InvalidToken):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # try hathor authority UTXO
         output = TxOutput(value, script, 0b10000000)
@@ -94,7 +94,7 @@ class BaseTokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx.resolve()
         with self.assertRaises(InvalidToken):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
     def test_token_transfer(self):
         wallet = self.manager.wallet
@@ -114,7 +114,7 @@ class BaseTokenTest(unittest.TestCase):
         public_bytes, signature = wallet.get_input_aux_data(data_to_sign, wallet.get_private_key(self.address_b58))
         tx2.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx2.resolve()
-        tx2.verify()
+        self.manager.verification_service.verify(tx2)
 
         # missing tokens
         token_output = TxOutput(utxo.value - 1, script, 1)
@@ -125,7 +125,7 @@ class BaseTokenTest(unittest.TestCase):
         tx3.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx3.resolve()
         with self.assertRaises(InputOutputMismatch):
-            tx3.verify()
+            self.manager.verification_service.verify(tx3)
 
     def test_token_mint(self):
         wallet = self.manager.wallet
@@ -157,7 +157,7 @@ class BaseTokenTest(unittest.TestCase):
         tx2.inputs[0].data = data
         tx2.inputs[1].data = data
         tx2.resolve()
-        tx2.verify()
+        self.manager.verification_service.verify(tx2)
         self.manager.propagate_tx(tx2)
         self.run_to_completion()
 
@@ -193,7 +193,7 @@ class BaseTokenTest(unittest.TestCase):
         tx3.inputs[0].data = data
         tx3.resolve()
         with self.assertRaises(InputOutputMismatch):
-            tx3.verify()
+            self.manager.verification_service.verify(tx3)
 
         # try to mint and deposit less tokens than necessary
         mint_amount = 10000000
@@ -219,7 +219,7 @@ class BaseTokenTest(unittest.TestCase):
         tx4.inputs[1].data = data
         tx4.resolve()
         with self.assertRaises(InputOutputMismatch):
-            tx4.verify()
+            self.manager.verification_service.verify(tx4)
 
         # try to mint using melt authority UTXO
         _input1 = TxInput(tx.hash, 2, b'')
@@ -231,7 +231,7 @@ class BaseTokenTest(unittest.TestCase):
         tx5.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx5.resolve()
         with self.assertRaises(InputOutputMismatch):
-            tx5.verify()
+            self.manager.verification_service.verify(tx5)
 
     def test_token_melt(self):
         wallet = self.manager.wallet
@@ -264,7 +264,7 @@ class BaseTokenTest(unittest.TestCase):
         tx2.inputs[0].data = data
         tx2.inputs[1].data = data
         tx2.resolve()
-        tx2.verify()
+        self.manager.verification_service.verify(tx2)
         self.manager.propagate_tx(tx2)
         self.run_to_completion()
 
@@ -304,7 +304,7 @@ class BaseTokenTest(unittest.TestCase):
         tx3.inputs[1].data = data
         tx3.resolve()
         with self.assertRaises(InputOutputMismatch):
-            tx3.verify()
+            self.manager.verification_service.verify(tx3)
 
         # try to melt using mint authority UTXO
         _input1 = TxInput(tx.hash, 0, b'')
@@ -319,7 +319,7 @@ class BaseTokenTest(unittest.TestCase):
         tx4.inputs[1].data = data
         tx4.resolve()
         with self.assertRaises(InputOutputMismatch):
-            tx4.verify()
+            self.manager.verification_service.verify(tx4)
 
     def test_token_transfer_authority(self):
         wallet = self.manager.wallet
@@ -338,7 +338,7 @@ class BaseTokenTest(unittest.TestCase):
         tx2.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx2.resolve()
         with self.assertRaises(InvalidToken):
-            tx2.verify()
+            self.manager.verification_service.verify(tx2)
 
         # input with melt and output with mint
         _input1 = TxInput(tx.hash, 2, b'')
@@ -350,7 +350,7 @@ class BaseTokenTest(unittest.TestCase):
         tx3.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx3.resolve()
         with self.assertRaises(InvalidToken):
-            tx3.verify()
+            self.manager.verification_service.verify(tx3)
 
     def test_token_index_with_conflict(self, mint_amount=0):
         # create a new token and have a mint operation done. The tx that mints the
@@ -403,7 +403,7 @@ class BaseTokenTest(unittest.TestCase):
         tx2.inputs[1].data = data
         tx2.inputs[2].data = data
         tx2.resolve()
-        tx2.verify()
+        self.manager.verification_service.verify(tx2)
         self.manager.propagate_tx(tx2)
         self.run_to_completion()
 
@@ -455,39 +455,39 @@ class BaseTokenTest(unittest.TestCase):
         # max token name length
         tx.token_name = 'a' * settings.MAX_LENGTH_TOKEN_NAME
         update_tx(tx)
-        tx.verify()
+        self.manager.verification_service.verify(tx)
 
         # max token symbol length
         tx.token_symbol = 'a' * settings.MAX_LENGTH_TOKEN_SYMBOL
         update_tx(tx)
-        tx.verify()
+        self.manager.verification_service.verify(tx)
 
         # long token name
         tx.token_name = 'a' * (settings.MAX_LENGTH_TOKEN_NAME + 1)
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # long token symbol
         tx.token_name = 'ValidName'
         tx.token_symbol = 'a' * (settings.MAX_LENGTH_TOKEN_SYMBOL + 1)
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # Hathor token name
         tx.token_name = settings.HATHOR_TOKEN_NAME
         tx.token_symbol = 'TST'
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # Hathor token symbol
         tx.token_name = 'Test'
         tx.token_symbol = settings.HATHOR_TOKEN_SYMBOL
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         # Token name unicode
         tx.token_name = 'Test ∞'
@@ -495,7 +495,7 @@ class BaseTokenTest(unittest.TestCase):
         token_info = tx.serialize_token_info()
         TokenCreationTransaction.deserialize_token_info(token_info)
         update_tx(tx)
-        tx.verify()
+        self.manager.verification_service.verify(tx)
 
         # Token symbol unicode
         tx.token_name = 'Test Token'
@@ -503,7 +503,7 @@ class BaseTokenTest(unittest.TestCase):
         token_info = tx.serialize_token_info()
         TokenCreationTransaction.deserialize_token_info(token_info)
         update_tx(tx)
-        tx.verify()
+        self.manager.verification_service.verify(tx)
 
     def test_token_mint_zero(self):
         # try to mint 0 tokens
@@ -542,7 +542,7 @@ class BaseTokenTest(unittest.TestCase):
         tx2.inputs[1].data = data
         tx2.resolve()
         with self.assertRaises(InvalidToken):
-            tx2.verify()
+            self.manager.verification_service.verify(tx2)
 
     def test_token_info_serialization(self):
         tx = create_tokens(self.manager, self.address_b58, mint_amount=500)
@@ -595,7 +595,7 @@ class BaseTokenTest(unittest.TestCase):
 
         block.resolve()
         with self.assertRaises(InvalidToken):
-            block.verify()
+            self.manager.verification_service.verify(block)
 
     def test_voided_token_creation(self):
         tx1 = create_tokens(self.manager, self.address_b58, mint_amount=500, use_genesis=False)

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -64,7 +64,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.block = Block(timestamp=MIN_TIMESTAMP, weight=12, outputs=[output], parents=block_parents,
                            nonce=100781, storage=self.tx_storage)
         self.block.resolve()
-        self.block.verify()
+        self.manager.verification_service.verify(self.block)
         self.block.get_metadata().validation = ValidationState.FULL
 
         tx_parents = [tx.hash for tx in self.genesis_txs]
@@ -114,7 +114,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.assertEqual(1, len(self.genesis_blocks))
         self.assertEqual(2, len(self.genesis_txs))
         for tx in self.genesis:
-            tx.verify()
+            self.manager.verification_service.verify(tx)
 
         for tx in self.genesis:
             tx2 = self.tx_storage.get_transaction(tx.hash)
@@ -526,7 +526,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
             block.parents = parents
         block.weight = 10
         self.assertTrue(block.resolve())
-        block.verify()
+        self.manager.verification_service.verify(block)
         self.manager.propagate_tx(block, fails_silently=False)
         self.reactor.advance(5)
         return block

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -204,7 +204,7 @@ def gen_new_tx(manager, address, value, verify=True):
     tx.parents = manager.get_new_tx_parents(tx.timestamp)
     tx.resolve()
     if verify:
-        tx.verify()
+        manager.verification_service.verify(tx)
     return tx
 
 
@@ -266,7 +266,7 @@ def add_new_block(manager, advance_clock=None, *, parent_block_hash=None,
     if weight is not None:
         block.weight = weight
     block.resolve()
-    block.validate_full()
+    manager.verification_service.validate_full(block)
     if propagate:
         manager.propagate_tx(block, fails_silently=False)
     if advance_clock:
@@ -554,7 +554,7 @@ def create_tokens(manager: 'HathorManager', address_b58: Optional[str] = None, m
 
     tx.resolve()
     if propagate:
-        tx.verify()
+        manager.verification_service.verify(tx)
         manager.propagate_tx(tx, fails_silently=False)
         assert isinstance(manager.reactor, Clock)
         manager.reactor.advance(8)
@@ -643,7 +643,7 @@ def add_tx_with_data_script(manager: 'HathorManager', data: list[str], propagate
     tx.resolve()
 
     if propagate:
-        tx.verify()
+        manager.verification_service.verify(tx)
         manager.propagate_tx(tx, fails_silently=False)
         assert isinstance(manager.reactor, Clock)
         manager.reactor.advance(8)

--- a/tests/wallet/test_balance_update.py
+++ b/tests/wallet/test_balance_update.py
@@ -428,7 +428,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
                                   )
         tx2.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         tx2.resolve()
-        tx2.verify()
+        self.manager.verification_service.verify(tx2)
         self.manager.propagate_tx(tx2)
         self.run_to_completion()
         # verify balance

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -208,7 +208,7 @@ class BaseBasicWalletTest(unittest.TestCase):
         tx2.timestamp = tx.timestamp + 1
         tx2.parents = self.manager.get_new_tx_parents()
         tx2.resolve()
-        tx2.verify()
+        self.manager.verification_service.verify(tx2)
 
         self.assertNotEqual(len(tx2.inputs), 0)
         token_dict = defaultdict(int)

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -31,7 +31,7 @@ class BaseWalletHDTest(unittest.TestCase):
         new_address = self.wallet.get_unused_address()
         out = WalletOutputInfo(decode_address(new_address), self.TOKENS, timelock=None)
         block = add_new_block(self.manager)
-        block.verify()
+        self.manager.verification_service.verify(block)
         utxo = self.wallet.unspent_txs[settings.HATHOR_TOKEN_UID].get((block.hash, 0))
         self.assertIsNotNone(utxo)
         self.assertEqual(self.wallet.balance[settings.HATHOR_TOKEN_UID], WalletBalance(0, self.BLOCK_TOKENS))


### PR DESCRIPTION
### Motivation

This PR is the first one on a series of refactors related to vertex verification, aiming to move all verification related code out of model classes and to their own files, improving code modularity and enabling other future improvements related to injection of dependencies, patching, etc.

The 4 main entrypoint methods used for validation/verification (detailed below) were moved to a new class and modules. Now, instead of using inheritance, we implement concrete methods and functions that are explicit about from where each implementation is coming from. This also allows to remove unused arguments from method signatures, as they're not overrides of the same method anymore. Verification of each vertex type accepts a specific set of arguments. Other than this change of structure, no behavior should be changed by this PR, it's only a refactor moving code.

In the next PRs, we'll move the remaining verification methods.

### Acceptance Criteria

- Create new `VerificationService` class and `(block|transaction|token_creation_transaction)_verification` modules.
- Move `BaseTransaction` methods to `VerificationService`. The only change in them is adding `*` to make the signatures more explicit.
  - Move `validate_basic()` and `validate_full()` concrete methods as-is.
  - Move `verify_basic()` and `verify()` abstract methods, making them concrete.
  - Move `validate_tx_error()` renaming it to `validate_vertex_error()`.
- Move `Block`, `Transaction` and `TokenCreationTransaction` methods `verify_basic()` and `verify()` to each respective `*_verification` module. The only change is also adding `*` to their signatures.
- Update `HathorManager` to use a `VerificationService`, and update `Builder` and `CliBuilder` accordingly.
- Update all usages of verification to use the new `VerificationService` instead of calling verification methods directly on vertices, including in tests.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 