### PR TITLE
feat(p2p): run periodic bootstrap discovery

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -262,10 +262,10 @@ class CliBuilder:
             dns_hosts.extend(self._args.dns)
 
         if dns_hosts:
-            self.manager.add_peer_discovery(DNSPeerDiscovery(dns_hosts))
+            p2p_manager.add_peer_discovery(DNSPeerDiscovery(dns_hosts))
 
         if self._args.bootstrap:
-            self.manager.add_peer_discovery(BootstrapPeerDiscovery(self._args.bootstrap))
+            p2p_manager.add_peer_discovery(BootstrapPeerDiscovery(self._args.bootstrap))
 
         if self._args.test_mode_tx_weight:
             _set_test_mode(TestMode.TEST_TX_WEIGHT)
@@ -281,7 +281,7 @@ class CliBuilder:
             self.log.warn('--memory-indexes is implied for memory storage or JSON storage')
 
         for description in self._args.listen:
-            self.manager.add_listen_address(description)
+            p2p_manager.add_listen_address(description)
 
         if self._args.peer_id_blacklist:
             self.log.info('with peer id blacklist', blacklist=self._args.peer_id_blacklist)

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -392,6 +392,9 @@ class HathorSettings(NamedTuple):
     # Time to update the peers that are running sync.
     SYNC_UPDATE_INTERVAL: int = 10 * 60  # seconds
 
+    # Interval to re-run peer discovery.
+    PEER_DISCOVERY_INTERVAL: int = 5 * 60  # seconds
+
     # All settings related to Feature Activation
     FEATURE_ACTIVATION: FeatureActivationSettings = FeatureActivationSettings()
 


### PR DESCRIPTION
### Motivation

The DNS bootstrap mechanism used to run only when there were no longer any connections, however it's better to run it periodically to pick up new DNS records.

### Acceptance Criteria

- move `PeerDiscovery` object from `HathorManager` to `ConnectionsManager`
- add new settings `PEER_DISCOVERY_INTERVAL` with interval that discovery should run again

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 