### PR TITLE
feat[healthcheck]: make the p2p healthcheck use the GET-BEST-BLOCKCHAIN capability if enabled

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -189,6 +189,9 @@ class HathorSettings(NamedTuple):
     # positive, it could be a good idea to decrease the value in this setting.
     P2P_RECENT_ACTIVITY_THRESHOLD_MULTIPLIER: int = 15
 
+    # Maximum height difference between our best block and the highest peer height to consider that we are healthy.
+    HEALTHCHECK_MAX_HEIGHT_DIFF: int = 10
+
     # Whether to warn the other peer of the reason for closing the connection
     WHITELIST_WARN_BLOCKED_PEERS: bool = False
 

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -18,6 +18,7 @@ import hathor
 from hathor.api_util import Resource, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.conf.get_settings import get_settings
+from hathor.manager import HathorManager
 from hathor.p2p.utils import to_serializable_best_blockchain
 from hathor.util import json_dumpb
 
@@ -33,7 +34,7 @@ class StatusResource(Resource):
 
     def __init__(self, manager):
         self._settings = get_settings()
-        self.manager = manager
+        self.manager: HathorManager = manager
 
     def render_GET(self, request):
         request.setHeader(b'content-type', b'application/json; charset=utf-8')

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -71,6 +71,16 @@ class FakeConnection:
         self._proto1.disable_idle_timeout()
         self._proto2.disable_idle_timeout()
 
+    def disable_sync(self):
+        """Disable sync in both peers."""
+        from hathor.p2p.states.ready import ReadyState
+
+        assert isinstance(self._proto1.state, ReadyState)
+        assert isinstance(self._proto2.state, ReadyState)
+
+        self._proto1.state.sync_agent.disable_sync()
+        self._proto2.state.sync_agent.disable_sync()
+
     def is_both_synced(self) -> bool:
         """Short-hand check that can be used to make "step loops" without having to guess the number of iterations."""
         from hathor.p2p.states.ready import ReadyState

--- a/tests/resources/p2p/test_healthcheck.py
+++ b/tests/resources/p2p/test_healthcheck.py
@@ -1,5 +1,6 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.conf.get_settings import get_settings
 from hathor.manager import HathorManager
 from hathor.p2p.resources.healthcheck import HealthcheckReadinessResource
 from hathor.simulator import FakeConnection
@@ -80,6 +81,51 @@ class BaseHealthcheckReadinessTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
 
         self.assertEqual(data['success'], True)
+
+    @inlineCallbacks
+    def test_peer_best_blockchain_too_far_ahead(self):
+        """Scenarion where there is a connected peer which is too far ahead
+        """
+        self.manager2 = self.create_peer('testnet')
+        self.manager3 = self.create_peer('testnet')
+        self.conn1 = FakeConnection(self.manager, self.manager2)
+        self.conn2 = FakeConnection(self.manager, self.manager3)
+
+        # This will make sure the node has recent activity
+        add_new_blocks(self.manager, 5)
+
+        # This will make sure the peers are synced with us
+        for _ in range(600):
+            self.conn1.run_one_step(debug=True)
+            self.conn2.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        # Disable sync between us and manager3, because we want to guarantee that manager3
+        # will have more blocks than us, while still being connected to us and reporting its
+        # best-blockchain to us
+        self.conn2.disable_sync()
+
+        # This will make sure manager 3 has more blocks than us, enough to trigger the
+        # BEST_PEER_HEIGHT_TOO_FAR unhealthiness
+        additional_blocks_count = get_settings().HEALTHCHECK_MAX_HEIGHT_DIFF + 1
+        add_new_blocks(self.manager3, additional_blocks_count)
+
+        # This will let the peers exchange their best-blockchain. We won't sync with manager3
+        # because we disabled it above. We let them run for 3 times the interval to be sure.
+        for _ in range(3 * 10 * get_settings().BEST_BLOCKCHAIN_INTERVAL):
+            self.conn1.run_one_step(debug=True)
+            self.conn2.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        response = yield self.web.get("p2p/readiness")
+        data = response.json_value()
+
+        self.assertEqual(data['success'], False)
+        self.assertEqual(
+            data['reason'],
+            HathorManager.UnhealthinessReason.BEST_PEER_HEIGHT_TOO_FAR
+            + f" Theirs is {additional_blocks_count + 5}, ours is 5"
+        )
 
 
 class SyncV1StatusTest(unittest.SyncV1Params, BaseHealthcheckReadinessTest):


### PR DESCRIPTION
### Motivation

Improving our current healthcheck so we detect more situations where we may be out of sync in relation to the network.

### Acceptance Criteria

We should include a new check in our healthcheck that will use the GET-BEST-BLOCKCHAIN capability to compare our current best blockchain with the other connected peers.

The previous logic was able to do something similar, but only for peers with which we are syncing now.

Including all other connected peers in this check will expand our capacity to detect out-of-sync situations and warn about this in the healthcheck.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 