### PR TITLE
feat(sync-v2): Improve overall logging

### DIFF
--- a/hathor/p2p/sync_v2/blockchain_streaming_client.py
+++ b/hathor/p2p/sync_v2/blockchain_streaming_client.py
@@ -111,7 +111,7 @@ class BlockchainStreamingClient:
             self._blk_repeated += 1
             is_duplicated = True
             if self._blk_repeated > self.max_repeated_blocks:
-                self.log.debug('too many repeated block received', total_repeated=self._blk_repeated)
+                self.log.info('too many repeated block received', total_repeated=self._blk_repeated)
                 self.fails(TooManyRepeatedVerticesError())
             self._last_received_block = blk
             return

--- a/hathor/p2p/sync_v2/streamers.py
+++ b/hathor/p2p/sync_v2/streamers.py
@@ -234,7 +234,7 @@ class TransactionsStreamingServer(_StreamingServerBase):
             else:
                 root = self.start_from
                 skip_root = False
-            self.log.debug('sending transactions from block',
+            self.log.debug('iterating over transactions from block',
                            block=not_none(self.current_block.hash).hex(),
                            height=self.current_block.get_height(),
                            start_from=self.start_from,

--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -103,7 +103,7 @@ class TransactionStreamingClient:
         if tx.hash not in self._waiting_for:
             if tx.hash in self._db:
                 # This case might happen during a resume, so we just log and keep syncing.
-                self.log.info('duplicated vertex received', tx_id=tx.hash.hex())
+                self.log.debug('duplicated vertex received', tx_id=tx.hash.hex())
             else:
                 # TODO Uncomment the following code to fail on receiving unexpected vertices.
                 # self.fails(UnexpectedVertex(tx.hash.hex()))
@@ -140,7 +140,7 @@ class TransactionStreamingClient:
         """This method is called by the sync agent when a TRANSACTIONS-END message is received."""
         if self._deferred.called:
             return
-        self.log.info('transactions streaming ended', waiting_for=len(self._waiting_for))
+        self.log.info('transactions streaming ended', reason=response_code, waiting_for=len(self._waiting_for))
         self._deferred.callback(response_code)
 
     def _execute_and_prepare_next(self) -> None:


### PR DESCRIPTION
### Motivation

After running our latest QA, we noticed that the sync-v2 logging can be improved in a way that we don't get too many duplicated log messages but got enough messages to debug an issue.

### Acceptance Criteria

1. Add `_HeightInfo.__str__()` because it is used by the log json serializer.
2. Only log "blocks are synced" and "nothing to sync because peer is behind me at the same best blockchain" when we transition from not synced to synced. So it stops logging duplicated messages all the time.
3. Improve other log levels and messages.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 