### PR TITLE
fix(cli): do not include sync-v2 indexes when not explicitly enabled

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -353,12 +353,17 @@ class Builder:
             whitelist_only=False,
             rng=self._rng,
         )
+
+        # XXX: always have sync-v1 factory available
         p2p_manager.add_sync_factory(SyncVersion.V1_1, SyncV11Factory(p2p_manager))
-        p2p_manager.add_sync_factory(SyncVersion.V2, SyncV2Factory(p2p_manager))
         if self._enable_sync_v1:
             p2p_manager.enable_sync_version(SyncVersion.V1_1)
+
         if self._enable_sync_v2:
+            # XXX: only enable sync-v2 factory on demand, prevents enabling sync-v2 indexes when sync-v2 is not enabled
+            p2p_manager.add_sync_factory(SyncVersion.V2, SyncV2Factory(p2p_manager))
             p2p_manager.enable_sync_version(SyncVersion.V2)
+
         return p2p_manager
 
     def _get_or_create_indexes_manager(self) -> IndexesManager:

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -237,11 +237,15 @@ class CliBuilder:
             whitelist_only=False,
             rng=Random(),
         )
+
+        # XXX: always have sync-v1 factory available
         p2p_manager.add_sync_factory(SyncVersion.V1_1, SyncV11Factory(p2p_manager))
-        p2p_manager.add_sync_factory(SyncVersion.V2, SyncV2Factory(p2p_manager))
         if enable_sync_v1:
             p2p_manager.enable_sync_version(SyncVersion.V1_1)
+
         if enable_sync_v2:
+            # XXX: only enable sync-v2 factory on demand, prevents enabling sync-v2 indexes when sync-v2 is not enabled
+            p2p_manager.add_sync_factory(SyncVersion.V2, SyncV2Factory(p2p_manager))
             p2p_manager.enable_sync_version(SyncVersion.V2)
 
         self.manager = HathorManager(


### PR DESCRIPTION
### Motivation

This PR addresses the issue caught on the QA of RC-1, detailed on #881 

### Acceptance Criteria

- Do not add sync-v2 factory when sync-v2 is not explicitly enabled, in turn making the sync-v2 index (the mempool-tips-index) to not be always turned on, the downside being that sync-v2 cannot be enabled through sysctl if a node starts with sync-v1 only.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 