### PR TITLE
refactor(verification): remove BlockVerifier inheritance [part 4/9]

### DIFF
--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -138,11 +138,12 @@ def execute(args: Namespace) -> None:
 
         try:
             from hathor.daa import DifficultyAdjustmentAlgorithm
-            from hathor.verification.block_verifier import BlockVerifier
+            from hathor.verification.verification_service import VerificationService, VertexVerifiers
             settings = get_settings()
             daa = DifficultyAdjustmentAlgorithm(settings=settings)
-            verifier = BlockVerifier(settings=settings, daa=daa)
-            verifier.verify_without_storage(block)
+            verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
+            verification_service = VerificationService(verifiers=verifiers)
+            verification_service.verify_without_storage(block)
         except HathorError:
             print('[{}] ERROR: Block has not been pushed because it is not valid.'.format(datetime.datetime.now()))
         else:

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -259,11 +259,7 @@ def _build_vertex_verifiers(
     """
     return VertexVerifiers(
         block=SimulatorBlockVerifier(settings=settings, daa=daa, feature_service=feature_service),
-        merge_mined_block=SimulatorMergeMinedBlockVerifier(
-            settings=settings,
-            daa=daa,
-            feature_service=feature_service
-        ),
+        merge_mined_block=SimulatorMergeMinedBlockVerifier(),
         tx=SimulatorTransactionVerifier(settings=settings, daa=daa),
         token_creation_tx=SimulatorTokenCreationTransactionVerifier(settings=settings, daa=daa),
     )

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -15,7 +15,6 @@
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling, FeatureService
-from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block
 from hathor.transaction.exceptions import (
     BlockMustSignalError,
@@ -27,8 +26,6 @@ from hathor.transaction.exceptions import (
     WeightError,
 )
 from hathor.verification.vertex_verifier import VertexVerifier
-
-cpu = get_cpu_profiler()
 
 
 class BlockVerifier(VertexVerifier):
@@ -43,45 +40,6 @@ class BlockVerifier(VertexVerifier):
     ) -> None:
         super().__init__(settings=settings, daa=daa)
         self._feature_service = feature_service
-
-    def verify_basic(self, block: Block, *, skip_block_weight_verification: bool = False) -> None:
-        """Partially run validations, the ones that need parents/inputs are skipped."""
-        if not skip_block_weight_verification:
-            self.verify_weight(block)
-        self.verify_reward(block)
-
-    @cpu.profiler(key=lambda _, block: 'block-verify!{}'.format(block.hash.hex()))
-    def verify(self, block: Block) -> None:
-        """
-            (1) confirms at least two pending transactions and references last block
-            (2) solves the pow with the correct weight (done in HathorManager)
-            (3) creates the correct amount of tokens in the output (done in HathorManager)
-            (4) all parents must exist and have timestamp smaller than ours
-            (5) data field must contain at most BLOCK_DATA_MAX_SIZE bytes
-            (6) whether this block must signal feature support
-        """
-        # TODO Should we validate a limit of outputs?
-        if block.is_genesis:
-            # TODO do genesis validation
-            return
-
-        self.verify_without_storage(block)
-
-        # (1) and (4)
-        self.verify_parents(block)
-
-        self.verify_height(block)
-
-        self.verify_mandatory_signaling(block)
-
-    def verify_without_storage(self, block: Block) -> None:
-        """ Run all verifications that do not need a storage.
-        """
-        self.verify_pow(block)
-        self.verify_no_inputs(block)
-        self.verify_outputs(block)
-        self.verify_data(block)
-        self.verify_sigops_output(block)
 
     def verify_height(self, block: Block) -> None:
         """Validate that the block height is enough to confirm all transactions being confirmed."""

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -12,17 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from hathor.transaction import Block, MergeMinedBlock
-from hathor.verification.block_verifier import BlockVerifier
+from hathor.transaction import MergeMinedBlock
 
 
-class MergeMinedBlockVerifier(BlockVerifier):
+class MergeMinedBlockVerifier:
     __slots__ = ()
-
-    def verify_without_storage(self, block: Block) -> None:
-        assert isinstance(block, MergeMinedBlock)
-        self.verify_aux_pow(block)
-        super().verify_without_storage(block)
 
     def verify_aux_pow(self, block: MergeMinedBlock) -> None:
         """ Verify auxiliary proof-of-work (for merged mining).

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -137,7 +137,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.verifiers.block.verify_without_storage(block)
+            self.manager.verification_service.verify_without_storage(block)
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
@@ -270,12 +270,12 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_verify_basic(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        verify_weight_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_weight)
-        verify_reward_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_reward)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
-            patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_reward', verify_reward_wrapped),
+            patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
+            patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
             self.manager.verification_service.verify_basic(block)
 
@@ -286,25 +286,25 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_verify_without_storage(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_sigops_output)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.block.verify_sigops_output)
 
         verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
-            patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
+            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
+            patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
-            self.verifiers.merge_mined_block.verify_without_storage(block)
+            self.manager.verification_service.verify_without_storage(block)
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
@@ -320,29 +320,29 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_verify(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_parents)
-        verify_height_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_height)
-        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_mandatory_signaling)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.block.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.block.verify_parents)
+        verify_height_wrapped = Mock(wraps=self.verifiers.block.verify_height)
+        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.block.verify_mandatory_signaling)
 
         verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
-            patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_height', verify_height_wrapped),
+            patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
+            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
+            patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(BlockVerifier, 'verify_parents', verify_parents_wrapped),
+            patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
+            patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
             self.manager.verification_service.verify(block)
 
@@ -363,12 +363,12 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_validate_basic(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        verify_weight_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_weight)
-        verify_reward_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_reward)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
-            patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_reward', verify_reward_wrapped),
+            patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
+            patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
             self.manager.verification_service.validate_basic(block)
 
@@ -403,33 +403,33 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_validate_full(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        verify_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_pow)
-        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_number_of_outputs)
-        verify_data_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_data)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_sigops_output)
-        verify_parents_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_parents)
-        verify_height_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_height)
-        verify_weight_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_weight)
-        verify_reward_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_reward)
-        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_mandatory_signaling)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.block.verify_pow)
+        verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_number_of_outputs)
+        verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.block.verify_sigops_output)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.block.verify_parents)
+        verify_height_wrapped = Mock(wraps=self.verifiers.block.verify_height)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
+        verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
+        verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.block.verify_mandatory_signaling)
 
         verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
-            patch.object(MergeMinedBlockVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_data', verify_data_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_height', verify_height_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_reward', verify_reward_wrapped),
+            patch.object(BlockVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
+            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
+            patch.object(BlockVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(BlockVerifier, 'verify_parents', verify_parents_wrapped),
+            patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
+            patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
+            patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
+            patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
             self.manager.verification_service.validate_full(block)
 


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/832

### Motivation

Simplify block verification by removing the `BlockVerifier` inheritance from `MergeMinedBlockVerifier`, as it was not necessary.

To do that, the main verification "entrypoints" (`verify_basic()`, `verify()`, and `verify_without_storage()`) are moved to the `VerificationService`, making it a single source of verification definition for all vertex types (the same will be done for other types in the next PRs).

This also guarantees that it's not possible to call `BlockVerifier.verify()`  with a `MergeMinedBlock`, for example, which would be wrong. By using the single implementation from the `VerificationService`, we make sure the most specific verifier is called.

### Acceptance Criteria

- Move `verify_basic()`, `verify()`, and `verify_without_storage()` from `BlockVerifier` to `VerificationService`.
- Move `verify_without_storage()` from `MergeMinedBlockVerifier` to `VerificationService`, removing its `BlockVerifier` inheritance, which is not needed anymore.
- Update usages accordingly.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 