### PR TITLE
feat(consensus): Use DAG of funds to set first_block

### DIFF
--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -432,7 +432,7 @@ class BlockConsensusAlgorithm:
         storage = block.storage
 
         from hathor.transaction.storage.traversal import BFSTimestampWalk
-        bfs = BFSTimestampWalk(storage, is_dag_verifications=True, is_left_to_right=False)
+        bfs = BFSTimestampWalk(storage, is_dag_verifications=True, is_dag_funds=True, is_left_to_right=False)
         for tx in bfs.run(block, skip_root=True):
             if tx.is_block:
                 bfs.skip_neighbors(tx)
@@ -469,9 +469,12 @@ class BlockConsensusAlgorithm:
 
             else:
                 from hathor.transaction.storage.traversal import BFSTimestampWalk
-                bfs = BFSTimestampWalk(storage, is_dag_verifications=True, is_left_to_right=False)
+                bfs = BFSTimestampWalk(storage, is_dag_verifications=True, is_dag_funds=True, is_left_to_right=False)
                 for tx in bfs.run(parent, skip_root=False):
-                    assert not tx.is_block
+                    assert tx.hash is not None
+                    if tx.is_block:
+                        bfs.skip_neighbors(tx)
+                        continue
 
                     if tx.hash in used:
                         bfs.skip_neighbors(tx)

--- a/hathor/transaction/storage/migrations/include_funds_for_first_block.py
+++ b/hathor/transaction/storage/migrations/include_funds_for_first_block.py
@@ -1,0 +1,37 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+
+from hathor.transaction.storage.migrations import BaseMigration
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage import TransactionStorage
+
+logger = get_logger()
+
+
+class Migration(BaseMigration):
+    def skip_empty_db(self) -> bool:
+        return True
+
+    def get_db_name(self) -> str:
+        return 'include_funds_for_first_block'
+
+    def run(self, storage: 'TransactionStorage') -> None:
+        raise Exception('Cannot migrate your database due to an incompatible change in the metadata. '
+                        'Please, delete your data folder and use the latest available snapshot or sync '
+                        'from beginning.')

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -37,7 +37,13 @@ from hathor.transaction.storage.exceptions import (
     TransactionIsNotABlock,
     TransactionNotInAllowedScopeError,
 )
-from hathor.transaction.storage.migrations import BaseMigration, MigrationState, change_score_acc_weight_metadata
+from hathor.transaction.storage.migrations import (
+    BaseMigration,
+    MigrationState,
+    add_closest_ancestor_block,
+    change_score_acc_weight_metadata,
+    include_funds_for_first_block,
+)
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope, tx_allow_context
 from hathor.transaction.transaction import Transaction
 from hathor.transaction.transaction_metadata import TransactionMetadata
@@ -88,6 +94,8 @@ class TransactionStorage(ABC):
     # history of migrations that have to be applied in the order defined here
     _migration_factories: list[type[BaseMigration]] = [
         change_score_acc_weight_metadata.Migration,
+        add_closest_ancestor_block.Migration,
+        include_funds_for_first_block.Migration,
     ]
 
     _migrations: list[BaseMigration]

--- a/tests/consensus/test_first_block.py
+++ b/tests/consensus/test_first_block.py
@@ -1,0 +1,71 @@
+from tests import unittest
+
+
+class FirstBlockTestCase(unittest.TestCase):
+    _enable_sync_v1 = True
+    _enable_sync_v2 = True
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        from hathor.simulator.patches import SimulatorCpuMiningService
+        from hathor.simulator.simulator import _build_vertex_verifiers
+
+        cpu_mining_service = SimulatorCpuMiningService()
+
+        builder = self.get_builder() \
+            .set_vertex_verifiers_builder(_build_vertex_verifiers) \
+            .set_cpu_mining_service(cpu_mining_service)
+
+        self.manager = self.create_peer_from_builder(builder)
+        self.dag_builder = self.get_dag_builder(self.manager)
+
+    def test_first_block(self) -> None:
+        artifacts = self.dag_builder.build_from_str("""
+            blockchain genesis b[1..50]
+
+            b30 < dummy
+
+            tx10.out[0] <<< tx50
+            tx20.out[0] <<< tx50
+            tx30 <-- tx50
+            tx40 <-- tx50
+
+            tx41.out[0] <<< tx40
+            tx42 <-- tx40
+            tx43 <-- tx40
+
+            b31 --> tx10
+
+            b32 --> tx30
+            b32 --> tx43
+
+            b33 --> tx50
+        """)
+
+        for node, vertex in artifacts.list:
+            self.manager.on_new_tx(vertex, fails_silently=False)
+
+        b31 = artifacts.by_name['b31'].vertex
+        b32 = artifacts.by_name['b32'].vertex
+        b33 = artifacts.by_name['b33'].vertex
+
+        tx10 = artifacts.by_name['tx10'].vertex
+        tx20 = artifacts.by_name['tx20'].vertex
+        tx30 = artifacts.by_name['tx30'].vertex
+        tx40 = artifacts.by_name['tx40'].vertex
+        tx41 = artifacts.by_name['tx41'].vertex
+        tx42 = artifacts.by_name['tx42'].vertex
+        tx43 = artifacts.by_name['tx43'].vertex
+        tx50 = artifacts.by_name['tx50'].vertex
+
+        self.assertEqual(tx10.get_metadata().first_block, b31.hash)
+
+        self.assertEqual(tx30.get_metadata().first_block, b32.hash)
+        self.assertEqual(tx43.get_metadata().first_block, b32.hash)
+
+        self.assertEqual(tx50.get_metadata().first_block, b33.hash)
+        self.assertEqual(tx20.get_metadata().first_block, b33.hash)
+        self.assertEqual(tx40.get_metadata().first_block, b33.hash)
+        self.assertEqual(tx41.get_metadata().first_block, b33.hash)
+        self.assertEqual(tx42.get_metadata().first_block, b33.hash)


### PR DESCRIPTION
### Motivation

When setting the metadata `first_block`, the consensus algorithm currently traverses only the DAG of verifications (i.e., the parents). This PR changes this behavior and begin to traverse the DAG of funds as well (i.e., the inputs).

### Acceptance Criteria

1. Traverse the DAG of funds when setting the `first_block` in the `BlockConsensusAlgorithm`.
2. Traverse the DAG of funds when clearing the `first_block` in the `BlockConsensusAlgorithm`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 