### PR TITLE
feat(feature-activation): implement must signal

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Any, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 from structlog import get_logger
 
@@ -63,6 +63,7 @@ class BuildArtifacts(NamedTuple):
     pubsub: PubSubManager
     consensus: ConsensusAlgorithm
     tx_storage: TransactionStorage
+    feature_service: FeatureService
     indexes: Optional[IndexesManager]
     wallet: Optional[BaseWallet]
     rocksdb_storage: Optional[RocksDBStorage]
@@ -103,6 +104,7 @@ class Builder:
         self._bit_signaling_service: Optional[BitSignalingService] = None
 
         self._vertex_verifiers: Optional[VertexVerifiers] = None
+        self._vertex_verifiers_builder: Callable[[HathorSettingsType, FeatureService], VertexVerifiers] | None = None
         self._verification_service: Optional[VerificationService] = None
 
         self._rocksdb_path: Optional[str] = None
@@ -158,9 +160,9 @@ class Builder:
         wallet = self._get_or_create_wallet()
         event_manager = self._get_or_create_event_manager()
         indexes = self._get_or_create_indexes_manager()
-        tx_storage = self._get_or_create_tx_storage(indexes)
-        feature_service = self._get_or_create_feature_service(tx_storage)
-        bit_signaling_service = self._get_or_create_bit_signaling_service(tx_storage)
+        tx_storage = self._get_or_create_tx_storage()
+        feature_service = self._get_or_create_feature_service()
+        bit_signaling_service = self._get_or_create_bit_signaling_service()
         verification_service = self._get_or_create_verification_service()
 
         if self._enable_address_index:
@@ -221,6 +223,7 @@ class Builder:
             wallet=wallet,
             rocksdb_storage=self._rocksdb_storage,
             stratum_factory=stratum_factory,
+            feature_service=feature_service,
         )
 
         return self.artifacts
@@ -265,6 +268,7 @@ class Builder:
         return self
 
     def _get_or_create_settings(self) -> HathorSettingsType:
+        """Return the HathorSettings instance set on this builder, or a new one if not set."""
         if self._settings is None:
             self._settings = get_settings()
         return self._settings
@@ -352,7 +356,9 @@ class Builder:
 
         return self._indexes_manager
 
-    def _get_or_create_tx_storage(self, indexes: IndexesManager) -> TransactionStorage:
+    def _get_or_create_tx_storage(self) -> TransactionStorage:
+        indexes = self._get_or_create_indexes_manager()
+
         if self._tx_storage is not None:
             # If a tx storage is provided, set the indexes manager to it.
             self._tx_storage.indexes = indexes
@@ -415,9 +421,11 @@ class Builder:
 
         return self._event_manager
 
-    def _get_or_create_feature_service(self, tx_storage: TransactionStorage) -> FeatureService:
+    def _get_or_create_feature_service(self) -> FeatureService:
+        """Return the FeatureService instance set on this builder, or a new one if not set."""
         if self._feature_service is None:
             settings = self._get_or_create_settings()
+            tx_storage = self._get_or_create_tx_storage()
             self._feature_service = FeatureService(
                 feature_settings=settings.FEATURE_ACTIVATION,
                 tx_storage=tx_storage
@@ -425,12 +433,14 @@ class Builder:
 
         return self._feature_service
 
-    def _get_or_create_bit_signaling_service(self, tx_storage: TransactionStorage) -> BitSignalingService:
+    def _get_or_create_bit_signaling_service(self) -> BitSignalingService:
         if self._bit_signaling_service is None:
             settings = self._get_or_create_settings()
+            tx_storage = self._get_or_create_tx_storage()
+            feature_service = self._get_or_create_feature_service()
             self._bit_signaling_service = BitSignalingService(
                 feature_settings=settings.FEATURE_ACTIVATION,
-                feature_service=self._get_or_create_feature_service(tx_storage),
+                feature_service=feature_service,
                 tx_storage=tx_storage,
                 support_features=self._support_features,
                 not_support_features=self._not_support_features,
@@ -448,7 +458,15 @@ class Builder:
     def _get_or_create_vertex_verifiers(self) -> VertexVerifiers:
         if self._vertex_verifiers is None:
             settings = self._get_or_create_settings()
-            self._vertex_verifiers = VertexVerifiers.create_defaults(settings=settings)
+            feature_service = self._get_or_create_feature_service()
+
+            if self._vertex_verifiers_builder:
+                self._vertex_verifiers = self._vertex_verifiers_builder(settings, feature_service)
+            else:
+                self._vertex_verifiers = VertexVerifiers.create_defaults(
+                    settings=settings,
+                    feature_service=feature_service
+                )
 
         return self._vertex_verifiers
 
@@ -552,6 +570,14 @@ class Builder:
     def set_vertex_verifiers(self, vertex_verifiers: VertexVerifiers) -> 'Builder':
         self.check_if_can_modify()
         self._vertex_verifiers = vertex_verifiers
+        return self
+
+    def set_vertex_verifiers_builder(
+        self,
+        builder: Callable[[HathorSettingsType, FeatureService], VertexVerifiers]
+    ) -> 'Builder':
+        self.check_if_can_modify()
+        self._vertex_verifiers_builder = builder
         return self
 
     def set_reactor(self, reactor: Reactor) -> 'Builder':

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -207,7 +207,7 @@ class CliBuilder:
             not_support_features=self._args.signal_not_support
         )
 
-        vertex_verifiers = VertexVerifiers.create_defaults(settings=settings)
+        vertex_verifiers = VertexVerifiers.create_defaults(settings=settings, feature_service=self.feature_service)
         verification_service = VerificationService(verifiers=vertex_verifiers)
 
         p2p_manager = ConnectionsManager(

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -191,6 +191,7 @@ class RunNode:
             wallet=self.manager.wallet,
             rocksdb_storage=getattr(builder, 'rocksdb_storage', None),
             stratum_factory=self.manager.stratum_factory,
+            feature_service=self.manager._feature_service
         )
 
     def start_sentry_if_possible(self) -> None:

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -672,12 +672,6 @@ class BaseTransaction(ABC):
             #        happens include generating new mining blocks and some tests
             height = self.calculate_height() if self.storage else None
             score = self.weight if self.is_genesis else 0
-            kwargs: dict[str, Any] = {}
-
-            if self.is_block:
-                from hathor.transaction import Block
-                assert isinstance(self, Block)
-                kwargs['feature_activation_bit_counts'] = self.calculate_feature_activation_bit_counts()
 
             metadata = TransactionMetadata(
                 hash=self.hash,
@@ -685,7 +679,6 @@ class BaseTransaction(ABC):
                 height=height,
                 score=score,
                 min_height=0,
-                **kwargs
             )
             self._metadata = metadata
         if not metadata.hash:
@@ -769,7 +762,6 @@ class BaseTransaction(ABC):
         self._update_height_metadata()
         self._update_parents_children_metadata()
         self._update_reward_lock_metadata()
-        self._update_feature_activation_bit_counts_metadata()
         if save:
             assert self.storage is not None
             self.storage.save_transaction(self, only_metadata=True)
@@ -794,16 +786,6 @@ class BaseTransaction(ABC):
             if self.hash not in metadata.children:
                 metadata.children.append(self.hash)
                 self.storage.save_transaction(parent, only_metadata=True)
-
-    def _update_feature_activation_bit_counts_metadata(self) -> None:
-        """Update the block feature_activation_bit_counts metadata."""
-        if not self.is_block:
-            return
-
-        from hathor.transaction import Block
-        assert isinstance(self, Block)
-        metadata = self.get_metadata()
-        metadata.feature_activation_bit_counts = self.calculate_feature_activation_bit_counts()
 
     def update_timestamp(self, now: int) -> None:
         """Update this tx's timestamp

--- a/hathor/transaction/exceptions.py
+++ b/hathor/transaction/exceptions.py
@@ -146,6 +146,10 @@ class CheckpointError(BlockError):
     """Block hash does not match checkpoint hash for its height"""
 
 
+class BlockMustSignalError(BlockError):
+    """Block does not signal support for a feature during mandatory signaling."""
+
+
 class ScriptError(HathorError):
     """Base class for script evaluation errors"""
 

--- a/hathor/transaction/transaction_metadata.py
+++ b/hathor/transaction/transaction_metadata.py
@@ -53,7 +53,8 @@ class TransactionMetadata:
     feature_activation_bit_counts: Optional[list[int]]
 
     # A dict of features in the feature activation process and their respective state. Must only be used by Blocks,
-    # is None otherwise.
+    # is None otherwise. This is only used for caching, so it can be safely cleared up, as it would be recalculated
+    # when necessary.
     feature_states: Optional[dict[Feature, FeatureState]] = None
     # It must be a weakref.
     _tx_ref: Optional['ReferenceType[BaseTransaction]']

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -15,6 +15,7 @@
 from typing import NamedTuple
 
 from hathor.conf.settings import HathorSettings
+from hathor.feature_activation.feature_service import FeatureService
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.exceptions import TxValidationError
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
@@ -33,14 +34,19 @@ class VertexVerifiers(NamedTuple):
     token_creation_tx: TokenCreationTransactionVerifier
 
     @classmethod
-    def create_defaults(cls, *, settings: HathorSettings) -> 'VertexVerifiers':
+    def create_defaults(
+        cls,
+        *,
+        settings: HathorSettings,
+        feature_service: FeatureService | None = None
+    ) -> 'VertexVerifiers':
         """
         Create a VertexVerifiers instance using the default verifier for each vertex type,
         from all required dependencies.
         """
         return VertexVerifiers(
-            block=BlockVerifier(settings=settings),
-            merge_mined_block=MergeMinedBlockVerifier(settings=settings),
+            block=BlockVerifier(settings=settings, feature_service=feature_service),
+            merge_mined_block=MergeMinedBlockVerifier(settings=settings, feature_service=feature_service),
             tx=TransactionVerifier(settings=settings),
             token_creation_tx=TokenCreationTransactionVerifier(settings=settings),
         )

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hathor.builder import Builder
+from hathor.conf.get_settings import get_settings
 from hathor.feature_activation import feature_service as feature_service_module
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
@@ -25,15 +26,17 @@ from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.resources.feature import FeatureResource
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.simulator import FakeConnection
-from hathor.simulator.trigger import StopAfterNMinedBlocks
+from hathor.transaction.exceptions import BlockMustSignalError
 from tests import unittest
 from tests.resources.base_resource import StubSite
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import HAS_ROCKSDB
+from tests.utils import HAS_ROCKSDB, add_new_blocks
 
 
 class BaseFeatureSimulationTest(SimulatorTestCase):
-    builder: Builder
+    def get_simulator_builder(self) -> Builder:
+        """Return a pre-configured builder to be used in tests."""
+        raise NotImplementedError
 
     @staticmethod
     def _get_result(web_client: StubSite) -> dict[str, Any]:
@@ -46,20 +49,17 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         return result
 
     @staticmethod
-    def _get_state_mock_block_height_calls(get_state_mock: Mock) -> list[int]:
-        """Returns the heights of blocks that get_state_mock was called with."""
-        return [call.kwargs['block'].get_height() for call in get_state_mock.call_args_list]
+    def _calculate_new_state_mock_block_height_calls(calculate_new_state_mock: Mock) -> list[int]:
+        """Return the heights of blocks that calculate_new_state_mock was called with."""
+        return [call.kwargs['boundary_block'].get_height() for call in calculate_new_state_mock.call_args_list]
 
     def test_feature(self) -> None:
         """
         Tests that a feature goes through all possible states in the correct block heights, and also assert internal
-        method call counts and args to make sure we're executing it in the most performatic way.
+        method calls to make sure we're executing it in the intended, most performatic way.
         """
-        artifacts = self.simulator.create_artifacts(self.builder)
-        manager = artifacts.manager
-        manager.allow_mining_without_peers()
-
         feature_settings = FeatureSettings(
+            enable_usage=True,
             evaluation_interval=4,
             max_signal_bits=4,
             default_threshold=3,
@@ -75,10 +75,12 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             }
         )
 
-        feature_service = FeatureService(
-            feature_settings=feature_settings,
-            tx_storage=artifacts.tx_storage
-        )
+        settings = get_settings()._replace(FEATURE_ACTIVATION=feature_settings)
+        builder = self.get_simulator_builder().set_settings(settings)
+        artifacts = self.simulator.create_artifacts(builder)
+        feature_service = artifacts.feature_service
+        manager = artifacts.manager
+
         feature_resource = FeatureResource(
             feature_settings=feature_settings,
             feature_service=feature_service,
@@ -86,19 +88,16 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         )
         web_client = StubSite(feature_resource)
 
-        miner = self.simulator.create_miner(manager, hashpower=1e6)
-        miner.start()
-
-        get_state_mock = Mock(wraps=feature_service.get_state)
+        calculate_new_state_mock = Mock(wraps=feature_service._calculate_new_state)
         get_ancestor_iteratively_mock = Mock(wraps=feature_service_module._get_ancestor_iteratively)
 
         with (
-            patch.object(FeatureService, 'get_state', get_state_mock),
+            patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock),
             patch.object(feature_service_module, '_get_ancestor_iteratively', get_ancestor_iteratively_mock)
         ):
             # at the beginning, the feature is DEFINED:
-            trigger = StopAfterNMinedBlocks(miner, quantity=10)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 10)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=10,
@@ -116,15 +115,15 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            # so we query states all the way down to genesis:
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [10, 8, 4, 0]
+            # so we calculate states all the way down to the first evaluation boundary (after genesis):
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 4
             # no blocks are voided, so we only use the height index, and not get_ancestor_iteratively:
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
             # at block 19, the feature is DEFINED, just before becoming STARTED:
-            trigger = StopAfterNMinedBlocks(miner, quantity=9)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 9)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=19,
@@ -142,14 +141,14 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            # so we query states from block 19 to 8, as it's cached:
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [19, 16, 12, 8]
+            # so we calculate states down to block 12, as block 8's state is saved:
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 12
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
             # at block 20, the feature becomes STARTED:
-            trigger = StopAfterNMinedBlocks(miner, quantity=1)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 1)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=20,
@@ -167,13 +166,16 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [20, 16]
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 20
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+
+            # we add one block before resetting the mock, just to make sure block 20 gets a chance to be saved
+            add_new_blocks(manager, 1)
+            calculate_new_state_mock.reset_mock()
 
             # at block 55, the feature is STARTED, just before becoming MUST_SIGNAL:
-            trigger = StopAfterNMinedBlocks(miner, quantity=35)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 34)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=55,
@@ -191,15 +193,13 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert (
-                self._get_state_mock_block_height_calls(get_state_mock) == [55, 52, 48, 44, 40, 36, 32, 28, 24, 20]
-            )
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 24
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
             # at block 56, the feature becomes MUST_SIGNAL:
-            trigger = StopAfterNMinedBlocks(miner, quantity=1)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 1)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=56,
@@ -217,13 +217,26 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [56, 52]
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 56
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+
+            # we add one block before resetting the mock, just to make sure block 56 gets a chance to be saved
+            add_new_blocks(manager, 1, signal_bits=0b1)
+            calculate_new_state_mock.reset_mock()
+
+            # if we try to propagate a non-signaling block, it is not accepted
+            non_signaling_block = manager.generate_mining_block()
+            non_signaling_block.resolve()
+            non_signaling_block.signal_bits = 0b10
+
+            with pytest.raises(BlockMustSignalError):
+                manager.verification_service.verify(non_signaling_block)
+
+            assert not manager.propagate_tx(non_signaling_block)
 
             # at block 59, the feature is MUST_SIGNAL, just before becoming LOCKED_IN:
-            trigger = StopAfterNMinedBlocks(miner, quantity=3)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, num_blocks=2, signal_bits=0b1)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=59,
@@ -231,7 +244,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     dict(
                         name='NOP_FEATURE_1',
                         state='MUST_SIGNAL',
-                        acceptance=0,
+                        acceptance=0.75,
                         threshold=0.75,
                         start_height=20,
                         timeout_height=60,
@@ -241,15 +254,14 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert (
-                self._get_state_mock_block_height_calls(get_state_mock) == [59, 56]
-            )
+            # we don't need to calculate any new state, as block 56's state is saved:
+            assert len(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 0
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
             # at block 60, the feature becomes LOCKED_IN:
-            trigger = StopAfterNMinedBlocks(miner, quantity=1)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 1)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=60,
@@ -267,13 +279,16 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [60, 56]
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 60
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+
+            # we add one block before resetting the mock, just to make sure block 60 gets a chance to be saved
+            add_new_blocks(manager, 1)
+            calculate_new_state_mock.reset_mock()
 
             # at block 71, the feature is LOCKED_IN, just before becoming ACTIVE:
-            trigger = StopAfterNMinedBlocks(miner, quantity=11)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 10)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=71,
@@ -291,15 +306,13 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert (
-                self._get_state_mock_block_height_calls(get_state_mock) == [71, 68, 64, 60]
-            )
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 64
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
             # at block 72, the feature becomes ACTIVE, forever:
-            trigger = StopAfterNMinedBlocks(miner, quantity=1)
-            self.simulator.run(36000, trigger=trigger)
+            add_new_blocks(manager, 1)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=72,
@@ -317,16 +330,13 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                     )
                 ]
             )
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [72, 68]
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 72
             assert get_ancestor_iteratively_mock.call_count == 0
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
     def test_reorg(self) -> None:
-        artifacts = self.simulator.create_artifacts(self.builder)
-        manager = artifacts.manager
-        manager.allow_mining_without_peers()
-
         feature_settings = FeatureSettings(
+            enable_usage=True,
             evaluation_interval=4,
             max_signal_bits=4,
             default_threshold=3,
@@ -340,10 +350,13 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
                 )
             }
         )
-        feature_service = FeatureService(
-            feature_settings=feature_settings,
-            tx_storage=artifacts.tx_storage
-        )
+
+        settings = get_settings()._replace(FEATURE_ACTIVATION=feature_settings)
+        builder = self.get_simulator_builder().set_settings(settings)
+        artifacts = self.simulator.create_artifacts(builder)
+        feature_service = artifacts.feature_service
+        manager = artifacts.manager
+
         feature_resource = FeatureResource(
             feature_settings=feature_settings,
             feature_service=feature_service,
@@ -351,19 +364,8 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         )
         web_client = StubSite(feature_resource)
 
-        # 4 blocks per evaluation interval, and the genesis is skipped
-        signal_bits = [
-            0b0000, 0b0000, 0b0000,          # 0% acceptance
-            0b0000, 0b0000, 0b0010, 0b0000,  # 25% acceptance
-            0b0010, 0b0000, 0b0010, 0b0010,  # 75% acceptance
-        ]
-
-        miner = self.simulator.create_miner(manager, hashpower=1e6, signal_bits=signal_bits)
-        miner.start()
-
         # at the beginning, the feature is DEFINED:
-        trigger = StopAfterNMinedBlocks(miner, quantity=0)
-        self.simulator.run(36000, trigger=trigger)
+        self.simulator.run(60)
         result = self._get_result(web_client)
         assert result == dict(
             block_height=0,
@@ -383,8 +385,8 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         )
 
         # at block 4, the feature becomes STARTED with 0% acceptance
-        trigger = StopAfterNMinedBlocks(miner, quantity=4)
-        self.simulator.run(36000, trigger=trigger)
+        add_new_blocks(manager, 4)
+        self.simulator.run(60)
         result = self._get_result(web_client)
         assert result == dict(
             block_height=4,
@@ -403,9 +405,10 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             ]
         )
 
-        # at block 7, acceptance was 25%
-        trigger = StopAfterNMinedBlocks(miner, quantity=3)
-        self.simulator.run(36000, trigger=trigger)
+        # at block 7, acceptance is 25% (we're signaling 1 block out of 4)
+        add_new_blocks(manager, 2)
+        add_new_blocks(manager, 1, signal_bits=0b10)
+        self.simulator.run(60)
         result = self._get_result(web_client)
         assert result == dict(
             block_height=7,
@@ -424,9 +427,11 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             ]
         )
 
-        # at block 11, acceptance was 75%, so the feature will be locked-in in the next block
-        trigger = StopAfterNMinedBlocks(miner, quantity=4)
-        self.simulator.run(36000, trigger=trigger)
+        # at block 11, acceptance is 75% (we're signaling 3 blocks out of 4),
+        # so the feature will be locked-in in the next block
+        add_new_blocks(manager, 1)
+        add_new_blocks(manager, 3, signal_bits=0b10)
+        self.simulator.run(60)
         result = self._get_result(web_client)
         assert result == dict(
             block_height=11,
@@ -446,8 +451,8 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         )
 
         # at block 12, the feature is locked-in
-        trigger = StopAfterNMinedBlocks(miner, quantity=1)
-        self.simulator.run(36000, trigger=trigger)
+        add_new_blocks(manager, 1)
+        self.simulator.run(60)
         result = self._get_result(web_client)
         assert result == dict(
             block_height=12,
@@ -467,8 +472,8 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         )
 
         # at block 16, the feature is activated
-        trigger = StopAfterNMinedBlocks(miner, quantity=4)
-        self.simulator.run(36000, trigger=trigger)
+        add_new_blocks(manager, 4)
+        self.simulator.run(60)
         result = self._get_result(web_client)
         assert result == dict(
             block_height=16,
@@ -487,19 +492,14 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             ]
         )
 
-        miner.stop()
-
-        # We then create a new manager with a miner that mines one more block (17 vs 16), so its blockchain wins when
+        # We then create a new manager with one more block (17 vs 16), so its blockchain wins when
         # both managers are connected. This causes a reorg and the feature goes back to the STARTED state.
-        manager2 = self.simulator.create_peer()
-        manager2.allow_mining_without_peers()
+        builder2 = self.get_simulator_builder().set_settings(settings)
+        artifacts2 = self.simulator.create_artifacts(builder2)
+        manager2 = artifacts2.manager
 
-        miner2 = self.simulator.create_miner(manager2, hashpower=1e6)
-
-        miner2.start()
-        trigger = StopAfterNMinedBlocks(miner2, quantity=17)
-        self.simulator.run(36000, trigger=trigger)
-        miner2.stop()
+        add_new_blocks(manager2, 17)
+        self.simulator.run(60)
 
         connection = FakeConnection(manager, manager2)
         self.simulator.add_connection(connection)
@@ -525,33 +525,33 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
 
 
 class BaseMemoryStorageFeatureSimulationTest(BaseFeatureSimulationTest):
-    def setUp(self):
-        super().setUp()
-        self.builder = self.simulator.get_default_builder()
+    def get_simulator_builder(self) -> Builder:
+        return self.simulator.get_default_builder()
 
 
 @pytest.mark.skipif(not HAS_ROCKSDB, reason='requires python-rocksdb')
 class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
-    def setUp(self):
-        super().setUp()
+    def get_rocksdb_directory(self) -> str:
         import tempfile
+        tmp_dir = tempfile.mkdtemp()
+        self.tmpdirs.append(tmp_dir)
+        return tmp_dir
 
-        self.rocksdb_directory = tempfile.mkdtemp()
-        self.tmpdirs.append(self.rocksdb_directory)
-
-        self.builder = self.simulator.get_default_builder() \
-            .use_rocksdb(path=self.rocksdb_directory) \
+    def get_simulator_builder_from_dir(self, rocksdb_directory: str) -> Builder:
+        return self.simulator.get_default_builder() \
+            .use_rocksdb(path=rocksdb_directory) \
             .disable_full_verification()
+
+    def get_simulator_builder(self) -> Builder:
+        rocksdb_directory = self.get_rocksdb_directory()
+        return self.get_simulator_builder_from_dir(rocksdb_directory)
 
     def test_feature_from_existing_storage(self) -> None:
         """
         Tests that feature states are correctly retrieved from an existing storage, so no recalculation is required.
         """
-        artifacts1 = self.simulator.create_artifacts(self.builder)
-        manager1 = artifacts1.manager
-        manager1.allow_mining_without_peers()
-
         feature_settings = FeatureSettings(
+            enable_usage=True,
             evaluation_interval=4,
             max_signal_bits=4,
             default_threshold=3,
@@ -566,31 +566,33 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
             }
         )
 
-        feature_service = FeatureService(
-            feature_settings=feature_settings,
-            tx_storage=artifacts1.tx_storage
-        )
+        settings = get_settings()._replace(FEATURE_ACTIVATION=feature_settings)
+        rocksdb_dir = self.get_rocksdb_directory()
+        builder1 = self.get_simulator_builder_from_dir(rocksdb_dir).set_settings(settings)
+        artifacts1 = self.simulator.create_artifacts(builder1)
+        feature_service1 = artifacts1.feature_service
+        manager1 = artifacts1.manager
+
         feature_resource = FeatureResource(
             feature_settings=feature_settings,
-            feature_service=feature_service,
+            feature_service=feature_service1,
             tx_storage=artifacts1.tx_storage
         )
         web_client = StubSite(feature_resource)
 
-        miner = self.simulator.create_miner(manager1, hashpower=1e6)
-        miner.start()
-
-        get_state_mock = Mock(wraps=feature_service.get_state)
+        calculate_new_state_mock = Mock(wraps=feature_service1._calculate_new_state)
         get_ancestor_iteratively_mock = Mock(wraps=feature_service_module._get_ancestor_iteratively)
 
         with (
-            patch.object(FeatureService, 'get_state', get_state_mock),
+            patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock),
             patch.object(feature_service_module, '_get_ancestor_iteratively', get_ancestor_iteratively_mock)
         ):
             assert artifacts1.tx_storage.get_vertices_count() == 3  # genesis vertices in the storage
 
-            trigger = StopAfterNMinedBlocks(miner, quantity=64)
-            self.simulator.run(36000, trigger=trigger)
+            # we add 64 blocks so the feature becomes active. It would be active by timeout anyway,
+            # we just set signal bits to conform with the MUST_SIGNAL phase.
+            add_new_blocks(manager1, 64, signal_bits=0b1)
+            self.simulator.run(60)
             result = self._get_result(web_client)
             assert result == dict(
                 block_height=64,
@@ -608,28 +610,22 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
                     )
                 ]
             )
-            # feature states have to be calculated for all blocks in evaluation interval boundaries, as this is the
-            # first run:
-            assert self._get_state_mock_block_height_calls(get_state_mock) == list(range(64, -4, -4))
+            # feature states have to be calculated for all blocks in evaluation interval boundaries,
+            # down to the first one (after genesis), as this is the first run:
+            assert min(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 4
             # no blocks are voided, so we only use the height index:
             assert get_ancestor_iteratively_mock.call_count == 0
             assert artifacts1.tx_storage.get_vertices_count() == 67
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
-        miner.stop()
         manager1.stop()
         artifacts1.rocksdb_storage.close()
 
-        builder = self.simulator.get_default_builder() \
-            .use_rocksdb(path=self.rocksdb_directory) \
-            .disable_full_verification()
-        artifacts2 = self.simulator.create_artifacts(builder)
+        # new builder is created with the same storage from the previous manager
+        builder2 = self.get_simulator_builder_from_dir(rocksdb_dir).set_settings(settings)
+        artifacts2 = self.simulator.create_artifacts(builder2)
+        feature_service = artifacts2.feature_service
 
-        # new feature_service is created with the same storage generated above
-        feature_service = FeatureService(
-            feature_settings=feature_settings,
-            tx_storage=artifacts2.tx_storage
-        )
         feature_resource = FeatureResource(
             feature_settings=feature_settings,
             feature_service=feature_service,
@@ -637,19 +633,20 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
         )
         web_client = StubSite(feature_resource)
 
-        get_state_mock = Mock(wraps=feature_service.get_state)
+        calculate_new_state_mock = Mock(wraps=feature_service._calculate_new_state)
         get_ancestor_iteratively_mock = Mock(wraps=feature_service_module._get_ancestor_iteratively)
 
         with (
-            patch.object(FeatureService, 'get_state', get_state_mock),
+            patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock),
             patch.object(feature_service_module, '_get_ancestor_iteratively', get_ancestor_iteratively_mock)
         ):
             # the new storage starts populated
             assert artifacts2.tx_storage.get_vertices_count() == 67
-            self.simulator.run(3600)
+            self.simulator.run(60)
 
             result = self._get_result(web_client)
 
+            # the result should be the same as before
             assert result == dict(
                 block_height=64,
                 features=[
@@ -666,11 +663,11 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
                     )
                 ]
             )
-            # features states are not queried for previous blocks, as they have it cached:
-            assert self._get_state_mock_block_height_calls(get_state_mock) == [64]
+            # features states are not calculate for any block, as they're all saved:
+            assert len(self._calculate_new_state_mock_block_height_calls(calculate_new_state_mock)) == 0
             assert get_ancestor_iteratively_mock.call_count == 0
             assert artifacts2.tx_storage.get_vertices_count() == 67
-            get_state_mock.reset_mock()
+            calculate_new_state_mock.reset_mock()
 
 
 class SyncV1MemoryStorageFeatureSimulationTest(unittest.SyncV1Params, BaseMemoryStorageFeatureSimulationTest):

--- a/tests/resources/transaction/test_mining.py
+++ b/tests/resources/transaction/test_mining.py
@@ -39,7 +39,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'height': 1,
                 'min_height': 0,
                 'first_block': None,
-                'feature_activation_bit_counts': [0, 0, 0, 0]
+                'feature_activation_bit_counts': None
             },
             'tokens': [],
             'data': '',
@@ -72,7 +72,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'height': 1,
                 'min_height': 0,
                 'first_block': None,
-                'feature_activation_bit_counts': [0, 0, 0, 0]
+                'feature_activation_bit_counts': None
             },
             'tokens': [],
             'data': '',

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -16,10 +16,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from hathor.conf import HathorSettings
 from hathor.conf.get_settings import get_settings
+from hathor.conf.settings import HathorSettings
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling, FeatureService
 from hathor.transaction import Block, TransactionMetadata
+from hathor.transaction.exceptions import BlockMustSignalError
 from hathor.transaction.storage import TransactionMemoryStorage, TransactionStorage
+from hathor.verification.block_verifier import BlockVerifier
 
 
 def test_calculate_feature_activation_bit_counts_genesis():
@@ -27,13 +31,14 @@ def test_calculate_feature_activation_bit_counts_genesis():
     storage = TransactionMemoryStorage()
     genesis_block = storage.get_transaction(settings.GENESIS_BLOCK_HASH)
     assert isinstance(genesis_block, Block)
-    result = genesis_block.calculate_feature_activation_bit_counts()
+    result = genesis_block.get_feature_activation_bit_counts()
 
     assert result == [0, 0, 0, 0]
 
 
 @pytest.fixture
 def block_mocks() -> list[Block]:
+    settings = get_settings()
     blocks: list[Block] = []
     feature_activation_bits = [
         0b0000,  # 0: boundary block
@@ -51,7 +56,6 @@ def block_mocks() -> list[Block]:
     ]
 
     for i, bits in enumerate(feature_activation_bits):
-        settings = HathorSettings()
         genesis_hash = settings.GENESIS_BLOCK_HASH
         block_hash = genesis_hash if i == 0 else b'some_hash'
 
@@ -88,7 +92,7 @@ def test_calculate_feature_activation_bit_counts(
     expected_counts: list[int]
 ) -> None:
     block = block_mocks[block_height]
-    result = block.calculate_feature_activation_bit_counts()
+    result = block.get_feature_activation_bit_counts()
 
     assert result == expected_counts
 
@@ -132,3 +136,45 @@ def test_get_feature_activation_bit_value() -> None:
     assert block.get_feature_activation_bit_value(1) == 0
     assert block.get_feature_activation_bit_value(2) == 1
     assert block.get_feature_activation_bit_value(3) == 0
+
+
+@pytest.mark.parametrize(
+    'is_signaling_mandatory_features',
+    [BlockIsSignaling(), BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)]
+)
+def test_verify_must_signal_when_feature_activation_is_disabled(is_signaling_mandatory_features: bool) -> None:
+    settings = Mock(spec_set=HathorSettings)
+    settings.FEATURE_ACTIVATION.enable_usage = False
+    feature_service = Mock(spec_set=FeatureService)
+    feature_service.is_signaling_mandatory_features = Mock(return_value=is_signaling_mandatory_features)
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service)
+    block = Block()
+
+    verifier.verify_mandatory_signaling(block)
+
+
+def test_verify_must_signal() -> None:
+    settings = Mock(spec_set=HathorSettings)
+    settings.FEATURE_ACTIVATION.enable_usage = True
+    feature_service = Mock(spec_set=FeatureService)
+    feature_service.is_signaling_mandatory_features = Mock(
+        return_value=BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)
+    )
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service)
+    block = Block()
+
+    with pytest.raises(BlockMustSignalError) as e:
+        verifier.verify_mandatory_signaling(block)
+
+    assert str(e.value) == "Block must signal support for feature 'NOP_FEATURE_1' during MUST_SIGNAL phase."
+
+
+def test_verify_must_not_signal() -> None:
+    settings = Mock(spec_set=HathorSettings)
+    settings.FEATURE_ACTIVATION.enable_usage = True
+    feature_service = Mock(spec_set=FeatureService)
+    feature_service.is_signaling_mandatory_features = Mock(return_value=BlockIsSignaling())
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service)
+    block = Block()
+
+    verifier.verify_mandatory_signaling(block)

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -160,6 +160,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
         verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
+        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
 
         with (
             patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -170,6 +171,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(BlockVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
+            patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
             self.manager.verification_service.verify(block)
 
@@ -182,6 +184,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
         verify_parents_wrapped.assert_called_once()
         verify_height_wrapped.assert_called_once()
+        verify_mandatory_signaling_wrapped.assert_called_once()
 
     def test_block_validate_basic(self) -> None:
         verifier = self.manager.verification_service.verifiers.block
@@ -214,6 +217,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
+        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
 
         with (
             patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -226,6 +230,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
+            patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
             self.manager.verification_service.validate_full(block)
 
@@ -240,6 +245,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_height_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         verify_reward_wrapped.assert_called_once()
+        verify_mandatory_signaling_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify_basic(self) -> None:
         verifier = self.manager.verification_service.verifiers.merge_mined_block
@@ -305,6 +311,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
         verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
+        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
 
         verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
 
@@ -318,6 +325,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(MergeMinedBlockVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
             self.manager.verification_service.verify(block)
 
@@ -330,6 +338,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
         verify_parents_wrapped.assert_called_once()
         verify_height_wrapped.assert_called_once()
+        verify_mandatory_signaling_wrapped.assert_called_once()
 
         # MergeMinedBlock methods
         verify_pow_wrapped.assert_called_once()
@@ -365,6 +374,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
+        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
 
         verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
 
@@ -380,6 +390,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_reward', verify_reward_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
             self.manager.verification_service.validate_full(block)
 
@@ -394,6 +405,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_height_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         verify_reward_wrapped.assert_called_once()
+        verify_mandatory_signaling_wrapped.assert_called_once()
 
         # MergeMinedBlock methods
         verify_pow_wrapped.assert_called_once()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -250,7 +250,7 @@ def add_new_transactions(manager, num_txs, advance_clock=None, propagate=True):
 
 
 def add_new_block(manager, advance_clock=None, *, parent_block_hash=None,
-                  data=b'', weight=None, address=None, propagate=True):
+                  data=b'', weight=None, address=None, propagate=True, signal_bits=None):
     """ Create, resolve and propagate a new block
 
         :param manager: Manager object to handle the creation
@@ -262,6 +262,8 @@ def add_new_block(manager, advance_clock=None, *, parent_block_hash=None,
     block = manager.generate_mining_block(parent_block_hash=parent_block_hash, data=data, address=address)
     if weight is not None:
         block.weight = weight
+    if signal_bits is not None:
+        block.signal_bits = signal_bits
     block.resolve()
     manager.verification_service.validate_full(block)
     if propagate:
@@ -272,7 +274,7 @@ def add_new_block(manager, advance_clock=None, *, parent_block_hash=None,
 
 
 def add_new_blocks(manager, num_blocks, advance_clock=None, *, parent_block_hash=None,
-                   block_data=b'', weight=None, address=None):
+                   block_data=b'', weight=None, address=None, signal_bits=None):
     """ Create, resolve and propagate some blocks
 
         :param manager: Manager object to handle the creation
@@ -288,7 +290,7 @@ def add_new_blocks(manager, num_blocks, advance_clock=None, *, parent_block_hash
     for _ in range(num_blocks):
         blocks.append(
             add_new_block(manager, advance_clock, parent_block_hash=parent_block_hash,
-                          data=block_data, weight=weight, address=address)
+                          data=block_data, weight=weight, address=address, signal_bits=signal_bits)
         )
         if parent_block_hash:
             parent_block_hash = blocks[-1].hash


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/800

### Motivation

Implement the mandatory signaling mechanism required by the Feature Activation process.

### Acceptance Criteria

- Improvements in `Builder`:
  - Add `FeatureService` to `BuildArtifacts`
  - Change implementation of some `_get_or_create_*` methods so they can all be used without arguments.
  - Change private `_get_or_create_settings()` and `_get_or_create_feature_service()` methods to public so they can be used externally (specifically, so the `Simulator` can properly customize the builder).
- Implement `FeatureService.check_must_signal()`.
- Fix problem in caching mechanism in `FeatureService.get_state()` caused by must signal verification.
- Remove the original `Block.get_feature_activation_bit_counts()`, and change `calculate_feature_activation_bit_counts()` to `get_feature_activation_bit_counts()`.
- Change `Block.update_feature_state()` to `set_feature_state()`.
- Remove `BaseTransaction._update_feature_activation_bit_counts_metadata()` as it's not necessary anymore.
- Implement `BlockVerifier.verify_mandatory_signaling()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 