### PR TITLE
chore(ci): fix codecov main branch name

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: dev
+  branch: master
 
 coverage:
   # https://docs.codecov.com/docs/coverage-configuration


### PR DESCRIPTION
### Motivation

Codecov branch config has been wrong since we changed the default branch, this likely only affects coverage comparisons.

### Acceptance Criteria

- Use `master` as codecov branch

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 