### PR TITLE
refactor(verification): move token info [part 2b/9]

### DIFF
--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -217,8 +217,8 @@ class TokenCreationTransaction(Transaction):
         return json
 
     @override
-    def get_token_info_from_inputs(self) -> dict[TokenUid, TokenInfo]:
-        token_dict = super().get_token_info_from_inputs()
+    def _get_token_info_from_inputs(self) -> dict[TokenUid, TokenInfo]:
+        token_dict = super()._get_token_info_from_inputs()
 
         # we add the created token's info to token_dict, as the creation tx allows for mint/melt
         assert self.hash is not None

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -40,7 +40,7 @@ class TokenCreationTransactionVerifier(TransactionVerifier):
         :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
         """
         assert isinstance(tx, TokenCreationTransaction)
-        token_dict = self.get_complete_token_info(tx)
+        token_dict = tx.get_complete_token_info()
 
         # make sure tokens are being minted
         token_info = token_dict[not_none(tx.hash)]


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/831

### Motivation

During the verification refactors, some methods were moved from `Transaction` to `TransactionVerifier`. Now that the refactors are complete (with PRs still to be merged), it's clear that those methods should be indeed in `Transaction`, so they were moved back.

### Acceptance Criteria

- Move `update_token_info_from_outputs()` from `TransactionVerifier` to `Transaction`, changing it to private.
- Move `get_complete_token_info()` from `TransactionVerifier` to `Transaction`. 
- Change `Transaction.get_token_info_from_inputs()` to private.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 