### PR TITLE
chore(custom-checks): add check to prevent circular imports

### DIFF
--- a/extras/custom_checks.sh
+++ b/extras/custom_checks.sh
@@ -89,12 +89,25 @@ function check_do_not_import_tests_in_hathor() {
 	return 0
 }
 
+function check_do_not_import_from_hathor_in_entrypoints() {
+    PATTERN='^import .*hathor.*\|^from .*hathor.* import'
+
+    if grep -R "$PATTERN" "hathor/cli" | grep -v 'from hathor.cli.run_node import RunNode' | grep -v '# skip-cli-import-custom-check'; then
+        echo 'do not import from `hathor` in the module-level of a CLI entrypoint.'
+        echo 'instead, import locally inside the function that uses the import.'
+        echo 'alternatively, comment `# skip-cli-import-custom-check` to exclude a line.'
+        return 1
+    fi
+    return 0
+}
+
 # List of functions to be executed
 checks=(
 	check_version_match
 	check_do_not_use_builtin_random_in_tests
 	check_deprecated_typing
 	check_do_not_import_tests_in_hathor
+	check_do_not_import_from_hathor_in_entrypoints
 )
 
 # Initialize a variable to track if any check fails

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -21,7 +21,7 @@ from typing import Any, Optional
 
 from structlog import get_logger
 
-from hathor.cli.run_node import RunNodeArgs
+from hathor.cli.run_node_args import RunNodeArgs
 from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.event import EventManager

--- a/hathor/cli/db_import.py
+++ b/hathor/cli/db_import.py
@@ -18,7 +18,6 @@ import sys
 from argparse import ArgumentParser, FileType
 from typing import TYPE_CHECKING, Iterator
 
-from hathor.cli.db_export import MAGIC_HEADER
 from hathor.cli.run_node import RunNode
 
 if TYPE_CHECKING:
@@ -46,6 +45,7 @@ class DbImport(RunNode):
         self.in_file = io.BufferedReader(self._args.import_file)
 
     def run(self) -> None:
+        from hathor.cli.db_export import MAGIC_HEADER
         from hathor.util import tx_progress
 
         header = self.in_file.read(len(MAGIC_HEADER))

--- a/hathor/cli/events_simulator/event_forwarding_websocket_factory.py
+++ b/hathor/cli/events_simulator/event_forwarding_websocket_factory.py
@@ -12,21 +12,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from twisted.internet.interfaces import IAddress
 
-from hathor.cli.events_simulator.event_forwarding_websocket_protocol import EventForwardingWebsocketProtocol
-from hathor.event.websocket import EventWebsocketFactory
-from hathor.simulator import Simulator
+from hathor.event.websocket import EventWebsocketFactory  # skip-cli-import-custom-check
+
+if TYPE_CHECKING:
+    from hathor.cli.events_simulator.event_forwarding_websocket_protocol import EventForwardingWebsocketProtocol
+    from hathor.simulator import Simulator
 
 
 class EventForwardingWebsocketFactory(EventWebsocketFactory):
-    def __init__(self, simulator: Simulator, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, simulator: 'Simulator', *args: Any, **kwargs: Any) -> None:
         self._simulator = simulator
         super().__init__(*args, **kwargs)
 
-    def buildProtocol(self, _: IAddress) -> EventForwardingWebsocketProtocol:
+    def buildProtocol(self, _: IAddress) -> 'EventForwardingWebsocketProtocol':
         protocol = EventForwardingWebsocketProtocol(self._simulator)
         protocol.factory = self
         return protocol

--- a/hathor/cli/events_simulator/event_forwarding_websocket_protocol.py
+++ b/hathor/cli/events_simulator/event_forwarding_websocket_protocol.py
@@ -16,17 +16,17 @@ from typing import TYPE_CHECKING
 
 from autobahn.websocket import ConnectionRequest
 
-from hathor.event.websocket import EventWebsocketProtocol
-from hathor.simulator import Simulator
+from hathor.event.websocket import EventWebsocketProtocol  # skip-cli-import-custom-check
 
 if TYPE_CHECKING:
     from hathor.cli.events_simulator.event_forwarding_websocket_factory import EventForwardingWebsocketFactory
+    from hathor.simulator import Simulator
 
 
 class EventForwardingWebsocketProtocol(EventWebsocketProtocol):
     factory: 'EventForwardingWebsocketFactory'
 
-    def __init__(self, simulator: Simulator) -> None:
+    def __init__(self, simulator: 'Simulator') -> None:
         self._simulator = simulator
         super().__init__()
 

--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -24,8 +24,6 @@ from multiprocessing import Process, Queue
 
 import requests
 
-from hathor.conf.get_settings import get_settings
-
 _SLEEP_ON_ERROR_SECONDS = 5
 _MAX_CONN_RETRIES = math.inf
 
@@ -137,6 +135,7 @@ def execute(args: Namespace) -> None:
                                                                       block.nonce, block.weight))
 
         try:
+            from hathor.conf.get_settings import get_settings
             from hathor.daa import DifficultyAdjustmentAlgorithm
             from hathor.verification.verification_service import VerificationService, VertexVerifiers
             settings = get_settings()

--- a/hathor/cli/multisig_spend.py
+++ b/hathor/cli/multisig_spend.py
@@ -14,8 +14,6 @@
 
 from argparse import ArgumentParser, Namespace
 
-from hathor.mining.cpu_mining_service import CpuMiningService
-
 
 def create_parser() -> ArgumentParser:
     from hathor.cli.util import create_parser
@@ -29,6 +27,7 @@ def create_parser() -> ArgumentParser:
 
 
 def execute(args: Namespace) -> None:
+    from hathor.mining.cpu_mining_service import CpuMiningService
     from hathor.transaction import Transaction
     from hathor.transaction.scripts import MultiSig
 

--- a/hathor/cli/nginx_config.py
+++ b/hathor/cli/nginx_config.py
@@ -17,8 +17,6 @@ import os
 from enum import Enum
 from typing import Any, NamedTuple, Optional, TextIO
 
-from hathor.cli.openapi_json import get_openapi_dict
-
 BASE_PATH = os.path.join(os.path.dirname(__file__), 'nginx_files')
 
 
@@ -26,6 +24,7 @@ def get_openapi(src_file: Optional[TextIO] = None) -> dict[str, Any]:
     """ Open and parse the json file or generate OpenAPI dict on-the-fly
     """
     if src_file is None:
+        from hathor.cli.openapi_json import get_openapi_dict
         return get_openapi_dict()
     else:
         return json.load(src_file)

--- a/hathor/cli/openapi_files/register.py
+++ b/hathor/cli/openapi_files/register.py
@@ -14,7 +14,7 @@
 
 from typing import TypeVar
 
-from hathor.api_util import Resource
+from hathor.api_util import Resource  # skip-cli-import-custom-check
 
 _registered_resources: list[type[Resource]] = []
 

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -16,8 +16,8 @@ from typing import Optional
 
 from pydantic import Extra
 
-from hathor.feature_activation.feature import Feature
-from hathor.utils.pydantic import BaseModel
+from hathor.feature_activation.feature import Feature  # skip-cli-import-custom-check
+from hathor.utils.pydantic import BaseModel  # skip-cli-import-custom-check
 
 
 class RunNodeArgs(BaseModel, extra=Extra.allow):

--- a/hathor/cli/twin_tx.py
+++ b/hathor/cli/twin_tx.py
@@ -19,8 +19,6 @@ from json.decoder import JSONDecodeError
 
 import requests
 
-from hathor.mining.cpu_mining_service import CpuMiningService
-
 
 def create_parser() -> ArgumentParser:
     from hathor.cli.util import create_parser
@@ -36,6 +34,7 @@ def create_parser() -> ArgumentParser:
 
 
 def execute(args: Namespace) -> None:
+    from hathor.mining.cpu_mining_service import CpuMiningService
     from hathor.transaction import Transaction
 
     # Get tx you want to create a twin


### PR DESCRIPTION
### Motivation

Sometimes, when something is imported from the `hathor` module in an entrypoint file (from CLI commands), a circular import could happen, causing the full node node startup to fail. This has happened a couple times in the past ([example](https://github.com/HathorNetwork/hathor-core/pull/762)).

This problem would not be caught by our linters and neither tests, so it would only appear after the merge to `master`, when the docker image is generated. This PR aims to prevent this by adding a custom lint check that prohibits importing from `hathor` in the module-level of CLI entrypoints. For specific cases, a `# no-custom-check` comment can be added to opt-out of this check. [Here's an example](https://github.com/HathorNetwork/hathor-core/actions/runs/7121270335/job/19390180920?pr=887) of a failing output.

This will also be useful in https://github.com/HathorNetwork/hathor-core/pull/889, as it prevents indirect calls that could automatically install the default Twisted Reactor before our code had a chance to customize it.

### Acceptance Criteria

- Add new custom check to prevent importing from the `hathor` module in the module-level of CLI related files.
- Update code to conform with the new check.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 