### PR TITLE
feat(sync-v2): Always relay vertices in real-time if the peer requested it

### DIFF
--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -193,9 +193,6 @@ class NodeBlockSync(SyncAgent):
         if not self._is_enabled:
             self.log.debug('sync is disabled')
             return
-        if not self.is_synced():
-            # XXX Should we accept any tx while I am not synced?
-            return
 
         # XXX When we start having many txs/s this become a performance issue
         # Then we could change this to be a streaming of real time data with


### PR DESCRIPTION
### Motivation

The logic to decide whether we would relay real-time vertices to peer used by in the sender. But now we moved it to the client, which means each peer can independently decide whether they want to receive real-time vertices or not.

This PR removes an outdated condition that was preventing the peer to decide.

### Acceptance Criteria

1. Remove `is_synced()` verification of `send_tx_to_peer_if_possible()`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 