### PR TITLE
feat(p2p): Add ping salt and improve rtt information

### DIFF
--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -69,6 +69,7 @@ class StatusResource(Resource):
                 'address': '{}:{}'.format(remote.host, remote.port),
                 'state': conn.state.state_name,
                 # 'received_bytes': conn.received_bytes,
+                'rtt': list(conn.state.rtt_window),
                 'last_message': time.time() - conn.last_message,
                 'plugins': status,
                 'warning_flags': [flag.value for flag in conn.warning_flags],

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -356,14 +356,14 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
         self.conn.run_one_step()  # TIPS
         self.assertIsConnected()
         self.clock.advance(5)
-        self.assertEqual(b'PING\r\n', self.conn.peek_tr1_value())
-        self.assertEqual(b'PING\r\n', self.conn.peek_tr2_value())
+        self.assertRegex(self.conn.peek_tr1_value(), b'^PING .*\r\n')
+        self.assertRegex(self.conn.peek_tr2_value(), b'^PING .*\r\n')
         self.conn.run_one_step()  # PING
         self.conn.run_one_step()  # GET-TIPS
         self.conn.run_one_step()  # GET-BEST-BLOCKCHAIN
-        self.assertEqual(b'PONG\r\n', self.conn.peek_tr1_value())
-        self.assertEqual(b'PONG\r\n', self.conn.peek_tr2_value())
-        while b'PONG\r\n' in self.conn.peek_tr1_value():
+        self.assertRegex(self.conn.peek_tr1_value(), b'PONG .*\r\n')
+        self.assertRegex(self.conn.peek_tr2_value(), b'PONG .*\r\n')
+        while b'PONG ' in self.conn.peek_tr1_value():
             self.conn.run_one_step()
         self.assertEqual(self.clock.seconds(), self.conn.proto1.last_message)
 
@@ -489,8 +489,8 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
         self.assertAndStepConn(self.conn, b'^TIPS')
         self.assertAndStepConn(self.conn, b'^TIPS')
         self.assertAndStepConn(self.conn, b'^TIPS-END')
-        self.assertEqual(b'PONG\r\n', self.conn.peek_tr1_value())
-        self.assertEqual(b'PONG\r\n', self.conn.peek_tr2_value())
+        self.assertRegex(self.conn.peek_tr1_value(), b'^PONG .*\r\n')
+        self.assertRegex(self.conn.peek_tr2_value(), b'^PONG .*\r\n')
         while b'PONG\r\n' in self.conn.peek_tr1_value():
             self.conn.run_one_step()
         self.assertEqual(self.clock.seconds(), self.conn.proto1.last_message)


### PR DESCRIPTION
### Motivation

RTT information was weak and almost useless because we kept only the latest sample and the minimum value since the connection has been established. Besides that, RTT information was subject to manipulation.

### Acceptance Criteria

1. Add a salt to PING/PONG messages to prevent RTT manipulation.
2. Store the latest 200 samples for RTT.
3. Present the RTT samples in the `/v1a/status` API.
4. Keep compatibility with PING/PONG without salt.
5. Connections with older full nodes will not calculate rtt because they will lack the salt.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 