### PR TITLE
refactor(verification): remove VertexVerifier from TransactionVerifier [part 8/9]

### DIFF
--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -111,7 +111,8 @@ class CreateTxResource(Resource):
         verifiers = self.manager.verification_service.verifiers
         verifiers.tx.verify_number_of_inputs(tx)
         verifiers.vertex.verify_number_of_outputs(tx)
-        verifiers.tx.verify_outputs(tx)
+        verifiers.vertex.verify_outputs(tx)
+        verifiers.tx.verify_output_token_indexes(tx)
         verifiers.vertex.verify_sigops_output(tx)
         verifiers.tx.verify_sigops_input(tx)
         # need to run verify_inputs first to check if all inputs exist

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -36,23 +36,15 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.transaction import TokenInfo
 from hathor.transaction.util import get_deposit_amount, get_withdraw_amount
 from hathor.types import TokenUid, VertexId
-from hathor.verification.vertex_verifier import VertexVerifier
 
 cpu = get_cpu_profiler()
 
 
 class TransactionVerifier:
-    __slots__ = ('_settings', '_vertex_verifier', '_daa')
+    __slots__ = ('_settings', '_daa')
 
-    def __init__(
-        self,
-        *,
-        settings: HathorSettings,
-        vertex_verifier: VertexVerifier,
-        daa: DifficultyAdjustmentAlgorithm,
-    ) -> None:
+    def __init__(self, *, settings: HathorSettings, daa: DifficultyAdjustmentAlgorithm) -> None:
         self._settings = settings
-        self._vertex_verifier = vertex_verifier
         self._daa = daa
 
     def verify_parents_basic(self, tx: Transaction) -> None:
@@ -177,12 +169,11 @@ class TransactionVerifier:
             if not tx.is_genesis:
                 raise NoInputError('Transaction must have at least one input')
 
-    def verify_outputs(self, tx: Transaction) -> None:
+    def verify_output_token_indexes(self, tx: Transaction) -> None:
         """Verify outputs reference an existing token uid in the tokens list
 
         :raises InvalidToken: output references non existent token uid
         """
-        self._vertex_verifier.verify_outputs(tx)
         for output in tx.outputs:
             # check index is valid
             if output.get_token_index() > len(tx.tokens):

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -236,7 +236,8 @@ class VerificationService:
         """
         self.verifiers.vertex.verify_pow(tx)
         self.verifiers.tx.verify_number_of_inputs(tx)
-        self.verifiers.tx.verify_outputs(tx)
+        self.verifiers.vertex.verify_outputs(tx)
+        self.verifiers.tx.verify_output_token_indexes(tx)
         self.verifiers.vertex.verify_sigops_output(tx)
 
     def _verify_without_storage_token_creation_tx(self, tx: TokenCreationTransaction) -> None:

--- a/hathor/verification/vertex_verifiers.py
+++ b/hathor/verification/vertex_verifiers.py
@@ -67,7 +67,7 @@ class VertexVerifiers(NamedTuple):
         """
         block_verifier = BlockVerifier(settings=settings, daa=daa, feature_service=feature_service)
         merge_mined_block_verifier = MergeMinedBlockVerifier()
-        tx_verifier = TransactionVerifier(settings=settings, vertex_verifier=vertex_verifier, daa=daa)
+        tx_verifier = TransactionVerifier(settings=settings, daa=daa)
         token_creation_tx_verifier = TokenCreationTransactionVerifier(settings=settings)
 
         return VertexVerifiers(

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -881,7 +881,8 @@ class BaseTransactionTest(unittest.TestCase):
         _output = TxOutput(value, script)
 
         tx = Transaction(inputs=[_input], outputs=[_output], storage=self.tx_storage)
-        self._verifiers.tx.verify_outputs(tx)
+        self._verifiers.vertex.verify_outputs(tx)
+        self._verifiers.tx.verify_output_token_indexes(tx)
 
     def test_txout_script_limit_exceeded(self):
         with self.assertRaises(InvalidOutputScriptSize):

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -489,68 +489,68 @@ class BaseVerificationTest(unittest.TestCase):
     def test_transaction_verify_basic(self) -> None:
         tx = self._get_valid_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_basic(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_parents_basic_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_transaction_verify_without_storage(self) -> None:
         tx = self._get_valid_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_without_storage(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
 
@@ -558,11 +558,11 @@ class BaseVerificationTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
@@ -573,10 +573,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
@@ -589,12 +589,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.verify(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
         verify_sigops_input_wrapped.assert_called_once()
@@ -609,37 +609,37 @@ class BaseVerificationTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.validate_basic(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_parents_basic_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
 
@@ -655,7 +655,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_weight_wrapped2 = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_outputs)
         verify_number_of_outputs_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
@@ -664,7 +664,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped2),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped2),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped2),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped2),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
@@ -686,13 +686,13 @@ class BaseVerificationTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
         tx = self._get_valid_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
@@ -703,12 +703,12 @@ class BaseVerificationTest(unittest.TestCase):
         verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
@@ -721,14 +721,14 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.validate_full(tx)
 
         # Vertex methods
-        assert vertex_verify_outputs_wrapped.call_count == 2
+        assert verify_outputs_wrapped.call_count == 2
 
         # Transaction methods
         verify_parents_basic_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         assert verify_pow_wrapped.call_count == 2
         assert verify_number_of_inputs_wrapped.call_count == 2
-        assert verify_outputs_wrapped.call_count == 2
+        assert verify_output_token_indexes_wrapped.call_count == 2
         assert verify_number_of_outputs_wrapped.call_count == 2
         assert verify_sigops_output_wrapped.call_count == 2
         verify_sigops_input_wrapped.assert_called_once()
@@ -746,7 +746,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_weight_wrapped2 = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_outputs)
         verify_number_of_outputs_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
@@ -755,7 +755,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped2),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped2),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped2),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped2),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
@@ -776,79 +776,79 @@ class BaseVerificationTest(unittest.TestCase):
     def test_token_creation_transaction_verify_basic(self) -> None:
         tx = self._get_valid_token_creation_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_basic(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_parents_basic_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify_without_storage(self) -> None:
         tx = self._get_valid_token_creation_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.verify_without_storage(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
 
     def test_token_creation_transaction_verify(self) -> None:
         tx = self._get_valid_token_creation_tx()
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
@@ -862,10 +862,10 @@ class BaseVerificationTest(unittest.TestCase):
         verify_minted_tokens_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_minted_tokens)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
@@ -880,12 +880,12 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.verify(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
         verify_sigops_input_wrapped.assert_called_once()
@@ -903,37 +903,37 @@ class BaseVerificationTest(unittest.TestCase):
         tx = self._get_valid_token_creation_tx()
         tx.get_metadata().validation = ValidationState.INITIAL
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
             self.manager.verification_service.validate_basic(tx)
 
         # Vertex methods
-        vertex_verify_outputs_wrapped.assert_called_once()
+        verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
         verify_parents_basic_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         verify_pow_wrapped.assert_called_once()
         verify_number_of_inputs_wrapped.assert_called_once()
-        verify_outputs_wrapped.assert_called_once()
+        verify_output_token_indexes_wrapped.assert_called_once()
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
 
@@ -949,7 +949,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_weight_wrapped2 = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_outputs_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_outputs)
         verify_number_of_outputs_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped2 = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
@@ -958,7 +958,7 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped2),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped2),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped2),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped2),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
@@ -980,13 +980,13 @@ class BaseVerificationTest(unittest.TestCase):
         tx = self._get_valid_token_creation_tx()
         tx.get_metadata().validation = ValidationState.INITIAL
 
-        vertex_verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
+        verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
         verify_weight_wrapped = Mock(wraps=self.verifiers.tx.verify_weight)
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
         verify_number_of_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_number_of_inputs)
-        verify_outputs_wrapped = Mock(wraps=self.verifiers.tx.verify_outputs)
+        verify_output_token_indexes_wrapped = Mock(wraps=self.verifiers.tx.verify_output_token_indexes)
         verify_number_of_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_number_of_outputs)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
         verify_sigops_input_wrapped = Mock(wraps=self.verifiers.tx.verify_sigops_input)
@@ -1000,12 +1000,12 @@ class BaseVerificationTest(unittest.TestCase):
         verify_minted_tokens_wrapped = Mock(wraps=self.verifiers.token_creation_tx.verify_minted_tokens)
 
         with (
-            patch.object(VertexVerifier, 'verify_outputs', vertex_verify_outputs_wrapped),
+            patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(TransactionVerifier, 'verify_number_of_inputs', verify_number_of_inputs_wrapped),
-            patch.object(TransactionVerifier, 'verify_outputs', verify_outputs_wrapped),
+            patch.object(TransactionVerifier, 'verify_output_token_indexes', verify_output_token_indexes_wrapped),
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
             patch.object(TransactionVerifier, 'verify_sigops_input', verify_sigops_input_wrapped),
@@ -1020,14 +1020,14 @@ class BaseVerificationTest(unittest.TestCase):
             self.manager.verification_service.validate_full(tx)
 
         # Vertex methods
-        assert vertex_verify_outputs_wrapped.call_count == 2
+        assert verify_outputs_wrapped.call_count == 2
 
         # Transaction methods
         verify_parents_basic_wrapped.assert_called_once()
         verify_weight_wrapped.assert_called_once()
         assert verify_pow_wrapped.call_count == 2
         assert verify_number_of_inputs_wrapped.call_count == 2
-        assert verify_outputs_wrapped.call_count == 2
+        assert verify_output_token_indexes_wrapped.call_count == 2
         assert verify_number_of_outputs_wrapped.call_count == 2
         assert verify_sigops_output_wrapped.call_count == 2
         verify_sigops_input_wrapped.assert_called_once()


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/836

### Motivation

Simplify code by removing the `VertexVerifier` composition from `TransactionVerifier`.

### Acceptance Criteria

- Remove `TransactionVerifier.verify_outputs()`, moving its only custom verification to a new `verify_output_token_indexes()` method, and moving its call to `VerificationService._verify_without_storage_tx()`. This allows us to remove the `VertexVerifier` composition from `TransactionVerifier`.
- Update usages accordingly.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 