### PR TITLE
fix(storage): Fix wrong update to the best_block_tips_cache

### DIFF
--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -216,7 +216,9 @@ class BlockConsensusAlgorithm:
                         if common_block not in heads:
                             self.context.mark_as_reorg(common_block)
                 else:
-                    storage.update_best_block_tips_cache([not_none(blk.hash) for blk in heads])
+                    best_block_tips = [not_none(blk.hash) for blk in heads]
+                    best_block_tips.append(not_none(block.hash))
+                    storage.update_best_block_tips_cache(best_block_tips)
                     if not meta.voided_by:
                         self.context.mark_as_reorg(common_block)
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -333,7 +333,8 @@ class TestCase(unittest.TestCase):
         # best block (from height index)
         b1 = manager1.tx_storage.indexes.height.get_tip()
         b2 = manager2.tx_storage.indexes.height.get_tip()
-        self.assertEqual(b1, b2)
+        self.assertIn(b1, s2)
+        self.assertIn(b2, s1)
 
     def assertConsensusEqual(self, manager1, manager2):
         _, enable_sync_v2 = self._syncVersionFlags()


### PR DESCRIPTION
### Motivation

The `tests/simulation/test_simulator.py::SyncV2RandomSimulatorTestCase::test_many_miners_since_beginning` was flaky because of this issue.

When the consensus algorithm updates the `best_block_tips_cache`, it does not include the current block being evaluated. Notice that the current block is not part of the `heads`.

### Acceptance Criteria

1. Include `block` to the list of best block tips used to update the `best_block_tips_cache`.
2. In the `assertTipsEqualSyncV2()`, we shouldn't assert `b1 == b2` because the height index keeps its previous entry when two or more blocks have the same score. So we can safely just check if `b1 in s1` and `b2 in s2`.
3. Notice that, when `len(s1) == len(s2) == 1`, checking if `b1 in s1` and `b2 in s2` is exactly the same as checking if `b1 == b2`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 