### PR TITLE
refactor(verification): remove VertexVerifier from BlockVerifier [part 7/9]

### DIFF
--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -25,22 +25,19 @@ from hathor.transaction.exceptions import (
     TransactionDataError,
     WeightError,
 )
-from hathor.verification.vertex_verifier import VertexVerifier
 
 
 class BlockVerifier:
-    __slots__ = ('_settings', '_vertex_verifier', '_daa', '_feature_service')
+    __slots__ = ('_settings', '_daa', '_feature_service')
 
     def __init__(
         self,
         *,
         settings: HathorSettings,
-        vertex_verifier: VertexVerifier,
         daa: DifficultyAdjustmentAlgorithm,
         feature_service: FeatureService | None = None
     ) -> None:
         self._settings = settings
-        self._vertex_verifier = vertex_verifier
         self._daa = daa
         self._feature_service = feature_service
 
@@ -74,8 +71,7 @@ class BlockVerifier:
         if inputs:
             raise BlockWithInputs('number of inputs {}'.format(len(inputs)))
 
-    def verify_outputs(self, block: Block) -> None:
-        self._vertex_verifier.verify_outputs(block)
+    def verify_output_token_indexes(self, block: Block) -> None:
         for output in block.outputs:
             if output.get_token_index() > 0:
                 raise BlockWithTokensError('in output: {}'.format(output.to_human_readable()))

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -222,7 +222,8 @@ class VerificationService:
         """
         self.verifiers.vertex.verify_pow(block)
         self.verifiers.block.verify_no_inputs(block)
-        self.verifiers.block.verify_outputs(block)
+        self.verifiers.vertex.verify_outputs(block)
+        self.verifiers.block.verify_output_token_indexes(block)
         self.verifiers.block.verify_data(block)
         self.verifiers.vertex.verify_sigops_output(block)
 

--- a/hathor/verification/vertex_verifiers.py
+++ b/hathor/verification/vertex_verifiers.py
@@ -65,12 +65,7 @@ class VertexVerifiers(NamedTuple):
         """
         Create a VertexVerifiers instance using a custom vertex_verifier.
         """
-        block_verifier = BlockVerifier(
-            settings=settings,
-            vertex_verifier=vertex_verifier,
-            daa=daa,
-            feature_service=feature_service
-        )
+        block_verifier = BlockVerifier(settings=settings, daa=daa, feature_service=feature_service)
         merge_mined_block_verifier = MergeMinedBlockVerifier()
         tx_verifier = TransactionVerifier(settings=settings, vertex_verifier=vertex_verifier, daa=daa)
         token_creation_tx_verifier = TokenCreationTransactionVerifier(settings=settings)

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -147,7 +147,7 @@ def test_verify_must_signal_when_feature_activation_is_disabled(is_signaling_man
     settings.FEATURE_ACTIVATION.enable_usage = False
     feature_service = Mock(spec_set=FeatureService)
     feature_service.is_signaling_mandatory_features = Mock(return_value=is_signaling_mandatory_features)
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock(), vertex_verifier=Mock())
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
     block = Block()
 
     verifier.verify_mandatory_signaling(block)
@@ -160,7 +160,7 @@ def test_verify_must_signal() -> None:
     feature_service.is_signaling_mandatory_features = Mock(
         return_value=BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)
     )
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock(), vertex_verifier=Mock())
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
     block = Block()
 
     with pytest.raises(BlockMustSignalError) as e:
@@ -174,7 +174,7 @@ def test_verify_must_not_signal() -> None:
     settings.FEATURE_ACTIVATION.enable_usage = True
     feature_service = Mock(spec_set=FeatureService)
     feature_service.is_signaling_mandatory_features = Mock(return_value=BlockIsSignaling())
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock(), vertex_verifier=Mock())
+    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
     block = Block()
 
     verifier.verify_mandatory_signaling(block)

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -360,7 +360,7 @@ class BaseTransactionTest(unittest.TestCase):
             storage=self.tx_storage)
 
         with self.assertRaises(TooManyOutputs):
-            self._verifiers.block.verify_outputs(block)
+            self._verifiers.vertex.verify_outputs(block)
 
     def test_tx_number_parents(self):
         genesis_block = self.genesis_blocks[0]

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -123,20 +123,20 @@ class BaseVerificationTest(unittest.TestCase):
     def test_block_verify_without_storage(self) -> None:
         block = self._get_valid_block()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.block.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -144,12 +144,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.verify_without_storage(block)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
         verify_no_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
@@ -157,11 +157,11 @@ class BaseVerificationTest(unittest.TestCase):
     def test_block_verify(self) -> None:
         block = self._get_valid_block()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.block.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
@@ -170,10 +170,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.block.verify_mandatory_signaling)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -184,12 +184,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.verify(block)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
         verify_no_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
@@ -240,11 +240,11 @@ class BaseVerificationTest(unittest.TestCase):
     def test_block_validate_full(self) -> None:
         block = self._get_valid_block()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.block.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
@@ -255,10 +255,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_mandatory_signaling_wrapped = Mock(wraps=self.verifiers.block.verify_mandatory_signaling)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -271,12 +271,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.validate_full(block)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
         verify_no_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
@@ -305,11 +305,11 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_verify_without_storage(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.block.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
@@ -317,10 +317,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -329,12 +329,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.verify_without_storage(block)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
         verify_no_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
@@ -345,11 +345,11 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_verify(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.block.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
@@ -360,10 +360,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -375,12 +375,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.verify(block)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
         verify_no_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
@@ -434,11 +434,11 @@ class BaseVerificationTest(unittest.TestCase):
     def test_merge_mined_block_validate_full(self) -> None:
         block = self._get_valid_merge_mined_block()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_no_inputs_wrapped = Mock(wraps=self.verifiers.block.verify_no_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.block.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.block.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
@@ -451,10 +451,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
-            patch.object(BlockVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(BlockVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
@@ -468,12 +468,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.validate_full(block)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Block methods
         verify_pow_wrapped.assert_called_once()
         verify_no_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/835

### Motivation

Simplify code by removing the `VertexVerifier` composition from `BlockVerifier`.

### Acceptance Criteria

- Remove `BlockVerifier.verify_outputs()`, moving its only custom verification to a new `verify_output_token_indexes()` method, and moving its call to `VerificationService._verify_without_storage_block()`. This allows us to remove the `VertexVerifier` composition from `BlockVerifier`.
- Update usages accordingly.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 