### PR TITLE
fix(sync-v2): adjust init assertion

### DIFF
--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -84,7 +84,6 @@ class TransactionStreamingClient:
         self._existing_deps: set[VertexId] = set()
 
         self._prepare_block(self.partial_blocks[0])
-        assert self._waiting_for
 
     def wait(self) -> Deferred[StreamEnd]:
         """Return the deferred."""


### PR DESCRIPTION
### Motivation

During the QA of sync-v2 some errors were caught during a sync from scratch ([see here](https://github.com/HathorNetwork/internal-issues/issues/199#issuecomment-1808646707)). In particular this one:

```
2023-11-12 05:10:57 [warning  ] [hathor.p2p.protocol] send error                     msg=internal error peer_id=7181d23 remote=127.0.0.1:9001
2023-11-12 05:10:57 [error    ] [hathor.p2p.sync_v2.agent] unhandled exception            peer=7181d23
Traceback (most recent call last):
  File "/Users/jan/Projects/hathor-core/hathor/p2p/sync_v2/agent.py", line 296, in run_sync
    yield self._run_sync()
  File "/Users/jan/Library/Caches/pypoetry/virtualenvs/hathor-JIQwCn9w-py3.11/lib/python3.11/site-packages/twisted/internet/defer.py", line 1693, in _inlineCallbacks
    result = context.run(
             ^^^^^^^^^^^^
  File "/Users/jan/Library/Caches/pypoetry/virtualenvs/hathor-JIQwCn9w-py3.11/lib/python3.11/site-packages/twisted/python/failure.py", line 518, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/Projects/hathor-core/hathor/p2p/sync_v2/agent.py", line 311, in _run_sync
    is_block_synced = yield self.run_sync_blocks()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/Library/Caches/pypoetry/virtualenvs/hathor-JIQwCn9w-py3.11/lib/python3.11/site-packages/twisted/internet/defer.py", line 1697, in _inlineCallbacks
    result = context.run(gen.send, result)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/Projects/hathor-core/hathor/p2p/sync_v2/agent.py", line 397, in run_sync_blocks
    reason = yield self.start_transactions_streaming(partial_blocks)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/Projects/hathor-core/hathor/p2p/sync_v2/agent.py", line 834, in start_transactions_streaming
    self._tx_streaming_client = TransactionStreamingClient(self,
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/Projects/hathor-core/hathor/p2p/sync_v2/transaction_streaming_client.py", line 87, in __init__
    assert self._waiting_for
AssertionError
2023-11-12 05:10:57 [info     ] [hathor.p2p.protocol] disconnected                   peer_id=7181d23 reason=Connection was closed cleanly. remote=127.0.0.1:9001
```

This indicates that the assertion inside `TransactionStreamingClient.__init__` is not correct.

### Acceptance Criteria

- Adjust `TransactionStreamingClient.__init__` assertion to account for `_existing_deps` and not only `_waiting_for`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 