### PR TITLE
chore(custom_checks): Skip binary files when checking for deprecated typing

### DIFF
--- a/extras/custom_checks.sh
+++ b/extras/custom_checks.sh
@@ -72,7 +72,7 @@ function check_do_not_use_builtin_random_in_tests() {
 }
 
 function check_deprecated_typing() {
-	if grep -R '\<typing .*\<import .*\<\(Tuple\|List\|Dict\|Set\|FrozenSet\|AbstractSet\|DefaultDict\|OrderedDict\)\>' "${SOURCE_DIRS[@]}"; then
+	if grep -RI '\<typing .*\<import .*\<\(Tuple\|List\|Dict\|Set\|FrozenSet\|AbstractSet\|DefaultDict\|OrderedDict\)\>' "${SOURCE_DIRS[@]}"; then
 		echo 'do not use typing.List/Tuple/Dict/... for type annotations use builtin list/tuple/dict/... instead'
 		echo 'for more info check the PEP 585 doc: https://peps.python.org/pep-0585/'
 		return 1


### PR DESCRIPTION
### Motivation

If a file is open in vim, this skip wrongfully fails because the `.swp` file concatenate lines using a custom separator so the whole file is considered as in one line.

### Acceptance Criteria

1. Use grep `-I` option to skip binary files.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 