### PR TITLE
refactor(verification): organization and typing improvements [part 1/9]

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -929,9 +929,10 @@ class HathorManager:
             raise NonStandardTxError('Transaction is non standard.')
 
         # Validate tx.
-        success, message = self.verification_service.validate_vertex_error(tx)
-        if not success:
-            raise InvalidNewTransaction(message)
+        try:
+            self.verification_service.verify(tx)
+        except TxValidationError as e:
+            raise InvalidNewTransaction(str(e))
 
         self.propagate_tx(tx, fails_silently=False)
 

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -139,7 +139,7 @@ class BaseTransaction(ABC):
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
                  signal_bits: int = 0,
-                 version: int = TxVersion.REGULAR_BLOCK,
+                 version: TxVersion = TxVersion.REGULAR_BLOCK,
                  weight: float = 0,
                  inputs: Optional[list['TxInput']] = None,
                  outputs: Optional[list['TxOutput']] = None,

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -47,7 +47,7 @@ class Block(BaseTransaction):
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
                  signal_bits: int = 0,
-                 version: int = TxVersion.REGULAR_BLOCK,
+                 version: TxVersion = TxVersion.REGULAR_BLOCK,
                  weight: float = 0,
                  outputs: Optional[list[TxOutput]] = None,
                  parents: Optional[list[bytes]] = None,

--- a/hathor/transaction/merge_mined_block.py
+++ b/hathor/transaction/merge_mined_block.py
@@ -28,7 +28,7 @@ class MergeMinedBlock(Block):
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
                  signal_bits: int = 0,
-                 version: int = TxVersion.MERGE_MINED_BLOCK,
+                 version: TxVersion = TxVersion.MERGE_MINED_BLOCK,
                  weight: float = 0,
                  outputs: Optional[list[TxOutput]] = None,
                  parents: Optional[list[bytes]] = None,

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -36,7 +36,7 @@ class TokenCreationTransaction(Transaction):
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
                  signal_bits: int = 0,
-                 version: int = TxVersion.TOKEN_CREATION_TRANSACTION,
+                 version: TxVersion = TxVersion.TOKEN_CREATION_TRANSACTION,
                  weight: float = 0,
                  inputs: Optional[list[TxInput]] = None,
                  outputs: Optional[list[TxOutput]] = None,

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -57,7 +57,7 @@ class Transaction(BaseTransaction):
                  nonce: int = 0,
                  timestamp: Optional[int] = None,
                  signal_bits: int = 0,
-                 version: int = TxVersion.REGULAR_TRANSACTION,
+                 version: TxVersion = TxVersion.REGULAR_TRANSACTION,
                  weight: float = 0,
                  inputs: Optional[list[TxInput]] = None,
                  outputs: Optional[list[TxOutput]] = None,

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -75,17 +75,6 @@ class TransactionVerifier(VertexVerifier):
         if reject_locked_reward:
             self.verify_reward_locked(tx)
 
-    def verify_unsigned_skip_pow(self, tx: Transaction) -> None:
-        """ Same as .verify but skipping pow and signature verification."""
-        self.verify_number_of_inputs(tx)
-        self.verify_number_of_outputs(tx)
-        self.verify_outputs(tx)
-        self.verify_sigops_output(tx)
-        self.verify_sigops_input(tx)
-        self.verify_inputs(tx, skip_script=True)  # need to run verify_inputs first to check if all inputs exist
-        self.verify_parents(tx)
-        self.verify_sum(tx)
-
     def verify_parents_basic(self, tx: Transaction) -> None:
         """Verify number and non-duplicity of parents."""
         assert tx.storage is not None

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -14,11 +14,12 @@
 
 from typing import NamedTuple
 
+from typing_extensions import assert_never
+
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion
-from hathor.transaction.exceptions import TxValidationError
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.validation_state import ValidationState
 from hathor.verification.block_verifier import BlockVerifier
@@ -107,76 +108,64 @@ class VerificationService:
         """Basic verifications (the ones without access to dependencies: parents+inputs). Raises on error.
 
         Used by `self.validate_basic`. Should not modify the validation state."""
+        # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
-                assert isinstance(vertex, Block)
+                assert type(vertex) is Block
                 self.verifiers.block.verify_basic(
                     vertex,
                     skip_block_weight_verification=skip_block_weight_verification
                 )
             case TxVersion.MERGE_MINED_BLOCK:
-                assert isinstance(vertex, MergeMinedBlock)
+                assert type(vertex) is MergeMinedBlock
                 self.verifiers.merge_mined_block.verify_basic(
                     vertex,
                     skip_block_weight_verification=skip_block_weight_verification
                 )
             case TxVersion.REGULAR_TRANSACTION:
-                assert isinstance(vertex, Transaction)
+                assert type(vertex) is Transaction
                 self.verifiers.tx.verify_basic(vertex)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
-                assert isinstance(vertex, TokenCreationTransaction)
+                assert type(vertex) is TokenCreationTransaction
                 self.verifiers.token_creation_tx.verify_basic(vertex)
             case _:
-                raise NotImplementedError
+                assert_never(vertex.version)
 
     def verify(self, vertex: BaseTransaction, *, reject_locked_reward: bool = True) -> None:
         """Run all verifications. Raises on error.
 
         Used by `self.validate_full`. Should not modify the validation state."""
+        # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
-                assert isinstance(vertex, Block)
+                assert type(vertex) is Block
                 self.verifiers.block.verify(vertex)
             case TxVersion.MERGE_MINED_BLOCK:
-                assert isinstance(vertex, MergeMinedBlock)
+                assert type(vertex) is MergeMinedBlock
                 self.verifiers.merge_mined_block.verify(vertex)
             case TxVersion.REGULAR_TRANSACTION:
-                assert isinstance(vertex, Transaction)
+                assert type(vertex) is Transaction
                 self.verifiers.tx.verify(vertex, reject_locked_reward=reject_locked_reward)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
-                assert isinstance(vertex, TokenCreationTransaction)
+                assert type(vertex) is TokenCreationTransaction
                 self.verifiers.token_creation_tx.verify(vertex, reject_locked_reward=reject_locked_reward)
             case _:
-                raise NotImplementedError
+                assert_never(vertex.version)
 
     def verify_without_storage(self, vertex: BaseTransaction) -> None:
+        # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
-                assert isinstance(vertex, Block)
+                assert type(vertex) is Block
                 self.verifiers.block.verify_without_storage(vertex)
             case TxVersion.MERGE_MINED_BLOCK:
-                assert isinstance(vertex, MergeMinedBlock)
+                assert type(vertex) is MergeMinedBlock
                 self.verifiers.merge_mined_block.verify_without_storage(vertex)
             case TxVersion.REGULAR_TRANSACTION:
-                assert isinstance(vertex, Transaction)
+                assert type(vertex) is Transaction
                 self.verifiers.tx.verify_without_storage(vertex)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
-                assert isinstance(vertex, TokenCreationTransaction)
+                assert type(vertex) is TokenCreationTransaction
                 self.verifiers.token_creation_tx.verify_without_storage(vertex)
             case _:
-                raise NotImplementedError
-
-    def validate_vertex_error(self, vertex: BaseTransaction) -> tuple[bool, str]:
-        """ Verify if tx is valid and return success and possible error message
-
-            :return: Success if tx is valid and possible error message, if not
-            :rtype: tuple[bool, str]
-        """
-        success = True
-        message = ''
-        try:
-            self.verify(vertex)
-        except TxValidationError as e:
-            success = False
-            message = str(e)
-        return success, message
+                assert_never(vertex.version)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1897,13 +1897,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.8.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
+    {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
 ]
 
 [[package]]
@@ -2135,4 +2135,4 @@ sentry = ["sentry-sdk", "structlog-sentry"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "9897502edcb704e27fc11d44c881c89ca5858e9513b31f15615a1f9b216e2868"
+content-hash = "1a2830d269a9d5a6fe449b5e884438b5f17a5dacd89110b7ada5af2026c4ab97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ structlog-sentry = {version = "^1.4.0", optional = true}
 hathorlib = "0.3.0"
 pydantic = "~1.10.13"
 pyyaml = "^6.0.1"
+typing-extensions = "~4.8.0"
 
 [tool.poetry.extras]
 sentry = ["sentry-sdk", "structlog-sentry"]

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -39,6 +39,7 @@ class BaseVerificationTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.manager: HathorManager = self.create_peer('network')
+        self.verifiers = self.manager.verification_service.verifiers
 
     def _get_valid_block(self) -> Block:
         return Block(
@@ -103,11 +104,10 @@ class BaseVerificationTest(unittest.TestCase):
         return create_tokens(self.manager, self.manager.wallet.get_unused_address())
 
     def test_block_verify_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
@@ -120,15 +120,14 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_wrapped.assert_called_once()
 
     def test_block_verify_without_storage(self) -> None:
-        verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.block.verify_sigops_output)
 
         with (
             patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -138,7 +137,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            verifier.verify_without_storage(block)
+            self.verifiers.block.verify_without_storage(block)
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
@@ -149,18 +148,17 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_block_verify(self) -> None:
-        verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_height_wrapped = Mock(wraps=verifier.verify_height)
-        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.block.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.block.verify_parents)
+        verify_height_wrapped = Mock(wraps=self.verifiers.block.verify_height)
+        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.block.verify_mandatory_signaling)
 
         with (
             patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -187,11 +185,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_mandatory_signaling_wrapped.assert_called_once()
 
     def test_block_validate_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
@@ -204,20 +201,19 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_wrapped.assert_called_once()
 
     def test_block_validate_full(self) -> None:
-        verifier = self.manager.verification_service.verifiers.block
         block = self._get_valid_block()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_height_wrapped = Mock(wraps=verifier.verify_height)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
-        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.block.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.block.verify_parents)
+        verify_height_wrapped = Mock(wraps=self.verifiers.block.verify_height)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
+        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.block.verify_mandatory_signaling)
 
         with (
             patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -248,11 +244,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_mandatory_signaling_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_reward)
 
         with (
             patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
@@ -265,17 +260,16 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify_without_storage(self) -> None:
-        verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_sigops_output)
 
-        verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
+        verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
             patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -286,7 +280,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
-            verifier.verify_without_storage(block)
+            self.verifiers.merge_mined_block.verify_without_storage(block)
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
@@ -300,20 +294,19 @@ class BaseVerificationTest(unittest.TestCase):
         verify_pow_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify(self) -> None:
-        verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_height_wrapped = Mock(wraps=verifier.verify_height)
-        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_parents)
+        verify_height_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_height)
+        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_mandatory_signaling)
 
-        verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
+        verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
             patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -344,11 +337,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_pow_wrapped.assert_called_once()
 
     def test_merge_mined_block_validate_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_reward)
 
         with (
             patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
@@ -361,22 +353,21 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_wrapped.assert_called_once()
 
     def test_merge_mined_block_validate_full(self) -> None:
-        verifier = self.manager.verification_service.verifiers.merge_mined_block
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=verifier.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=verifier.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_height_wrapped = Mock(wraps=verifier.verify_height)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_reward_wrapped = Mock(wraps=verifier.verify_reward)
-        verify_mandatory_signaling_wrapped = Mock(wraps=verifier.verify_mandatory_signaling)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_parents)
+        verify_height_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_height)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_reward)
+        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_mandatory_signaling)
 
-        verify_aux_pow_wrapped = Mock(wraps=verifier.verify_aux_pow)
+        verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
             patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
@@ -411,16 +402,15 @@ class BaseVerificationTest(unittest.TestCase):
         verify_pow_wrapped.assert_called_once()
 
     def test_transaction_verify_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
@@ -443,14 +433,13 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_verify_without_storage(self) -> None:
-        verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
             patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
@@ -459,7 +448,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            verifier.verify_without_storage(tx)
+            self.verifiers.tx.verify_without_storage(tx)
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
@@ -469,21 +458,20 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_verify(self) -> None:
-        verifier = self.manager.verification_service.verifiers.tx
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
-        verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
+        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
+        verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.tx.verify_parents)
+        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
 
         with (
             patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
@@ -514,16 +502,15 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped.assert_called_once()
 
     def test_transaction_validate_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.tx
         tx = self._get_valid_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
@@ -546,23 +533,22 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_validate_full(self) -> None:
-        verifier = self.manager.verification_service.verifiers.tx
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
-        verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
+        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
+        verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.tx.verify_parents)
+        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
 
         with (
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
@@ -597,16 +583,15 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
@@ -630,14 +615,13 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify_without_storage(self) -> None:
-        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
@@ -647,7 +631,7 @@ class BaseVerificationTest(unittest.TestCase):
                          verify_number_of_outputs_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            verifier.verify_without_storage(tx)
+            self.verifiers.token_creation_tx.verify_without_storage(tx)
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
@@ -657,22 +641,21 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify(self) -> None:
-        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
-        verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
+        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_inputs)
+        verify_script_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_script)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents)
+        verify_sum_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_reward_locked)
 
-        verify_token_info_wrapped = Mock(wraps=verifier.verify_token_info)
+        verify_token_info_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_token_info)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
@@ -708,16 +691,15 @@ class BaseVerificationTest(unittest.TestCase):
         verify_token_info_wrapped.assert_called_once()
 
     def test_token_creation_transaction_validate_basic(self) -> None:
-        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
@@ -741,25 +723,24 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_validate_full(self) -> None:
-        verifier = self.manager.verification_service.verifiers.token_creation_tx
         tx = self._get_valid_token_creation_tx()
         tx.get_metadata().validation = ValidationState.INITIAL
 
-        verify_parents_basic_wrapped = Mock(wraps=verifier.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=verifier.verify_weight)
-        verify_pow_wrapped = Mock(wraps=verifier.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=verifier.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=verifier.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=verifier.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=verifier.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=verifier.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=verifier.verify_inputs)
-        verify_script_wrapped = Mock(wraps=verifier.verify_script)
-        verify_parents_wrapped = Mock(wraps=verifier.verify_parents)
-        verify_sum_wrapped = Mock(wraps=verifier.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=verifier.verify_reward_locked)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
+        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_inputs)
+        verify_script_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_script)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents)
+        verify_sum_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_reward_locked)
 
-        verify_token_info_wrapped = Mock(wraps=verifier.verify_token_info)
+        verify_token_info_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_token_info)
 
         with (
             patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),


### PR DESCRIPTION
### Motivation

This PR is the first one in a series of 9 PRs that finishes the vertex verification refactors. The objective is to completely remove all inheritance from the verification process, removing implicit dependencies between verifiers, streamlining the verification process and improving clarity on the scope/origin of each verification method, all to improve code readability, maintainability, and patching (for the simulator).

This is done incrementally. In previous PRs, we moved the verification out of the model classes. Now, in this series, we'll first change inheritance to composition, and then completely remove the composition too, leaving each verifier with the least possible amount of dependencies.

Also, in this PR, we install the [typing_extensions](https://github.com/python/typing_extensions) dev dependency. This is a project from the official Python organization, and what it does is enable use of new type system features on older Python versions. In other words, it simply allows us to use features from the `typing` module that are not available in all Python versions we support.

Specifically, for this refactor we'll use [`assert_never()`](https://typing.readthedocs.io/en/latest/source/unreachable.html), a function to be used were we would normally use something like `assert False`, but that can be correctly type-checked by mypy. This improves robustness of `match` statements for example, that can be made exhaustive with this. We also use the [`@override`](https://peps.python.org/pep-0698/) annotation in next PRs, improving robustness and safety guarantees of inheritance. We may also find other useful typing features in the future that wouldn't be available otherwise.

### Acceptance Criteria

- Change `BaseTransaction` and all subclasses to use `TxVersion` as the `version` type, instead of `int`.
- Install the `typing_extensions` dev dependency.
- Move `verify_unsigned_skip_pow()` from `TransactionVerifier` to `create_tx.py`. This resolves https://github.com/HathorNetwork/hathor-core/issues/825.
- In `VerificationService`:
  - Change all `isinstance()` checks to `type() is`, which is more restrictive.
  - Change `raise NotImplementedError` usages in `match` statements to `assert_never()`, which can be checked by the static type checker.
  - Remove `validate_vertex_error()`, inlining it `HathorManager`.
- Set `self.verifiers` variable in `test_verification`, updating all usages. This will be useful in the next PRs.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 