### PR TITLE
refactor(verification): refactor verify_sum [part 2/9]

### DIFF
--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -186,8 +186,7 @@ class TransactionVerifier(VertexVerifier):
         :raises InvalidToken: when there's an error in token operations
         :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
         """
-        token_dict = tx.get_token_info_from_inputs()
-        self.update_token_info_from_outputs(tx, token_dict=token_dict)
+        token_dict = self.get_complete_token_info(tx)
         self.verify_authorities_and_deposit(token_dict)
 
     def verify_reward_locked(self, tx: Transaction) -> None:
@@ -290,3 +289,12 @@ class TransactionVerifier(VertexVerifier):
                     # for regular outputs, just subtract from the total amount
                     sum_tokens = token_info.amount + tx_output.value
                     token_dict[token_uid] = TokenInfo(sum_tokens, token_info.can_mint, token_info.can_melt)
+
+    def get_complete_token_info(self, tx: Transaction) -> dict[TokenUid, TokenInfo]:
+        """
+        Get a complete token info dict, including data from both inputs and outputs.
+        """
+        token_dict = tx.get_token_info_from_inputs()
+        self.update_token_info_from_outputs(tx, token_dict=token_dict)
+
+        return token_dict


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/830

### Motivation

Currently, `TokenCreationTransactionVerifier.verify_sum()` has duplicate code from `TransactionVerifier.verify_sum()`. This PR changes it so it calls the super method instead.

### Acceptance Criteria

- Implement `TransactionVerifier.get_complete_token_info()` and update its `verify_sum()` to use it.
- Implement `TokenCreationTransaction.get_token_info_from_inputs()`, overriding the `Transaction` implementation.
- Update `TokenCreationTransaction.verify_sum()` to use the new `get_complete_token_info()`.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 