### PR TITLE
refactor(daa): remove global daa test mode

### DIFF
--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -28,9 +28,10 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.internet.interfaces import ISSLTransport
 from twisted.internet.ssl import Certificate, CertificateOptions, TLSVersion, trustRootFromCertificates
 
-from hathor import daa
 from hathor.conf.get_settings import get_settings
+from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.p2p.utils import connection_string_to_host, discover_dns, generate_certificate
+from hathor.util import not_none
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol  # noqa: F401
@@ -347,7 +348,8 @@ class PeerId:
                     break
                 host = connection_string_to_host(entrypoint)
                 # TODO: don't use `daa.TEST_MODE` for this
-                result = yield discover_dns(host, daa.TEST_MODE)
+                test_mode = not_none(DifficultyAdjustmentAlgorithm.singleton).TEST_MODE
+                result = yield discover_dns(host, test_mode)
                 if protocol.connection_string in result:
                     # Found the entrypoint
                     found_entrypoint = True
@@ -366,7 +368,8 @@ class PeerId:
                 if connection_host == host:
                     found_entrypoint = True
                     break
-                result = yield discover_dns(host, daa.TEST_MODE)
+                test_mode = not_none(DifficultyAdjustmentAlgorithm.singleton).TEST_MODE
+                result = yield discover_dns(host, test_mode)
                 if connection_host in [connection_string_to_host(x) for x in result]:
                     # Found the entrypoint
                     found_entrypoint = True

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -23,7 +23,7 @@ from structlog import get_logger
 from hathor.builder import BuildArtifacts, Builder
 from hathor.conf.get_settings import get_settings
 from hathor.conf.settings import HathorSettings
-from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode, _set_test_mode
+from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
@@ -63,7 +63,6 @@ class Simulator:
         Patches:
 
         - disable Transaction.resolve method
-        - set DAA test-mode to DISABLED (will actually run the pow function, that won't actually verify the pow)
         """
         from hathor.transaction import BaseTransaction
 
@@ -74,8 +73,6 @@ class Simulator:
 
         cls._original_resolve = BaseTransaction.resolve
         BaseTransaction.resolve = resolve
-
-        _set_test_mode(TestMode.DISABLED)
 
     @classmethod
     def _remove_patches(cls):

--- a/tests/p2p/test_split_brain.py
+++ b/tests/p2p/test_split_brain.py
@@ -1,7 +1,7 @@
 import pytest
 from mnemonic import Mnemonic
 
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection
 from hathor.wallet import HDWallet
@@ -24,8 +24,8 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         wallet = HDWallet(gap_limit=2)
         wallet._manually_initialize()
 
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
         manager = super().create_peer(network, wallet=wallet)
+        manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
         manager.avg_time_between_blocks = 64
 
         # Don't use it anywhere else. It is unsafe to generate mnemonic words like this.

--- a/tests/resources/base_resource.py
+++ b/tests/resources/base_resource.py
@@ -2,7 +2,7 @@ from twisted.internet.defer import succeed
 from twisted.web import server
 from twisted.web.test.requesthelper import DummyRequest
 
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.util import json_dumpb, json_loadb
 from tests import unittest
 
@@ -19,7 +19,7 @@ class _BaseResourceTest:
                 unlock_wallet=unlock_wallet
             )
             self.manager.allow_mining_without_peers()
-            _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+            self.manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
 
         def tearDown(self):
             return self.manager.stop()

--- a/tests/resources/transaction/test_create_tx.py
+++ b/tests/resources/transaction/test_create_tx.py
@@ -2,7 +2,7 @@ import base64
 
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.transaction import Transaction
 from hathor.transaction.resources import CreateTxResource
 from hathor.transaction.scripts import P2PKH, create_base_script
@@ -195,7 +195,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
 
     @inlineCallbacks
     def test_tx_propagate(self):
-        _set_test_mode(TestMode.DISABLED)      # disable test_mode so the weight is not 1
+        self.manager.daa.TEST_MODE = TestMode.DISABLED  # disable test_mode so the weight is not 1
         src_tx = self.unspent_tx
         output_address = 'HNXsVtRUmwDCtpcCJUrH4QiHo9kUKx199A'
         resp = (yield self.web.post('create_tx', {
@@ -233,7 +233,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
 
     @inlineCallbacks
     def test_tx_propagate_multiple_inputs(self):
-        _set_test_mode(TestMode.DISABLED)      # disable test_mode so the weight is not 1
+        self.manager.daa.TEST_MODE = TestMode.DISABLED  # disable test_mode so the weight is not 1
         output_address = 'HNXsVtRUmwDCtpcCJUrH4QiHo9kUKx199A'
         resp = (yield self.web.post('create_tx', {
             'inputs': [

--- a/tests/resources/wallet/test_send_tokens.py
+++ b/tests/resources/wallet/test_send_tokens.py
@@ -2,7 +2,7 @@ import base64
 
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.p2p.resources import MiningResource
 from hathor.wallet.resources import BalanceResource, HistoryResource, SendTokensResource
 from tests import unittest
@@ -168,7 +168,7 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
 
     @inlineCallbacks
     def test_tx_weight(self):
-        _set_test_mode(TestMode.DISABLED)
+        self.manager.daa.TEST_MODE = TestMode.DISABLED
         add_new_blocks(self.manager, 3, advance_clock=1)
         add_blocks_unlock_reward(self.manager)
         self.reactor.advance(3)

--- a/tests/tx/test_blockchain.py
+++ b/tests/tx/test_blockchain.py
@@ -1,7 +1,7 @@
 from itertools import chain
 
 from hathor.conf import HathorSettings
-from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode, _set_test_mode
+from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
 from hathor.transaction import sum_weights
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
@@ -390,8 +390,8 @@ class BaseBlockchainTestCase(unittest.TestCase):
 
     def test_daa_sanity(self):
         # sanity test the DAA
-        _set_test_mode(TestMode.DISABLED)
         manager = self.create_peer('testnet', tx_storage=self.tx_storage)
+        manager.daa.TEST_MODE = TestMode.DISABLED
         N = settings.BLOCK_DIFFICULTY_N_BLOCKS
         T = settings.AVG_TIME_BETWEEN_BLOCKS
         manager.avg_time_between_blocks = T
@@ -417,7 +417,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
             self.assertLess(new_weight, base_weight)
 
     def test_daa_weight_decay_amount(self):
-        _set_test_mode(TestMode.DISABLED)
+        self.daa.TEST_MODE = TestMode.DISABLED
         amount = settings.WEIGHT_DECAY_AMOUNT
 
         for distance in range(0, settings.WEIGHT_DECAY_ACTIVATE_DISTANCE, 10):
@@ -434,8 +434,8 @@ class BaseBlockchainTestCase(unittest.TestCase):
         self.assertAlmostEqual(self.daa.get_weight_decay_amount(distance), 11 * amount)
 
     def test_daa_weight_decay_blocks(self):
-        _set_test_mode(TestMode.DISABLED)
         manager = self.create_peer('testnet', tx_storage=self.tx_storage)
+        manager.daa.TEST_MODE = TestMode.DISABLED
         amount = settings.WEIGHT_DECAY_AMOUNT
 
         manager.daa.AVG_TIME_BETWEEN_BLOCKS = settings.AVG_TIME_BETWEEN_BLOCKS

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -1,4 +1,4 @@
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.transaction import Transaction, TransactionMetadata
 from hathor.transaction.storage import TransactionCacheStorage
 from tests import unittest
@@ -144,7 +144,7 @@ class BaseCacheStorageTest(unittest.TestCase):
         self.cache_storage._flush_to_storage(self.cache_storage.dirty_txs.copy())
 
     def test_topological_sort_dfs(self):
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+        self.manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
         add_new_blocks(self.manager, 11, advance_clock=1)
         tx = add_new_transactions(self.manager, 1, advance_clock=1)[0]
 

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -1,5 +1,5 @@
 from hathor.conf import HathorSettings
-from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode, _set_test_mode
+from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
 from hathor.transaction.storage import TransactionMemoryStorage
 from hathor.verification.verification_service import VerificationService, VertexVerifiers
 from hathor.verification.vertex_verifier import VertexVerifier
@@ -70,10 +70,10 @@ class GenesisTest(unittest.TestCase):
 
         # Validate the block and tx weight
         # in test mode weight is always 1
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+        self._daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
         self.assertEqual(self._daa.calculate_block_difficulty(genesis_block), 1)
         self.assertEqual(self._daa.minimum_tx_weight(genesis_tx), 1)
 
-        _set_test_mode(TestMode.DISABLED)
+        self._daa.TEST_MODE = TestMode.DISABLED
         self.assertEqual(self._daa.calculate_block_difficulty(genesis_block), genesis_block.weight)
         self.assertEqual(self._daa.minimum_tx_weight(genesis_tx), genesis_tx.weight)

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -3,7 +3,7 @@ import hashlib
 from math import isinf, isnan
 
 from hathor.crypto.util import decode_address, get_address_from_public_key, get_private_key_from_bytes
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.transaction import MAX_OUTPUT_VALUE, Block, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import (
     BlockWithInputs,
@@ -629,8 +629,8 @@ class BaseTransactionTest(unittest.TestCase):
         self.assertEquals(tx.timestamp, ts)
 
     def test_propagation_error(self):
-        _set_test_mode(TestMode.DISABLED)
         manager = self.create_peer('testnet', unlock_wallet=True)
+        manager.daa.TEST_MODE = TestMode.DISABLED
 
         # 1. propagate genesis
         genesis_block = self.genesis_blocks[0]

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -9,7 +9,7 @@ from twisted.internet.threads import deferToThread
 from twisted.trial import unittest
 
 from hathor.conf import HathorSettings
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import TestMode
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
@@ -145,7 +145,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.assertEqual(set(tx_parents_hash), {self.genesis_txs[0].hash, self.genesis_txs[1].hash})
 
     def test_vertices_count(self):
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+        self.manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
 
         blocks_count = 1
         txs_count = 2
@@ -522,7 +522,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         return block
 
     def test_best_block_tips_cache(self):
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+        self.manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
         self.manager.wallet.unlock(b'MYPASS')
         spent_blocks = add_new_blocks(self.manager, 10)
         self.assertEqual(self.tx_storage._best_block_tips_cache, [spent_blocks[-1].hash])
@@ -534,7 +534,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.assertEqual(self.tx_storage._best_block_tips_cache, [latest_blocks[-1].hash])
 
     def test_topological_sort(self):
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
+        self.manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
         _total = 0
         blocks = add_new_blocks(self.manager, 1, advance_clock=1)
         _total += len(blocks)

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -12,7 +12,7 @@ from twisted.trial import unittest
 from hathor.builder import BuildArtifacts, Builder
 from hathor.conf import HathorSettings
 from hathor.conf.get_settings import get_settings
-from hathor.daa import TestMode, _set_test_mode
+from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.sync_version import SyncVersion
 from hathor.simulator.clock import MemoryReactorHeapClock
@@ -104,7 +104,6 @@ class TestCase(unittest.TestCase):
     seed_config: Optional[int] = None
 
     def setUp(self):
-        _set_test_mode(TestMode.TEST_ALL_WEIGHT)
         self.tmpdirs = []
         self.clock = TestMemoryReactorClock()
         self.clock.advance(time.time())
@@ -183,7 +182,7 @@ class TestCase(unittest.TestCase):
     def create_peer(self, network, peer_id=None, wallet=None, tx_storage=None, unlock_wallet=True, wallet_index=False,
                     capabilities=None, full_verification=True, enable_sync_v1=None, enable_sync_v2=None,
                     checkpoints=None, utxo_index=False, event_manager=None, use_memory_index=None, start_manager=True,
-                    pubsub=None, event_storage=None, enable_event_queue=None, use_memory_storage=None, daa=None):
+                    pubsub=None, event_storage=None, enable_event_queue=None, use_memory_storage=None):
 
         enable_sync_v1, enable_sync_v2 = self._syncVersionFlags(enable_sync_v1, enable_sync_v2)
 
@@ -246,9 +245,8 @@ class TestCase(unittest.TestCase):
         if utxo_index:
             builder.enable_utxo_index()
 
-        if daa:
-            builder.set_daa(daa)
-
+        daa = DifficultyAdjustmentAlgorithm(settings=self._settings, test_mode=TestMode.TEST_ALL_WEIGHT)
+        builder.set_daa(daa)
         manager = self.create_peer_from_builder(builder, start_manager=start_manager)
 
         # XXX: just making sure that tests set this up correctly


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/801

### Motivation

This PR refactors the global daa `TEST_MODE`, allowing its simulator patch to be removed.

### Acceptance Criteria

- Remove the global `daa.TEST_MODE` and `daa._set_test_mode()`, moving it to an attribute in the DAA class. Also, update respective usages.
- Create temporary DAA singleton to be used exclusively in the `PeerId` class. It should be removed in a future PR.
- Remove `_set_test_mode()` simulator patch.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 