### PR TITLE
fix(sync-v2): stop _process_transaction on error

### DIFF
--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -99,6 +99,9 @@ class TransactionStreamingClient:
 
     def fails(self, reason: 'StreamingError') -> None:
         """Fail the execution by resolving the deferred with an error."""
+        if self._deferred.called:
+            self.log.warn('already failed before', new_reason=repr(reason))
+            return
         self._deferred.errback(reason)
 
     def handle_transaction(self, tx: BaseTransaction) -> None:
@@ -125,6 +128,9 @@ class TransactionStreamingClient:
     @inlineCallbacks
     def process_queue(self) -> Generator[Any, Any, None]:
         """Process next transaction in the queue."""
+        if self._deferred.called:
+            return
+
         if self._is_processing:
             return
 


### PR DESCRIPTION
### Motivation

During the last QA when a node was syncing from scratch, we caught a case where more than one unexpected transaction was sent on a streamer, the first one correctly failed the streamer client, but the second one lead to an error because the deferred had already been called.

### Acceptance Criteria

- Add test to reproduce the case;
- Make it so `TransactionStreamingClient.fails` will not call `self._deferred.errback` if the deferred has already been called.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 