### PR TITLE
chore: improve push_tx log

### DIFF
--- a/hathor/transaction/resources/push_tx.py
+++ b/hathor/transaction/resources/push_tx.py
@@ -101,9 +101,9 @@ class PushTxResource(Resource):
             self.manager.push_tx(tx, allow_non_standard_script=self.allow_non_standard_script,
                                  max_output_script_size=self.max_output_script_size)
         except (InvalidNewTransaction, TxValidationError) as e:
-            self.log.warn('push tx rejected', exc_info=True)
             success = False
             message = str(e)
+            self.log.warn('push tx rejected', reason=repr(e))
         data = {'success': success, 'message': message}
         if success:
             data['tx'] = tx.to_json()


### PR DESCRIPTION
### Motivation

The `/push_tx` API currently generates alerts when it fails. It should simply log the reason, but not generate an alert. For more info, read https://github.com/HathorNetwork/on-call-incidents/issues/97.

### Acceptance Criteria

- Substitute `exc_info` by an human-readable message from the warning logged by `/push_tx`. By removing the "Traceback" from the log, an alert is not fired anymore.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 