### PR TITLE
feat(sync-v2): Stop streaming of transactions if an unexpected vertex is received

### DIFF
--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -17,7 +17,12 @@ from typing import TYPE_CHECKING, Iterator
 from structlog import get_logger
 from twisted.internet.defer import Deferred
 
-from hathor.p2p.sync_v2.exception import InvalidVertexError, StreamingError, TooManyVerticesReceivedError
+from hathor.p2p.sync_v2.exception import (
+    InvalidVertexError,
+    StreamingError,
+    TooManyVerticesReceivedError,
+    UnexpectedVertex,
+)
 from hathor.p2p.sync_v2.streamers import StreamEnd
 from hathor.transaction import BaseTransaction
 from hathor.transaction.exceptions import HathorError, TxValidationError
@@ -105,9 +110,8 @@ class TransactionStreamingClient:
                 # This case might happen during a resume, so we just log and keep syncing.
                 self.log.debug('duplicated vertex received', tx_id=tx.hash.hex())
             else:
-                # TODO Uncomment the following code to fail on receiving unexpected vertices.
-                # self.fails(UnexpectedVertex(tx.hash.hex()))
                 self.log.info('unexpected vertex received', tx_id=tx.hash.hex())
+                self.fails(UnexpectedVertex(tx.hash.hex()))
             return
         self._waiting_for.remove(tx.hash)
 


### PR DESCRIPTION
### Motivation

The `first_block` issue caused us to not stop the streaming of transactions when an unexpected vertex is received. But it not necessary to do it anymore because the streamer server is handling this case.

### Acceptance Criteria

1. Stop the streaming of transactions if an unexpected vertex is received.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 