### PR TITLE
feat(feature-activation): configure new NOP features on testnet

### DIFF
--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -84,6 +84,33 @@ SETTINGS = HathorSettings(
               lock_in_on_timeout=False,
               version='0.56.0',
               signal_support_by_default=False
+            ),
+            Feature.NOP_FEATURE_4: Criteria(
+              bit=0,
+              start_height=3_386_880,  # N (right now the best block is 3_346_600 on testnet)
+              timeout_height=3_467_520,  # N + 2 * 40320 (4 weeks after the start)
+              minimum_activation_height=3_507_840,  # N + 3 * 40320 (6 weeks after the start)
+              lock_in_on_timeout=False,
+              version='0.57.0',
+              signal_support_by_default=True
+            ),
+            Feature.NOP_FEATURE_5: Criteria(
+              bit=1,
+              start_height=3_386_880,  # N (right now the best block is 3_346_600 on testnet)
+              timeout_height=3_467_520,  # N + 2 * 40320 (4 weeks after the start)
+              minimum_activation_height=0,
+              lock_in_on_timeout=True,
+              version='0.57.0',
+              signal_support_by_default=False
+            ),
+            Feature.NOP_FEATURE_6: Criteria(
+              bit=2,
+              start_height=3_386_880,  # N (right now the best block is 3_346_600 on testnet)
+              timeout_height=3_467_520,  # N + 2 * 40320 (4 weeks after the start)
+              minimum_activation_height=0,
+              lock_in_on_timeout=False,
+              version='0.57.0',
+              signal_support_by_default=False
             )
         }
     )

--- a/hathor/conf/testnet.yml
+++ b/hathor/conf/testnet.yml
@@ -40,6 +40,8 @@ FEATURE_ACTIVATION:
   enable_usage: true
   default_threshold: 30_240 # 30240 = 75% of evaluation_interval (40320)
   features:
+    #### First Phased Testing features ####
+
     NOP_FEATURE_1:
       bit: 0
       start_height: 3_144_960 # N (right now the best block is 3093551 on testnet)
@@ -65,4 +67,33 @@ FEATURE_ACTIVATION:
       minimum_activation_height: 0
       lock_in_on_timeout: false
       version: 0.56.0
+      signal_support_by_default: false
+
+    #### Second Phased Testing features ####
+
+    NOP_FEATURE_4:
+      bit: 0
+      start_height: 3_386_880 # N (right now the best block is 3_346_600 on testnet)
+      timeout_height: 3_467_520 # N + 2 * 40320 (4 weeks after the start)
+      minimum_activation_height: 3_507_840 # N + 3 * 40320 (6 weeks after the start)
+      lock_in_on_timeout: false
+      version: 0.57.0
+      signal_support_by_default: true
+
+    NOP_FEATURE_5:
+      bit: 1
+      start_height: 3_386_880 # N (right now the best block is 3_346_600 on testnet)
+      timeout_height: 3_467_520 # N + 2 * 40320 (4 weeks after the start)
+      minimum_activation_height: 0
+      lock_in_on_timeout: true
+      version: 0.57.0
+      signal_support_by_default: false
+
+    NOP_FEATURE_6:
+      bit: 2
+      start_height: 3_386_880 # N (right now the best block is 3_346_600 on testnet)
+      timeout_height: 3_467_520 # N + 2 * 40320 (4 weeks after the start)
+      minimum_activation_height: 0
+      lock_in_on_timeout: false
+      version: 0.57.0
       signal_support_by_default: false

--- a/hathor/feature_activation/feature.py
+++ b/hathor/feature_activation/feature.py
@@ -23,6 +23,12 @@ class Feature(Enum):
     should NOT be changed either, as configuration uses them for setting feature activation criteria.
     """
 
+    # First Phased Testing features
     NOP_FEATURE_1 = 'NOP_FEATURE_1'
     NOP_FEATURE_2 = 'NOP_FEATURE_2'
     NOP_FEATURE_3 = 'NOP_FEATURE_3'
+
+    # Second Phased Testing features
+    NOP_FEATURE_4 = 'NOP_FEATURE_4'
+    NOP_FEATURE_5 = 'NOP_FEATURE_5'
+    NOP_FEATURE_6 = 'NOP_FEATURE_6'

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -1075,7 +1075,7 @@ class HathorManager:
             features_states=state_by_feature
         )
 
-        features = [Feature.NOP_FEATURE_1, Feature.NOP_FEATURE_2, Feature.NOP_FEATURE_3]
+        features = [Feature.NOP_FEATURE_4, Feature.NOP_FEATURE_5, Feature.NOP_FEATURE_6]
         for feature in features:
             self._log_if_feature_is_active(vertex, feature)
 


### PR DESCRIPTION
### Motivation

Configure the new NOP features in testnet to restart the Phased Testing.

The start height is 3.386.880, which is 38.000 blocks from the current best height in testnet. This is equivalent to 13 days, meaning the Phase Testing should start around Dec 6th. We need to deploy this code before that.

### Acceptance Criteria

- Configure new NOP features in `testnet.yml` and `testnet.py`.
- Update logging from old to new NOP features.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 