### PR TITLE
fix(feature-activation): add missing metadata migration

### DIFF
--- a/hathor/feature_activation/bit_signaling_service.py
+++ b/hathor/feature_activation/bit_signaling_service.py
@@ -54,6 +54,10 @@ class BitSignalingService:
         self._validate_support_intersection()
 
     def start(self) -> None:
+        """
+        Log information related to bit signaling. Must be called after the storage is ready and migrations have
+        been applied.
+        """
         best_block = self._tx_storage.get_best_block()
 
         self._warn_non_signaling_features(best_block)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -269,8 +269,6 @@ class HathorManager:
         if self._enable_event_queue:
             self._event_manager.start(not_none(self.my_peer.id))
 
-        self._bit_signaling_service.start()
-
         self.state = self.NodeState.INITIALIZING
         self.pubsub.publish(HathorEvents.MANAGER_ON_START)
         self._event_manager.load_started()
@@ -545,6 +543,8 @@ class HathorManager:
 
         self.tx_storage.pre_init()
         assert self.tx_storage.indexes is not None
+
+        self._bit_signaling_service.start()
 
         started_at = int(time.time())
         last_started_at = self.tx_storage.get_last_started_at()

--- a/hathor/transaction/storage/migrations/add_feature_activation_bit_counts_metadata.py
+++ b/hathor/transaction/storage/migrations/add_feature_activation_bit_counts_metadata.py
@@ -1,0 +1,41 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+
+from hathor.transaction.storage.migrations import BaseMigration
+from hathor.util import progress
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage import TransactionStorage
+
+logger = get_logger()
+
+
+class Migration(BaseMigration):
+    def skip_empty_db(self) -> bool:
+        return True
+
+    def get_db_name(self) -> str:
+        return 'add_feature_activation_bit_counts_metadata'
+
+    def run(self, storage: 'TransactionStorage') -> None:
+        log = logger.new()
+        topological_iterator = storage.topological_iterator()
+
+        for vertex in progress(topological_iterator, log=log, total=None):
+            if vertex.is_block:
+                vertex.update_initial_metadata()

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -35,7 +35,12 @@ from hathor.transaction.storage.exceptions import (
     TransactionIsNotABlock,
     TransactionNotInAllowedScopeError,
 )
-from hathor.transaction.storage.migrations import BaseMigration, MigrationState, add_min_height_metadata
+from hathor.transaction.storage.migrations import (
+    BaseMigration,
+    MigrationState,
+    add_feature_activation_bit_counts_metadata,
+    add_min_height_metadata,
+)
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope, tx_allow_context
 from hathor.transaction.transaction import Transaction
 from hathor.transaction.transaction_metadata import TransactionMetadata
@@ -81,6 +86,7 @@ class TransactionStorage(ABC):
     # history of migrations that have to be applied in the order defined here
     _migration_factories: list[type[BaseMigration]] = [
         add_min_height_metadata.Migration,
+        add_feature_activation_bit_counts_metadata.Migration,
     ]
 
     _migrations: list[BaseMigration]


### PR DESCRIPTION
### Motivation

During the latest release, we noticed that full node initialization could fail depending on the snapshot state (only on testnet). This was caused by a missing migration on the new Feature Activation metadata attribute.

### Acceptance Criteria

- Rename `BitSignalingService.start()` to `generate_initial_logs()` and add docstring. Also move call to after migrations are applied in `HathorManager`.
- Implement `add_feature_activation_bit_counts_metadata` migration.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 