### PR TITLE
refactor(p2p): use async/await syntax on peer discovery

### DIFF
--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -248,7 +248,8 @@ class ConnectionsManager:
         Do a discovery and connect on all discovery strategies.
         """
         for peer_discovery in self.peer_discoveries:
-            peer_discovery.discover_and_connect(self.connect_to)
+            coro = peer_discovery.discover_and_connect(self.connect_to)
+            Deferred.fromCoroutine(coro)
 
     def disable_rate_limiter(self) -> None:
         """Disable global rate limiter."""

--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -16,7 +16,7 @@ import base64
 import hashlib
 from enum import Enum
 from math import inf
-from typing import TYPE_CHECKING, Any, Generator, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -24,7 +24,6 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from OpenSSL.crypto import X509, PKey
-from twisted.internet.defer import inlineCallbacks
 from twisted.internet.interfaces import ISSLTransport
 from twisted.internet.ssl import Certificate, CertificateOptions, TLSVersion, trustRootFromCertificates
 
@@ -324,8 +323,7 @@ class PeerId:
         )
         return certificate_options
 
-    @inlineCallbacks
-    def validate_entrypoint(self, protocol: 'HathorProtocol') -> Generator[Any, Any, bool]:
+    async def validate_entrypoint(self, protocol: 'HathorProtocol') -> bool:
         """ Validates if connection entrypoint is one of the peer entrypoints
         """
         found_entrypoint = False
@@ -349,7 +347,7 @@ class PeerId:
                 host = connection_string_to_host(entrypoint)
                 # TODO: don't use `daa.TEST_MODE` for this
                 test_mode = not_none(DifficultyAdjustmentAlgorithm.singleton).TEST_MODE
-                result = yield discover_dns(host, test_mode)
+                result = await discover_dns(host, test_mode)
                 if protocol.connection_string in result:
                     # Found the entrypoint
                     found_entrypoint = True
@@ -369,7 +367,7 @@ class PeerId:
                     found_entrypoint = True
                     break
                 test_mode = not_none(DifficultyAdjustmentAlgorithm.singleton).TEST_MODE
-                result = yield discover_dns(host, test_mode)
+                result = await discover_dns(host, test_mode)
                 if connection_host in [connection_string_to_host(x) for x in result]:
                     # Found the entrypoint
                     found_entrypoint = True

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -14,7 +14,7 @@
 
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generator, Optional, cast
+from typing import TYPE_CHECKING, Any, Coroutine, Generator, Optional, cast
 
 from structlog import get_logger
 from twisted.internet.defer import Deferred
@@ -311,7 +311,8 @@ class HathorProtocol:
         fn = self.state.cmd_map.get(cmd)
         if fn is not None:
             try:
-                return fn(payload)
+                result = fn(payload)
+                return Deferred.fromCoroutine(result) if isinstance(result, Coroutine) else result
             except Exception:
                 self.log.warn('recv_message processing error', exc_info=True)
                 raise

--- a/hathor/p2p/states/base.py
+++ b/hathor/p2p/states/base.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from structlog import get_logger
 from twisted.internet.defer import Deferred
@@ -27,7 +28,10 @@ logger = get_logger()
 
 class BaseState:
     protocol: 'HathorProtocol'
-    cmd_map: dict[ProtocolMessages, Union[Callable[[str], None], Callable[[str], Deferred[None]]]]
+    cmd_map: dict[
+        ProtocolMessages,
+        Callable[[str], None] | Callable[[str], Deferred[None]] | Callable[[str], Coroutine[Deferred[None], Any, None]]
+    ]
 
     def __init__(self, protocol: 'HathorProtocol'):
         self.log = logger.new(**protocol.get_logger_context())

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING
 
 from structlog import get_logger
-from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
 from hathor.p2p.messages import ProtocolMessages
@@ -77,8 +76,7 @@ class PeerIdState(BaseState):
         }
         self.send_message(ProtocolMessages.PEER_ID, json_dumps(hello))
 
-    @inlineCallbacks
-    def handle_peer_id(self, payload: str) -> Generator[Any, Any, None]:
+    async def handle_peer_id(self, payload: str) -> None:
         """ Executed when a PEER-ID is received. It basically checks
         the identity of the peer. Only after this step, the peer connection
         is considered established and ready to communicate.
@@ -117,7 +115,7 @@ class PeerIdState(BaseState):
                 protocol.send_error_and_close_connection('We are already connected.')
                 return
 
-        entrypoint_valid = yield peer.validate_entrypoint(protocol)
+        entrypoint_valid = await peer.validate_entrypoint(protocol)
         if not entrypoint_valid:
             protocol.send_error_and_close_connection('Connection string is not in the entrypoints.')
             return

--- a/hathor/p2p/utils.py
+++ b/hathor/p2p/utils.py
@@ -14,7 +14,7 @@
 
 import datetime
 import re
-from typing import Any, Generator, Optional
+from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 import requests
@@ -25,7 +25,6 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.x509 import Certificate
 from cryptography.x509.oid import NameOID
-from twisted.internet.defer import inlineCallbacks
 from twisted.internet.interfaces import IAddress
 
 from hathor.conf.get_settings import get_settings
@@ -100,15 +99,14 @@ def connection_string_to_host(connection_string: str) -> str:
     return urlparse(connection_string).netloc.split(':')[0]
 
 
-@inlineCallbacks
-def discover_dns(host: str, test_mode: int = 0) -> Generator[Any, Any, list[str]]:
+async def discover_dns(host: str, test_mode: int = 0) -> list[str]:
     """ Start a DNS peer discovery object and execute a search for the host
 
         Returns the DNS string from the requested host
         E.g., localhost -> tcp://127.0.0.1:40403
     """
     discovery = DNSPeerDiscovery([], test_mode=test_mode)
-    result = yield discovery.dns_seed_lookup(host)
+    result = await discovery.dns_seed_lookup(host)
     return result
 
 

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -2,8 +2,6 @@ import os
 import shutil
 import tempfile
 
-from twisted.internet.defer import inlineCallbacks
-
 from hathor.conf import HathorSettings
 from hathor.p2p.peer_id import InvalidPeerIdException, PeerId
 from hathor.p2p.peer_storage import PeerStorage
@@ -212,8 +210,7 @@ class PeerIdTest(unittest.TestCase):
 class BasePeerIdTest(unittest.TestCase):
     __test__ = False
 
-    @inlineCallbacks
-    def test_validate_entrypoint(self):
+    async def test_validate_entrypoint(self):
         manager = self.create_peer('testnet', unlock_wallet=False)
         peer_id = manager.my_peer
         peer_id.entrypoints = ['tcp://127.0.0.1:40403']
@@ -221,15 +218,15 @@ class BasePeerIdTest(unittest.TestCase):
         # we consider that we are starting the connection to the peer
         protocol = manager.connections.client_factory.buildProtocol('127.0.0.1')
         protocol.connection_string = 'tcp://127.0.0.1:40403'
-        result = yield peer_id.validate_entrypoint(protocol)
+        result = await peer_id.validate_entrypoint(protocol)
         self.assertTrue(result)
         # if entrypoint is an URI
         peer_id.entrypoints = ['uri_name']
-        result = yield peer_id.validate_entrypoint(protocol)
+        result = await peer_id.validate_entrypoint(protocol)
         self.assertTrue(result)
         # test invalid. DNS in test mode will resolve to '127.0.0.1:40403'
         protocol.connection_string = 'tcp://45.45.45.45:40403'
-        result = yield peer_id.validate_entrypoint(protocol)
+        result = await peer_id.validate_entrypoint(protocol)
         self.assertFalse(result)
 
         # now test when receiving the connection - i.e. the peer starts it
@@ -242,11 +239,11 @@ class BasePeerIdTest(unittest.TestCase):
                 Peer = namedtuple('Peer', 'host')
                 return Peer(host='127.0.0.1')
         protocol.transport = FakeTransport()
-        result = yield peer_id.validate_entrypoint(protocol)
+        result = await peer_id.validate_entrypoint(protocol)
         self.assertTrue(result)
         # if entrypoint is an URI
         peer_id.entrypoints = ['uri_name']
-        result = yield peer_id.validate_entrypoint(protocol)
+        result = await peer_id.validate_entrypoint(protocol)
         self.assertTrue(result)
 
 


### PR DESCRIPTION
### Motivation

While studying for another project, I found out that our version of Twisted actually supports using the `async/await` python syntax, and even recommends it ([docs](https://docs.twisted.org/en/twisted-22.10.0/core/howto/defer-intro.html#coroutines-with-async-await)):

> Unless your code supports Python 2 (and therefore needs compatibility with older versions of Twisted), writing coroutines with the functionality described in “Coroutines with async/await” is preferred over `inlineCallbacks`. Coroutines are supported by dedicated Python syntax, are compatible with `asyncio`, and provide higher performance.

This has multiple benefits, improving readability, static type checking, and may even boost performance, according to the docs above.

We should aim to gradually convert this code, where it makes sense. Mostly, it makes sense to convert it everywhere the `@inlineCallbacks`decorator is used, as the conversion is pretty straightforward. Places using direct `Deferred` callback manipulation require a bit more thought so we may not want to convert them. Ideally, new could should always use the new syntax.

Here's a small cheat sheet for conversion:

- For decorated functions/methods, simply change `@inlineCallbacks` to `async` and `yield` to `await` (`Deferred`s are `Awaitable`). Also, change the return type from `Generator[_, _, T]` to `T`.
- `Deferred`s are eager (they start running as soon as they're created) while coroutines (`async` functions) are lazy (they start running when they're awaited). This means that currently we have places in code where synchronous code ("non-`inlineCallbacks`") create a `Deferred` without any callbacks, so the behavior is "fire and forget". Since coroutines cannot be awaited in "non-async" functions, we need to use `Deferred.fromCoroutine()` in order to convert and automatically make them run.

It is my understanding that we could have only a single `Deferred.fromCoroutine()` in the code, in the outermost async function, and all subsequent usages could leverage the `async/await` syntax directly. This is currently not possible because of those "fire and forget" cases. They may indicate that we should explicitly handle those deferred's callbacks, improving robustness (since they're currently ignored), and then they could be converted to `async/await`s too. That would bubble up async functions all the way to the startup of our code. This is a larger refactor and we could do it incrementally.

### Acceptance Criteria

- Change all `@inlineCallbacks/yield` functions and methods related to peer discovery to use `async/await` instead. Also, update return types accordingly.
- Update `HathorProtocol` and `BaseState` to accept coroutines as commands.
- Update `ConnectionsManager` to fire and forget a coroutine.
- No behavior should be changed by this PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 