### PR TITLE
refactor(reactor): remove module-level global reactor

### DIFF
--- a/extras/custom_checks.sh
+++ b/extras/custom_checks.sh
@@ -101,6 +101,18 @@ function check_do_not_import_from_hathor_in_entrypoints() {
     return 0
 }
 
+function check_do_not_import_twisted_reactor_directly() {
+    EXCLUDES="--exclude=reactor.py --exclude=conftest.py"
+    PATTERN='\<.*from .*twisted.internet import .*reactor\>'
+
+    if grep -R $EXCLUDES "$PATTERN" "${SOURCE_DIRS[@]}"; then
+        echo 'do not use `from twisted.internet import reactor` directly.'
+        echo 'instead, use `hathor.reactor.get_global_reactor()`.'
+        return 1
+    fi
+    return 0
+}
+
 # List of functions to be executed
 checks=(
 	check_version_match
@@ -108,6 +120,7 @@ checks=(
 	check_deprecated_typing
 	check_do_not_import_tests_in_hathor
 	check_do_not_import_from_hathor_in_entrypoints
+	check_do_not_import_twisted_reactor_directly
 )
 
 # Initialize a variable to track if any check fails

--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -34,6 +34,7 @@ from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer_id import PeerId
 from hathor.pubsub import PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.storage import RocksDBStorage
 from hathor.stratum import StratumFactory
 from hathor.transaction.storage import (
@@ -42,7 +43,7 @@ from hathor.transaction.storage import (
     TransactionRocksDBStorage,
     TransactionStorage,
 )
-from hathor.util import Random, Reactor, get_environment_info, not_none
+from hathor.util import Random, get_environment_info, not_none
 from hathor.verification.verification_service import VerificationService, VertexVerifiers
 from hathor.wallet import BaseWallet, Wallet
 
@@ -311,7 +312,7 @@ class Builder:
         return self._pubsub
 
     def _create_stratum_server(self, manager: HathorManager) -> StratumFactory:
-        stratum_factory = StratumFactory(manager=manager)
+        stratum_factory = StratumFactory(manager=manager, reactor=self._get_reactor())
         manager.stratum_factory = stratum_factory
         manager.metrics.stratum_factory = stratum_factory
         return stratum_factory

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -35,8 +35,9 @@ from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.utils import discover_hostname, get_genesis_short_hash
 from hathor.pubsub import PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.stratum import StratumFactory
-from hathor.util import Random, Reactor, not_none
+from hathor.util import Random, not_none
 from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor.wallet import BaseWallet, HDWallet, Wallet
@@ -271,7 +272,7 @@ class CliBuilder:
         p2p_manager.set_manager(self.manager)
 
         if self._args.stratum:
-            stratum_factory = StratumFactory(self.manager)
+            stratum_factory = StratumFactory(self.manager, reactor=reactor)
             self.manager.stratum_factory = stratum_factory
             self.manager.metrics.stratum_factory = stratum_factory
 

--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -224,15 +224,15 @@ class ResourcesBuilder:
             root.putChild(b'_debug', debug_resource)
             resources.extend([
                 (b'log', DebugLogResource(), debug_resource),
-                (b'raise', DebugRaiseResource(), debug_resource),
-                (b'reject', DebugRejectResource(), debug_resource),
+                (b'raise', DebugRaiseResource(self.manager.reactor), debug_resource),
+                (b'reject', DebugRejectResource(self.manager.reactor), debug_resource),
                 (b'print', DebugPrintResource(), debug_resource),
             ])
         if self._args.enable_crash_api:
             crash_resource = Resource()
             root.putChild(b'_crash', crash_resource)
             resources.extend([
-                (b'exit', DebugCrashResource(), crash_resource),
+                (b'exit', DebugCrashResource(self.manager.reactor), crash_resource),
                 (b'mess_around', DebugMessAroundResource(self.manager), crash_resource),
             ])
 

--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -44,8 +44,8 @@ def execute(args: Namespace) -> None:
     os.environ['HATHOR_CONFIG_YAML'] = UNITTESTS_SETTINGS_FILEPATH
     from hathor.cli.events_simulator.event_forwarding_websocket_factory import EventForwardingWebsocketFactory
     from hathor.cli.events_simulator.scenario import Scenario
+    from hathor.reactor import get_global_reactor
     from hathor.simulator import Simulator
-    from hathor.util import reactor
 
     try:
         scenario = Scenario[args.scenario]
@@ -53,6 +53,7 @@ def execute(args: Namespace) -> None:
         possible_scenarios = [scenario.name for scenario in Scenario]
         raise ValueError(f'Invalid scenario "{args.scenario}". Choose one of {possible_scenarios}') from e
 
+    reactor = get_global_reactor()
     log = logger.new()
     simulator = Simulator(args.seed)
     simulator.start()

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -138,7 +138,8 @@ class RunNode:
         self.check_unsafe_arguments()
         self.check_python_version()
 
-        from hathor.util import reactor
+        from hathor.reactor import get_global_reactor
+        reactor = get_global_reactor()
         self.reactor = reactor
 
         from hathor.builder import CliBuilder, ResourcesBuilder

--- a/hathor/cli/stratum_mining.py
+++ b/hathor/cli/stratum_mining.py
@@ -30,8 +30,8 @@ def create_parser() -> ArgumentParser:
 
 def execute(args: Namespace) -> None:
     from hathor.crypto.util import decode_address
+    from hathor.reactor import get_global_reactor
     from hathor.stratum import StratumClient
-    from hathor.util import reactor
     from hathor.wallet.exceptions import InvalidAddress
 
     address = None
@@ -43,7 +43,8 @@ def execute(args: Namespace) -> None:
             print('The given address is invalid')
             sys.exit(-1)
 
-    miner = StratumClient(proc_count=args.nproc, address=address)
+    reactor = get_global_reactor()
+    miner = StratumClient(proc_count=args.nproc, address=address, reactor=reactor)
     miner.start()
     point = TCP4ClientEndpoint(reactor, args.host, args.port)
     connectProtocol(point, miner)

--- a/hathor/event/event_manager.py
+++ b/hathor/event/event_manager.py
@@ -23,8 +23,9 @@ from hathor.event.model.node_state import NodeState
 from hathor.event.storage import EventStorage
 from hathor.event.websocket import EventWebsocketFactory
 from hathor.pubsub import EventArguments, HathorEvents, PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction
-from hathor.util import Reactor, not_none, progress
+from hathor.util import not_none, progress
 from hathor.utils.iter import batch_iterator
 
 logger = get_logger()

--- a/hathor/event/websocket/factory.py
+++ b/hathor/event/websocket/factory.py
@@ -21,7 +21,8 @@ from hathor.event.model.base_event import BaseEvent
 from hathor.event.storage import EventStorage
 from hathor.event.websocket.protocol import EventWebsocketProtocol
 from hathor.event.websocket.response import EventResponse, InvalidRequestType
-from hathor.util import Reactor, not_none
+from hathor.reactor import ReactorProtocol as Reactor
+from hathor.util import not_none
 
 logger = get_logger()
 

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -50,6 +50,7 @@ from hathor.p2p.peer_id import PeerId
 from hathor.p2p.protocol import HathorProtocol
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.stratum import StratumFactory
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion, sum_weights
 from hathor.transaction.exceptions import TxValidationError
@@ -57,7 +58,7 @@ from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope
 from hathor.types import Address, VertexId
-from hathor.util import EnvironmentInfo, LogDuration, Random, Reactor, calculate_min_significant_weight, not_none
+from hathor.util import EnvironmentInfo, LogDuration, Random, calculate_min_significant_weight, not_none
 from hathor.verification.verification_service import VerificationService
 from hathor.wallet import BaseWallet
 

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -22,11 +22,11 @@ from twisted.internet.task import LoopingCall
 from hathor.conf import HathorSettings
 from hathor.p2p.manager import ConnectionsManager, PeerConnectionsMetrics
 from hathor.pubsub import EventArguments, HathorEvents, PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction.base_transaction import sum_weights
 from hathor.transaction.block import Block
 from hathor.transaction.storage import TransactionRocksDBStorage, TransactionStorage
 from hathor.transaction.storage.cache_storage import TransactionCacheStorage
-from hathor.util import Reactor
 
 if TYPE_CHECKING:
     from hathor.stratum import StratumFactory  # noqa: F401
@@ -63,7 +63,7 @@ class Metrics:
     connections: ConnectionsManager
     tx_storage: TransactionStorage
     # Twisted reactor that handles the time and callLater
-    reactor: Optional[Reactor] = None
+    reactor: Reactor
 
     # Transactions count in the network
     transactions: int = 0
@@ -126,10 +126,6 @@ class Metrics:
 
         # Stores caculated block weights saved in tx storage
         self.weight_block_deque: deque[WeightValue] = deque(maxlen=self.weight_block_deque_len)
-
-        if self.reactor is None:
-            from hathor.util import reactor as twisted_reactor
-            self.reactor = twisted_reactor
 
         # A timer to periodically collect data
         self._lc_collect_data = LoopingCall(self._collect_data)

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -34,8 +34,9 @@ from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_version import SyncVersion
 from hathor.p2p.utils import description_to_connection_string, parse_whitelist
 from hathor.pubsub import HathorEvents, PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction
-from hathor.util import Random, Reactor
+from hathor.util import Random
 
 if TYPE_CHECKING:
     from twisted.internet.interfaces import IDelayedCall

--- a/hathor/p2p/netfilter/matches_remote.py
+++ b/hathor/p2p/netfilter/matches_remote.py
@@ -20,7 +20,7 @@ from twisted.internet.defer import Deferred
 from twisted.internet.task import LoopingCall
 
 from hathor.p2p.netfilter.matches import NetfilterMatch, NetfilterMatchIPAddress
-from hathor.util import Reactor
+from hathor.reactor import ReactorProtocol as Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.netfilter.context import NetfilterContext

--- a/hathor/p2p/rate_limiter.py
+++ b/hathor/p2p/rate_limiter.py
@@ -14,7 +14,7 @@
 
 from typing import NamedTuple, Optional
 
-from hathor.util import Reactor
+from hathor.reactor import ReactorProtocol as Reactor
 
 
 class RateLimiterLimit(NamedTuple):
@@ -32,12 +32,9 @@ class RateLimiter:
     # Stores the last hit for each key
     hits: dict[str, RateLimiterLimit]
 
-    def __init__(self, reactor: Optional[Reactor] = None):
+    def __init__(self, reactor: Reactor):
         self.keys = {}
         self.hits = {}
-        if reactor is None:
-            from hathor.util import reactor as twisted_reactor
-            reactor = twisted_reactor
         self.reactor = reactor
 
     def set_limit(self, key: str, max_hits: int, window_seconds: float) -> None:

--- a/hathor/p2p/sync_factory.py
+++ b/hathor/p2p/sync_factory.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from hathor.p2p.sync_agent import SyncAgent
-from hathor.util import Reactor
+from hathor.reactor import ReactorProtocol as Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
@@ -24,5 +24,5 @@ if TYPE_CHECKING:
 
 class SyncAgentFactory(ABC):
     @abstractmethod
-    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Reactor) -> SyncAgent:
         pass

--- a/hathor/p2p/sync_v1/agent.py
+++ b/hathor/p2p/sync_v1/agent.py
@@ -26,10 +26,11 @@ from hathor.conf.get_settings import get_settings
 from hathor.p2p.messages import GetNextPayload, GetTipsPayload, NextPayload, ProtocolMessages, TipsPayload
 from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.sync_v1.downloader import Downloader
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction
 from hathor.transaction.base_transaction import tx_or_block_from_bytes
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
-from hathor.util import Reactor, json_dumps, json_loads
+from hathor.util import json_dumps, json_loads
 
 logger = get_logger()
 
@@ -59,7 +60,7 @@ class NodeSyncTimestamp(SyncAgent):
 
     MAX_HASHES: int = 40
 
-    def __init__(self, protocol: 'HathorProtocol', downloader: Downloader, reactor: Optional[Reactor] = None) -> None:
+    def __init__(self, protocol: 'HathorProtocol', downloader: Downloader, reactor: Reactor) -> None:
         """
         :param protocol: Protocol of the connection.
         :type protocol: HathorProtocol
@@ -72,9 +73,6 @@ class NodeSyncTimestamp(SyncAgent):
         self.manager = protocol.node
         self.downloader = downloader
 
-        if reactor is None:
-            from hathor.util import reactor as twisted_reactor
-            reactor = twisted_reactor
         self.reactor: Reactor = reactor
 
         # Rate limit for this connection.

--- a/hathor/p2p/sync_v1/factory.py
+++ b/hathor/p2p/sync_v1/factory.py
@@ -19,7 +19,7 @@ from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 from hathor.p2p.sync_v1.downloader import Downloader
-from hathor.util import Reactor
+from hathor.reactor import ReactorProtocol as Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
@@ -36,5 +36,5 @@ class SyncV11Factory(SyncAgentFactory):
             self._downloader = Downloader(self.connections.manager)
         return self._downloader
 
-    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Reactor) -> SyncAgent:
         return NodeSyncTimestamp(protocol, downloader=self.get_downloader(), reactor=reactor)

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -37,11 +37,12 @@ from hathor.p2p.sync_v2.streamers import (
     TransactionsStreamingServer,
 )
 from hathor.p2p.sync_v2.transaction_streaming_client import TransactionStreamingClient
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction, Block, Transaction
 from hathor.transaction.base_transaction import tx_or_block_from_bytes
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.types import VertexId
-from hathor.util import Reactor, not_none
+from hathor.util import not_none
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
@@ -82,7 +83,7 @@ class NodeBlockSync(SyncAgent):
     """
     name: str = 'node-block-sync'
 
-    def __init__(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> None:
+    def __init__(self, protocol: 'HathorProtocol', reactor: Reactor) -> None:
         """
         :param protocol: Protocol of the connection.
         :type protocol: HathorProtocol
@@ -98,10 +99,6 @@ class NodeBlockSync(SyncAgent):
 
         self.DEFAULT_STREAMING_LIMIT = DEFAULT_STREAMING_LIMIT
 
-        if reactor is None:
-            from hathor.util import reactor as twisted_reactor
-            reactor = twisted_reactor
-        assert reactor is not None
         self.reactor: Reactor = reactor
         self._is_streaming: bool = False
 

--- a/hathor/p2p/sync_v2/factory.py
+++ b/hathor/p2p/sync_v2/factory.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_v2.agent import NodeBlockSync
-from hathor.util import Reactor
+from hathor.reactor import ReactorProtocol as Reactor
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
@@ -28,5 +28,5 @@ class SyncV2Factory(SyncAgentFactory):
     def __init__(self, connections: ConnectionsManager):
         self.connections = connections
 
-    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Optional[Reactor] = None) -> SyncAgent:
+    def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Reactor) -> SyncAgent:
         return NodeBlockSync(protocol, reactor=reactor)

--- a/hathor/prometheus.py
+++ b/hathor/prometheus.py
@@ -19,7 +19,7 @@ from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
 from twisted.internet.task import LoopingCall
 
 from hathor.conf.get_settings import get_settings
-from hathor.util import reactor
+from hathor.reactor import get_global_reactor
 
 if TYPE_CHECKING:
     from hathor.metrics import Metrics
@@ -102,7 +102,7 @@ class PrometheusMetricsExporter:
 
         # A timer to periodically write data to prometheus
         self._lc_write_data = LoopingCall(self._write_data)
-        self._lc_write_data.clock = reactor
+        self._lc_write_data.clock = get_global_reactor()
 
     def _initial_setup(self) -> None:
         """ Start a collector registry to send data to node exporter

--- a/hathor/pubsub.py
+++ b/hathor/pubsub.py
@@ -20,7 +20,7 @@ from structlog import get_logger
 from twisted.internet.interfaces import IDelayedCall, IReactorFromThreads
 from twisted.python.threadable import isInIOThread
 
-from hathor.util import Reactor
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.utils.zope import verified_cast
 
 if TYPE_CHECKING:

--- a/hathor/reactor/__init__.py
+++ b/hathor/reactor/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathor.reactor.reactor import get_global_reactor
+from hathor.reactor.reactor_protocol import ReactorProtocol
+
+__all__ = [
+    'get_global_reactor',
+    'ReactorProtocol',
+]

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -18,11 +18,11 @@ from typing import Any, Iterator, Optional
 from twisted.internet import threads
 
 from hathor.indexes import IndexesManager
+from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction
 from hathor.transaction.storage.migrations import MigrationState
 from hathor.transaction.storage.transaction_storage import BaseTransactionStorage
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope
-from hathor.util import Reactor
 
 
 class TransactionCacheStorage(BaseTransactionStorage):

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -30,19 +30,12 @@ from structlog import get_logger
 
 import hathor
 from hathor.conf.get_settings import get_settings
-from hathor.reactor.reactor import reactor as hathor_reactor
-from hathor.reactor.reactor_protocol import ReactorProtocol
 from hathor.types import TokenUid
 
 if TYPE_CHECKING:
     import structlog
 
     from hathor.transaction.base_transaction import BaseTransaction
-
-# TODO: Those reexports are kept for retro-compatibility, but users could import them directly and then we can remove
-#  them from this file.
-Reactor = ReactorProtocol
-reactor = hathor_reactor
 
 logger = get_logger()
 

--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -27,13 +27,13 @@ from twisted.internet.interfaces import IDelayedCall
 from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.pubsub import EventArguments, HathorEvents, PubSubManager
+from hathor.reactor import ReactorProtocol as Reactor, get_global_reactor
 from hathor.transaction import BaseTransaction, Block, TxInput, TxOutput
 from hathor.transaction.base_transaction import int_to_bytes
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
 from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.transaction import Transaction
 from hathor.types import AddressB58, Amount, TokenUid
-from hathor.util import Reactor
 from hathor.wallet.exceptions import InputDuplicated, InsufficientFunds, PrivateKeyNotFound
 
 settings = HathorSettings()
@@ -129,8 +129,7 @@ class BaseWallet:
         ]
 
         if reactor is None:
-            from hathor.util import reactor as twisted_reactor
-            reactor = twisted_reactor
+            reactor = get_global_reactor()
         self.reactor = reactor
 
     def _manually_initialize(self) -> None:

--- a/tests/tx/test_stratum.py
+++ b/tests/tx/test_stratum.py
@@ -256,7 +256,7 @@ class BaseStratumClientTest(unittest.TestCase):
         storage = TransactionMemoryStorage()
         self.block = storage.get_transaction(self._settings.GENESIS_BLOCK_HASH)
         self.transport = StringTransportWithDisconnection()
-        self.protocol = StratumClient()
+        self.protocol = StratumClient(reactor=self.clock)
         self.protocol.makeConnection(self.transport)
         self.job_request_params = {
             'data': self.block.get_header_without_nonce().hex(),

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -15,9 +15,10 @@ from hathor.conf.get_settings import get_settings
 from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.sync_version import SyncVersion
+from hathor.reactor import ReactorProtocol as Reactor, get_global_reactor
 from hathor.simulator.clock import MemoryReactorHeapClock
 from hathor.transaction import BaseTransaction
-from hathor.util import Random, Reactor, reactor
+from hathor.util import Random
 from hathor.wallet import HDWallet, Wallet
 from tests.test_memory_reactor_clock import TestMemoryReactorClock
 
@@ -499,6 +500,7 @@ class TestCase(unittest.TestCase):
 
         Copy from: https://github.com/zooko/pyutil/blob/master/pyutil/testutil.py#L68
         """
+        reactor = get_global_reactor()
         pending = reactor.getDelayedCalls()
         active = bool(pending)
         for p in pending:


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/887

### Motivation

Similarly to the settings refactors, this PR removes the global reactor instance from all module-level accesses and move them to inside functions. In the future, we should also remove all calls to the `get_global_reactor()`, in favor of passing the reactor instance through class dependencies.

This will also be useful to allow installing different Twisted Reactors during runtime, after we evaluate our CLI options. This was not possible before since the default Twisted reactor was automatically installed during module-level evaluation.

### Acceptance Criteria

- Create a `get_global_reactor()` function so we access the Twisted reactor from the runtime only, and not during module-level evaluation.
- Remove `Reactor` and `reactor` from the `util` module.
- Update all reactor usages accordingly.
- Add custom check to prevent importing the Twisted Reactor directly.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 