### PR TITLE
fix(mining): Fix block template not checking for MAX_FUTURE_TIMESTAMP_ALLOWED

### DIFF
--- a/hathor/exception.py
+++ b/hathor/exception.py
@@ -23,6 +23,16 @@ class BuilderError(Exception):
     pass
 
 
+class BlockTemplateError(Exception):
+    """Base class for exceptions generating block template."""
+    pass
+
+
+class BlockTemplateTimestampError(BlockTemplateError):
+    """Raised when there is no timestamp available to prepare a block template."""
+    pass
+
+
 class InvalidNewTransaction(HathorError):
     """Raised when a new received tx/block is not valid.
     """

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -31,6 +31,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.consensus import ConsensusAlgorithm
 from hathor.event.event_manager import EventManager
 from hathor.exception import (
+    BlockTemplateTimestampError,
     DoubleSpendingError,
     HathorError,
     InitializationError,
@@ -807,6 +808,13 @@ class HathorManager:
             timestamp_max = min(timestamp_abs_max, timestamp_max_decay)
         else:
             timestamp_max = timestamp_abs_max
+        timestamp_max = min(timestamp_max, int(current_timestamp + self._settings.MAX_FUTURE_TIMESTAMP_ALLOWED))
+        if timestamp_max < timestamp_min:
+            raise BlockTemplateTimestampError(
+                f'Unable to create a block template because there is no timestamp available. '
+                f'(min={timestamp_min}, max={timestamp_max}) '
+                f'(current_timestamp={current_timestamp})'
+            )
         timestamp = min(max(current_timestamp, timestamp_min), timestamp_max)
         parent_block_metadata = parent_block.get_metadata()
         # this is the min weight to cause an increase of twice the WEIGHT_TOL, we make sure to generate a template with

--- a/tests/tx/test_mining.py
+++ b/tests/tx/test_mining.py
@@ -37,13 +37,19 @@ class BaseMiningTest(unittest.TestCase):
 
         block_templates = manager.get_block_templates()
         self.assertEqual(len(block_templates), 1)
+
+        timestamp_max = min(
+            0xffffffff,
+            int(manager.reactor.seconds()) + self._settings.MAX_FUTURE_TIMESTAMP_ALLOWED
+        )
+
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
             reward=settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=settings.GENESIS_BLOCK_TIMESTAMP + 3,
-            timestamp_max=0xffffffff,  # no limit for next block after genesis
+            timestamp_max=timestamp_max,  # no limit for next block after genesis
             # parents=[tx.hash for tx in self.genesis_blocks + self.genesis_txs],
             parents=block_templates[0].parents,
             parents_any=[],
@@ -60,13 +66,19 @@ class BaseMiningTest(unittest.TestCase):
 
         block_templates = manager.get_block_templates()
         self.assertEqual(len(block_templates), 1)
+
+        timestamp_max = min(
+            blocks[-1].timestamp + settings.MAX_DISTANCE_BETWEEN_BLOCKS - 1,
+            int(manager.reactor.seconds()) + self._settings.MAX_FUTURE_TIMESTAMP_ALLOWED
+        )
+
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
             reward=settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=blocks[-1].timestamp + 1,
-            timestamp_max=blocks[-1].timestamp + settings.MAX_DISTANCE_BETWEEN_BLOCKS - 1,
+            timestamp_max=timestamp_max,
             # parents=[blocks[-1].hash, self.genesis_txs[-1].hash, self.genesis_txs[-2].hash],
             parents=block_templates[0].parents,
             parents_any=[],


### PR DESCRIPTION
## Background

Some flaky tests using simulator were failing with the following error: `hathor.exception.InvalidNewTransaction: Ignoring transaction in the future`.

Why?

Because a miner was trying to push a block with a timestamp set too far in the future.

Why?

Because `HathorManager.generate_mining_block()` was returning a block template with an invalid timestamp.

Why?

After a chain of calls started by `Hathor.generate_mining_block()`, the method `_make_block_template()` was called. This method was not taking into consideration the `MAX_FUTURE_TIMESTAMP_ALLOWED` when calculating the maximum allowed timestamp.

## Acceptance criteria

1. Add the following exceptions: `BlockTemplateError` and `BlockTemplateTimestampError`.
2. Fix `HathorManager._make_block_template()` to take `MAX_FUTURE_TIMESTAMP_ALLOWED` into consideration when calculating `max_timestamp`.
3. Adjust `hathor.simulator.GeometricMiner` to handle the `BlockTemplateTimestampError` trying again in 5 seconds.