### PR TITLE
test(sync-v1): Reset rate limit hit counter after simulation

### DIFF
--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -227,6 +227,7 @@ class ConnectionsManager:
     def disable_rate_limiter(self) -> None:
         """Disable global rate limiter."""
         self.rate_limiter.unset_limit(self.GlobalRateLimiter.SEND_TIPS)
+        self.rate_limiter.reset(self.GlobalRateLimiter.SEND_TIPS)
 
     def enable_rate_limiter(self, max_hits: int = 16, window_seconds: float = 1) -> None:
         """Enable global rate limiter. This method can be called to change the current rate limit."""

--- a/tests/p2p/test_sync_rate_limiter.py
+++ b/tests/p2p/test_sync_rate_limiter.py
@@ -25,6 +25,8 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, SimulatorTestCase):
         self.simulator.add_connection(conn12)
         self.simulator.run(3600)
 
+        # Disable to reset all previous hits to the rate limiter.
+        manager2.connections.disable_rate_limiter()
         manager2.connections.enable_rate_limiter(8, 2)
 
         connected_peers2 = list(manager2.connections.connected_peers.values())


### PR DESCRIPTION
### Motivation

Fix flaky test `FAILED tests/p2p/test_sync_rate_limiter.py::SyncV1RandomSimulatorTestCase::test_sync_rate_limiter - twisted.trial.unittest.FailTest: 7 != 8`.

This test fails when there's a pending call to `send_tips()` after simulation.

### Acceptance Criteria

1. Reset rate limit hit counter after simulation.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 