### PR TITLE
refactor(verification): externalize verification dependencies [part 1/2]

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -531,8 +531,13 @@ class Builder:
     def _get_or_create_verification_service(self) -> VerificationService:
         if self._verification_service is None:
             verifiers = self._get_or_create_vertex_verifiers()
+            daa = self._get_or_create_daa()
             feature_service = self._get_or_create_feature_service()
-            self._verification_service = VerificationService(verifiers=verifiers, feature_service=feature_service)
+            self._verification_service = VerificationService(
+                verifiers=verifiers,
+                daa=daa,
+                feature_service=feature_service
+            )
 
         return self._verification_service
 

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -280,7 +280,11 @@ class CliBuilder:
         daa = DifficultyAdjustmentAlgorithm(settings=settings, test_mode=test_mode)
 
         vertex_verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
-        verification_service = VerificationService(verifiers=vertex_verifiers, feature_service=self.feature_service)
+        verification_service = VerificationService(
+            verifiers=vertex_verifiers,
+            daa=daa,
+            feature_service=self.feature_service
+        )
 
         cpu_mining_service = CpuMiningService()
 

--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -140,7 +140,7 @@ def execute(args: Namespace) -> None:
             settings = get_global_settings()
             daa = DifficultyAdjustmentAlgorithm(settings=settings)
             verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
-            verification_service = VerificationService(verifiers=verifiers)
+            verification_service = VerificationService(verifiers=verifiers, daa=daa)
             verification_service.verify_without_storage(block)
         except HathorError:
             print('[{}] ERROR: Block has not been pushed because it is not valid.'.format(datetime.datetime.now()))

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -22,6 +22,7 @@ from hathor.manager import HathorManager
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import create_output_script
 from hathor.util import api_catch_exceptions, json_dumpb, json_loadb
+from hathor.verification.verification_dependencies import TransactionDependencies
 
 
 def from_raw_output(raw_output: dict, tokens: list[bytes]) -> TxOutput:
@@ -109,15 +110,16 @@ class CreateTxResource(Resource):
         """ Same as .verify but skipping pow and signature verification."""
         assert type(tx) is Transaction
         verifiers = self.manager.verification_service.verifiers
+        deps = TransactionDependencies.create(tx)
         verifiers.tx.verify_number_of_inputs(tx)
         verifiers.vertex.verify_number_of_outputs(tx)
         verifiers.vertex.verify_outputs(tx)
         verifiers.tx.verify_output_token_indexes(tx)
         verifiers.vertex.verify_sigops_output(tx)
-        verifiers.tx.verify_sigops_input(tx)
+        verifiers.tx.verify_sigops_input(tx, deps)
         # need to run verify_inputs first to check if all inputs exist
-        verifiers.tx.verify_inputs(tx, skip_script=True)
-        verifiers.vertex.verify_parents(tx)
+        verifiers.tx.verify_inputs(tx, deps, skip_script=True)
+        verifiers.vertex.verify_parents(tx, deps)
         verifiers.tx.verify_sum(tx.get_complete_token_info())
 
 

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -16,7 +16,7 @@ from typing_extensions import assert_never
 
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
-from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling, BlockSignalingState
+from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling
 from hathor.transaction import Block
 from hathor.transaction.exceptions import (
     BlockMustSignalError,
@@ -27,8 +27,7 @@ from hathor.transaction.exceptions import (
     TransactionDataError,
     WeightError,
 )
-from hathor.transaction.storage.simple_memory_storage import SimpleMemoryStorage
-from hathor.util import not_none
+from hathor.verification.verification_dependencies import BasicBlockDependencies, BlockDependencies
 
 
 class BlockVerifier:
@@ -51,20 +50,16 @@ class BlockVerifier:
         if meta.height < meta.min_height:
             raise RewardLocked(f'Block needs {meta.min_height} height but has {meta.height}')
 
-    def verify_weight(self, block: Block) -> None:
+    def verify_weight(self, block: Block, block_deps: BasicBlockDependencies) -> None:
         """Validate minimum block difficulty."""
-        memory_storage = SimpleMemoryStorage()
-        dependencies = self._daa.get_block_dependencies(block)
-        memory_storage.add_vertices_from_storage(not_none(block.storage), dependencies)
-
-        min_block_weight = self._daa.calculate_block_difficulty(block, memory_storage)
+        min_block_weight = self._daa.calculate_block_difficulty(block, block_deps.storage)
         if block.weight < min_block_weight - self._settings.WEIGHT_TOL:
             raise WeightError(f'Invalid new block {block.hash_hex}: weight ({block.weight}) is '
                               f'smaller than the minimum weight ({min_block_weight})')
 
-    def verify_reward(self, block: Block) -> None:
+    def verify_reward(self, block: Block, block_deps: BasicBlockDependencies) -> None:
         """Validate reward amount."""
-        parent_block = block.get_block_parent()
+        parent_block = block_deps.storage.get_parent_block(block)
         tokens_issued_per_block = self._daa.get_tokens_issued_per_block(parent_block.get_height() + 1)
         if block.sum_outputs != tokens_issued_per_block:
             raise InvalidBlockReward(
@@ -86,9 +81,9 @@ class BlockVerifier:
         if len(block.data) > self._settings.BLOCK_DATA_MAX_SIZE:
             raise TransactionDataError('block data has {} bytes'.format(len(block.data)))
 
-    def verify_mandatory_signaling(self, signaling_state: BlockSignalingState) -> None:
+    def verify_mandatory_signaling(self, block_deps: BlockDependencies) -> None:
         """Verify whether this block is missing mandatory signaling for any feature."""
-        match signaling_state:
+        match block_deps.signaling_state:
             case BlockIsSignaling():
                 return
             case BlockIsMissingSignal(feature):
@@ -96,4 +91,4 @@ class BlockVerifier:
                     f"Block must signal support for feature '{feature.value}' during MUST_SIGNAL phase."
                 )
             case _:
-                assert_never(signaling_state)
+                assert_never(block_deps.signaling_state)

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -14,8 +14,8 @@
 
 from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
-from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.transaction import MergeMinedBlock
+from hathor.verification.verification_dependencies import BlockDependencies
 
 
 class MergeMinedBlockVerifier:
@@ -24,13 +24,13 @@ class MergeMinedBlockVerifier:
     def __init__(self, *, settings: HathorSettings) -> None:
         self._settings = settings
 
-    def verify_aux_pow(self, block: MergeMinedBlock, feature_info: dict[Feature, FeatureInfo]) -> None:
+    def verify_aux_pow(self, block: MergeMinedBlock, block_deps: BlockDependencies) -> None:
         """ Verify auxiliary proof-of-work (for merged mining).
         """
         assert block.aux_pow is not None
 
         max_merkle_path_length = self._settings.OLD_MAX_MERKLE_PATH_LENGTH
-        merkle_path_info = feature_info.get(Feature.INCREASE_MAX_MERKLE_PATH_LENGTH)
+        merkle_path_info = block_deps.feature_info.get(Feature.INCREASE_MAX_MERKLE_PATH_LENGTH)
 
         if merkle_path_info and merkle_path_info.state.is_active():
             max_merkle_path_length = self._settings.NEW_MAX_MERKLE_PATH_LENGTH

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -38,6 +38,7 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.transaction import TokenInfo
 from hathor.transaction.util import get_deposit_amount, get_withdraw_amount
 from hathor.types import TokenUid, VertexId
+from hathor.verification.verification_dependencies import TransactionDependencies
 
 cpu = get_cpu_profiler()
 
@@ -51,8 +52,6 @@ class TransactionVerifier:
 
     def verify_parents_basic(self, tx: Transaction) -> None:
         """Verify number and non-duplicity of parents."""
-        assert tx.storage is not None
-
         # check if parents are duplicated
         parents_set = set(tx.parents)
         if len(tx.parents) > len(parents_set):
@@ -72,7 +71,7 @@ class TransactionVerifier:
             raise WeightError(f'Invalid new tx {tx.hash_hex}: weight ({tx.weight}) is '
                               f'greater than the maximum allowed ({max_tx_weight})')
 
-    def verify_sigops_input(self, tx: Transaction) -> None:
+    def verify_sigops_input(self, tx: Transaction, tx_deps: TransactionDependencies) -> None:
         """ Count sig operations on all inputs and verify that the total sum is below the limit
         """
         from hathor.transaction.scripts import get_sigops_count
@@ -80,7 +79,7 @@ class TransactionVerifier:
         n_txops = 0
         for tx_input in tx.inputs:
             try:
-                spent_tx = tx.get_spent_tx(tx_input)
+                spent_tx = tx_deps.storage.get_vertex(tx_input.tx_id)
             except TransactionDoesNotExist:
                 raise InexistentInput('Input tx does not exist: {}'.format(tx_input.tx_id.hex()))
             if tx_input.index >= len(spent_tx.outputs):
@@ -92,7 +91,7 @@ class TransactionVerifier:
             raise TooManySigOps(
                 'TX[{}]: Max number of sigops for inputs exceeded ({})'.format(tx.hash_hex, n_txops))
 
-    def verify_inputs(self, tx: Transaction, *, skip_script: bool = False) -> None:
+    def verify_inputs(self, tx: Transaction, tx_deps: TransactionDependencies, *, skip_script: bool = False) -> None:
         """Verify inputs signatures and ownership and all inputs actually exist"""
         from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 
@@ -104,7 +103,8 @@ class TransactionVerifier:
                 ))
 
             try:
-                spent_tx = tx.get_spent_tx(input_tx)
+                spent_tx = tx_deps.storage.get_vertex(input_tx.tx_id)
+                assert spent_tx.hash is not None
                 if input_tx.index >= len(spent_tx.outputs):
                     raise InexistentInput('Output spent by this input does not exist: {} index {}'.format(
                         input_tx.tx_id.hex(), input_tx.index))

--- a/hathor/verification/verification_dependencies.py
+++ b/hathor/verification/verification_dependencies.py
@@ -1,0 +1,88 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dataclasses import dataclass
+
+from typing_extensions import Self
+
+from hathor.daa import DifficultyAdjustmentAlgorithm
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.feature_service import BlockSignalingState, FeatureService
+from hathor.feature_activation.model.feature_description import FeatureInfo
+from hathor.transaction import Block
+from hathor.transaction.storage.simple_memory_storage import SimpleMemoryStorage
+from hathor.transaction.transaction import Transaction
+
+
+@dataclass(frozen=True, slots=True)
+class VertexDependencies:
+    """A dataclass of dependencies necessary for vertex verification."""
+    storage: SimpleMemoryStorage
+
+
+@dataclass(frozen=True, slots=True)
+class BasicBlockDependencies(VertexDependencies):
+    """A dataclass of dependencies necessary for basic block verification."""
+
+    @classmethod
+    def create(cls, block: Block, daa: DifficultyAdjustmentAlgorithm, *, skip_weight_verification: bool) -> Self:
+        """Create a basic block dependencies instance."""
+        assert block.storage is not None
+        simple_storage = SimpleMemoryStorage()
+        daa_deps = [] if skip_weight_verification else daa.get_block_dependencies(block)
+        deps = block.parents + daa_deps
+
+        simple_storage.add_vertices_from_storage(block.storage, deps)
+
+        return cls(simple_storage)
+
+
+@dataclass(frozen=True, slots=True)
+class BlockDependencies(VertexDependencies):
+    """A dataclass of dependencies necessary for block verification."""
+    signaling_state: BlockSignalingState
+    feature_info: dict[Feature, FeatureInfo]
+
+    @classmethod
+    def create(cls, block: Block, feature_service: FeatureService) -> Self:
+        """Create a block dependencies instance."""
+        assert block.storage is not None
+        signaling_state = feature_service.is_signaling_mandatory_features(block)
+        feature_info = feature_service.get_feature_info(block=block)
+        simple_storage = SimpleMemoryStorage()
+
+        simple_storage.add_vertices_from_storage(block.storage, block.parents)
+        simple_storage.add_vertex(block)  # we add the block itself so its metadata can be used as a dependency.
+
+        return cls(
+            storage=simple_storage,
+            signaling_state=signaling_state,
+            feature_info=feature_info,
+        )
+
+
+class TransactionDependencies(VertexDependencies):
+    """A dataclass of dependencies necessary for transaction verification."""
+
+    @classmethod
+    def create(cls, tx: Transaction) -> Self:
+        """Create a transaction dependencies instance."""
+        assert tx.storage is not None
+        simple_storage = SimpleMemoryStorage()
+        spent_txs = [tx_input.tx_id for tx_input in tx.inputs]
+        deps = tx.parents + spent_txs
+
+        simple_storage.add_vertices_from_storage(tx.storage, deps)
+
+        return cls(storage=simple_storage)

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -14,25 +14,36 @@
 
 from typing_extensions import assert_never
 
-from hathor.feature_activation.feature import Feature
-from hathor.feature_activation.feature_service import BlockSignalingState, FeatureService
-from hathor.feature_activation.model.feature_description import FeatureInfo
+from hathor.daa import DifficultyAdjustmentAlgorithm
+from hathor.feature_activation.feature_service import FeatureService
 from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.transaction import TokenInfo
 from hathor.transaction.validation_state import ValidationState
 from hathor.types import TokenUid
+from hathor.verification.verification_dependencies import (
+    BasicBlockDependencies,
+    BlockDependencies,
+    TransactionDependencies,
+)
 from hathor.verification.vertex_verifiers import VertexVerifiers
 
 cpu = get_cpu_profiler()
 
 
 class VerificationService:
-    __slots__ = ('verifiers', '_feature_service')
+    __slots__ = ('verifiers', '_daa', '_feature_service')
 
-    def __init__(self, *, verifiers: VertexVerifiers, feature_service: FeatureService | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        verifiers: VertexVerifiers,
+        daa: DifficultyAdjustmentAlgorithm,
+        feature_service: FeatureService | None = None
+    ) -> None:
         self.verifiers = verifiers
+        self._daa = daa
         self._feature_service = feature_service
 
     def validate_basic(self, vertex: BaseTransaction, *, skip_block_weight_verification: bool = False) -> bool:
@@ -86,14 +97,24 @@ class VerificationService:
         """Basic verifications (the ones without access to dependencies: parents+inputs). Raises on error.
 
         Used by `self.validate_basic`. Should not modify the validation state."""
+        assert self._feature_service is not None
+
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
                 assert type(vertex) is Block
-                self._verify_basic_block(vertex, skip_weight_verification=skip_block_weight_verification)
+                block_deps = BasicBlockDependencies.create(
+                    vertex, self._daa, skip_weight_verification=skip_block_weight_verification
+                )
+                self._verify_basic_block(vertex, block_deps, skip_weight_verification=skip_block_weight_verification)
             case TxVersion.MERGE_MINED_BLOCK:
                 assert type(vertex) is MergeMinedBlock
-                self._verify_basic_merge_mined_block(vertex, skip_weight_verification=skip_block_weight_verification)
+                block_deps = BasicBlockDependencies.create(
+                    vertex, self._daa, skip_weight_verification=skip_block_weight_verification
+                )
+                self._verify_basic_merge_mined_block(
+                    vertex, block_deps, skip_weight_verification=skip_block_weight_verification
+                )
             case TxVersion.REGULAR_TRANSACTION:
                 assert type(vertex) is Transaction
                 self._verify_basic_tx(vertex)
@@ -103,14 +124,26 @@ class VerificationService:
             case _:
                 assert_never(vertex.version)
 
-    def _verify_basic_block(self, block: Block, *, skip_weight_verification: bool) -> None:
+    def _verify_basic_block(
+        self,
+        block: Block,
+        block_deps: BasicBlockDependencies,
+        *,
+        skip_weight_verification: bool
+    ) -> None:
         """Partially run validations, the ones that need parents/inputs are skipped."""
         if not skip_weight_verification:
-            self.verifiers.block.verify_weight(block)
-        self.verifiers.block.verify_reward(block)
+            self.verifiers.block.verify_weight(block, block_deps)
+        self.verifiers.block.verify_reward(block, block_deps)
 
-    def _verify_basic_merge_mined_block(self, block: MergeMinedBlock, *, skip_weight_verification: bool) -> None:
-        self._verify_basic_block(block, skip_weight_verification=skip_weight_verification)
+    def _verify_basic_merge_mined_block(
+        self,
+        block: MergeMinedBlock,
+        block_deps: BasicBlockDependencies,
+        *,
+        skip_weight_verification: bool
+    ) -> None:
+        self._verify_basic_block(block, block_deps, skip_weight_verification=skip_weight_verification)
 
     def _verify_basic_tx(self, tx: Transaction) -> None:
         """Partially run validations, the ones that need parents/inputs are skipped."""
@@ -128,29 +161,34 @@ class VerificationService:
         """Run all verifications. Raises on error.
 
         Used by `self.validate_full`. Should not modify the validation state."""
+        if vertex.is_genesis:
+            # TODO do genesis validation
+            return
+
         assert self._feature_service is not None
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
                 assert type(vertex) is Block
-                signaling_state = self._feature_service.is_signaling_mandatory_features(vertex)
-                self._verify_block(vertex, signaling_state)
+                block_deps = BlockDependencies.create(vertex, self._feature_service)
+                self._verify_block(vertex, block_deps)
             case TxVersion.MERGE_MINED_BLOCK:
                 assert type(vertex) is MergeMinedBlock
-                signaling_state = self._feature_service.is_signaling_mandatory_features(vertex)
-                feature_info = self._feature_service.get_feature_info(block=vertex)
-                self._verify_merge_mined_block(vertex, signaling_state, feature_info)
+                block_deps = BlockDependencies.create(vertex, self._feature_service)
+                self._verify_merge_mined_block(vertex, block_deps)
             case TxVersion.REGULAR_TRANSACTION:
                 assert type(vertex) is Transaction
-                self._verify_tx(vertex, reject_locked_reward=reject_locked_reward)
+                tx_deps = TransactionDependencies.create(vertex)
+                self._verify_tx(vertex, tx_deps, reject_locked_reward=reject_locked_reward)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
                 assert type(vertex) is TokenCreationTransaction
-                self._verify_token_creation_tx(vertex, reject_locked_reward=reject_locked_reward)
+                tx_deps = TransactionDependencies.create(vertex)
+                self._verify_token_creation_tx(vertex, tx_deps, reject_locked_reward=reject_locked_reward)
             case _:
                 assert_never(vertex.version)
 
     @cpu.profiler(key=lambda _, block: 'block-verify!{}'.format(block.hash.hex()))
-    def _verify_block(self, block: Block, signaling_state: BlockSignalingState) -> None:
+    def _verify_block(self, block: Block, block_deps: BlockDependencies) -> None:
         """
             (1) confirms at least two pending transactions and references last block
             (2) solves the pow with the correct weight (done in HathorManager)
@@ -160,32 +198,25 @@ class VerificationService:
             (6) whether this block must signal feature support
         """
         # TODO Should we validate a limit of outputs?
-        if block.is_genesis:
-            # TODO do genesis validation
-            return
 
         self.verify_without_storage(block)
 
         # (1) and (4)
-        self.verifiers.vertex.verify_parents(block)
+        self.verifiers.vertex.verify_parents(block, block_deps)
 
         self.verifiers.block.verify_height(block)
 
-        self.verifiers.block.verify_mandatory_signaling(signaling_state)
+        self.verifiers.block.verify_mandatory_signaling(block_deps)
 
-    def _verify_merge_mined_block(
-        self,
-        block: MergeMinedBlock,
-        signaling_state: BlockSignalingState,
-        feature_info: dict[Feature, FeatureInfo]
-    ) -> None:
-        self.verifiers.merge_mined_block.verify_aux_pow(block, feature_info)
-        self._verify_block(block, signaling_state)
+    def _verify_merge_mined_block(self, block: MergeMinedBlock, block_deps: BlockDependencies) -> None:
+        self.verifiers.merge_mined_block.verify_aux_pow(block, block_deps)
+        self._verify_block(block, block_deps)
 
     @cpu.profiler(key=lambda _, tx: 'tx-verify!{}'.format(tx.hash.hex()))
     def _verify_tx(
         self,
         tx: Transaction,
+        tx_deps: TransactionDependencies,
         *,
         reject_locked_reward: bool,
         token_dict: dict[TokenUid, TokenInfo] | None = None
@@ -201,24 +232,27 @@ class VerificationService:
         (viii) validate input's timestamps
           (ix) validate inputs and outputs sum
         """
-        if tx.is_genesis:
-            # TODO do genesis validation
-            return
         self.verify_without_storage(tx)
-        self.verifiers.tx.verify_sigops_input(tx)
-        self.verifiers.tx.verify_inputs(tx)  # need to run verify_inputs first to check if all inputs exist
-        self.verifiers.vertex.verify_parents(tx)
+        self.verifiers.tx.verify_sigops_input(tx, tx_deps)
+        self.verifiers.tx.verify_inputs(tx, tx_deps)  # need to run verify_inputs first to check if all inputs exist
+        self.verifiers.vertex.verify_parents(tx, tx_deps)
         self.verifiers.tx.verify_sum(token_dict or tx.get_complete_token_info())
         if reject_locked_reward:
             self.verifiers.tx.verify_reward_locked(tx)
 
-    def _verify_token_creation_tx(self, tx: TokenCreationTransaction, *, reject_locked_reward: bool) -> None:
+    def _verify_token_creation_tx(
+        self,
+        tx: TokenCreationTransaction,
+        tx_deps: TransactionDependencies,
+        *,
+        reject_locked_reward: bool
+    ) -> None:
         """ Run all validations as regular transactions plus validation on token info.
 
         We also overload verify_sum to make some different checks
         """
         token_dict = tx.get_complete_token_info()
-        self._verify_tx(tx, reject_locked_reward=reject_locked_reward, token_dict=token_dict)
+        self._verify_tx(tx, tx_deps, reject_locked_reward=reject_locked_reward, token_dict=token_dict)
         self.verifiers.token_creation_tx.verify_minted_tokens(tx, token_dict)
         self.verifiers.token_creation_tx.verify_token_info(tx)
 

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -29,6 +29,7 @@ from hathor.transaction.exceptions import (
     TooManyOutputs,
     TooManySigOps,
 )
+from hathor.verification.verification_dependencies import VertexDependencies
 
 # tx should have 2 parents, both other transactions
 _TX_PARENTS_TXS = 2
@@ -46,7 +47,7 @@ class VertexVerifier:
         self._settings = settings
         self._daa = daa
 
-    def verify_parents(self, vertex: BaseTransaction) -> None:
+    def verify_parents(self, vertex: BaseTransaction, vertex_deps: VertexDependencies) -> None:
         """All parents must exist and their timestamps must be smaller than ours.
 
         Also, txs should have 2 other txs as parents, while blocks should have 2 txs + 1 block.
@@ -59,8 +60,6 @@ class VertexVerifier:
         """
         from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 
-        assert vertex.storage is not None
-
         # check if parents are duplicated
         parents_set = set(vertex.parents)
         if len(vertex.parents) > len(parents_set):
@@ -72,7 +71,8 @@ class VertexVerifier:
 
         for parent_hash in vertex.parents:
             try:
-                parent = vertex.storage.get_transaction(parent_hash)
+                parent = vertex_deps.storage.get_vertex(parent_hash)
+                assert parent.hash is not None
                 if vertex.timestamp <= parent.timestamp:
                     raise TimestampError('tx={} timestamp={}, parent={} timestamp={}'.format(
                         vertex.hash_hex,
@@ -89,7 +89,7 @@ class VertexVerifier:
                     if my_parents_txs > 0:
                         raise IncorrectParents('Parents which are blocks must come before transactions')
                     for pi_hash in parent.parents:
-                        pi = vertex.storage.get_transaction(parent_hash)
+                        pi = vertex_deps.storage.get_vertex(parent_hash)
                         if not pi.is_block:
                             min_timestamp = (
                                 min(min_timestamp, pi.timestamp) if min_timestamp is not None
@@ -158,7 +158,7 @@ class VertexVerifier:
                 ))
 
     def verify_number_of_outputs(self, vertex: BaseTransaction) -> None:
-        """Verify number of outputs does not exceeds the limit"""
+        """Verify number of outputs does not exceed the limit"""
         if len(vertex.outputs) > self._settings.MAX_NUM_OUTPUTS:
             raise TooManyOutputs('Maximum number of outputs exceeded')
 

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -24,6 +24,7 @@ from hathor.transaction import Block, TransactionMetadata
 from hathor.transaction.exceptions import BlockMustSignalError
 from hathor.transaction.storage import TransactionMemoryStorage, TransactionStorage
 from hathor.verification.block_verifier import BlockVerifier
+from hathor.verification.verification_dependencies import BlockDependencies
 
 
 def test_calculate_feature_activation_bit_counts_genesis():
@@ -141,9 +142,14 @@ def test_get_feature_activation_bit_value() -> None:
 def test_verify_must_signal() -> None:
     settings = Mock(spec_set=HathorSettings)
     verifier = BlockVerifier(settings=settings, daa=Mock())
+    deps = BlockDependencies(
+        storage=Mock(),
+        signaling_state=BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1),
+        feature_info={}
+    )
 
     with pytest.raises(BlockMustSignalError) as e:
-        verifier.verify_mandatory_signaling(BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1))
+        verifier.verify_mandatory_signaling(deps)
 
     assert str(e.value) == "Block must signal support for feature 'NOP_FEATURE_1' during MUST_SIGNAL phase."
 
@@ -151,5 +157,6 @@ def test_verify_must_signal() -> None:
 def test_verify_must_not_signal() -> None:
     settings = Mock(spec_set=HathorSettings)
     verifier = BlockVerifier(settings=settings, daa=Mock())
+    deps = BlockDependencies(storage=Mock(), signaling_state=BlockIsSignaling(), feature_info={})
 
-    verifier.verify_mandatory_signaling(BlockIsSignaling())
+    verifier.verify_mandatory_signaling(deps)

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -33,7 +33,7 @@ class GenesisTest(unittest.TestCase):
         super().setUp()
         self._daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
         verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=self._daa)
-        self._verification_service = VerificationService(verifiers=verifiers)
+        self._verification_service = VerificationService(verifiers=verifiers, daa=self._daa)
         self.storage = TransactionMemoryStorage()
 
     def test_pow(self):

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -12,7 +12,7 @@ class _BaseTest:
             super().setUp()
             daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
             verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=daa)
-            self._verification_service = VerificationService(verifiers=verifiers)
+            self._verification_service = VerificationService(verifiers=verifiers, daa=daa)
 
         def test_deserialize(self):
             cls = self.get_tx_class()


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/896

### Motivation

This PR introduces the concept of verification dependencies. Before, to perform verifications, it was necessary to retrieve data from the vertex itself and also from multiple other sources, for example from the `TransactionStorage`.

Now, instead of doing this dependency retrieval one by one, interspersed in the whole verification process, a single point retrieves all necessary dependencies and everything is verified from the vertex data plus those pre-calculated dependencies. This prevents unnecessary duplicate calculations, and will be necessary for the Multiprocess Verification project.

There are also some other side-benefits:

- This is one step forward in completely removing the `TransactionStorage` from inside vertices.
- Sync-v2 may verify vertices using dependencies from its memory instead of the `TransactionStorage` (as discussed [here](https://github.com/HathorNetwork/hathor-core/pull/850#discussion_r1385422268)).
- Improved typing and ergonomics of `VerificationService` methods.

Note: in this PR, not all ad-hoc dependencies have been moved yet. This will be completed in the next PR.

### Acceptance Criteria

- Create new verification dependency models that are pre-calculated before verification.
- Update verifiers to use dependency models instead of directly accessing storage.
- Add new auxiliary methods to `SimpleMemoryStorage`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged