### PR TITLE
refactor(verification): finish moving all verification methods [part 5/5]

### DIFF
--- a/hathor/simulator/verification.py
+++ b/hathor/simulator/verification.py
@@ -1,0 +1,54 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional
+
+from structlog import get_logger
+
+from hathor.transaction import BaseTransaction
+from hathor.verification.block_verifier import BlockVerifier
+from hathor.verification.merge_mined_block_verifier import MergeMinedBlockVerifier
+from hathor.verification.token_creation_transaction_verifier import TokenCreationTransactionVerifier
+from hathor.verification.transaction_verifier import TransactionVerifier
+
+logger = get_logger()
+
+
+def verify_pow(vertex: BaseTransaction) -> None:
+    assert vertex.hash is not None
+    logger.new().debug('Skipping BaseTransaction.verify_pow() for simulator')
+
+
+class SimulatorBlockVerifier(BlockVerifier):
+    @classmethod
+    def verify_pow(cls, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+        verify_pow(vertex)
+
+
+class SimulatorMergeMinedBlockVerifier(MergeMinedBlockVerifier):
+    @classmethod
+    def verify_pow(cls, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+        verify_pow(vertex)
+
+
+class SimulatorTransactionVerifier(TransactionVerifier):
+    @classmethod
+    def verify_pow(cls, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+        verify_pow(vertex)
+
+
+class SimulatorTokenCreationTransactionVerifier(TokenCreationTransactionVerifier):
+    @classmethod
+    def verify_pow(cls, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+        verify_pow(vertex)

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -28,19 +28,7 @@ from structlog import get_logger
 
 from hathor.checkpoint import Checkpoint
 from hathor.conf.get_settings import get_settings
-from hathor.transaction.exceptions import (
-    DuplicatedParents,
-    IncorrectParents,
-    InvalidOutputScriptSize,
-    InvalidOutputValue,
-    InvalidToken,
-    ParentDoesNotExist,
-    PowError,
-    TimestampError,
-    TooManyOutputs,
-    TooManySigOps,
-    WeightError,
-)
+from hathor.transaction.exceptions import InvalidOutputValue, WeightError
 from hathor.transaction.transaction_metadata import TransactionMetadata
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
 from hathor.transaction.validation_state import ValidationState
@@ -69,14 +57,6 @@ _SIGHASH_ALL_FORMAT_STRING = '!BBBBB'
 
 # Weight (d), timestamp (I), and parents len (B)
 _GRAPH_FORMAT_STRING = '!dIB'
-
-# tx should have 2 parents, both other transactions
-_TX_PARENTS_TXS = 2
-_TX_PARENTS_BLOCKS = 0
-
-# blocks have 3 parents, 2 txs and 1 block
-_BLOCK_PARENTS_TXS = 2
-_BLOCK_PARENTS_BLOCKS = 1
 
 # The int value of one byte
 _ONE_BYTE = 0xFF
@@ -539,137 +519,6 @@ class BaseTransaction(ABC):
 
         To be implemented by tx/block, used by `self.validate_checkpoint`. Should not modify the validation state."""
         raise NotImplementedError
-
-    def verify_parents(self) -> None:
-        """All parents must exist and their timestamps must be smaller than ours.
-
-        Also, txs should have 2 other txs as parents, while blocks should have 2 txs + 1 block.
-
-        Parents must be ordered with blocks first, followed by transactions.
-
-        :raises TimestampError: when our timestamp is less or equal than our parent's timestamp
-        :raises ParentDoesNotExist: when at least one of our parents does not exist
-        :raises IncorrectParents: when tx does not confirm the correct number/type of parent txs
-        """
-        from hathor.transaction.storage.exceptions import TransactionDoesNotExist
-
-        assert self.storage is not None
-
-        # check if parents are duplicated
-        parents_set = set(self.parents)
-        if len(self.parents) > len(parents_set):
-            raise DuplicatedParents('Tx has duplicated parents: {}', [tx_hash.hex() for tx_hash in self.parents])
-
-        my_parents_txs = 0      # number of tx parents
-        my_parents_blocks = 0   # number of block parents
-        min_timestamp: Optional[int] = None
-
-        for parent_hash in self.parents:
-            try:
-                parent = self.storage.get_transaction(parent_hash)
-                assert parent.hash is not None
-                if self.timestamp <= parent.timestamp:
-                    raise TimestampError('tx={} timestamp={}, parent={} timestamp={}'.format(
-                        self.hash_hex,
-                        self.timestamp,
-                        parent.hash_hex,
-                        parent.timestamp,
-                    ))
-
-                if parent.is_block:
-                    if self.is_block and not parent.is_genesis:
-                        if self.timestamp - parent.timestamp > self._settings.MAX_DISTANCE_BETWEEN_BLOCKS:
-                            raise TimestampError('Distance between blocks is too big'
-                                                 ' ({} seconds)'.format(self.timestamp - parent.timestamp))
-                    if my_parents_txs > 0:
-                        raise IncorrectParents('Parents which are blocks must come before transactions')
-                    for pi_hash in parent.parents:
-                        pi = self.storage.get_transaction(parent_hash)
-                        if not pi.is_block:
-                            min_timestamp = (
-                                min(min_timestamp, pi.timestamp) if min_timestamp is not None
-                                else pi.timestamp
-                            )
-                    my_parents_blocks += 1
-                else:
-                    if min_timestamp and parent.timestamp < min_timestamp:
-                        raise TimestampError('tx={} timestamp={}, parent={} timestamp={}, min_timestamp={}'.format(
-                            self.hash_hex,
-                            self.timestamp,
-                            parent.hash_hex,
-                            parent.timestamp,
-                            min_timestamp
-                        ))
-                    my_parents_txs += 1
-            except TransactionDoesNotExist:
-                raise ParentDoesNotExist('tx={} parent={}'.format(self.hash_hex, parent_hash.hex()))
-
-        # check for correct number of parents
-        if self.is_block:
-            parents_txs = _BLOCK_PARENTS_TXS
-            parents_blocks = _BLOCK_PARENTS_BLOCKS
-        else:
-            parents_txs = _TX_PARENTS_TXS
-            parents_blocks = _TX_PARENTS_BLOCKS
-        if my_parents_blocks != parents_blocks:
-            raise IncorrectParents('wrong number of parents (block type): {}, expecting {}'.format(
-                my_parents_blocks, parents_blocks))
-        if my_parents_txs != parents_txs:
-            raise IncorrectParents('wrong number of parents (tx type): {}, expecting {}'.format(
-                my_parents_txs, parents_txs))
-
-    def verify_pow(self, override_weight: Optional[float] = None) -> None:
-        """Verify proof-of-work
-
-        :raises PowError: when the hash is equal or greater than the target
-        """
-        assert self.hash is not None
-        numeric_hash = int(self.hash_hex, self.HEX_BASE)
-        minimum_target = self.get_target(override_weight)
-        if numeric_hash >= minimum_target:
-            raise PowError(f'Transaction has invalid data ({numeric_hash} < {minimum_target})')
-
-    def verify_number_of_outputs(self) -> None:
-        """Verify number of outputs does not exceeds the limit"""
-        if len(self.outputs) > self._settings.MAX_NUM_OUTPUTS:
-            raise TooManyOutputs('Maximum number of outputs exceeded')
-
-    def verify_sigops_output(self) -> None:
-        """ Count sig operations on all outputs and verify that the total sum is below the limit
-        """
-        from hathor.transaction.scripts import get_sigops_count
-        n_txops = 0
-
-        for tx_output in self.outputs:
-            n_txops += get_sigops_count(tx_output.script)
-
-        if n_txops > self._settings.MAX_TX_SIGOPS_OUTPUT:
-            raise TooManySigOps('TX[{}]: Maximum number of sigops for all outputs exceeded ({})'.format(
-                self.hash_hex, n_txops))
-
-    def verify_outputs(self) -> None:
-        """Verify there are no hathor authority UTXOs and outputs are all positive
-
-        :raises InvalidToken: when there's a hathor authority utxo
-        :raises InvalidOutputValue: output has negative value
-        :raises TooManyOutputs: when there are too many outputs
-        """
-        self.verify_number_of_outputs()
-        for index, output in enumerate(self.outputs):
-            # no hathor authority UTXO
-            if (output.get_token_index() == 0) and output.is_token_authority():
-                raise InvalidToken('Cannot have authority UTXO for hathor tokens: {}'.format(
-                    output.to_human_readable()))
-
-            # output value must be positive
-            if output.value <= 0:
-                raise InvalidOutputValue('Output value must be a positive integer. Value: {} and index: {}'.format(
-                    output.value, index))
-
-            if len(output.script) > self._settings.MAX_OUTPUT_SCRIPT_SIZE:
-                raise InvalidOutputScriptSize('size: {} and max-size: {}'.format(
-                    len(output.script), self._settings.MAX_OUTPUT_SCRIPT_SIZE
-                ))
 
     def resolve(self, update_time: bool = False) -> bool:
         """Run a CPU mining looking for the nonce that solves the proof-of-work

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -23,7 +23,7 @@ from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, TxOutput, TxVersion
-from hathor.transaction.exceptions import BlockWithTokensError, CheckpointError
+from hathor.transaction.exceptions import CheckpointError
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
 from hathor.util import not_none
 from hathor.utils.int import get_bit_list
@@ -327,12 +327,6 @@ class Block(BaseTransaction):
         else:
             # TODO: check whether self is a parent of any checkpoint-valid block, this is left for a future PR
             pass
-
-    def verify_outputs(self) -> None:
-        super().verify_outputs()
-        for output in self.outputs:
-            if output.get_token_index() > 0:
-                raise BlockWithTokensError('in output: {}'.format(output.to_human_readable()))
 
     def get_base_hash(self) -> bytes:
         from hathor.merged_mining.bitcoin import sha256d_hash

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -22,7 +22,6 @@ from hathor.exception import InvalidNewTransaction
 from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block, TxInput, TxOutput, TxVersion
 from hathor.transaction.base_transaction import TX_HASH_SIZE
-from hathor.transaction.exceptions import InvalidToken
 from hathor.transaction.util import VerboseCallback, unpack, unpack_len
 from hathor.types import TokenUid, VertexId
 from hathor.util import not_none
@@ -278,17 +277,6 @@ class Transaction(BaseTransaction):
                 return
         raise InvalidNewTransaction(f'Invalid new transaction {self.hash_hex}: expected to reach a checkpoint but '
                                     'none of its children is checkpoint-valid')
-
-    def verify_outputs(self) -> None:
-        """Verify outputs reference an existing token uid in the tokens list
-
-        :raises InvalidToken: output references non existent token uid
-        """
-        super().verify_outputs()
-        for output in self.outputs:
-            # check index is valid
-            if output.get_token_index() > len(self.tokens):
-                raise InvalidToken('token uid index not available: index {}'.format(output.get_token_index()))
 
     def get_token_info_from_inputs(self) -> dict[TokenUid, TokenInfo]:
         """Sum up all tokens present in the inputs and their properties (amount, can_mint, can_melt)

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -17,6 +17,7 @@ from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block
 from hathor.transaction.exceptions import (
     BlockWithInputs,
+    BlockWithTokensError,
     InvalidBlockReward,
     RewardLocked,
     TransactionDataError,
@@ -97,7 +98,11 @@ class BlockVerifier(VertexVerifier):
             raise BlockWithInputs('number of inputs {}'.format(len(inputs)))
 
     def verify_outputs(self, block: BaseTransaction) -> None:
-        block.verify_outputs()
+        assert isinstance(block, Block)
+        super().verify_outputs(block)
+        for output in block.outputs:
+            if output.get_token_index() > 0:
+                raise BlockWithTokensError('in output: {}'.format(output.to_human_readable()))
 
     def verify_data(self, block: Block) -> None:
         if len(block.data) > self._settings.BLOCK_DATA_MAX_SIZE:

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -223,7 +223,12 @@ class TransactionVerifier(VertexVerifier):
 
         :raises InvalidToken: output references non existent token uid
         """
-        tx.verify_outputs()
+        assert isinstance(tx, Transaction)
+        super().verify_outputs(tx)
+        for output in tx.outputs:
+            # check index is valid
+            if output.get_token_index() > len(tx.tokens):
+                raise InvalidToken('token uid index not available: index {}'.format(output.get_token_index()))
 
     def verify_authorities_and_deposit(self, token_dict: dict[TokenUid, TokenInfo]) -> None:
         """Verify that the sum of outputs is equal of the sum of inputs, for each token. If sum of inputs

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -16,6 +16,26 @@ from typing import Optional
 
 from hathor.conf.settings import HathorSettings
 from hathor.transaction import BaseTransaction
+from hathor.transaction.exceptions import (
+    DuplicatedParents,
+    IncorrectParents,
+    InvalidOutputScriptSize,
+    InvalidOutputValue,
+    InvalidToken,
+    ParentDoesNotExist,
+    PowError,
+    TimestampError,
+    TooManyOutputs,
+    TooManySigOps,
+)
+
+# tx should have 2 parents, both other transactions
+_TX_PARENTS_TXS = 2
+_TX_PARENTS_BLOCKS = 0
+
+# blocks have 3 parents, 2 txs and 1 block
+_BLOCK_PARENTS_TXS = 2
+_BLOCK_PARENTS_BLOCKS = 1
 
 
 class VertexVerifier:
@@ -35,14 +55,83 @@ class VertexVerifier:
         :raises ParentDoesNotExist: when at least one of our parents does not exist
         :raises IncorrectParents: when tx does not confirm the correct number/type of parent txs
         """
-        vertex.verify_parents()
+        from hathor.transaction.storage.exceptions import TransactionDoesNotExist
+
+        assert vertex.storage is not None
+
+        # check if parents are duplicated
+        parents_set = set(vertex.parents)
+        if len(vertex.parents) > len(parents_set):
+            raise DuplicatedParents('Tx has duplicated parents: {}', [tx_hash.hex() for tx_hash in vertex.parents])
+
+        my_parents_txs = 0      # number of tx parents
+        my_parents_blocks = 0   # number of block parents
+        min_timestamp: Optional[int] = None
+
+        for parent_hash in vertex.parents:
+            try:
+                parent = vertex.storage.get_transaction(parent_hash)
+                assert parent.hash is not None
+                if vertex.timestamp <= parent.timestamp:
+                    raise TimestampError('tx={} timestamp={}, parent={} timestamp={}'.format(
+                        vertex.hash_hex,
+                        vertex.timestamp,
+                        parent.hash_hex,
+                        parent.timestamp,
+                    ))
+
+                if parent.is_block:
+                    if vertex.is_block and not parent.is_genesis:
+                        if vertex.timestamp - parent.timestamp > self._settings.MAX_DISTANCE_BETWEEN_BLOCKS:
+                            raise TimestampError('Distance between blocks is too big'
+                                                 ' ({} seconds)'.format(vertex.timestamp - parent.timestamp))
+                    if my_parents_txs > 0:
+                        raise IncorrectParents('Parents which are blocks must come before transactions')
+                    for pi_hash in parent.parents:
+                        pi = vertex.storage.get_transaction(parent_hash)
+                        if not pi.is_block:
+                            min_timestamp = (
+                                min(min_timestamp, pi.timestamp) if min_timestamp is not None
+                                else pi.timestamp
+                            )
+                    my_parents_blocks += 1
+                else:
+                    if min_timestamp and parent.timestamp < min_timestamp:
+                        raise TimestampError('tx={} timestamp={}, parent={} timestamp={}, min_timestamp={}'.format(
+                            vertex.hash_hex,
+                            vertex.timestamp,
+                            parent.hash_hex,
+                            parent.timestamp,
+                            min_timestamp
+                        ))
+                    my_parents_txs += 1
+            except TransactionDoesNotExist:
+                raise ParentDoesNotExist('tx={} parent={}'.format(vertex.hash_hex, parent_hash.hex()))
+
+        # check for correct number of parents
+        if vertex.is_block:
+            parents_txs = _BLOCK_PARENTS_TXS
+            parents_blocks = _BLOCK_PARENTS_BLOCKS
+        else:
+            parents_txs = _TX_PARENTS_TXS
+            parents_blocks = _TX_PARENTS_BLOCKS
+        if my_parents_blocks != parents_blocks:
+            raise IncorrectParents('wrong number of parents (block type): {}, expecting {}'.format(
+                my_parents_blocks, parents_blocks))
+        if my_parents_txs != parents_txs:
+            raise IncorrectParents('wrong number of parents (tx type): {}, expecting {}'.format(
+                my_parents_txs, parents_txs))
 
     def verify_pow(self, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
         """Verify proof-of-work
 
         :raises PowError: when the hash is equal or greater than the target
         """
-        vertex.verify_pow(override_weight)
+        assert vertex.hash is not None
+        numeric_hash = int(vertex.hash_hex, vertex.HEX_BASE)
+        minimum_target = vertex.get_target(override_weight)
+        if numeric_hash >= minimum_target:
+            raise PowError(f'Transaction has invalid data ({numeric_hash} < {minimum_target})')
 
     def verify_outputs(self, vertex: BaseTransaction) -> None:
         """Verify there are no hathor authority UTXOs and outputs are all positive
@@ -51,13 +140,37 @@ class VertexVerifier:
         :raises InvalidOutputValue: output has negative value
         :raises TooManyOutputs: when there are too many outputs
         """
-        vertex.verify_outputs()
+        self.verify_number_of_outputs(vertex)
+        for index, output in enumerate(vertex.outputs):
+            # no hathor authority UTXO
+            if (output.get_token_index() == 0) and output.is_token_authority():
+                raise InvalidToken('Cannot have authority UTXO for hathor tokens: {}'.format(
+                    output.to_human_readable()))
+
+            # output value must be positive
+            if output.value <= 0:
+                raise InvalidOutputValue('Output value must be a positive integer. Value: {} and index: {}'.format(
+                    output.value, index))
+
+            if len(output.script) > self._settings.MAX_OUTPUT_SCRIPT_SIZE:
+                raise InvalidOutputScriptSize('size: {} and max-size: {}'.format(
+                    len(output.script), self._settings.MAX_OUTPUT_SCRIPT_SIZE
+                ))
 
     def verify_number_of_outputs(self, vertex: BaseTransaction) -> None:
         """Verify number of outputs does not exceeds the limit"""
-        vertex.verify_number_of_outputs()
+        if len(vertex.outputs) > self._settings.MAX_NUM_OUTPUTS:
+            raise TooManyOutputs('Maximum number of outputs exceeded')
 
     def verify_sigops_output(self, vertex: BaseTransaction) -> None:
         """ Count sig operations on all outputs and verify that the total sum is below the limit
         """
-        vertex.verify_sigops_output()
+        from hathor.transaction.scripts import get_sigops_count
+        n_txops = 0
+
+        for tx_output in vertex.outputs:
+            n_txops += get_sigops_count(tx_output.script)
+
+        if n_txops > self._settings.MAX_TX_SIGOPS_OUTPUT:
+            raise TooManySigOps('TX[{}]: Maximum number of sigops for all outputs exceeded ({})'.format(
+                vertex.hash_hex, n_txops))

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -30,7 +30,6 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.scripts import P2PKH, parse_address_script
 from hathor.transaction.util import int_to_bytes
 from hathor.transaction.validation_state import ValidationState
-from hathor.verification.verification_service import VertexVerifiers
 from hathor.wallet import Wallet
 from tests import unittest
 from tests.utils import (
@@ -47,11 +46,11 @@ class BaseTransactionTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self._verifiers = VertexVerifiers.create_defaults(settings=self._settings)
         self.wallet = Wallet()
 
         # this makes sure we can spend the genesis outputs
         self.manager = self.create_peer('testnet', unlock_wallet=True, wallet_index=True, use_memory_storage=True)
+        self._verifiers = self.manager.verification_service.verifiers
         self.tx_storage = self.manager.tx_storage
 
         # read genesis keys

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -123,20 +123,20 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_pow_wrapped = Mock(wraps=block.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=block.verify_number_of_outputs)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=block.verify_sigops_output)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
-            patch.object(Block, 'verify_pow', verify_pow_wrapped),
+            patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(Block, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Block, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(Block, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             verifier.verify_without_storage(block)
 
@@ -152,23 +152,23 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_pow_wrapped = Mock(wraps=block.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=block.verify_number_of_outputs)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=block.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=block.verify_parents)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
 
         with (
-            patch.object(Block, 'verify_pow', verify_pow_wrapped),
+            patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(Block, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Block, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(Block, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(Block, 'verify_parents', verify_parents_wrapped),
+            patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(BlockVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
         ):
             self.manager.verification_service.verify(block)
@@ -204,25 +204,25 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_pow_wrapped = Mock(wraps=block.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=block.verify_number_of_outputs)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=block.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=block.verify_parents)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
 
         with (
-            patch.object(Block, 'verify_pow', verify_pow_wrapped),
+            patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(Block, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Block, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(Block, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(Block, 'verify_parents', verify_parents_wrapped),
+            patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(BlockVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
@@ -262,22 +262,22 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=block.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=block.verify_number_of_outputs)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=block.verify_sigops_output)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
 
         with (
-            patch.object(MergeMinedBlock, 'verify_pow', verify_pow_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(MergeMinedBlock, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(MergeMinedBlock, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(MergeMinedBlock, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
             verifier.verify_without_storage(block)
@@ -297,25 +297,25 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=block.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=block.verify_number_of_outputs)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=block.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=block.verify_parents)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
 
         verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
 
         with (
-            patch.object(MergeMinedBlock, 'verify_pow', verify_pow_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(MergeMinedBlock, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(MergeMinedBlock, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(MergeMinedBlock, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(MergeMinedBlock, 'verify_parents', verify_parents_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
@@ -355,13 +355,13 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=block.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=block.verify_number_of_outputs)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=block.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=block.verify_parents)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_height_wrapped = Mock(wraps=verifier.verify_height)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
         verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
@@ -369,13 +369,13 @@ class BaseVerificationTest(unittest.TestCase):
         verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
 
         with (
-            patch.object(MergeMinedBlock, 'verify_pow', verify_pow_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(MergeMinedBlock, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(MergeMinedBlock, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(MergeMinedBlock, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(MergeMinedBlock, 'verify_parents', verify_parents_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(MergeMinedBlockVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_reward', verify_reward_wrapped),
@@ -404,20 +404,20 @@ class BaseVerificationTest(unittest.TestCase):
 
         verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_basic(tx)
 
@@ -434,18 +434,18 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
-            patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             verifier.verify_without_storage(tx)
 
@@ -461,11 +461,11 @@ class BaseVerificationTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
         verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
         verify_script_wrapped = Mock(wraps=verifier.verify_script)
@@ -474,11 +474,11 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
         with (
-            patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
             patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
@@ -507,20 +507,20 @@ class BaseVerificationTest(unittest.TestCase):
 
         verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.validate_basic(tx)
 
@@ -540,30 +540,30 @@ class BaseVerificationTest(unittest.TestCase):
 
         verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
         verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
         verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=tx.verify_parents)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
         verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
         with (
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(Transaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(Transaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(Transaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(Transaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
             patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
-            patch.object(Transaction, 'verify_parents', verify_parents_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
         ):
@@ -590,20 +590,21 @@ class BaseVerificationTest(unittest.TestCase):
 
         verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
+                         verify_number_of_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_basic(tx)
 
@@ -620,18 +621,19 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
+                         verify_number_of_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             verifier.verify_without_storage(tx)
 
@@ -646,30 +648,31 @@ class BaseVerificationTest(unittest.TestCase):
         verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
         verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
         verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=tx.verify_parents)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
         verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
         verify_token_info_wrapped = Mock(wraps=verifier.verify_token_info)
 
         with (
-            patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
+                         verify_number_of_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_script', verify_script_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_parents', verify_parents_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_sum', verify_sum_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
@@ -698,20 +701,21 @@ class BaseVerificationTest(unittest.TestCase):
 
         verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
+                         verify_number_of_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.validate_basic(tx)
 
@@ -731,15 +735,15 @@ class BaseVerificationTest(unittest.TestCase):
 
         verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=tx.verify_pow)
+        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=tx.verify_sigops_output)
+        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
         verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
         verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=tx.verify_parents)
+        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
         verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
         verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
 
@@ -748,15 +752,16 @@ class BaseVerificationTest(unittest.TestCase):
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_pow', verify_pow_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
+                         verify_number_of_outputs_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_script', verify_script_wrapped),
-            patch.object(TokenCreationTransaction, 'verify_parents', verify_parents_wrapped),
+            patch.object(TokenCreationTransactionVerifier, 'verify_parents', verify_parents_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_sum', verify_sum_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -1,7 +1,6 @@
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.transaction import Transaction
-from hathor.verification.transaction_verifier import TransactionVerifier
 from hathor.wallet import HDWallet
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds
@@ -43,7 +42,7 @@ class BaseWalletHDTest(unittest.TestCase):
         out = WalletOutputInfo(decode_address(new_address2), self.TOKENS, timelock=None)
         tx1 = self.wallet.prepare_transaction_compute_inputs(Transaction, [out], self.tx_storage)
         tx1.update_hash()
-        verifier = TransactionVerifier(settings=self._settings)
+        verifier = self.manager.verification_service.verifiers.tx
         verifier.verify_script(tx=tx1, input_tx=tx1.inputs[0], spent_tx=block)
         tx1.storage = self.tx_storage
         tx1.get_metadata().validation = ValidationState.FULL


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/799

### Motivation

This is the last PR in a 5-part series of PRs that completely move verification-related code out of the vertex model classes.

This PR moves the verification method implementations of `BaseTransaction`, finishing the code migration. This also allows us to remove the `verify_pow()` simulator patch, as it can now be customized via injected verifiers.

### Acceptance Criteria

- Remove all `BaseTransaction` verification methods from the original model classes, moving the implementation to the `VertexVerifier` class.
- Move each respective `verify_outputs()` implementation.
- Create custom `Simulator` verifiers such that `verify_pow()` is overridden.
- Update `Simulator` to use the custom verifiers, removing the `verify_pow()` patch.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 