### PR TITLE
fix(mining): Wrong timestamp sent to _make_block_template

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -756,7 +756,7 @@ class HathorManager:
         assert isinstance(parent_block, Block)
         parent_txs = self.generate_parent_txs(parent_block.timestamp + self._settings.MAX_DISTANCE_BETWEEN_BLOCKS)
         if timestamp is None:
-            current_timestamp = int(max(self.tx_storage.latest_timestamp, self.reactor.seconds()))
+            current_timestamp = int(self.reactor.seconds())
         else:
             current_timestamp = timestamp
         return self._make_block_template(parent_block, parent_txs, current_timestamp)


### PR DESCRIPTION
### Motivation

[PR #822](https://github.com/HathorNetwork/hathor-core/pull/822) was not enough to fix the flaky tests because the caller of `_make_block_template()` was sending the wrong `current_timestamp`.

### Acceptance Criteria

1. Fix the calculation of `current_timestamp` in `HathorManager.make_block_template()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 