### PR TITLE
fix(pubsub): Event queue becoming too long

### DIFF
--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -1,47 +1,8 @@
-import threading
-import time
-
-from twisted.internet import threads
-from twisted.python import threadable
-
 from hathor.pubsub import HathorEvents, PubSubManager
-from hathor.util import reactor
-from tests import unittest
+from tests.unittest import TestCase
 
 
-class PubSubTestCase(unittest.TestCase):
-    def _waitForThread(self):
-        """
-        The reactor's threadpool is only available when the reactor is running,
-        so to have a sane behavior during the tests we make a dummy
-        L{threads.deferToThread} call.
-        """
-        # copied from twisted/test/test_threads.py [yan]
-        return threads.deferToThread(time.sleep, 0)
-
-    def test_pubsub_thread(self):
-        """ Test pubsub function is always called in reactor thread.
-        """
-        def _on_new_event(*args):
-            self.assertTrue(threadable.isInIOThread())
-
-        pubsub = PubSubManager(reactor)
-        pubsub.subscribe(HathorEvents.NETWORK_NEW_TX_ACCEPTED, _on_new_event)
-
-        def cb(_ignore):
-            waiter = threading.Event()
-
-            def threadedFunc():
-                self.assertFalse(threadable.isInIOThread())
-                pubsub.publish(HathorEvents.NETWORK_NEW_TX_ACCEPTED)
-                waiter.set()
-
-            reactor.callInThread(threadedFunc)
-            waiter.wait(20)
-            self.assertTrue(waiter.isSet())
-
-        return self._waitForThread().addCallback(cb)
-
+class PubSubTestCase(TestCase):
     def test_duplicate_subscribe(self):
         def noop():
             pass


### PR DESCRIPTION
### Motivation

In the sync-v1 process, there's a bottleneck occurring due to the differing speeds of data processing and data arrival. Firstly, the `sync_v1_agent.send_data_queue.priority_queue` is unable to process transactions as quickly as they arrive. This discrepancy results in the queue continuously expanding throughout the synchronization process, keeping references to `BaseTransaction` objects.

In addition, each set of blocks received by sync-v1 triggers approximately 200 events in the pubsub system. However, similar to the first issue, the event queue processes these transactions at a slower rate than their arrival rate. Consequently, this queue also grows continually during synchronization, maintaining references to `BaseTransaction` objects.

Both of these issues contribute to a critical memory management problem. Since these queues hold onto references to vertices, the garbage collector is unable to free up the memory space that these objects occupy.

For context, when operating a full node on my local computer (a MacBook), it initially consumed 3.19 GB of memory while processing 450,000 vertices. After this fix, the memory usage significantly decreased to just 0.62 GB. I also checked the number of blocks in memory every 25,000 blocks and this number was always between 800 and 2,000.

#### Useful commands:

```python
import gc
from hathor.transaction import Block
from sys import getrefcount

gcl = gc.get_objects()
gcl_blocks = [x for x in gcl if isinstance(x, Block)]
print('blocks', len(gcl_blocks))

blk = gcl_blocks[10]
print('height', blk.get_height())
print('refs', getrefcount(blk))

refs = gc.get_referrers(blk)
refs[0]
```

```python
from IPython import start_ipython
start_ipython(argv=[], user_ns={
    'manager': self,
})
```

### Acceptance Criteria

- Include here all things that this PR should solve

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 