### PR TITLE
refactor(sync-v2): Refactor sync_v2 agent to hold (block_height, block_id) information in an internal namedtuple

### DIFF
--- a/tests/p2p/test_get_best_blockchain.py
+++ b/tests/p2p/test_get_best_blockchain.py
@@ -18,6 +18,8 @@ settings = HathorSettings()
 
 class BaseGetBestBlockchainTestCase(SimulatorTestCase):
 
+    seed_config = 6
+
     def _send_cmd(self, proto, cmd, payload=None):
         if not payload:
             line = '{}\r\n'.format(cmd)

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -503,9 +503,9 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         # check they have the same consensus
         node_sync1 = conn.proto1.state.sync_agent
         node_sync2 = conn.proto2.state.sync_agent
-        self.assertEqual(node_sync1.peer_height, height)
-        self.assertEqual(node_sync1.synced_height, height)
-        self.assertEqual(node_sync2.peer_height, height)
+        self.assertEqual(node_sync1.peer_best_block.height, height)
+        self.assertEqual(node_sync1.synced_block.height, height)
+        self.assertEqual(node_sync2.peer_best_block.height, height)
         # 3 genesis + blocks + 8 txs
         self.assertEqual(self.manager1.tx_storage.get_vertices_count(), height + 11)
         self.assertEqual(manager2.tx_storage.get_vertices_count(), height + 11)
@@ -527,14 +527,14 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
 
         node_sync1 = self.conn1.proto1.state.sync_agent
         self.assertEqual(self.manager1.tx_storage.latest_timestamp, self.manager2.tx_storage.latest_timestamp)
-        self.assertEqual(node_sync1.peer_height, node_sync1.synced_height)
-        self.assertEqual(node_sync1.peer_height, self.manager1.tx_storage.get_height_best_block())
+        self.assertEqual(node_sync1.peer_best_block, node_sync1.synced_block)
+        self.assertEqual(node_sync1.peer_best_block.height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, self.manager2)
 
         node_sync2 = self.conn2.proto1.state.sync_agent
         self.assertEqual(self.manager2.tx_storage.latest_timestamp, self.manager3.tx_storage.latest_timestamp)
-        self.assertEqual(node_sync2.peer_height, node_sync2.synced_height)
-        self.assertEqual(node_sync2.peer_height, self.manager2.tx_storage.get_height_best_block())
+        self.assertEqual(node_sync2.peer_best_block, node_sync2.synced_block)
+        self.assertEqual(node_sync2.peer_best_block.height, self.manager2.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager2, self.manager3)
 
     def test_block_sync_new_blocks_and_txs(self):
@@ -560,8 +560,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
 
         node_sync = conn.proto1.state.sync_agent
         self.assertEqual(self.manager1.tx_storage.latest_timestamp, manager2.tx_storage.latest_timestamp)
-        self.assertEqual(node_sync.peer_height, node_sync.synced_height)
-        self.assertEqual(node_sync.peer_height, self.manager1.tx_storage.get_height_best_block())
+        self.assertEqual(node_sync.peer_best_block, node_sync.synced_block)
+        self.assertEqual(node_sync.peer_best_block.height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, manager2)
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
@@ -581,8 +581,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             self.clock.advance(1)
 
         node_sync = conn.proto1.state.sync_agent
-        self.assertEqual(node_sync.peer_height, node_sync.synced_height)
-        self.assertEqual(node_sync.peer_height, self.manager1.tx_storage.get_height_best_block())
+        self.assertEqual(node_sync.peer_best_block, node_sync.synced_block)
+        self.assertEqual(node_sync.peer_best_block.height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, manager2)
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
@@ -602,8 +602,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             self.clock.advance(1)
 
         node_sync = conn.proto1.state.sync_agent
-        self.assertEqual(node_sync.peer_height, node_sync.synced_height)
-        self.assertEqual(node_sync.peer_height, self.manager1.tx_storage.get_height_best_block())
+        self.assertEqual(node_sync.peer_best_block, node_sync.synced_block)
+        self.assertEqual(node_sync.peer_best_block.height, self.manager1.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager1, manager2)
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
@@ -664,9 +664,9 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
 
         node_sync1 = conn.proto1.state.sync_agent
         node_sync2 = conn.proto2.state.sync_agent
-        self.assertEqual(node_sync1.peer_height, common_height)
-        self.assertEqual(node_sync1.synced_height, common_height)
-        self.assertEqual(node_sync2.peer_height, common_height)
+        self.assertEqual(node_sync1.peer_best_block.height, common_height)
+        self.assertEqual(node_sync1.synced_block.height, common_height)
+        self.assertEqual(node_sync2.peer_best_block.height, common_height)
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
         self.assertConsensusEqual(self.manager1, manager2)
@@ -715,9 +715,9 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         node_sync1 = conn.proto1.state.sync_agent
         node_sync2 = conn.proto2.state.sync_agent
 
-        self.assertEqual(node_sync1.peer_height, TOTAL_BLOCKS)
-        self.assertEqual(node_sync1.synced_height, TOTAL_BLOCKS)
-        self.assertEqual(node_sync2.peer_height, len(blocks))
+        self.assertEqual(node_sync1.peer_best_block.height, TOTAL_BLOCKS)
+        self.assertEqual(node_sync1.synced_block.height, TOTAL_BLOCKS)
+        self.assertEqual(node_sync2.peer_best_block.height, len(blocks))
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
@@ -738,8 +738,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             self.clock.advance(1)
 
         node_sync = conn.proto1.state.sync_agent
-        self.assertEqual(node_sync.synced_height, 0)
-        self.assertEqual(node_sync.peer_height, 0)
+        self.assertEqual(node_sync.synced_block.height, 0)
+        self.assertEqual(node_sync.peer_best_block.height, 0)
 
         self.assertEqual(self.manager1.tx_storage.get_vertices_count(), 3)
         self.assertEqual(manager2.tx_storage.get_vertices_count(), 3)

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -157,14 +157,10 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, BaseRandomSimulatorTe
 class SyncV2RandomSimulatorTestCase(unittest.SyncV2Params, BaseRandomSimulatorTestCase):
     __test__ = True
 
-    seed_config = 3
-
 
 # sync-bridge should behave like sync-v2
 class SyncBridgeRandomSimulatorTestCase(unittest.SyncBridgeParams, SyncV2RandomSimulatorTestCase):
     __test__ = True
-
-    seed_config = 4
 
     def test_compare_mempool_implementations(self):
         manager1 = self.create_peer()

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -10,7 +10,6 @@ from structlog import get_logger
 from twisted.trial import unittest
 
 from hathor.builder import BuildArtifacts, Builder
-from hathor.cli.util import setup_logging
 from hathor.conf import HathorSettings
 from hathor.conf.get_settings import get_settings
 from hathor.daa import TestMode, _set_test_mode
@@ -105,7 +104,6 @@ class TestCase(unittest.TestCase):
     seed_config: Optional[int] = None
 
     def setUp(self):
-        setup_logging()
         _set_test_mode(TestMode.TEST_ALL_WEIGHT)
         self.tmpdirs = []
         self.clock = TestMemoryReactorClock()
@@ -473,7 +471,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
 
     def assertV2SyncedProgress(self, node_sync):
-        self.assertEqual(node_sync.synced_height, node_sync.peer_height)
+        self.assertEqual(node_sync.synced_block, node_sync.peer_best_block)
 
     def clean_tmpdirs(self):
         for tmpdir in self.tmpdirs:


### PR DESCRIPTION
### Motivation

Sync-v2 agent code uses the pair `(block_height, block_hash)` multiple times. So this PR refactors it to use a namedtuple `BlockInfo` (instead of handling with both information separately).

### Acceptance Criteria

1. Add `hathor.p2p.sync_v2.agent.BlockInfo`.
2. Add `hathor.p2p.sync_v2.agent.NodeBlockSync.get_my_best_block()` method.
3. Refactor `find_best_common_block()` and `run_sync_blocks()` methds to use `BlockInfo`.
4. Rename variables `(synced, not_synced)` to `(lo, hi)` in the n-ary search.
5. There are two behavior changes in this PR: (i) change of keys in the `get_status()`, and (ii) using `lo=0` instead of `lo=self.synced_block.height`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 