### PR TITLE
refactor(settings): change daa to use injected settings

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -23,6 +23,7 @@ from structlog import get_logger
 
 from hathor.cli.run_node import RunNodeArgs
 from hathor.consensus import ConsensusAlgorithm
+from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.event import EventManager
 from hathor.exception import BuilderError
 from hathor.feature_activation.bit_signaling_service import BitSignalingService
@@ -207,7 +208,13 @@ class CliBuilder:
             not_support_features=self._args.signal_not_support
         )
 
-        vertex_verifiers = VertexVerifiers.create_defaults(settings=settings, feature_service=self.feature_service)
+        daa = DifficultyAdjustmentAlgorithm(settings=settings)
+
+        vertex_verifiers = VertexVerifiers.create_defaults(
+            settings=settings,
+            daa=daa,
+            feature_service=self.feature_service
+        )
         verification_service = VerificationService(verifiers=vertex_verifiers)
 
         p2p_manager = ConnectionsManager(
@@ -230,6 +237,7 @@ class CliBuilder:
             hostname=hostname,
             pubsub=pubsub,
             consensus_algorithm=consensus_algorithm,
+            daa=daa,
             peer_id=peer_id,
             tx_storage=tx_storage,
             p2p_manager=p2p_manager,

--- a/hathor/cli/events_simulator/scenario.py
+++ b/hathor/cli/events_simulator/scenario.py
@@ -50,7 +50,6 @@ def simulate_single_chain_one_block(simulator: 'Simulator', manager: 'HathorMana
 
 
 def simulate_single_chain_blocks_and_transactions(simulator: 'Simulator', manager: 'HathorManager') -> None:
-    from hathor import daa
     from hathor.conf.get_settings import get_settings
     from tests.utils import add_new_blocks, gen_new_tx
 
@@ -62,13 +61,13 @@ def simulate_single_chain_blocks_and_transactions(simulator: 'Simulator', manage
     simulator.run(60)
 
     tx = gen_new_tx(manager, address, 1000)
-    tx.weight = daa.minimum_tx_weight(tx)
+    tx.weight = manager.daa.minimum_tx_weight(tx)
     tx.update_hash()
     assert manager.propagate_tx(tx, fails_silently=False)
     simulator.run(60)
 
     tx = gen_new_tx(manager, address, 2000)
-    tx.weight = daa.minimum_tx_weight(tx)
+    tx.weight = manager.daa.minimum_tx_weight(tx)
     tx.update_hash()
     assert manager.propagate_tx(tx, fails_silently=False)
     simulator.run(60)

--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -136,9 +136,11 @@ def execute(args: Namespace) -> None:
                                                                       block.nonce, block.weight))
 
         try:
+            from hathor.daa import DifficultyAdjustmentAlgorithm
             from hathor.verification.block_verifier import BlockVerifier
             settings = get_settings()
-            verifier = BlockVerifier(settings=settings)
+            daa = DifficultyAdjustmentAlgorithm(settings=settings)
+            verifier = BlockVerifier(settings=settings, daa=daa)
             verifier.verify_without_storage(block)
         except HathorError:
             print('[{}] ERROR: Block has not been pushed because it is not valid.'.format(datetime.datetime.now()))

--- a/hathor/daa.py
+++ b/hathor/daa.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from structlog import get_logger
 
-from hathor.conf import HathorSettings
+from hathor.conf.settings import HathorSettings
 from hathor.profiler import get_cpu_profiler
 from hathor.util import iwindows
 
@@ -33,11 +33,7 @@ if TYPE_CHECKING:
     from hathor.transaction import Block, Transaction
 
 logger = get_logger()
-settings = HathorSettings()
 cpu = get_cpu_profiler()
-
-MIN_BLOCK_WEIGHT = settings.MIN_BLOCK_WEIGHT
-AVG_TIME_BETWEEN_BLOCKS = settings.AVG_TIME_BETWEEN_BLOCKS
 
 
 class TestMode(IntFlag):
@@ -58,173 +54,175 @@ def _set_test_mode(mode: TestMode) -> None:
     TEST_MODE = mode
 
 
-@cpu.profiler(key=lambda block: 'calculate_block_difficulty!{}'.format(block.hash.hex()))
-def calculate_block_difficulty(block: 'Block') -> float:
-    """ Calculate block weight according to the ascendents of `block`, using calculate_next_weight."""
-    if TEST_MODE & TestMode.TEST_BLOCK_WEIGHT:
-        return 1.0
+class DifficultyAdjustmentAlgorithm:
 
-    if block.is_genesis:
-        return MIN_BLOCK_WEIGHT
+    def __init__(self, *, settings: HathorSettings) -> None:
+        self._settings = settings
+        self.AVG_TIME_BETWEEN_BLOCKS = self._settings.AVG_TIME_BETWEEN_BLOCKS
+        self.MIN_BLOCK_WEIGHT = self._settings.MIN_BLOCK_WEIGHT
 
-    return calculate_next_weight(block.get_block_parent(), block.timestamp)
+    @cpu.profiler(key=lambda _, block: 'calculate_block_difficulty!{}'.format(block.hash.hex()))
+    def calculate_block_difficulty(self, block: 'Block') -> float:
+        """ Calculate block weight according to the ascendents of `block`, using calculate_next_weight."""
+        if TEST_MODE & TestMode.TEST_BLOCK_WEIGHT:
+            return 1.0
 
+        if block.is_genesis:
+            return self.MIN_BLOCK_WEIGHT
 
-def calculate_next_weight(parent_block: 'Block', timestamp: int) -> float:
-    """ Calculate the next block weight, aka DAA/difficulty adjustment algorithm.
+        return self.calculate_next_weight(block.get_block_parent(), block.timestamp)
 
-    The algorithm used is described in [RFC 22](https://gitlab.com/HathorNetwork/rfcs/merge_requests/22).
+    def calculate_next_weight(self, parent_block: 'Block', timestamp: int) -> float:
+        """ Calculate the next block weight, aka DAA/difficulty adjustment algorithm.
 
-    The weight must not be less than `MIN_BLOCK_WEIGHT`.
-    """
-    if TEST_MODE & TestMode.TEST_BLOCK_WEIGHT:
-        return 1.0
+        The algorithm used is described in [RFC 22](https://gitlab.com/HathorNetwork/rfcs/merge_requests/22).
 
-    from hathor.transaction import sum_weights
+        The weight must not be less than `MIN_BLOCK_WEIGHT`.
+        """
+        if TEST_MODE & TestMode.TEST_BLOCK_WEIGHT:
+            return 1.0
 
-    root = parent_block
-    N = min(2 * settings.BLOCK_DIFFICULTY_N_BLOCKS, parent_block.get_height() - 1)
-    K = N // 2
-    T = AVG_TIME_BETWEEN_BLOCKS
-    S = 5
-    if N < 10:
-        return MIN_BLOCK_WEIGHT
+        from hathor.transaction import sum_weights
 
-    blocks: list['Block'] = []
-    while len(blocks) < N + 1:
-        blocks.append(root)
-        root = root.get_block_parent()
-        assert root is not None
+        root = parent_block
+        N = min(2 * self._settings.BLOCK_DIFFICULTY_N_BLOCKS, parent_block.get_height() - 1)
+        K = N // 2
+        T = self.AVG_TIME_BETWEEN_BLOCKS
+        S = 5
+        if N < 10:
+            return self.MIN_BLOCK_WEIGHT
 
-    # TODO: revise if this assertion can be safely removed
-    assert blocks == sorted(blocks, key=lambda tx: -tx.timestamp)
-    blocks = list(reversed(blocks))
+        blocks: list['Block'] = []
+        while len(blocks) < N + 1:
+            blocks.append(root)
+            root = root.get_block_parent()
+            assert root is not None
 
-    assert len(blocks) == N + 1
-    solvetimes, weights = zip(*(
-        (block.timestamp - prev_block.timestamp, block.weight)
-        for prev_block, block in iwindows(blocks, 2)
-    ))
-    assert len(solvetimes) == len(weights) == N, f'got {len(solvetimes)}, {len(weights)} expected {N}'
+        # TODO: revise if this assertion can be safely removed
+        assert blocks == sorted(blocks, key=lambda tx: -tx.timestamp)
+        blocks = list(reversed(blocks))
 
-    sum_solvetimes = 0.0
-    logsum_weights = 0.0
+        assert len(blocks) == N + 1
+        solvetimes, weights = zip(*(
+            (block.timestamp - prev_block.timestamp, block.weight)
+            for prev_block, block in iwindows(blocks, 2)
+        ))
+        assert len(solvetimes) == len(weights) == N, f'got {len(solvetimes)}, {len(weights)} expected {N}'
 
-    prefix_sum_solvetimes = [0]
-    for st in solvetimes:
-        prefix_sum_solvetimes.append(prefix_sum_solvetimes[-1] + st)
+        sum_solvetimes = 0.0
+        logsum_weights = 0.0
 
-    # Loop through N most recent blocks. N is most recently solved block.
-    for i in range(K, N):
-        solvetime = solvetimes[i]
-        weight = weights[i]
-        x = (prefix_sum_solvetimes[i + 1] - prefix_sum_solvetimes[i - K]) / K
-        ki = K * (x - T)**2 / (2 * T * T)
-        ki = max(1, ki / S)
-        sum_solvetimes += ki * solvetime
-        logsum_weights = sum_weights(logsum_weights, log(ki, 2) + weight)
+        prefix_sum_solvetimes = [0]
+        for st in solvetimes:
+            prefix_sum_solvetimes.append(prefix_sum_solvetimes[-1] + st)
 
-    weight = logsum_weights - log(sum_solvetimes, 2) + log(T, 2)
+        # Loop through N most recent blocks. N is most recently solved block.
+        for i in range(K, N):
+            solvetime = solvetimes[i]
+            weight = weights[i]
+            x = (prefix_sum_solvetimes[i + 1] - prefix_sum_solvetimes[i - K]) / K
+            ki = K * (x - T)**2 / (2 * T * T)
+            ki = max(1, ki / S)
+            sum_solvetimes += ki * solvetime
+            logsum_weights = sum_weights(logsum_weights, log(ki, 2) + weight)
 
-    # Apply weight decay
-    weight -= get_weight_decay_amount(timestamp - parent_block.timestamp)
+        weight = logsum_weights - log(sum_solvetimes, 2) + log(T, 2)
 
-    # Apply minimum weight
-    if weight < MIN_BLOCK_WEIGHT:
-        weight = MIN_BLOCK_WEIGHT
+        # Apply weight decay
+        weight -= self.get_weight_decay_amount(timestamp - parent_block.timestamp)
 
-    return weight
+        # Apply minimum weight
+        if weight < self.MIN_BLOCK_WEIGHT:
+            weight = self.MIN_BLOCK_WEIGHT
 
+        return weight
 
-def get_weight_decay_amount(distance: int) -> float:
-    """Return the amount to be reduced in the weight of the block."""
-    if not settings.WEIGHT_DECAY_ENABLED:
-        return 0.0
-    if distance < settings.WEIGHT_DECAY_ACTIVATE_DISTANCE:
-        return 0.0
+    def get_weight_decay_amount(self, distance: int) -> float:
+        """Return the amount to be reduced in the weight of the block."""
+        if not self._settings.WEIGHT_DECAY_ENABLED:
+            return 0.0
+        if distance < self._settings.WEIGHT_DECAY_ACTIVATE_DISTANCE:
+            return 0.0
 
-    dt = distance - settings.WEIGHT_DECAY_ACTIVATE_DISTANCE
+        dt = distance - self._settings.WEIGHT_DECAY_ACTIVATE_DISTANCE
 
-    # Calculate the number of windows.
-    n_windows = 1 + (dt // settings.WEIGHT_DECAY_WINDOW_SIZE)
-    return n_windows * settings.WEIGHT_DECAY_AMOUNT
+        # Calculate the number of windows.
+        n_windows = 1 + (dt // self._settings.WEIGHT_DECAY_WINDOW_SIZE)
+        return n_windows * self._settings.WEIGHT_DECAY_AMOUNT
 
+    def minimum_tx_weight(self, tx: 'Transaction') -> float:
+        """ Returns the minimum weight for the param tx
+            The minimum is calculated by the following function:
 
-def minimum_tx_weight(tx: 'Transaction') -> float:
-    """ Returns the minimum weight for the param tx
-        The minimum is calculated by the following function:
+            w = alpha * log(size, 2) +       4.0         + 4.0
+                                       ----------------
+                                        1 + k / amount
 
-        w = alpha * log(size, 2) +       4.0         + 4.0
-                                   ----------------
-                                    1 + k / amount
+            :param tx: tx to calculate the minimum weight
+            :type tx: :py:class:`hathor.transaction.transaction.Transaction`
 
-        :param tx: tx to calculate the minimum weight
-        :type tx: :py:class:`hathor.transaction.transaction.Transaction`
+            :return: minimum weight for the tx
+            :rtype: float
+        """
+        # In test mode we don't validate the minimum weight for tx
+        # We do this to allow generating many txs for testing
+        if TEST_MODE & TestMode.TEST_TX_WEIGHT:
+            return 1.0
 
-        :return: minimum weight for the tx
-        :rtype: float
-    """
-    # In test mode we don't validate the minimum weight for tx
-    # We do this to allow generating many txs for testing
-    if TEST_MODE & TestMode.TEST_TX_WEIGHT:
-        return 1.0
+        if tx.is_genesis:
+            return self._settings.MIN_TX_WEIGHT
 
-    if tx.is_genesis:
-        return settings.MIN_TX_WEIGHT
+        tx_size = len(tx.get_struct())
 
-    tx_size = len(tx.get_struct())
+        # We need to take into consideration the decimal places because it is inside the amount.
+        # For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
+        # Max below is preventing division by 0 when handling authority methods that have no outputs
+        amount = max(1, tx.sum_outputs) / (10 ** self._settings.DECIMAL_PLACES)
+        weight = (
+            + self._settings.MIN_TX_WEIGHT_COEFFICIENT * log(tx_size, 2)
+            + 4 / (1 + self._settings.MIN_TX_WEIGHT_K / amount) + 4
+        )
 
-    # We need to take into consideration the decimal places because it is inside the amount.
-    # For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
-    # Max below is preventing division by 0 when handling authority methods that have no outputs
-    amount = max(1, tx.sum_outputs) / (10 ** settings.DECIMAL_PLACES)
-    weight = (
-        + settings.MIN_TX_WEIGHT_COEFFICIENT * log(tx_size, 2)
-        + 4 / (1 + settings.MIN_TX_WEIGHT_K / amount) + 4
-    )
+        # Make sure the calculated weight is at least the minimum
+        weight = max(weight, self._settings.MIN_TX_WEIGHT)
 
-    # Make sure the calculated weight is at least the minimum
-    weight = max(weight, settings.MIN_TX_WEIGHT)
+        return weight
 
-    return weight
+    def get_tokens_issued_per_block(self, height: int) -> int:
+        """Return the number of tokens issued (aka reward) per block of a given height."""
+        if self._settings.BLOCKS_PER_HALVING is None:
+            assert self._settings.MINIMUM_TOKENS_PER_BLOCK == self._settings.INITIAL_TOKENS_PER_BLOCK
+            return self._settings.MINIMUM_TOKENS_PER_BLOCK
 
+        number_of_halvings = (height - 1) // self._settings.BLOCKS_PER_HALVING
+        number_of_halvings = max(0, number_of_halvings)
 
-def get_tokens_issued_per_block(height: int) -> int:
-    """Return the number of tokens issued (aka reward) per block of a given height."""
-    if settings.BLOCKS_PER_HALVING is None:
-        assert settings.MINIMUM_TOKENS_PER_BLOCK == settings.INITIAL_TOKENS_PER_BLOCK
-        return settings.MINIMUM_TOKENS_PER_BLOCK
+        if number_of_halvings > self._settings.MAXIMUM_NUMBER_OF_HALVINGS:
+            return self._settings.MINIMUM_TOKENS_PER_BLOCK
 
-    number_of_halvings = (height - 1) // settings.BLOCKS_PER_HALVING
-    number_of_halvings = max(0, number_of_halvings)
+        amount = self._settings.INITIAL_TOKENS_PER_BLOCK // (2**number_of_halvings)
+        amount = max(amount, self._settings.MINIMUM_TOKENS_PER_BLOCK)
+        return amount
 
-    if number_of_halvings > settings.MAXIMUM_NUMBER_OF_HALVINGS:
-        return settings.MINIMUM_TOKENS_PER_BLOCK
+    def get_mined_tokens(self, height: int) -> int:
+        """Return the number of tokens mined in total at height
+        """
+        assert self._settings.BLOCKS_PER_HALVING is not None
+        number_of_halvings = (height - 1) // self._settings.BLOCKS_PER_HALVING
+        number_of_halvings = max(0, number_of_halvings)
 
-    amount = settings.INITIAL_TOKENS_PER_BLOCK // (2**number_of_halvings)
-    amount = max(amount, settings.MINIMUM_TOKENS_PER_BLOCK)
-    return amount
+        blocks_in_this_halving = height - number_of_halvings * self._settings.BLOCKS_PER_HALVING
 
+        tokens_per_block = self._settings.INITIAL_TOKENS_PER_BLOCK
+        mined_tokens = 0
 
-def get_mined_tokens(height: int) -> int:
-    """Return the number of tokens mined in total at height
-    """
-    assert settings.BLOCKS_PER_HALVING is not None
-    number_of_halvings = (height - 1) // settings.BLOCKS_PER_HALVING
-    number_of_halvings = max(0, number_of_halvings)
+        # Sum the past halvings
+        for _ in range(number_of_halvings):
+            mined_tokens += self._settings.BLOCKS_PER_HALVING * tokens_per_block
+            tokens_per_block //= 2
+            tokens_per_block = max(tokens_per_block, self._settings.MINIMUM_TOKENS_PER_BLOCK)
 
-    blocks_in_this_halving = height - number_of_halvings * settings.BLOCKS_PER_HALVING
+        # Sum the blocks in the current halving
+        mined_tokens += blocks_in_this_halving * tokens_per_block
 
-    tokens_per_block = settings.INITIAL_TOKENS_PER_BLOCK
-    mined_tokens = 0
-
-    # Sum the past halvings
-    for _ in range(number_of_halvings):
-        mined_tokens += settings.BLOCKS_PER_HALVING * tokens_per_block
-        tokens_per_block //= 2
-        tokens_per_block = max(tokens_per_block, settings.MINIMUM_TOKENS_PER_BLOCK)
-
-    # Sum the blocks in the current halving
-    mined_tokens += blocks_in_this_halving * tokens_per_block
-
-    return mined_tokens
+        return mined_tokens

--- a/hathor/p2p/resources/mining_info.py
+++ b/hathor/p2p/resources/mining_info.py
@@ -17,7 +17,6 @@ from math import log
 from hathor.api_util import Resource, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.conf.get_settings import get_settings
-from hathor.daa import get_mined_tokens
 from hathor.difficulty import Weight
 from hathor.util import json_dumpb
 
@@ -57,7 +56,7 @@ class MiningInfoResource(Resource):
         parent = block.get_block_parent()
         hashrate = 2**(parent.weight - log(30, 2))
 
-        mined_tokens = get_mined_tokens(height)
+        mined_tokens = self.manager.daa.get_mined_tokens(height)
 
         data = {
             'hashrate': hashrate,

--- a/hathor/simulator/tx_generator.py
+++ b/hathor/simulator/tx_generator.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 
 from structlog import get_logger
 
-from hathor import daa
 from hathor.conf.get_settings import get_settings
 from hathor.transaction.exceptions import RewardLocked
 from hathor.util import Random
@@ -128,7 +127,7 @@ class RandomTransactionGenerator:
                 self.delayedcall = self.clock.callLater(0, self.schedule_next_transaction)
                 return
 
-        tx.weight = daa.minimum_tx_weight(tx)
+        tx.weight = self.manager.daa.minimum_tx_weight(tx)
         tx.update_hash()
 
         geometric_p = 2**(-tx.weight)

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -526,7 +526,7 @@ class StratumProtocol(JSONRPC):
 
         self.log.debug('share received', block=tx, block_base=block_base.hex(), block_base_hash=block_base_hash.hex())
 
-        verifier = VertexVerifier(settings=self._settings)
+        verifier = VertexVerifier(settings=self._settings, daa=self.manager.daa)
 
         try:
             verifier.verify_pow(tx, override_weight=job.weight)

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -17,7 +17,6 @@ import base64
 from hathor.api_util import Resource, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.crypto.util import decode_address
-from hathor.daa import minimum_tx_weight
 from hathor.exception import InvalidNewTransaction
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import create_output_script
@@ -88,7 +87,7 @@ class CreateTxResource(Resource):
         for tx_input in fake_signed_tx.inputs:
             # conservative estimate of the input data size to estimate a valid weight
             tx_input.data = b'\0' * 107
-        tx.weight = minimum_tx_weight(fake_signed_tx)
+        tx.weight = self.manager.daa.minimum_tx_weight(fake_signed_tx)
         self.manager.verification_service.verifiers.tx.verify_unsigned_skip_pow(tx)
 
         if tx.is_double_spending():

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from hathor import daa
 from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import (
@@ -101,7 +100,7 @@ class TransactionVerifier(VertexVerifier):
 
     def verify_weight(self, tx: Transaction) -> None:
         """Validate minimum tx difficulty."""
-        min_tx_weight = daa.minimum_tx_weight(tx)
+        min_tx_weight = self._daa.minimum_tx_weight(tx)
         max_tx_weight = min_tx_weight + self._settings.MAX_TX_WEIGHT_DIFF
         if tx.weight < min_tx_weight - self._settings.WEIGHT_TOL:
             raise WeightError(f'Invalid new tx {tx.hash_hex}: weight ({tx.weight}) is '

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -15,6 +15,7 @@
 from typing import NamedTuple
 
 from hathor.conf.settings import HathorSettings
+from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.exceptions import TxValidationError
@@ -38,17 +39,18 @@ class VertexVerifiers(NamedTuple):
         cls,
         *,
         settings: HathorSettings,
-        feature_service: FeatureService | None = None
+        daa: DifficultyAdjustmentAlgorithm,
+        feature_service: FeatureService | None = None,
     ) -> 'VertexVerifiers':
         """
         Create a VertexVerifiers instance using the default verifier for each vertex type,
         from all required dependencies.
         """
         return VertexVerifiers(
-            block=BlockVerifier(settings=settings, feature_service=feature_service),
-            merge_mined_block=MergeMinedBlockVerifier(settings=settings, feature_service=feature_service),
-            tx=TransactionVerifier(settings=settings),
-            token_creation_tx=TokenCreationTransactionVerifier(settings=settings),
+            block=BlockVerifier(settings=settings, daa=daa, feature_service=feature_service),
+            merge_mined_block=MergeMinedBlockVerifier(settings=settings, daa=daa, feature_service=feature_service),
+            tx=TransactionVerifier(settings=settings, daa=daa),
+            token_creation_tx=TokenCreationTransactionVerifier(settings=settings, daa=daa),
         )
 
 

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -15,6 +15,7 @@
 from typing import Optional
 
 from hathor.conf.settings import HathorSettings
+from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.transaction import BaseTransaction
 from hathor.transaction.exceptions import (
     DuplicatedParents,
@@ -39,10 +40,11 @@ _BLOCK_PARENTS_BLOCKS = 1
 
 
 class VertexVerifier:
-    __slots__ = ('_settings', )
+    __slots__ = ('_settings', '_daa')
 
-    def __init__(self, *, settings: HathorSettings):
+    def __init__(self, *, settings: HathorSettings, daa: DifficultyAdjustmentAlgorithm):
         self._settings = settings
+        self._daa = daa
 
     def verify_parents(self, vertex: BaseTransaction) -> None:
         """All parents must exist and their timestamps must be smaller than ours.

--- a/hathor/wallet/resources/nano_contracts/execute.py
+++ b/hathor/wallet/resources/nano_contracts/execute.py
@@ -20,7 +20,6 @@ from typing import Any, NamedTuple
 from hathor.api_util import Resource, get_missing_params_msg, render_options, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.crypto.util import decode_address
-from hathor.daa import minimum_tx_weight
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH, NanoContractMatchValues
 from hathor.util import json_dumpb, json_loadb
@@ -99,7 +98,7 @@ class NanoContractExecuteResource(Resource):
 
         tx.parents = self.manager.get_new_tx_parents()
         tx.update_timestamp(int(self.manager.reactor.seconds()))
-        tx.weight = minimum_tx_weight(tx)
+        tx.weight = self.manager.daa.minimum_tx_weight(tx)
         tx.resolve()
         success = self.manager.propagate_tx(tx)
 

--- a/hathor/wallet/resources/send_tokens.py
+++ b/hathor/wallet/resources/send_tokens.py
@@ -20,7 +20,6 @@ from twisted.web.http import Request
 from hathor.api_util import Resource, render_options, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.crypto.util import decode_address
-from hathor.daa import minimum_tx_weight
 from hathor.exception import InvalidNewTransaction
 from hathor.transaction import Transaction
 from hathor.transaction.exceptions import TxValidationError
@@ -125,7 +124,7 @@ class SendTokensResource(Resource):
         tx.parents = values['parents']
         weight = values['weight']
         if weight is None:
-            weight = minimum_tx_weight(tx)
+            weight = self.manager.daa.minimum_tx_weight(tx)
         tx.weight = weight
         tx.resolve()
         self.manager.verification_service.verify(tx)

--- a/hathor/wallet/resources/sign_tx.py
+++ b/hathor/wallet/resources/sign_tx.py
@@ -17,7 +17,6 @@ import struct
 
 from hathor.api_util import Resource, get_args, get_missing_params_msg, set_cors
 from hathor.cli.openapi_files.register import register_resource
-from hathor.daa import minimum_tx_weight
 from hathor.transaction import Transaction
 from hathor.util import json_dumpb
 
@@ -67,7 +66,7 @@ class SignTxResource(Resource):
                 if prepare_to_send:
                     tx.parents = self.manager.get_new_tx_parents()
                     tx.update_timestamp(int(self.manager.reactor.seconds()))
-                    tx.weight = minimum_tx_weight(tx)
+                    tx.weight = self.manager.daa.minimum_tx_weight(tx)
                     tx.resolve()
 
                 data = {'hex_tx': tx.get_struct().hex(), 'success': True}

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -4,7 +4,6 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
-from hathor.daa import minimum_tx_weight
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
 from hathor.wallet.resources.thin_wallet import (
@@ -85,7 +84,7 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         i.data = P2PKH.create_input_data(public_key_bytes, signature_bytes)
         tx2.inputs = [i]
         tx2.timestamp = int(self.clock.seconds())
-        tx2.weight = minimum_tx_weight(tx2)
+        tx2.weight = self.manager.daa.minimum_tx_weight(tx2)
 
         response_wrong_amount = yield self.web.post('thin_wallet/send_tokens', {'tx_hex': tx2.get_struct().hex()})
         data_wrong_amount = response_wrong_amount.json_value()
@@ -100,7 +99,7 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         i.data = P2PKH.create_input_data(public_key_bytes, signature_bytes)
         tx3.inputs = [i]
         tx3.timestamp = int(self.clock.seconds())
-        tx3.weight = minimum_tx_weight(tx3)
+        tx3.weight = self.manager.daa.minimum_tx_weight(tx3)
 
         # Then send tokens
         response = yield self.web.post('thin_wallet/send_tokens', {'tx_hex': tx3.get_struct().hex()})
@@ -423,7 +422,7 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         i.data = P2PKH.create_input_data(public_key_bytes, signature_bytes)
         tx2.inputs = [i]
         tx2.timestamp = int(self.clock.seconds())
-        tx2.weight = minimum_tx_weight(tx2)
+        tx2.weight = self.manager.daa.minimum_tx_weight(tx2)
         tx2.parents = self.manager.get_new_tx_parents()
         tx2.resolve()
         self.manager.propagate_tx(tx2)

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -13,7 +13,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         # just get one of the genesis, we don't really need to create any transaction
         tx = next(iter(manager1.tx_storage.get_all_genesis()))
         # optional argument must be valid, it just has to not raise any exception, there's no assert for that
-        VertexVerifier(settings=self._settings).verify_pow(tx, override_weight=0.)
+        VertexVerifier(settings=self._settings, daa=manager1.daa).verify_pow(tx, override_weight=0.)
 
     def test_one_node(self):
         manager1 = self.create_peer()

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -147,7 +147,7 @@ def test_verify_must_signal_when_feature_activation_is_disabled(is_signaling_man
     settings.FEATURE_ACTIVATION.enable_usage = False
     feature_service = Mock(spec_set=FeatureService)
     feature_service.is_signaling_mandatory_features = Mock(return_value=is_signaling_mandatory_features)
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service)
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
     block = Block()
 
     verifier.verify_mandatory_signaling(block)
@@ -160,7 +160,7 @@ def test_verify_must_signal() -> None:
     feature_service.is_signaling_mandatory_features = Mock(
         return_value=BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)
     )
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service)
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
     block = Block()
 
     with pytest.raises(BlockMustSignalError) as e:
@@ -174,7 +174,7 @@ def test_verify_must_not_signal() -> None:
     settings.FEATURE_ACTIVATION.enable_usage = True
     feature_service = Mock(spec_set=FeatureService)
     feature_service.is_signaling_mandatory_features = Mock(return_value=BlockIsSignaling())
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service)
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
     block = Block()
 
     verifier.verify_mandatory_signaling(block)

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -1,5 +1,5 @@
 from hathor.conf import HathorSettings
-from hathor.daa import TestMode, _set_test_mode, calculate_block_difficulty, minimum_tx_weight
+from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode, _set_test_mode
 from hathor.transaction.storage import TransactionMemoryStorage
 from hathor.verification.verification_service import VerificationService, VertexVerifiers
 from hathor.verification.vertex_verifier import VertexVerifier
@@ -28,12 +28,13 @@ def get_genesis_output():
 class GenesisTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        verifiers = VertexVerifiers.create_defaults(settings=self._settings)
+        self._daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
+        verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=self._daa)
         self._verification_service = VerificationService(verifiers=verifiers)
         self.storage = TransactionMemoryStorage()
 
     def test_pow(self):
-        verifier = VertexVerifier(settings=self._settings)
+        verifier = VertexVerifier(settings=self._settings, daa=self._daa)
         genesis = self.storage.get_all_genesis()
         for g in genesis:
             self.assertEqual(g.calculate_hash(), g.hash)
@@ -70,9 +71,9 @@ class GenesisTest(unittest.TestCase):
         # Validate the block and tx weight
         # in test mode weight is always 1
         _set_test_mode(TestMode.TEST_ALL_WEIGHT)
-        self.assertEqual(calculate_block_difficulty(genesis_block), 1)
-        self.assertEqual(minimum_tx_weight(genesis_tx), 1)
+        self.assertEqual(self._daa.calculate_block_difficulty(genesis_block), 1)
+        self.assertEqual(self._daa.minimum_tx_weight(genesis_tx), 1)
 
         _set_test_mode(TestMode.DISABLED)
-        self.assertEqual(calculate_block_difficulty(genesis_block), genesis_block.weight)
-        self.assertEqual(minimum_tx_weight(genesis_tx), genesis_tx.weight)
+        self.assertEqual(self._daa.calculate_block_difficulty(genesis_block), genesis_block.weight)
+        self.assertEqual(self._daa.minimum_tx_weight(genesis_tx), genesis_tx.weight)

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 from math import isinf, isnan
 
-from hathor import daa
 from hathor.crypto.util import decode_address, get_address_from_public_key, get_private_key_from_bytes
 from hathor.daa import TestMode, _set_test_mode
 from hathor.transaction import MAX_OUTPUT_VALUE, Block, Transaction, TxInput, TxOutput
@@ -531,7 +530,7 @@ class BaseTransactionTest(unittest.TestCase):
         inputs = [TxInput(b'', 0, b'')]
         tx = Transaction(weight=1, inputs=inputs, outputs=outputs, parents=parents,
                          storage=self.tx_storage, timestamp=self.last_block.timestamp + 1)
-        tx.weight = daa.minimum_tx_weight(tx)
+        tx.weight = self.manager.daa.minimum_tx_weight(tx)
         tx.weight += self._settings.MAX_TX_WEIGHT_DIFF + 0.1
         tx.update_hash()
         with self.assertRaises(WeightError):

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -1,3 +1,4 @@
+from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.transaction import Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.verification.verification_service import VerificationService, VertexVerifiers
@@ -8,7 +9,8 @@ class _BaseTest:
     class _DeserializationTest(unittest.TestCase):
         def setUp(self) -> None:
             super().setUp()
-            verifiers = VertexVerifiers.create_defaults(settings=self._settings)
+            daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
+            verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=daa)
             self._verification_service = VerificationService(verifiers=verifiers)
 
         def test_deserialize(self):

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -183,7 +183,7 @@ class TestCase(unittest.TestCase):
     def create_peer(self, network, peer_id=None, wallet=None, tx_storage=None, unlock_wallet=True, wallet_index=False,
                     capabilities=None, full_verification=True, enable_sync_v1=None, enable_sync_v2=None,
                     checkpoints=None, utxo_index=False, event_manager=None, use_memory_index=None, start_manager=True,
-                    pubsub=None, event_storage=None, enable_event_queue=None, use_memory_storage=None):
+                    pubsub=None, event_storage=None, enable_event_queue=None, use_memory_storage=None, daa=None):
 
         enable_sync_v1, enable_sync_v2 = self._syncVersionFlags(enable_sync_v1, enable_sync_v2)
 
@@ -245,6 +245,9 @@ class TestCase(unittest.TestCase):
 
         if utxo_index:
             builder.enable_utxo_index()
+
+        if daa:
+            builder.set_daa(daa)
 
         manager = self.create_peer_from_builder(builder, start_manager=start_manager)
 


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/800

### Motivation

This PR changes the DAA module so it stops depending on global settings, allowing its simulator patch to be removed.

### Acceptance Criteria

- Move DAA functions to a new class with injected settings. No code logic should be changed.
- Remove `daa.MIN_BLOCK_WEIGHT` and `daa.AVG_TIME_BETWEEN_BLOCKS` global variables, moving them to the class instance.
- Add the new DAA class to be injected in `HathorManager`.
- Add the new DAA class to be injected in `VertexVerifiers`.
- Update `Builder` and `CliBuilder` accordingly.
- Update `Simulator` to use injected DAA class, removing the DAA simulator patch.
- Update all code using the `daa` module to use the DAA class.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 