### PR TITLE
test(sync): Improve test_sync_rotate to prevent false positives

### DIFF
--- a/tests/p2p/test_sync_enabled.py
+++ b/tests/p2p/test_sync_enabled.py
@@ -52,13 +52,20 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
 
         self.simulator.run(600)
 
+        ready = set(conn for conn in connections if conn.proto1.is_state(conn.proto1.PeerState.READY))
+        self.assertEqual(len(ready), len(other_managers))
+
         enabled = set(conn for conn in connections if conn.proto1.is_sync_enabled())
-        self.assertTrue(len(enabled), 3)
+        self.assertEqual(len(enabled), 3)
 
         manager1.connections._sync_rotate_if_needed(force=True)
         enabled2 = set(conn for conn in connections if conn.proto1.is_sync_enabled())
-        self.assertTrue(len(enabled2), 3)
-        # Chance of false positive: 1/comb(20, 3) = 0.0008771929824561404
+        self.assertEqual(len(enabled2), 3)
+        if enabled == enabled2:
+            manager1.connections._sync_rotate_if_needed(force=True)
+            enabled2 = set(conn for conn in connections if conn.proto1.is_sync_enabled())
+            self.assertEqual(len(enabled2), 3)
+        # Chance of false positive: (1/comb(15, 3))**2 = 0.00000483
         self.assertNotEqual(enabled, enabled2)
 
 


### PR DESCRIPTION
### Background

The `test_sync_rotate()` had an assert with 0.0877% change of failing. As every CI job executes it 6 times, it had a change of 0.52% of failing, i.e., 1 out of 200 CI executions.

### Acceptance Criteria

1. Modify `test_sync_rotate()` to reduce the chance of failing to 0.000483%, which reduces the chance of a CI failing from 0.52% to 0.00289797% (1 out of 35,000 CI executions).

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 