### PR TITLE
fix(sync-v2): Fix issues caused by concurrent syncing peers

### DIFF
--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -494,11 +494,12 @@ class NodeBlockSync(SyncAgent):
                                    start_block: _HeightInfo,
                                    end_block: _HeightInfo) -> Deferred[StreamEnd]:
         """Request peer to start streaming blocks to us."""
-        self.log.info('requesting blocks streaming',
-                      start_block=start_block,
-                      end_block=end_block)
         self._blk_streaming_client = BlockchainStreamingClient(self, start_block, end_block)
         quantity = self._blk_streaming_client._blk_max_quantity
+        self.log.info('requesting blocks streaming',
+                      start_block=start_block,
+                      end_block=end_block,
+                      quantity=quantity)
         self.send_get_next_blocks(start_block.id, end_block.id, quantity)
         return self._blk_streaming_client.wait()
 
@@ -579,11 +580,14 @@ class NodeBlockSync(SyncAgent):
     @inlineCallbacks
     def on_block_complete(self, blk: Block, vertex_list: list[BaseTransaction]) -> Generator[Any, Any, None]:
         """This method is called when a block and its transactions are downloaded."""
+        # Note: Any vertex and block could have already been added by another concurrent syncing peer.
         for tx in vertex_list:
-            self.manager.on_new_tx(tx, propagate_to_peers=False, fails_silently=False)
+            if not self.tx_storage.transaction_exists(not_none(tx.hash)):
+                self.manager.on_new_tx(tx, propagate_to_peers=False, fails_silently=False)
             yield deferLater(self.reactor, 0, lambda: None)
 
-        self.manager.on_new_tx(blk, propagate_to_peers=False, fails_silently=False)
+        if not self.tx_storage.transaction_exists(not_none(blk.hash)):
+            self.manager.on_new_tx(blk, propagate_to_peers=False, fails_silently=False)
 
     def get_peer_block_hashes(self, heights: list[int]) -> Deferred[list[_HeightInfo]]:
         """ Returns the peer's block hashes in the given heights.

--- a/hathor/p2p/sync_v2/streamers.py
+++ b/hathor/p2p/sync_v2/streamers.py
@@ -180,22 +180,14 @@ class BlockchainStreamingServer(_StreamingServerBase):
         if cur.hash == self.end_hash:
             # only send the last when not reverse
             if not self.reverse:
-                self.log.debug('send next block', blk_id=cur.hash.hex())
+                self.log.debug('send next block', height=cur.get_height(), blk_id=cur.hash.hex())
                 self.sync_agent.send_blocks(cur)
             self.sync_agent.stop_blk_streaming_server(StreamEnd.END_HASH_REACHED)
             return
 
-        if self.counter >= self.limit:
-            # only send the last when not reverse
-            if not self.reverse:
-                self.log.debug('send next block', blk_id=cur.hash.hex())
-                self.sync_agent.send_blocks(cur)
-            self.sync_agent.stop_blk_streaming_server(StreamEnd.LIMIT_EXCEEDED)
-            return
-
         self.counter += 1
 
-        self.log.debug('send next block', blk_id=cur.hash.hex())
+        self.log.debug('send next block', height=cur.get_height(), blk_id=cur.hash.hex())
         self.sync_agent.send_blocks(cur)
 
         if self.reverse:
@@ -206,6 +198,10 @@ class BlockchainStreamingServer(_StreamingServerBase):
         # XXX: don't send the genesis or the current block
         if self.current_block is None or self.current_block.is_genesis:
             self.sync_agent.stop_blk_streaming_server(StreamEnd.NO_MORE_BLOCKS)
+            return
+
+        if self.counter >= self.limit:
+            self.sync_agent.stop_blk_streaming_server(StreamEnd.LIMIT_EXCEEDED)
             return
 
 


### PR DESCRIPTION
### Motivation

Sync-v2 had some issues when syncing with multiple peers. It was causing some tests with three or more peers to be flaky. Notice that peers could still sync but it was taking longer because of the reconnections.

### Acceptance Criteria

1. Fix `on_block_complete()` to handle vertices that already exists. It might happen because other peer had added these vertices before the current peer.
2. Fix `BlockchainStreamingServer.send_next()` which was sending one block more than the limit.
3. Fix `TransactionStreamingClient.process_tx()` which was not correctly handling dependencies that already exists in the storage. This condition might happen because of a resume or because other peer had added these dependencies before the current peer.
4. Always add vertex to `_existing_deps` if it already exists. This is necessary because the streaming server does not know we already have it so it will always send the whole sub-DAG of transactions.
5. Improve logging.
