### PR TITLE
fix(p2p): fix update whitelist handler

### DIFF
--- a/tests/p2p/test_whitelist.py
+++ b/tests/p2p/test_whitelist.py
@@ -1,11 +1,18 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from hathor.conf import HathorSettings
+from twisted.internet.defer import Deferred, TimeoutError
+from twisted.python.failure import Failure
+from twisted.web.client import Agent
+
+from hathor.conf.get_settings import get_global_settings
+from hathor.conf.settings import HathorSettings
+from hathor.manager import HathorManager
+from hathor.p2p.manager import WHITELIST_REQUEST_TIMEOUT
 from hathor.p2p.sync_version import SyncVersion
 from hathor.simulator import FakeConnection
 from tests import unittest
 
-settings = HathorSettings()
+settings = get_global_settings()
 
 
 class WhitelistTestCase(unittest.SyncV1Params, unittest.TestCase):
@@ -79,3 +86,61 @@ class WhitelistTestCase(unittest.SyncV1Params, unittest.TestCase):
 
         self.assertFalse(conn.tr1.disconnecting)
         self.assertFalse(conn.tr2.disconnecting)
+
+    def test_update_whitelist(self) -> None:
+        network = 'testnet'
+        manager: HathorManager = self.create_peer(network)
+        connections_manager = manager.connections
+
+        settings_mock = Mock(spec_set=HathorSettings)
+        settings_mock.WHITELIST_URL = 'some_url'
+        connections_manager._settings = settings_mock
+
+        agent_mock = Mock(spec_set=Agent)
+        agent_mock.request = Mock()
+        connections_manager._http_agent = agent_mock
+
+        with (
+            patch.object(connections_manager, '_update_whitelist_cb') as _update_whitelist_cb_mock,
+            patch.object(connections_manager, '_update_whitelist_err') as _update_whitelist_err_mock,
+            patch('twisted.web.client.readBody') as read_body_mock
+        ):
+            # Test success
+            agent_mock.request.return_value = Deferred()
+            read_body_mock.return_value = b'body'
+            d = connections_manager.update_whitelist()
+            d.callback(None)
+
+            read_body_mock.assert_called_once_with(None)
+            _update_whitelist_cb_mock.assert_called_once_with(b'body')
+            _update_whitelist_err_mock.assert_not_called()
+
+            read_body_mock.reset_mock()
+            _update_whitelist_cb_mock.reset_mock()
+            _update_whitelist_err_mock.reset_mock()
+
+            # Test request error
+            agent_mock.request.return_value = Deferred()
+            d = connections_manager.update_whitelist()
+            error = Failure('some_error')
+            d.errback(error)
+
+            read_body_mock.assert_not_called()
+            _update_whitelist_cb_mock.assert_not_called()
+            _update_whitelist_err_mock.assert_called_once_with(error)
+
+            read_body_mock.reset_mock()
+            _update_whitelist_cb_mock.reset_mock()
+            _update_whitelist_err_mock.reset_mock()
+
+            # Test timeout
+            agent_mock.request.return_value = Deferred()
+            read_body_mock.return_value = b'body'
+            connections_manager.update_whitelist()
+
+            self.clock.advance(WHITELIST_REQUEST_TIMEOUT + 1)
+
+            read_body_mock.assert_not_called()
+            _update_whitelist_cb_mock.assert_not_called()
+            _update_whitelist_err_mock.assert_called_once()
+            assert isinstance(_update_whitelist_err_mock.call_args.args[0].value, TimeoutError)


### PR DESCRIPTION
### Motivation

There are some Twisted errors that are logged raw, causing each log line to become an alert in OpsGenie, as in this incident: https://github.com/HathorNetwork/on-call-incidents/issues/153.

After some investigation, the reason for this is not 100% clear, but there are some suspicions. This PR attempts to fix at least one case that would cause the problem. We've tested a full node running on mainnet for a few days, and by inspecting its logs, it looks like the error has improved.

### Acceptance Criteria

- Remove custom timeout handling in `update_whitelist()` to use `Deferred.addTimeout()`.
- Move the `readBody()` call to be included in the timeout.
- Change `update_whitelist()` so the errback is after the callback, so the errback handles exceptions from the callback.
- Add unit tests for `update_whitelist()`, including cases for success, request error, and request timeout.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 