### PR TITLE
chore(ci): use cancel-in-progress to prevent useless CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on: # yamllint disable-line rule:truthy
     tags:
       - v*
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

Very often we will push a new commit to a PR (recent rebase or otherwise) while the CI is still running and will continue to run wasting CI time and jamming the jobs queue.

### Acceptance Criteria

- Use [`cancel-in-progress`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run) config to automatically cancel workflow runs when a new one in the same "ref" (branch or tag) starts.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 