### PR TITLE
fix(sync-v2): Stop streaming if current block becomes voided

### DIFF
--- a/hathor/p2p/sync_v2/streamers.py
+++ b/hathor/p2p/sync_v2/streamers.py
@@ -143,6 +143,12 @@ class BlockchainStreaming(_StreamingBase):
         assert cur is not None
         assert cur.hash is not None
 
+        meta = cur.get_metadata()
+        if meta.voided_by:
+            self.stop()
+            self.node_sync.send_blocks_end(StreamEnd.STREAM_BECAME_VOIDED)
+            return
+
         if cur.hash == self.end_hash:
             # only send the last when not reverse
             if not self.reverse:


### PR DESCRIPTION
### Motivation

Fix one of the conditions that makes the `tests/simulation/test_simulator.py::SyncV2RandomSimulatorTestCase::test_many_miners_since_beginning` flaky.

If we do not stop the streaming, the later call to `get_next_block_best_chain()` will raise an assertion error since the next block will be voided.

### Acceptance Criteria

1. Stop streaming blocks if the current block gets voided.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 