### PR TITLE
test: Use INFO as default log level to reduce amount of logs

### DIFF
--- a/hathor/cli/util.py
+++ b/hathor/cli/util.py
@@ -157,6 +157,9 @@ def setup_logging(
     else:
         handlers = ['pretty']
 
+    # Flag to enable debug level for both sync-v1 and sync-v2.
+    debug_sync = False and debug
+
     # See: https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
     logging.config.dictConfig({
             'version': 1,
@@ -207,6 +210,14 @@ def setup_logging(
                     'handlers': handlers,
                     'level': 'DEBUG' if debug else 'INFO',
                 },
+                'hathor.p2p.sync_v1': {
+                    'handlers': handlers,
+                    'level': 'DEBUG' if debug_sync else 'INFO',
+                },
+                'hathor.p2p.sync_v2': {
+                    'handlers': handlers,
+                    'level': 'DEBUG' if debug_sync else 'INFO',
+                }
             }
     })
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -10,6 +10,7 @@ from structlog import get_logger
 from twisted.trial import unittest
 
 from hathor.builder import BuildArtifacts, Builder
+from hathor.cli.util import setup_logging
 from hathor.conf import HathorSettings
 from hathor.conf.get_settings import get_settings
 from hathor.daa import TestMode, _set_test_mode
@@ -104,6 +105,7 @@ class TestCase(unittest.TestCase):
     seed_config: Optional[int] = None
 
     def setUp(self):
+        setup_logging()
         _set_test_mode(TestMode.TEST_ALL_WEIGHT)
         self.tmpdirs = []
         self.clock = TestMemoryReactorClock()
@@ -111,7 +113,7 @@ class TestCase(unittest.TestCase):
         self.log = logger.new()
         self.reset_peer_id_pool()
         self.seed = secrets.randbits(64) if self.seed_config is None else self.seed_config
-        self.log.debug('set seed', seed=self.seed)
+        self.log.info('set seed', seed=self.seed)
         self.rng = Random(self.seed)
         self._pending_cleanups = []
         self._settings = get_settings()


### PR DESCRIPTION
### Motivation

Current log size is too big when a test fails. It's so big that it does not provide any help to understand what went wrong.

### Acceptance Criteria

1. Print seed using INFO log level.
2. Change default log level for INFO for all tests.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 