### PR TITLE
chore(ci): upload codecov results on Python 3.11 test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
             'os': ['ubuntu-22.04', 'macos-12', 'windows-2022'],
             'include': [
               # XXX: tests fail on these, not sure why, when running them individually each on passes, but not on `make tests`
-              # {'os': 'ubuntu-22.04', 'python': 'pypy-3.9'},
+              # {'os': 'ubuntu-22.04', 'python': 'pypy-3.10'},
             ],
           }
           # this is the fastest one:
           reduced_matrix = {
-            'python': ['3.9'],
+            'python': ['3.11'],
             'os': ['ubuntu-22.04'],
           }
           github_repository = os.environ['GITHUB_REPOSITORY']
@@ -99,4 +99,4 @@ jobs:
         run: poetry run make tests
       - name: Upload coverage
         uses: codecov/codecov-action@v3
-        if: matrix.python == 3.9 && startsWith(matrix.os, 'ubuntu')
+        if: matrix.python == 3.11 && startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
### Motivation

CI was no longer uploading codecov after removing Python 3.9 support.

### Acceptance Criteria

- Use Python 3.11 instead of 3.9 on reduced matrix (not directly related to codecov), and for uploading codecov report

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 