### PR TITLE
refactor(verification): move block-only verification methods [part 3/5]

### DIFF
--- a/hathor/transaction/merge_mined_block.py
+++ b/hathor/transaction/merge_mined_block.py
@@ -74,13 +74,3 @@ class MergeMinedBlock(Block):
         del json['nonce']
         json['aux_pow'] = bytes(self.aux_pow).hex() if self.aux_pow else None
         return json
-
-    def verify_without_storage(self) -> None:
-        self.verify_aux_pow()
-        super().verify_without_storage()
-
-    def verify_aux_pow(self) -> None:
-        """ Verify auxiliary proof-of-work (for merged mining).
-        """
-        assert self.aux_pow is not None
-        self.aux_pow.verify(self.get_base_hash())

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -12,14 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from hathor.transaction import MergeMinedBlock
+from hathor.transaction import Block, MergeMinedBlock
 from hathor.verification.block_verifier import BlockVerifier
 
 
 class MergeMinedBlockVerifier(BlockVerifier):
     __slots__ = ()
 
+    def verify_without_storage(self, block: Block) -> None:
+        assert isinstance(block, MergeMinedBlock)
+        self.verify_aux_pow(block)
+        super().verify_without_storage(block)
+
     def verify_aux_pow(self, block: MergeMinedBlock) -> None:
         """ Verify auxiliary proof-of-work (for merged mining).
         """
-        block.verify_aux_pow()
+        assert block.aux_pow is not None
+        block.aux_pow.verify(block.get_base_hash())


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/797

### Motivation

This is the third PR in a 5-part series of PRs that completely move verification-related code out of the vertex model classes.

This PR moves the verification method implementations of the `Block` inheritance branch.

### Acceptance Criteria

- Remove all `Block` and `MergeMinedBlock` verification methods from the original model classes, moving the implementation to each respective `Verifier` class. The only exception is the `verify_outputs()` method, which is part of the inheritance tree up to `BaseTransaction`, and will be moved in a separate PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 