### PR TITLE
feat(sync-v2): Wait for sync internal methods to finish before initiating next syncing cycle

### DIFF
--- a/hathor/p2p/sync_v2/mempool.py
+++ b/hathor/p2p/sync_v2/mempool.py
@@ -39,6 +39,8 @@ class SyncMempoolManager:
         self.tx_storage = self.manager.tx_storage
         self.reactor = self.sync_agent.reactor
 
+        self._deferred: Optional[Deferred[None]] = None
+
         # Set of tips we know but couldn't add to the DAG yet.
         self.missing_tips: set[bytes] = set()
 
@@ -52,13 +54,18 @@ class SyncMempoolManager:
         """Whether the sync-mempool is currently running."""
         return self._is_running
 
-    def run(self) -> None:
+    def run(self) -> Deferred[None]:
         """Starts _run in, won't start again if already running."""
         if self.is_running():
             self.log.warn('already started')
-            return
+            assert self._deferred is not None
+            return self._deferred
         self._is_running = True
         self.reactor.callLater(0, self._run)
+
+        assert self._deferred is None
+        self._deferred = Deferred()
+        return self._deferred
 
     @inlineCallbacks
     def _run(self) -> Generator[Deferred, Any, None]:
@@ -67,6 +74,9 @@ class SyncMempoolManager:
         finally:
             # sync_agent.run_sync will start it again when needed
             self._is_running = False
+            assert self._deferred is not None
+            self._deferred.callback(None)
+            self._deferred = None
 
     @inlineCallbacks
     def _unsafe_run(self) -> Generator[Deferred, Any, None]:


### PR DESCRIPTION
### Motivation

Previously, the `_run_sync()` method checked for ongoing mempool syncs or open streamings to prevent concurrent cycle runs. Despite the presence of the `_is_running: bool` flag, it was prematurely marked as `false` due to mempool syncs and streamings returning at the start, not the end, of their execution. This led to complexity and potential errors in `_run_sync()`. This PR streamlines this process for better clarity and reliability.

### Acceptance Criteria

1. Create the deferred `_deferred_blockchain_streaming` when we request the peer to open a block streaming.
2. Resolve the `_deferred_blockchain_streaming` when the streaming ends.
3. Create the deferred `_deferred_transactions_streaming` when we request the peer to open a transactions streaming.
4. Resolve the `_deferred_transactions_streaming` when the streaming ends.
5. Change `run_sync_transactions()` to wait for its streaming to end.
6. Change `run_sync_blocks()`to wait for its streaming to end.
7. Change `mempool_manager.run()` to return a deferred that is resolved when the execution is complete.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 