### PR TITLE
feat(unrecoverable-error): implement halting of full node execution

### DIFF
--- a/hathor/event/model/event_type.py
+++ b/hathor/event/model/event_type.py
@@ -25,6 +25,7 @@ class EventType(Enum):
     REORG_STARTED = 'REORG_STARTED'
     REORG_FINISHED = 'REORG_FINISHED'
     VERTEX_METADATA_CHANGED = 'VERTEX_METADATA_CHANGED'
+    FULL_NODE_CRASHED = 'FULL_NODE_CRASHED'
 
     @classmethod
     def from_hathor_event(cls, hathor_event: HathorEvents) -> 'EventType':
@@ -53,4 +54,5 @@ _EVENT_TYPE_TO_EVENT_DATA: dict[EventType, type[BaseEventData]] = {
     EventType.REORG_STARTED: ReorgData,
     EventType.REORG_FINISHED: EmptyData,
     EventType.VERTEX_METADATA_CHANGED: TxData,
+    EventType.FULL_NODE_CRASHED: EmptyData,
 }

--- a/hathor/execution_manager.py
+++ b/hathor/execution_manager.py
@@ -1,0 +1,65 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+from typing import Callable, NoReturn
+
+from structlog import get_logger
+
+from hathor.reactor import ReactorProtocol
+
+logger = get_logger()
+
+
+class ExecutionManager:
+    """Class to manage actions related to full node execution."""
+    __slots__ = ('_log', '_reactor', '_on_crash_callbacks')
+
+    def __init__(self, reactor: ReactorProtocol) -> None:
+        self._log = logger.new()
+        self._reactor = reactor
+        self._on_crash_callbacks: list[tuple[int, Callable[[], None]]] = []
+
+    def register_on_crash_callback(self, callback: Callable[[], None], *, priority: int = 0) -> None:
+        """Register a callback to be executed before the full node exits."""
+        self._on_crash_callbacks.append((priority, callback))
+
+    def _run_on_crash_callbacks(self) -> None:
+        """Run all registered on crash callbacks."""
+        callbacks = sorted(self._on_crash_callbacks, reverse=True)
+
+        for _, callback in callbacks:
+            try:
+                callback()
+            except BaseException as e:
+                self._log.critical(f'Failed execution of on_crash callback "{callback}". Exception: {repr(e)}')
+
+    def crash_and_exit(self, *, reason: str) -> NoReturn:
+        """
+        Calling this function is a very extreme thing to do, so be careful. It should only be called when a
+        critical, unrecoverable failure happens. It crashes and exits the full node, maybe rendering the database
+        corrupted, and requiring manual intervention. In other words, a restart with a clean database (from scratch
+        or a snapshot) may be required.
+        """
+        self._run_on_crash_callbacks()
+        self._log.critical(
+            'Critical failure occurred, causing the full node to halt execution. Manual intervention is required.',
+            reason=reason,
+            exc_info=True
+        )
+        # We sequentially call more extreme exit methods, so the full node exits as gracefully as possible, while
+        # guaranteeing that it will indeed exit.
+        self._reactor.stop()
+        self._reactor.crash()
+        sys.exit(-1)

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -24,6 +24,7 @@ from intervaltree.interval import Interval
 from structlog import get_logger
 
 from hathor.conf.get_settings import get_global_settings
+from hathor.execution_manager import ExecutionManager
 from hathor.indexes import IndexesManager
 from hathor.indexes.height_index import HeightInfo
 from hathor.profiler import get_cpu_profiler
@@ -83,6 +84,9 @@ class TransactionStorage(ABC):
 
     # Key storage attribute to save if the manager is running
     _manager_running_attribute: str = 'manager_running'
+
+    # Key storage attribute to save if the full node crashed
+    _full_node_crashed_attribute: str = 'full_node_crashed'
 
     # Ket storage attribute to save the last time the node started
     _last_start_attribute: str = 'last_start'
@@ -968,9 +972,10 @@ class TransactionStorage(ABC):
         """
         return self.get_value(self._running_full_verification_attribute) == '1'
 
-    def start_running_manager(self) -> None:
+    def start_running_manager(self, execution_manager: ExecutionManager) -> None:
         """ Save on storage that manager is running
         """
+        execution_manager.register_on_crash_callback(self.on_full_node_crash)
         self.add_value(self._manager_running_attribute, '1')
 
     def stop_running_manager(self) -> None:
@@ -982,6 +987,14 @@ class TransactionStorage(ABC):
         """ Return if the manager is running or was running and a sudden crash stopped the full node
         """
         return self.get_value(self._manager_running_attribute) == '1'
+
+    def on_full_node_crash(self) -> None:
+        """Save on storage that the full node crashed and cannot be recovered."""
+        self.add_value(self._full_node_crashed_attribute, '1')
+
+    def is_full_node_crashed(self) -> bool:
+        """Return whether the full node was crashed."""
+        return self.get_value(self._full_node_crashed_attribute) == '1'
 
     def get_last_started_at(self) -> int:
         """ Return the timestamp when the database was last started.

--- a/tests/consensus/test_consensus.py
+++ b/tests/consensus/test_consensus.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
+from hathor.execution_manager import ExecutionManager
 from hathor.simulator.utils import add_new_block, add_new_blocks, gen_new_tx
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
@@ -30,10 +31,15 @@ class BaseConsensusTestCase(unittest.TestCase):
         class MyError(Exception):
             pass
 
+        execution_manager_mock = Mock(spec_set=ExecutionManager)
+        manager.consensus_algorithm._execution_manager = execution_manager_mock
         manager.consensus_algorithm._unsafe_update = MagicMock(side_effect=MyError)
 
-        with self.assertRaises(MyError):
-            manager.propagate_tx(tx, fails_silently=False)
+        manager.propagate_tx(tx, fails_silently=False)
+
+        execution_manager_mock.crash_and_exit.assert_called_once_with(
+            reason=f"Consensus update failed for tx {tx.hash_hex}"
+        )
 
         tx2 = manager.tx_storage.get_transaction(tx.hash)
         meta2 = tx2.get_metadata()

--- a/tests/execution_manager/test_execution_manager.py
+++ b/tests/execution_manager/test_execution_manager.py
@@ -1,0 +1,47 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+from unittest.mock import Mock, patch
+
+from hathor.execution_manager import ExecutionManager
+from hathor.reactor import ReactorProtocol
+
+
+def test_crash_and_exit() -> None:
+    def callback() -> None:
+        pass
+
+    callback_wrapped = Mock(wraps=callback)
+    log_mock = Mock()
+    reactor_mock = Mock(spec_set=ReactorProtocol)
+    manager = ExecutionManager(reactor_mock)
+    manager._log = log_mock
+    reason = 'some critical failure'
+
+    manager.register_on_crash_callback(callback_wrapped)
+
+    with patch.object(sys, 'exit') as exit_mock:
+        manager.crash_and_exit(reason=reason)
+
+    callback_wrapped.assert_called_once()
+    log_mock.critical.assert_called_once_with(
+        'Critical failure occurred, causing the full node to halt execution. Manual intervention is required.',
+        reason=reason,
+        exc_info=True
+    )
+
+    reactor_mock.stop.assert_called_once()
+    reactor_mock.crash.assert_called_once()
+    exit_mock.assert_called_once_with(-1)


### PR DESCRIPTION
### Motivation

Currently, when an exception happens during a consensus update, it marks the tx as voided with a custom marker and continues to operate. This operation may be faulty, though, as the database is likely in an undesired state. For example, if such exception happens when a block is received, no following block will be accepted and the full node will not be able to sync anymore. If the full node is manually stopped and restarted, it starts up but continues to be unable to sync.

This PR's goal is to, instead, completely halt and exit the full node in those cases, forcing manual intervention. When some exception happens during a consensus update, the full node process exits with a non-zero exit code. This also guarantees that the database is marked as corrupted, so the full node cannot be restarted normally, only by a full verification or new database.

This PR is only _more_ restrictive than what's currently implemented, and will be necessary for the Feature Activation for Transactions.

### Acceptance Criteria

- Create new `ExecutionManager` with `crash_and_exit()` method.
- Create new related methods in `EventManager` and `TransactionStorage` for dealing with a full node crash.
- Change handling of exceptions during consensus so it halts and exit the full node, in addition to voiding the tx.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 