### PR TITLE
refactor(verification): remove TransactionVerifier inheritance [part 5/9]

### DIFF
--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -261,5 +261,5 @@ def _build_vertex_verifiers(
         block=SimulatorBlockVerifier(settings=settings, daa=daa, feature_service=feature_service),
         merge_mined_block=SimulatorMergeMinedBlockVerifier(),
         tx=SimulatorTransactionVerifier(settings=settings, daa=daa),
-        token_creation_tx=SimulatorTokenCreationTransactionVerifier(settings=settings, daa=daa),
+        token_creation_tx=SimulatorTokenCreationTransactionVerifier(settings=settings),
     )

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -12,24 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from hathor.conf.settings import HathorSettings
 from hathor.transaction.exceptions import InvalidToken, TransactionDataError
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.util import clean_token_string
 from hathor.util import not_none
-from hathor.verification.transaction_verifier import TransactionVerifier
 
 
-class TokenCreationTransactionVerifier(TransactionVerifier):
-    __slots__ = ()
+class TokenCreationTransactionVerifier:
+    __slots__ = ('_settings',)
 
-    def verify(self, tx: TokenCreationTransaction, *, reject_locked_reward: bool = True) -> None:
-        """ Run all validations as regular transactions plus validation on token info.
-
-        We also overload verify_sum to make some different checks
-        """
-        super().verify(tx, reject_locked_reward=reject_locked_reward)
-        self.verify_minted_tokens(tx)
-        self.verify_token_info(tx)
+    def __init__(self, *, settings: HathorSettings) -> None:
+        self._settings = settings
 
     def verify_minted_tokens(self, tx: TokenCreationTransaction) -> None:
         """ Besides all checks made on regular transactions, a few extra ones are made:

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -496,7 +496,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.verifiers.tx.verify_without_storage(tx)
+            self.manager.verification_service.verify_without_storage(tx)
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
@@ -709,23 +709,22 @@ class BaseVerificationTest(unittest.TestCase):
     def test_token_creation_transaction_verify_basic(self) -> None:
         tx = self._get_valid_token_creation_tx()
 
-        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
-        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
-                         verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_basic(tx)
 
@@ -741,21 +740,20 @@ class BaseVerificationTest(unittest.TestCase):
     def test_token_creation_transaction_verify_without_storage(self) -> None:
         tx = self._get_valid_token_creation_tx()
 
-        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
-                         verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.verifiers.token_creation_tx.verify_without_storage(tx)
+            self.manager.verification_service.verify_without_storage(tx)
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
@@ -767,34 +765,33 @@ class BaseVerificationTest(unittest.TestCase):
     def test_token_creation_transaction_verify(self) -> None:
         tx = self._get_valid_token_creation_tx()
 
-        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_inputs)
-        verify_script_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_script)
-        verify_parents_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents)
-        verify_sum_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_reward_locked)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
+        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
+        verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.tx.verify_parents)
+        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
 
         verify_token_info_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_token_info)
         verify_minted_tokens_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_minted_tokens)
 
         with (
-            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
-                         verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_script', verify_script_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sum', verify_sum_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
+            patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents', verify_parents_wrapped),
+            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_minted_tokens', verify_minted_tokens_wrapped),
         ):
@@ -821,23 +818,22 @@ class BaseVerificationTest(unittest.TestCase):
         tx = self._get_valid_token_creation_tx()
         tx.get_metadata().validation = ValidationState.INITIAL
 
-        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
-        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
-                         verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.validate_basic(tx)
 
@@ -858,24 +854,22 @@ class BaseVerificationTest(unittest.TestCase):
         self.assertEqual(tx.get_metadata().validation, ValidationState.FULL)
 
         # and if running basic validation again it shouldn't validate or change the validation state
-        verify_parents_basic_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
-        verify_weight_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
-        verify_pow_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
-        verify_number_of_inputs_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
-        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
-        verify_number_of_outputs_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped2 = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
+        verify_parents_basic_wrapped2 = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped2 = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped2 = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped2 = Mock(wraps=self.verifiers.tx.verify_sigops_output)
 
         with (
-            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped2),
-            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped2),
-            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped2),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs',
-                         verify_number_of_inputs_wrapped2),
-            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped2),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
-                         verify_number_of_outputs_wrapped2),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped2),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped2),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped2),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped2),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped2),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
             self.manager.verification_service.validate_basic(tx)
 
@@ -895,38 +889,37 @@ class BaseVerificationTest(unittest.TestCase):
         tx = self._get_valid_token_creation_tx()
         tx.get_metadata().validation = ValidationState.INITIAL
 
-        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents_basic)
-        verify_weight_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_weight)
-        verify_pow_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_pow)
-        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_outputs)
-        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_number_of_outputs)
-        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_output)
-        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sigops_input)
-        verify_inputs_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_inputs)
-        verify_script_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_script)
-        verify_parents_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_parents)
-        verify_sum_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_sum)
-        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_reward_locked)
+        verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
+        verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
+        verify_pow_wrapped = Mock(wraps=self.verifiers.tx.verify_pow)
+        verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_outputs)
+        verify_sigops_output_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_output)
+        verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
+        verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
+        verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
+        verify_parents_wrapped = Mock(wraps=self.verifiers.tx.verify_parents)
+        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
 
         verify_token_info_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_token_info)
         verify_minted_tokens_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_minted_tokens)
 
         with (
-            patch.object(TokenCreationTransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_weight', verify_weight_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_pow', verify_pow_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_number_of_outputs',
-                         verify_number_of_outputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_script', verify_script_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_sum', verify_sum_wrapped),
-            patch.object(TokenCreationTransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
+            patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
+            patch.object(TransactionVerifier, 'verify_pow', verify_pow_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
+            patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
+            patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
+            patch.object(TransactionVerifier, 'verify_parents', verify_parents_wrapped),
+            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_minted_tokens', verify_minted_tokens_wrapped),
         ):


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/833

### Motivation

Simplify transaction verification by removing the `TransactionVerifier` inheritance from `TokenCreationTransactionVerifier`, as it was not necessary. It's changed to composition instead, but this is also going to be removed in a next PR.

For more info, read the previous PR (https://github.com/HathorNetwork/hathor-core/pull/833).

### Acceptance Criteria

- Move `verify_basic()`, `verify()`, and `verify_without_storage()` from `TransactionVerifier` to `VerificationService`.
- Move `verify()` from `TokenCreationTransactionVerifier` to `VerificationService`, removing its `TransactionVerifier` inheritance, and changing it to composition instead.
- Update usages accordingly.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 