### PR TITLE
refactor(verification): move transaction-only verification methods [part 4/5]

### DIFF
--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -25,7 +25,6 @@ from multiprocessing import Process, Queue
 import requests
 
 from hathor.conf.get_settings import get_settings
-from hathor.verification.block_verifier import BlockVerifier
 
 _SLEEP_ON_ERROR_SECONDS = 5
 _MAX_CONN_RETRIES = math.inf
@@ -137,6 +136,7 @@ def execute(args: Namespace) -> None:
                                                                       block.nonce, block.weight))
 
         try:
+            from hathor.verification.block_verifier import BlockVerifier
             settings = get_settings()
             verifier = BlockVerifier(settings=settings)
             verifier.verify_without_storage(block)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -12,10 +12,29 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from hathor import daa
 from hathor.profiler import get_cpu_profiler
-from hathor.transaction import BaseTransaction, Transaction, TxInput
+from hathor.transaction import BaseTransaction, Transaction, TxInput, TxOutput
+from hathor.transaction.exceptions import (
+    ConflictingInputs,
+    DuplicatedParents,
+    IncorrectParents,
+    InexistentInput,
+    InputOutputMismatch,
+    InvalidInputData,
+    InvalidInputDataSize,
+    InvalidToken,
+    NoInputError,
+    RewardLocked,
+    ScriptError,
+    TimestampError,
+    TooManyInputs,
+    TooManySigOps,
+    WeightError,
+)
 from hathor.transaction.transaction import TokenInfo
-from hathor.types import TokenUid
+from hathor.transaction.util import get_deposit_amount, get_withdraw_amount
+from hathor.types import TokenUid, VertexId
 from hathor.verification.vertex_verifier import VertexVerifier
 
 cpu = get_cpu_profiler()
@@ -59,29 +78,104 @@ class TransactionVerifier(VertexVerifier):
 
     def verify_unsigned_skip_pow(self, tx: Transaction) -> None:
         """ Same as .verify but skipping pow and signature verification."""
-        tx.verify_unsigned_skip_pow()
+        self.verify_number_of_inputs(tx)
+        self.verify_number_of_outputs(tx)
+        self.verify_outputs(tx)
+        self.verify_sigops_output(tx)
+        self.verify_sigops_input(tx)
+        self.verify_inputs(tx, skip_script=True)  # need to run verify_inputs first to check if all inputs exist
+        self.verify_parents(tx)
+        self.verify_sum(tx)
 
     def verify_parents_basic(self, tx: Transaction) -> None:
         """Verify number and non-duplicity of parents."""
-        tx.verify_parents_basic()
+        assert tx.storage is not None
+
+        # check if parents are duplicated
+        parents_set = set(tx.parents)
+        if len(tx.parents) > len(parents_set):
+            raise DuplicatedParents('Tx has duplicated parents: {}', [tx_hash.hex() for tx_hash in tx.parents])
+
+        if len(tx.parents) != 2:
+            raise IncorrectParents(f'wrong number of parents (tx type): {len(tx.parents)}, expecting 2')
 
     def verify_weight(self, tx: Transaction) -> None:
         """Validate minimum tx difficulty."""
-        tx.verify_weight()
+        min_tx_weight = daa.minimum_tx_weight(tx)
+        max_tx_weight = min_tx_weight + self._settings.MAX_TX_WEIGHT_DIFF
+        if tx.weight < min_tx_weight - self._settings.WEIGHT_TOL:
+            raise WeightError(f'Invalid new tx {tx.hash_hex}: weight ({tx.weight}) is '
+                              f'smaller than the minimum weight ({min_tx_weight})')
+        elif min_tx_weight > self._settings.MAX_TX_WEIGHT_DIFF_ACTIVATION and tx.weight > max_tx_weight:
+            raise WeightError(f'Invalid new tx {tx.hash_hex}: weight ({tx.weight}) is '
+                              f'greater than the maximum allowed ({max_tx_weight})')
 
     def verify_without_storage(self, tx: Transaction) -> None:
         """ Run all verifications that do not need a storage.
         """
-        tx.verify_without_storage()
+        self.verify_pow(tx)
+        self.verify_number_of_inputs(tx)
+        self.verify_outputs(tx)
+        self.verify_sigops_output(tx)
 
     def verify_sigops_input(self, tx: Transaction) -> None:
         """ Count sig operations on all inputs and verify that the total sum is below the limit
         """
-        tx.verify_sigops_input()
+        from hathor.transaction.scripts import get_sigops_count
+        from hathor.transaction.storage.exceptions import TransactionDoesNotExist
+        n_txops = 0
+        for tx_input in tx.inputs:
+            try:
+                spent_tx = tx.get_spent_tx(tx_input)
+            except TransactionDoesNotExist:
+                raise InexistentInput('Input tx does not exist: {}'.format(tx_input.tx_id.hex()))
+            assert spent_tx.hash is not None
+            if tx_input.index >= len(spent_tx.outputs):
+                raise InexistentInput('Output spent by this input does not exist: {} index {}'.format(
+                    tx_input.tx_id.hex(), tx_input.index))
+            n_txops += get_sigops_count(tx_input.data, spent_tx.outputs[tx_input.index].script)
+
+        if n_txops > self._settings.MAX_TX_SIGOPS_INPUT:
+            raise TooManySigOps(
+                'TX[{}]: Max number of sigops for inputs exceeded ({})'.format(tx.hash_hex, n_txops))
 
     def verify_inputs(self, tx: Transaction, *, skip_script: bool = False) -> None:
         """Verify inputs signatures and ownership and all inputs actually exist"""
-        tx.verify_inputs(skip_script=skip_script)
+        from hathor.transaction.storage.exceptions import TransactionDoesNotExist
+
+        spent_outputs: set[tuple[VertexId, int]] = set()
+        for input_tx in tx.inputs:
+            if len(input_tx.data) > self._settings.MAX_INPUT_DATA_SIZE:
+                raise InvalidInputDataSize('size: {} and max-size: {}'.format(
+                    len(input_tx.data), self._settings.MAX_INPUT_DATA_SIZE
+                ))
+
+            try:
+                spent_tx = tx.get_spent_tx(input_tx)
+                assert spent_tx.hash is not None
+                if input_tx.index >= len(spent_tx.outputs):
+                    raise InexistentInput('Output spent by this input does not exist: {} index {}'.format(
+                        input_tx.tx_id.hex(), input_tx.index))
+            except TransactionDoesNotExist:
+                raise InexistentInput('Input tx does not exist: {}'.format(input_tx.tx_id.hex()))
+
+            if tx.timestamp <= spent_tx.timestamp:
+                raise TimestampError('tx={} timestamp={}, spent_tx={} timestamp={}'.format(
+                    tx.hash.hex() if tx.hash else None,
+                    tx.timestamp,
+                    spent_tx.hash.hex(),
+                    spent_tx.timestamp,
+                ))
+
+            if not skip_script:
+                self.verify_script(tx=tx, input_tx=input_tx, spent_tx=spent_tx)
+
+            # check if any other input in this tx is spending the same output
+            key = (input_tx.tx_id, input_tx.index)
+            if key in spent_outputs:
+                raise ConflictingInputs('tx {} inputs spend the same output: {} index {}'.format(
+                    tx.hash_hex, input_tx.tx_id.hex(), input_tx.index))
+            spent_outputs.add(key)
 
     def verify_script(self, *, tx: Transaction, input_tx: TxInput, spent_tx: BaseTransaction) -> None:
         """
@@ -89,7 +183,11 @@ class TransactionVerifier(VertexVerifier):
         :type input_tx: TxInput
         :type spent_tx: Transaction
         """
-        tx.verify_script(input_tx, spent_tx)
+        from hathor.transaction.scripts import script_eval
+        try:
+            script_eval(tx, input_tx, spent_tx)
+        except ScriptError as e:
+            raise InvalidInputData(e) from e
 
     def verify_sum(self, tx: Transaction) -> None:
         """Verify that the sum of outputs is equal of the sum of inputs, for each token.
@@ -100,16 +198,25 @@ class TransactionVerifier(VertexVerifier):
         :raises InvalidToken: when there's an error in token operations
         :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
         """
-        tx.verify_sum()
+        token_dict = tx.get_token_info_from_inputs()
+        self.update_token_info_from_outputs(tx, token_dict=token_dict)
+        self.verify_authorities_and_deposit(token_dict)
 
     def verify_reward_locked(self, tx: Transaction) -> None:
         """Will raise `RewardLocked` if any reward is spent before the best block height is enough, considering only
         the block rewards spent by this tx itself, and not the inherited `min_height`."""
-        tx.verify_reward_locked()
+        info = tx.get_spent_reward_locked_info()
+        if info is not None:
+            raise RewardLocked(f'Reward {info.block_hash.hex()} still needs {info.blocks_needed} to be unlocked.')
 
     def verify_number_of_inputs(self, tx: Transaction) -> None:
         """Verify number of inputs is in a valid range"""
-        tx.verify_number_of_inputs()
+        if len(tx.inputs) > self._settings.MAX_NUM_INPUTS:
+            raise TooManyInputs('Maximum number of inputs exceeded')
+
+        if len(tx.inputs) == 0:
+            if not tx.is_genesis:
+                raise NoInputError('Transaction must have at least one input')
 
     def verify_outputs(self, tx: BaseTransaction) -> None:
         """Verify outputs reference an existing token uid in the tokens list
@@ -118,6 +225,48 @@ class TransactionVerifier(VertexVerifier):
         """
         tx.verify_outputs()
 
+    def verify_authorities_and_deposit(self, token_dict: dict[TokenUid, TokenInfo]) -> None:
+        """Verify that the sum of outputs is equal of the sum of inputs, for each token. If sum of inputs
+        and outputs is not 0, make sure inputs have mint/melt authority.
+
+        token_dict sums up all tokens present in the tx and their properties (amount, can_mint, can_melt)
+        amount = outputs - inputs, thus:
+        - amount < 0 when melting
+        - amount > 0 when minting
+
+        :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
+        """
+        withdraw = 0
+        deposit = 0
+        for token_uid, token_info in token_dict.items():
+            if token_uid == self._settings.HATHOR_TOKEN_UID:
+                continue
+
+            if token_info.amount == 0:
+                # that's the usual behavior, nothing to do
+                pass
+            elif token_info.amount < 0:
+                # tokens have been melted
+                if not token_info.can_melt:
+                    raise InputOutputMismatch('{} {} tokens melted, but there is no melt authority input'.format(
+                        token_info.amount, token_uid.hex()))
+                withdraw += get_withdraw_amount(token_info.amount)
+            else:
+                # tokens have been minted
+                if not token_info.can_mint:
+                    raise InputOutputMismatch('{} {} tokens minted, but there is no mint authority input'.format(
+                        (-1) * token_info.amount, token_uid.hex()))
+                deposit += get_deposit_amount(token_info.amount)
+
+        # check whether the deposit/withdraw amount is correct
+        htr_expected_amount = withdraw - deposit
+        htr_info = token_dict[self._settings.HATHOR_TOKEN_UID]
+        if htr_info.amount != htr_expected_amount:
+            raise InputOutputMismatch('HTR balance is different than expected. (amount={}, expected={})'.format(
+                htr_info.amount,
+                htr_expected_amount,
+            ))
+
     def update_token_info_from_outputs(self, tx: Transaction, *, token_dict: dict[TokenUid, TokenInfo]) -> None:
         """Iterate over the outputs and add values to token info dict. Updates the dict in-place.
 
@@ -125,4 +274,26 @@ class TransactionVerifier(VertexVerifier):
 
         :raises InvalidToken: when there's an error in token operations
         """
-        tx.update_token_info_from_outputs(token_dict)
+        # iterate over outputs and add values to token_dict
+        for index, tx_output in enumerate(tx.outputs):
+            token_uid = tx.get_token_uid(tx_output.get_token_index())
+            token_info = token_dict.get(token_uid)
+            if token_info is None:
+                raise InvalidToken('no inputs for token {}'.format(token_uid.hex()))
+            else:
+                # for authority outputs, make sure the same capability (mint/melt) was present in the inputs
+                if tx_output.can_mint_token() and not token_info.can_mint:
+                    raise InvalidToken('output has mint authority, but no input has it: {}'.format(
+                        tx_output.to_human_readable()))
+                if tx_output.can_melt_token() and not token_info.can_melt:
+                    raise InvalidToken('output has melt authority, but no input has it: {}'.format(
+                        tx_output.to_human_readable()))
+
+                if tx_output.is_token_authority():
+                    # make sure we only have authorities that we know of
+                    if tx_output.value > TxOutput.ALL_AUTHORITIES:
+                        raise InvalidToken('Invalid authorities in output (0b{0:b})'.format(tx_output.value))
+                else:
+                    # for regular outputs, just subtract from the total amount
+                    sum_tokens = token_info.amount + tx_output.value
+                    token_dict[token_uid] = TokenInfo(sum_tokens, token_info.can_mint, token_info.can_melt)

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -22,6 +22,8 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.validation_state import ValidationState
 from hathor.verification.block_verifier import BlockVerifier
 from hathor.verification.merge_mined_block_verifier import MergeMinedBlockVerifier
+from hathor.verification.token_creation_transaction_verifier import TokenCreationTransactionVerifier
+from hathor.verification.transaction_verifier import TransactionVerifier
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, create_tokens, get_genesis_key
 
@@ -397,21 +399,22 @@ class BaseVerificationTest(unittest.TestCase):
         verify_pow_wrapped.assert_called_once()
 
     def test_transaction_verify_basic(self) -> None:
+        verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=tx.verify_weight)
+        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
 
         with (
-            patch.object(Transaction, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(Transaction, 'verify_weight', verify_weight_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(Transaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -428,22 +431,23 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_verify_without_storage(self) -> None:
+        verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
 
         with (
             patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(Transaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            tx.verify_without_storage()
+            verifier.verify_without_storage(tx)
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
@@ -453,33 +457,34 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_verify(self) -> None:
+        verifier = self.manager.verification_service.verifiers.tx
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=tx.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=tx.verify_inputs)
-        verify_script_wrapped = Mock(wraps=tx.verify_script)
-        verify_parents_wrapped = Mock(wraps=tx.verify_parents)
-        verify_sum_wrapped = Mock(wraps=tx.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=tx.verify_reward_locked)
+        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
+        verify_script_wrapped = Mock(wraps=verifier.verify_script)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
+        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
         with (
             patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(Transaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(Transaction, 'verify_sigops_input', verify_sigops_input_wrapped),
-            patch.object(Transaction, 'verify_inputs', verify_inputs_wrapped),
-            patch.object(Transaction, 'verify_script', verify_script_wrapped),
-            patch.object(Transaction, 'verify_parents', verify_parents_wrapped),
-            patch.object(Transaction, 'verify_sum', verify_sum_wrapped),
-            patch.object(Transaction, 'verify_reward_locked', verify_reward_locked_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
+            patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents', verify_parents_wrapped),
+            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
         ):
             self.manager.verification_service.verify(tx)
 
@@ -497,21 +502,22 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped.assert_called_once()
 
     def test_transaction_validate_basic(self) -> None:
+        verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=tx.verify_weight)
+        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
 
         with (
-            patch.object(Transaction, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(Transaction, 'verify_weight', verify_weight_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(Transaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -528,37 +534,38 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_validate_full(self) -> None:
+        verifier = self.manager.verification_service.verifiers.tx
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=tx.verify_weight)
+        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=tx.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=tx.verify_inputs)
-        verify_script_wrapped = Mock(wraps=tx.verify_script)
+        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
+        verify_script_wrapped = Mock(wraps=verifier.verify_script)
         verify_parents_wrapped = Mock(wraps=tx.verify_parents)
-        verify_sum_wrapped = Mock(wraps=tx.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=tx.verify_reward_locked)
+        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
         with (
-            patch.object(Transaction, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(Transaction, 'verify_weight', verify_weight_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(Transaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(Transaction, 'verify_sigops_input', verify_sigops_input_wrapped),
-            patch.object(Transaction, 'verify_inputs', verify_inputs_wrapped),
-            patch.object(Transaction, 'verify_script', verify_script_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
+            patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(Transaction, 'verify_parents', verify_parents_wrapped),
-            patch.object(Transaction, 'verify_sum', verify_sum_wrapped),
-            patch.object(Transaction, 'verify_reward_locked', verify_reward_locked_wrapped),
+            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
         ):
             self.manager.verification_service.validate_full(tx)
 
@@ -578,21 +585,22 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify_basic(self) -> None:
+        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=tx.verify_weight)
+        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransaction, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_weight', verify_weight_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -609,22 +617,23 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify_without_storage(self) -> None:
+        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
 
         with (
             patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            tx.verify_without_storage()
+            verifier.verify_without_storage(tx)
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
@@ -634,35 +643,36 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify(self) -> None:
+        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=tx.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=tx.verify_inputs)
-        verify_script_wrapped = Mock(wraps=tx.verify_script)
+        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
+        verify_script_wrapped = Mock(wraps=verifier.verify_script)
         verify_parents_wrapped = Mock(wraps=tx.verify_parents)
-        verify_sum_wrapped = Mock(wraps=tx.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=tx.verify_reward_locked)
+        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
-        verify_token_info_wrapped = Mock(wraps=tx.verify_token_info)
+        verify_token_info_wrapped = Mock(wraps=verifier.verify_token_info)
 
         with (
             patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_input', verify_sigops_input_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_inputs', verify_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_script', verify_script_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(TokenCreationTransaction, 'verify_parents', verify_parents_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sum', verify_sum_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_reward_locked', verify_reward_locked_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_token_info', verify_token_info_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
         ):
             self.manager.verification_service.verify(tx)
 
@@ -683,21 +693,22 @@ class BaseVerificationTest(unittest.TestCase):
         verify_token_info_wrapped.assert_called_once()
 
     def test_token_creation_transaction_validate_basic(self) -> None:
+        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=tx.verify_weight)
+        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransaction, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_weight', verify_weight_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -714,40 +725,41 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_validate_full(self) -> None:
+        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
         tx.get_metadata().validation = ValidationState.INITIAL
 
-        verify_parents_basic_wrapped = Mock(wraps=tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=tx.verify_weight)
+        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_pow_wrapped = Mock(wraps=tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=tx.verify_number_of_inputs)
+        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
         verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
         verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=tx.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=tx.verify_inputs)
-        verify_script_wrapped = Mock(wraps=tx.verify_script)
+        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
+        verify_script_wrapped = Mock(wraps=verifier.verify_script)
         verify_parents_wrapped = Mock(wraps=tx.verify_parents)
-        verify_sum_wrapped = Mock(wraps=tx.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=tx.verify_reward_locked)
+        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
-        verify_token_info_wrapped = Mock(wraps=tx.verify_token_info)
+        verify_token_info_wrapped = Mock(wraps=verifier.verify_token_info)
 
         with (
-            patch.object(TokenCreationTransaction, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_weight', verify_weight_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_input', verify_sigops_input_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_inputs', verify_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_script', verify_script_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(TokenCreationTransaction, 'verify_parents', verify_parents_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sum', verify_sum_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_reward_locked', verify_reward_locked_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_token_info', verify_token_info_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
         ):
             self.manager.verification_service.validate_full(tx)
 


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/798

### Motivation

This is the fourth PR in a 5-part series of PRs that completely move verification-related code out of the vertex model classes.

This PR moves the verification method implementations of the `Transaction` inheritance branch.

### Acceptance Criteria

- Remove all `Transaction` and `TokenCreationTransaction` verification methods from the original model classes, moving the implementation to each respective `Verifier` class. The only exception is the `verify_outputs()` method, which is part of the inheritance tree up to `BaseTransaction`, and will be moved in a separate PR.
- `check_authorities_and_deposit()` is renamed to `verify_authorities_and_deposit()`, for consistency.
- `update_token_info_from_outputs()` is also moved as it's only used by verification.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 