### PR TITLE
refactor(verification): move verification methods signatures [part 2/5]

### DIFF
--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -24,6 +24,9 @@ from multiprocessing import Process, Queue
 
 import requests
 
+from hathor.conf.get_settings import get_settings
+from hathor.verification.block_verifier import BlockVerifier
+
 _SLEEP_ON_ERROR_SECONDS = 5
 _MAX_CONN_RETRIES = math.inf
 
@@ -134,7 +137,9 @@ def execute(args: Namespace) -> None:
                                                                       block.nonce, block.weight))
 
         try:
-            block.verify_without_storage()
+            settings = get_settings()
+            verifier = BlockVerifier(settings=settings)
+            verifier.verify_without_storage(block)
         except HathorError:
             print('[{}] ERROR: Block has not been pushed because it is not valid.'.format(datetime.datetime.now()))
         else:

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -41,6 +41,7 @@ from hathor.pubsub import EventArguments, HathorEvents
 from hathor.transaction import BaseTransaction, BitcoinAuxPow, Block, MergeMinedBlock, Transaction, sum_weights
 from hathor.transaction.exceptions import PowError, ScriptError, TxValidationError
 from hathor.util import Reactor, json_dumpb, json_loadb, reactor
+from hathor.verification.vertex_verifier import VertexVerifier
 from hathor.wallet.exceptions import InvalidAddress
 
 if TYPE_CHECKING:
@@ -525,8 +526,10 @@ class StratumProtocol(JSONRPC):
 
         self.log.debug('share received', block=tx, block_base=block_base.hex(), block_base_hash=block_base_hash.hex())
 
+        verifier = VertexVerifier(settings=self._settings)
+
         try:
-            tx.verify_pow(job.weight)
+            verifier.verify_pow(tx, override_weight=job.weight)
         except PowError:
             self.log.error('bad share, discard', job_weight=job.weight, tx=tx)
             return self.send_error(INVALID_SOLUTION, msgid, {
@@ -542,7 +545,7 @@ class StratumProtocol(JSONRPC):
         self.manager.reactor.callLater(0, self.job_request)
 
         try:
-            tx.verify_pow()
+            verifier.verify_pow(tx)
         except PowError:
             # Transaction pow was not enough, but the share was succesfully submited
             self.log.info('high hash, keep mining', tx=tx)

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -89,7 +89,7 @@ class CreateTxResource(Resource):
             # conservative estimate of the input data size to estimate a valid weight
             tx_input.data = b'\0' * 107
         tx.weight = minimum_tx_weight(fake_signed_tx)
-        tx.verify_unsigned_skip_pow()
+        self.manager.verification_service.verifiers.tx.verify_unsigned_skip_pow(tx)
 
         if tx.is_double_spending():
             raise InvalidNewTransaction('At least one of your inputs has already been spent.')

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from hathor.profiler import get_cpu_profiler
-from hathor.transaction import Block
+from hathor.transaction import BaseTransaction, Block
 from hathor.verification.vertex_verifier import VertexVerifier
 
 cpu = get_cpu_profiler()
@@ -25,8 +25,8 @@ class BlockVerifier(VertexVerifier):
     def verify_basic(self, block: Block, *, skip_block_weight_verification: bool = False) -> None:
         """Partially run validations, the ones that need parents/inputs are skipped."""
         if not skip_block_weight_verification:
-            block.verify_weight()
-        block.verify_reward()
+            self.verify_weight(block)
+        self.verify_reward(block)
 
     @cpu.profiler(key=lambda _, block: 'block-verify!{}'.format(block.hash.hex()))
     def verify(self, block: Block) -> None:
@@ -42,9 +42,35 @@ class BlockVerifier(VertexVerifier):
             # TODO do genesis validation
             return
 
-        block.verify_without_storage()
+        self.verify_without_storage(block)
 
         # (1) and (4)
-        block.verify_parents()
+        self.verify_parents(block)
 
+        self.verify_height(block)
+
+    def verify_without_storage(self, block: Block) -> None:
+        """ Run all verifications that do not need a storage.
+        """
+        block.verify_without_storage()
+
+    def verify_height(self, block: Block) -> None:
+        """Validate that the block height is enough to confirm all transactions being confirmed."""
         block.verify_height()
+
+    def verify_weight(self, block: Block) -> None:
+        """Validate minimum block difficulty."""
+        block.verify_weight()
+
+    def verify_reward(self, block: Block) -> None:
+        """Validate reward amount."""
+        block.verify_reward()
+
+    def verify_no_inputs(self, block: Block) -> None:
+        block.verify_no_inputs()
+
+    def verify_outputs(self, block: BaseTransaction) -> None:
+        block.verify_outputs()
+
+    def verify_data(self, block: Block) -> None:
+        block.verify_data()

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -12,8 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from hathor.transaction import MergeMinedBlock
 from hathor.verification.block_verifier import BlockVerifier
 
 
 class MergeMinedBlockVerifier(BlockVerifier):
     __slots__ = ()
+
+    def verify_aux_pow(self, block: MergeMinedBlock) -> None:
+        """ Verify auxiliary proof-of-work (for merged mining).
+        """
+        block.verify_aux_pow()

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -25,4 +25,9 @@ class TokenCreationTransactionVerifier(TransactionVerifier):
         We also overload verify_sum to make some different checks
         """
         super().verify(tx, reject_locked_reward=reject_locked_reward)
+        self.verify_token_info(tx)
+
+    def verify_token_info(self, tx: TokenCreationTransaction) -> None:
+        """ Validates token info
+        """
         tx.verify_token_info()

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -13,7 +13,9 @@
 #  limitations under the License.
 
 from hathor.profiler import get_cpu_profiler
-from hathor.transaction import Transaction
+from hathor.transaction import BaseTransaction, Transaction, TxInput
+from hathor.transaction.transaction import TokenInfo
+from hathor.types import TokenUid
 from hathor.verification.vertex_verifier import VertexVerifier
 
 cpu = get_cpu_profiler()
@@ -27,9 +29,9 @@ class TransactionVerifier(VertexVerifier):
         if tx.is_genesis:
             # TODO do genesis validation?
             return
-        tx.verify_parents_basic()
-        tx.verify_weight()
-        tx.verify_without_storage()
+        self.verify_parents_basic(tx)
+        self.verify_weight(tx)
+        self.verify_without_storage(tx)
 
     @cpu.profiler(key=lambda _, tx: 'tx-verify!{}'.format(tx.hash.hex()))
     def verify(self, tx: Transaction, *, reject_locked_reward: bool = True) -> None:
@@ -47,10 +49,80 @@ class TransactionVerifier(VertexVerifier):
         if tx.is_genesis:
             # TODO do genesis validation
             return
-        tx.verify_without_storage()
-        tx.verify_sigops_input()
-        tx.verify_inputs()  # need to run verify_inputs first to check if all inputs exist
-        tx.verify_parents()
-        tx.verify_sum()
+        self.verify_without_storage(tx)
+        self.verify_sigops_input(tx)
+        self.verify_inputs(tx)  # need to run verify_inputs first to check if all inputs exist
+        self.verify_parents(tx)
+        self.verify_sum(tx)
         if reject_locked_reward:
-            tx.verify_reward_locked()
+            self.verify_reward_locked(tx)
+
+    def verify_unsigned_skip_pow(self, tx: Transaction) -> None:
+        """ Same as .verify but skipping pow and signature verification."""
+        tx.verify_unsigned_skip_pow()
+
+    def verify_parents_basic(self, tx: Transaction) -> None:
+        """Verify number and non-duplicity of parents."""
+        tx.verify_parents_basic()
+
+    def verify_weight(self, tx: Transaction) -> None:
+        """Validate minimum tx difficulty."""
+        tx.verify_weight()
+
+    def verify_without_storage(self, tx: Transaction) -> None:
+        """ Run all verifications that do not need a storage.
+        """
+        tx.verify_without_storage()
+
+    def verify_sigops_input(self, tx: Transaction) -> None:
+        """ Count sig operations on all inputs and verify that the total sum is below the limit
+        """
+        tx.verify_sigops_input()
+
+    def verify_inputs(self, tx: Transaction, *, skip_script: bool = False) -> None:
+        """Verify inputs signatures and ownership and all inputs actually exist"""
+        tx.verify_inputs(skip_script=skip_script)
+
+    def verify_script(self, *, tx: Transaction, input_tx: TxInput, spent_tx: BaseTransaction) -> None:
+        """
+        :type tx: Transaction
+        :type input_tx: TxInput
+        :type spent_tx: Transaction
+        """
+        tx.verify_script(input_tx, spent_tx)
+
+    def verify_sum(self, tx: Transaction) -> None:
+        """Verify that the sum of outputs is equal of the sum of inputs, for each token.
+
+        If there are authority UTXOs involved, tokens can be minted or melted, so the above rule may
+        not be respected.
+
+        :raises InvalidToken: when there's an error in token operations
+        :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
+        """
+        tx.verify_sum()
+
+    def verify_reward_locked(self, tx: Transaction) -> None:
+        """Will raise `RewardLocked` if any reward is spent before the best block height is enough, considering only
+        the block rewards spent by this tx itself, and not the inherited `min_height`."""
+        tx.verify_reward_locked()
+
+    def verify_number_of_inputs(self, tx: Transaction) -> None:
+        """Verify number of inputs is in a valid range"""
+        tx.verify_number_of_inputs()
+
+    def verify_outputs(self, tx: BaseTransaction) -> None:
+        """Verify outputs reference an existing token uid in the tokens list
+
+        :raises InvalidToken: output references non existent token uid
+        """
+        tx.verify_outputs()
+
+    def update_token_info_from_outputs(self, tx: Transaction, *, token_dict: dict[TokenUid, TokenInfo]) -> None:
+        """Iterate over the outputs and add values to token info dict. Updates the dict in-place.
+
+        Also, checks if no token has authorities on the outputs not present on the inputs
+
+        :raises InvalidToken: when there's an error in token operations
+        """
+        tx.update_token_info_from_outputs(token_dict)

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -141,6 +141,23 @@ class VerificationService:
             case _:
                 raise NotImplementedError
 
+    def verify_without_storage(self, vertex: BaseTransaction) -> None:
+        match vertex.version:
+            case TxVersion.REGULAR_BLOCK:
+                assert isinstance(vertex, Block)
+                self.verifiers.block.verify_without_storage(vertex)
+            case TxVersion.MERGE_MINED_BLOCK:
+                assert isinstance(vertex, MergeMinedBlock)
+                self.verifiers.merge_mined_block.verify_without_storage(vertex)
+            case TxVersion.REGULAR_TRANSACTION:
+                assert isinstance(vertex, Transaction)
+                self.verifiers.tx.verify_without_storage(vertex)
+            case TxVersion.TOKEN_CREATION_TRANSACTION:
+                assert isinstance(vertex, TokenCreationTransaction)
+                self.verifiers.token_creation_tx.verify_without_storage(vertex)
+            case _:
+                raise NotImplementedError
+
     def validate_vertex_error(self, vertex: BaseTransaction) -> tuple[bool, str]:
         """ Verify if tx is valid and return success and possible error message
 

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -12,7 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import Optional
+
 from hathor.conf.settings import HathorSettings
+from hathor.transaction import BaseTransaction
 
 
 class VertexVerifier:
@@ -20,3 +23,41 @@ class VertexVerifier:
 
     def __init__(self, *, settings: HathorSettings):
         self._settings = settings
+
+    def verify_parents(self, vertex: BaseTransaction) -> None:
+        """All parents must exist and their timestamps must be smaller than ours.
+
+        Also, txs should have 2 other txs as parents, while blocks should have 2 txs + 1 block.
+
+        Parents must be ordered with blocks first, followed by transactions.
+
+        :raises TimestampError: when our timestamp is less or equal than our parent's timestamp
+        :raises ParentDoesNotExist: when at least one of our parents does not exist
+        :raises IncorrectParents: when tx does not confirm the correct number/type of parent txs
+        """
+        vertex.verify_parents()
+
+    def verify_pow(self, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+        """Verify proof-of-work
+
+        :raises PowError: when the hash is equal or greater than the target
+        """
+        vertex.verify_pow(override_weight)
+
+    def verify_outputs(self, vertex: BaseTransaction) -> None:
+        """Verify there are no hathor authority UTXOs and outputs are all positive
+
+        :raises InvalidToken: when there's a hathor authority utxo
+        :raises InvalidOutputValue: output has negative value
+        :raises TooManyOutputs: when there are too many outputs
+        """
+        vertex.verify_outputs()
+
+    def verify_number_of_outputs(self, vertex: BaseTransaction) -> None:
+        """Verify number of outputs does not exceeds the limit"""
+        vertex.verify_number_of_outputs()
+
+    def verify_sigops_output(self, vertex: BaseTransaction) -> None:
+        """ Count sig operations on all outputs and verify that the total sum is below the limit
+        """
+        vertex.verify_sigops_output()

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -2,6 +2,7 @@ import pytest
 
 from hathor.simulator import FakeConnection
 from hathor.simulator.trigger import All as AllTriggers, StopWhenSynced
+from hathor.verification.vertex_verifier import VertexVerifier
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 
@@ -12,7 +13,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         # just get one of the genesis, we don't really need to create any transaction
         tx = next(iter(manager1.tx_storage.get_all_genesis()))
         # optional argument must be valid, it just has to not raise any exception, there's no assert for that
-        tx.verify_pow(0.)
+        VertexVerifier(settings=self._settings).verify_pow(tx, override_weight=0.)
 
     def test_one_node(self):
         manager1 = self.create_peer()

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -1,6 +1,8 @@
 from hathor.conf import HathorSettings
 from hathor.daa import TestMode, _set_test_mode, calculate_block_difficulty, minimum_tx_weight
 from hathor.transaction.storage import TransactionMemoryStorage
+from hathor.verification.verification_service import VerificationService, VertexVerifiers
+from hathor.verification.vertex_verifier import VertexVerifier
 from tests import unittest
 
 settings = HathorSettings()
@@ -26,18 +28,21 @@ def get_genesis_output():
 class GenesisTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
+        verifiers = VertexVerifiers.create_defaults(settings=self._settings)
+        self._verification_service = VerificationService(verifiers=verifiers)
         self.storage = TransactionMemoryStorage()
 
     def test_pow(self):
+        verifier = VertexVerifier(settings=self._settings)
         genesis = self.storage.get_all_genesis()
         for g in genesis:
             self.assertEqual(g.calculate_hash(), g.hash)
-            self.assertIsNone(g.verify_pow())
+            self.assertIsNone(verifier.verify_pow(g))
 
     def test_verify(self):
         genesis = self.storage.get_all_genesis()
         for g in genesis:
-            g.verify_without_storage()
+            self._verification_service.verify_without_storage(g)
 
     def test_output(self):
         # Test if block output is valid

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -30,6 +30,7 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.scripts import P2PKH, parse_address_script
 from hathor.transaction.util import int_to_bytes
 from hathor.transaction.validation_state import ValidationState
+from hathor.verification.verification_service import VertexVerifiers
 from hathor.wallet import Wallet
 from tests import unittest
 from tests.utils import (
@@ -46,6 +47,7 @@ class BaseTransactionTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
+        self._verifiers = VertexVerifiers.create_defaults(settings=self._settings)
         self.wallet = Wallet()
 
         # this makes sure we can spend the genesis outputs
@@ -80,7 +82,7 @@ class BaseTransactionTest(unittest.TestCase):
         _input.data = P2PKH.create_input_data(public_bytes, signature)
 
         with self.assertRaises(InputOutputMismatch):
-            tx.verify_sum()
+            self._verifiers.tx.verify_sum(tx)
 
     def test_validation(self):
         # add 100 blocks and check that walking through get_next_block_best_chain yields the same blocks
@@ -120,7 +122,7 @@ class BaseTransactionTest(unittest.TestCase):
         _input.data = data_wrong
 
         with self.assertRaises(InvalidInputData):
-            tx.verify_inputs()
+            self._verifiers.tx.verify_inputs(tx)
 
     def test_too_many_inputs(self):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
@@ -131,13 +133,13 @@ class BaseTransactionTest(unittest.TestCase):
         tx = Transaction(inputs=inputs, storage=self.tx_storage)
 
         with self.assertRaises(TooManyInputs):
-            tx.verify_number_of_inputs()
+            self._verifiers.tx.verify_number_of_inputs(tx)
 
     def test_no_inputs(self):
         tx = Transaction(inputs=[], storage=self.tx_storage)
 
         with self.assertRaises(NoInputError):
-            tx.verify_number_of_inputs()
+            self._verifiers.tx.verify_number_of_inputs(tx)
 
     def test_too_many_outputs(self):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
@@ -148,7 +150,7 @@ class BaseTransactionTest(unittest.TestCase):
         tx = Transaction(outputs=outputs, storage=self.tx_storage)
 
         with self.assertRaises(TooManyOutputs):
-            tx.verify_number_of_outputs()
+            self._verifiers.tx.verify_number_of_outputs(tx)
 
     def _gen_tx_spending_genesis_block(self):
         parents = [tx.hash for tx in self.genesis_txs]
@@ -246,11 +248,11 @@ class BaseTransactionTest(unittest.TestCase):
         )
 
         with self.assertRaises(AuxPowNoMagicError):
-            b.verify_aux_pow()
+            self._verifiers.merge_mined_block.verify_aux_pow(b)
 
         # adding the MAGIC_NUMBER makes it work:
         b.aux_pow = b.aux_pow._replace(coinbase_head=b.aux_pow.coinbase_head + MAGIC_NUMBER)
-        b.verify_aux_pow()
+        self._verifiers.merge_mined_block.verify_aux_pow(b)
 
     def test_merge_mined_multiple_magic(self):
         from hathor.merged_mining import MAGIC_NUMBER
@@ -312,9 +314,9 @@ class BaseTransactionTest(unittest.TestCase):
         assert bytes(b1) != bytes(b2)
         assert b1.calculate_hash() == b2.calculate_hash()
 
-        b1.verify_aux_pow()  # OK
+        self._verifiers.merge_mined_block.verify_aux_pow(b1)  # OK
         with self.assertRaises(AuxPowUnexpectedMagicError):
-            b2.verify_aux_pow()
+            self._verifiers.merge_mined_block.verify_aux_pow(b2)
 
     def test_merge_mined_long_merkle_path(self):
         from hathor.merged_mining import MAGIC_NUMBER
@@ -341,11 +343,11 @@ class BaseTransactionTest(unittest.TestCase):
         )
 
         with self.assertRaises(AuxPowLongMerklePathError):
-            b.verify_aux_pow()
+            self._verifiers.merge_mined_block.verify_aux_pow(b)
 
         # removing one path makes it work
         b.aux_pow.merkle_path.pop()
-        b.verify_aux_pow()
+        self._verifiers.merge_mined_block.verify_aux_pow(b)
 
     def test_block_outputs(self):
         from hathor.transaction.exceptions import TooManyOutputs
@@ -365,7 +367,7 @@ class BaseTransactionTest(unittest.TestCase):
             storage=self.tx_storage)
 
         with self.assertRaises(TooManyOutputs):
-            block.verify_outputs()
+            self._verifiers.block.verify_outputs(block)
 
     def test_tx_number_parents(self):
         genesis_block = self.genesis_blocks[0]
@@ -534,7 +536,7 @@ class BaseTransactionTest(unittest.TestCase):
         tx.weight += self._settings.MAX_TX_WEIGHT_DIFF + 0.1
         tx.update_hash()
         with self.assertRaises(WeightError):
-            tx.verify_weight()
+            self._verifiers.tx.verify_weight(tx)
 
     def test_weight_nan(self):
         # this should succeed
@@ -682,34 +684,34 @@ class BaseTransactionTest(unittest.TestCase):
         self.assertFalse(tx_equal.is_genesis)
 
         # Pow error
-        tx2.verify_pow()
+        self._verifiers.tx.verify_pow(tx2)
         tx2.weight = 100
         with self.assertRaises(PowError):
-            tx2.verify_pow()
+            self._verifiers.tx.verify_pow(tx2)
 
         # Verify parent timestamps
-        tx2.verify_parents()
+        self._verifiers.tx.verify_parents(tx2)
         tx2_timestamp = tx2.timestamp
         tx2.timestamp = 2
         with self.assertRaises(TimestampError):
-            tx2.verify_parents()
+            self._verifiers.tx.verify_parents(tx2)
         tx2.timestamp = tx2_timestamp
 
         # Verify inputs timestamps
-        tx2.verify_inputs()
+        self._verifiers.tx.verify_inputs(tx2)
         tx2.timestamp = 2
         with self.assertRaises(TimestampError):
-            tx2.verify_inputs()
+            self._verifiers.tx.verify_inputs(tx2)
         tx2.timestamp = tx2_timestamp
 
         # Validate maximum distance between blocks
         block = blocks[0]
         block2 = blocks[1]
         block2.timestamp = block.timestamp + self._settings.MAX_DISTANCE_BETWEEN_BLOCKS
-        block2.verify_parents()
+        self._verifiers.block.verify_parents(block2)
         block2.timestamp += 1
         with self.assertRaises(TimestampError):
-            block2.verify_parents()
+            self._verifiers.block.verify_parents(block2)
 
     def test_block_big_nonce(self):
         block = self.genesis_blocks[0]
@@ -886,7 +888,7 @@ class BaseTransactionTest(unittest.TestCase):
         _output = TxOutput(value, script)
 
         tx = Transaction(inputs=[_input], outputs=[_output], storage=self.tx_storage)
-        tx.verify_outputs()
+        self._verifiers.tx.verify_outputs(tx)
 
     def test_txout_script_limit_exceeded(self):
         with self.assertRaises(InvalidOutputScriptSize):
@@ -910,7 +912,7 @@ class BaseTransactionTest(unittest.TestCase):
             outputs=[_output],
             storage=self.tx_storage
         )
-        tx.verify_inputs(skip_script=True)
+        self._verifiers.tx.verify_inputs(tx, skip_script=True)
 
     def test_txin_data_limit_exceeded(self):
         with self.assertRaises(InvalidInputDataSize):
@@ -1063,7 +1065,7 @@ class BaseTransactionTest(unittest.TestCase):
         output3 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output3], storage=self.tx_storage)
         tx.update_hash()
-        tx.verify_sigops_output()
+        self._verifiers.tx.verify_sigops_output(tx)
 
     def test_sigops_output_multi_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1075,7 +1077,7 @@ class BaseTransactionTest(unittest.TestCase):
         output4 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output4]*num_outputs, storage=self.tx_storage)
         tx.update_hash()
-        tx.verify_sigops_output()
+        self._verifiers.tx.verify_sigops_output(tx)
 
     def test_sigops_input_single_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1117,7 +1119,7 @@ class BaseTransactionTest(unittest.TestCase):
         input3 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input3], outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
-        tx.verify_sigops_input()
+        self._verifiers.tx.verify_sigops_input(tx)
 
     def test_sigops_input_multi_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1131,7 +1133,7 @@ class BaseTransactionTest(unittest.TestCase):
         input4 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input4]*num_inputs, outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
-        tx.verify_sigops_input()
+        self._verifiers.tx.verify_sigops_input(tx)
 
     def test_compare_bytes_equal(self) -> None:
         # create some block

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -1,10 +1,16 @@
 from hathor.transaction import Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.verification.verification_service import VerificationService, VertexVerifiers
 from tests import unittest
 
 
 class _BaseTest:
     class _DeserializationTest(unittest.TestCase):
+        def setUp(self) -> None:
+            super().setUp()
+            verifiers = VertexVerifiers.create_defaults(settings=self._settings)
+            self._verification_service = VerificationService(verifiers=verifiers)
+
         def test_deserialize(self):
             cls = self.get_tx_class()
             tx = cls.create_from_struct(self.tx_bytes)
@@ -18,7 +24,7 @@ class _BaseTest:
 
             cls = self.get_tx_class()
             tx = cls.create_from_struct(self.tx_bytes, verbose=verbose)
-            tx.verify_without_storage()
+            self._verification_service.verify_without_storage(tx)
 
             key, version = v[1]
             self.assertEqual(key, 'version')

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -1,6 +1,7 @@
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.transaction import Transaction
+from hathor.verification.transaction_verifier import TransactionVerifier
 from hathor.wallet import HDWallet
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds
@@ -42,7 +43,8 @@ class BaseWalletHDTest(unittest.TestCase):
         out = WalletOutputInfo(decode_address(new_address2), self.TOKENS, timelock=None)
         tx1 = self.wallet.prepare_transaction_compute_inputs(Transaction, [out], self.tx_storage)
         tx1.update_hash()
-        tx1.verify_script(tx1.inputs[0], block)
+        verifier = TransactionVerifier(settings=self._settings)
+        verifier.verify_script(tx=tx1, input_tx=tx1.inputs[0], spent_tx=block)
         tx1.storage = self.tx_storage
         tx1.get_metadata().validation = ValidationState.FULL
         self.wallet.on_new_tx(tx1)
@@ -62,7 +64,7 @@ class BaseWalletHDTest(unittest.TestCase):
         tx2.storage = self.tx_storage
         tx2.update_hash()
         tx2.storage = self.tx_storage
-        tx2.verify_script(tx2.inputs[0], tx1)
+        verifier.verify_script(tx=tx2, input_tx=tx2.inputs[0], spent_tx=tx1)
         tx2.get_metadata().validation = ValidationState.FULL
         self.tx_storage.save_transaction(tx2)
         self.wallet.on_new_tx(tx2)


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/796

### Motivation

This is the second PR in a 5-part series of PRs that completely move verification-related code out of the vertex model classes.

The objective in this PR is to copy all verification methods _signatures_ from the vertex model classes to each respective `Verifier` class. The new methods simply call the original methods, effectively providing a new interface for existing implementations.

By doing this, we can update all callers of any verification method to use the new `Verifier` methods, while not touching the original model classes. This is the scaffolding necessary to actually move method implementations in the following PRs.

### Acceptance Criteria

- Copy all existing verification methods to each respective `Verifier` class. The implementation is simply a forward to the original method implemented by each vertex model class.
- Implement `VerificationService.verify_without_storage()`.
- Update every usage of any verification method to use the `Verifier` method, instead of the original model method.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 