### PR TITLE
tests: Fix a flaky protocol test

### DIFF
--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -411,18 +411,6 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
         self.assertAndStepConn(self.conn, b'^GET-TIPS')
         self.assertAndStepConn(self.conn, b'^PING')
 
-        for _ in range(20):
-            self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN')
-
-        self.assertAndStepConn(self.conn, b'^GET-PEERS',           b'^GET-PEERS')
-        self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN', b'^GET-BEST-BLOCKCHAIN')
-        self.assertAndStepConn(self.conn, b'^GET-PEERS',           b'^GET-PEERS')
-        self.assertAndStepConn(self.conn, b'^PEERS',               b'^GET-BEST-BLOCKCHAIN')
-        self.assertAndStepConn(self.conn, b'^GET-BEST-BLOCKCHAIN', b'^TIPS')
-        self.assertAndStepConn(self.conn, b'^TIPS',                b'^TIPS')
-        self.assertAndStepConn(self.conn, b'^TIPS',                b'^TIPS-END')
-        self.assertAndStepConn(self.conn, b'^TIPS-END',            b'^PONG')
-        self.assertAndStepConn(self.conn, b'^PONG',                b'^BEST-BLOCKCHAIN')
         self.assertIsConnected()
 
     @inlineCallbacks

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -176,7 +176,7 @@ class TestCase(unittest.TestCase):
         if start_manager:
             manager.start()
             self.clock.run()
-            self.run_to_completion()
+            self.clock.advance(5)
 
         return manager
 


### PR DESCRIPTION
### Motivation

The `run_to_completion()` method is designed to advance a test's clock until all scheduled calls are executed. This approach works well in isolation but presents issues in a simulation environment where multiple nodes share a single clock. 

The crux of the problem emerges when a new node is created in the middle of a simulation. The `create_peer()` method invokes the `run_to_completion()`, which causes an unintended ripple effect: while the intention is to execute delayed calls only for the newly created node, the shared clock architecture means that the delayed calls for *all* nodes get executed.

In essence, while `run_to_completion()` aims to streamline the handling of delayed calls, its current design inadvertently interferes with the natural flow of the simulation, especially when new nodes are dynamically added.

This issue was causing flakiness in the test `tests/p2p/test_protocol.py::SyncV2HathorProtocolTestCase::test_two_connections` because the initialization of a new node was calling `send_get_best_blockchain()` multiple times due to a looping call. The number of times changes randomly so the asserts were failing randomly too.

### Acceptance Criteria

1. Modify `create_peer()` to stop calling `run_to_completion()`. It will just advance the clock once to execute delayed calls set by `manager.start()`.
2. Remove unnecessary and unstable asserts from `tests/p2p/test_protocol.py::SyncV2HathorProtocolTestCase::test_two_connections`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 