### PR TITLE
feat(p2p): relay all recently-seen peers for neighbors

### DIFF
--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -15,6 +15,7 @@
 import base64
 import hashlib
 from enum import Enum
+from math import inf
 from typing import TYPE_CHECKING, Any, Generator, Optional, cast
 
 from cryptography import x509
@@ -61,6 +62,7 @@ class PeerId:
     retry_timestamp: int    # should only try connecting to this peer after this timestamp
     retry_interval: int     # how long to wait for next connection retry. It will double for each failure
     retry_attempts: int     # how many retries were made
+    last_seen: float        # last time this peer was seen
     flags: set[str]
 
     def __init__(self, auto_generate_keys: bool = True) -> None:
@@ -73,6 +75,7 @@ class PeerId:
         self.retry_timestamp = 0
         self.retry_interval = 5
         self.retry_attempts = 0
+        self.last_seen = inf
         self.flags = set()
         self._certificate_options: Optional[CertificateOptions] = None
 

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -293,7 +293,10 @@ class HathorProtocol:
         """
         assert self.state is not None
 
-        self.last_message = self.reactor.seconds()
+        now = self.reactor.seconds()
+        self.last_message = now
+        if self.peer is not None:
+            self.peer.last_seen = now
         self.reset_idle_timeout()
 
         if not self.ratelimit.add_hit(self.RateLimitKeys.GLOBAL):

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -411,16 +411,18 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
         self.assertAndStepConn(self.conn, b'^GET-TIPS')
         self.assertAndStepConn(self.conn, b'^PING')
 
-        for _ in range(19):
+        for _ in range(20):
             self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN')
 
-        # peer1 should now send a PEERS with the new peer that just connected
-        self.assertAndStepConn(self.conn, b'^PEERS',    b'^GET-BEST-BLOCKCHAIN')
-        self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN',    b'^TIPS')
-        self.assertAndStepConn(self.conn, b'^TIPS',     b'^TIPS')
-        self.assertAndStepConn(self.conn, b'^TIPS',     b'^TIPS-END')
-        self.assertAndStepConn(self.conn, b'^TIPS-END', b'^PONG')
-        self.assertAndStepConn(self.conn, b'^PONG',     b'^BEST-BLOCKCHAIN')
+        self.assertAndStepConn(self.conn, b'^GET-PEERS',           b'^GET-PEERS')
+        self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN', b'^GET-BEST-BLOCKCHAIN')
+        self.assertAndStepConn(self.conn, b'^GET-PEERS',           b'^GET-PEERS')
+        self.assertAndStepConn(self.conn, b'^PEERS',               b'^GET-BEST-BLOCKCHAIN')
+        self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN', b'^TIPS')
+        self.assertAndStepConn(self.conn, b'^TIPS',                b'^TIPS')
+        self.assertAndStepConn(self.conn, b'^TIPS',                b'^TIPS-END')
+        self.assertAndStepConn(self.conn, b'^TIPS-END',            b'^PONG')
+        self.assertAndStepConn(self.conn, b'^PONG',                b'^BEST-BLOCKCHAIN')
         self.assertIsConnected()
 
     @inlineCallbacks


### PR DESCRIPTION
### Motivation

The full node currently relays only connections in the ready state. So, if a connection drops for just a few seconds, we might not relay this peer information to our neighbors.

The current behavior of the full node involves requesting peer information from a neighboring node exclusively during the initial connection establishment phase. Consequently, if the full node attempts to establish a connection with a peer and that peer rejects the connection, there is a risk that the full node will subsequently remove this peer from its peer storage. As a result, there would be no further attempts made to connect to this particular peer in the future.

### Acceptance Criteria

1. Clean up aged peers in `ConnectionsManager.peer_storage`.
2. Add `PeerId.last_seen: float`.
3. Update `protocol.peer.last_seen` when the connection is ready and when new messages are received.
4. Add `known_peers.last_seen` to `/v1a/status` API.
5. Remove `time.time()` from `hathor.p2p.resources.StatusResource`.
6. Add a looping call to call `send_get_peers()` every 5 minutes.
7. Relay only peer information that contains at least one entrypoint.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 