### PR TITLE
feat(reactor): implement option to use asyncio reactor

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -100,6 +100,7 @@ class CliBuilder:
             python=python,
             platform=platform.platform(),
             settings=settings_source,
+            reactor_type=type(reactor).__name__,
         )
 
         tx_storage: TransactionStorage

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -33,7 +33,8 @@ class RunNode:
         ('--enable-crash-api', lambda args: bool(args.enable_crash_api)),
         ('--x-sync-bridge', lambda args: bool(args.x_sync_bridge)),
         ('--x-sync-v2-only', lambda args: bool(args.x_sync_v2_only)),
-        ('--x-enable-event-queue', lambda args: bool(args.x_enable_event_queue))
+        ('--x-enable-event-queue', lambda args: bool(args.x_enable_event_queue)),
+        ('--x-asyncio-reactor', lambda args: bool(args.x_asyncio_reactor))
     ]
 
     @classmethod
@@ -117,6 +118,8 @@ class RunNode:
                             help=f'Signal support for a feature. One of {possible_features}')
         parser.add_argument('--signal-not-support', default=[], action='append', choices=possible_features,
                             help=f'Signal not support for a feature. One of {possible_features}')
+        parser.add_argument('--x-asyncio-reactor', action='store_true',
+                            help='Use asyncio reactor instead of Twisted\'s default.')
         return parser
 
     def prepare(self, *, register_resources: bool = True) -> None:
@@ -138,8 +141,8 @@ class RunNode:
         self.check_unsafe_arguments()
         self.check_python_version()
 
-        from hathor.reactor import get_global_reactor
-        reactor = get_global_reactor()
+        from hathor.reactor import initialize_global_reactor
+        reactor = initialize_global_reactor(use_asyncio_reactor=self._args.x_asyncio_reactor)
         self.reactor = reactor
 
         from hathor.builder import CliBuilder, ResourcesBuilder

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -72,3 +72,4 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     config_yaml: Optional[str]
     signal_support: set[Feature]
     signal_not_support: set[Feature]
+    x_asyncio_reactor: bool

--- a/hathor/reactor/__init__.py
+++ b/hathor/reactor/__init__.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.reactor.reactor import get_global_reactor
+from hathor.reactor.reactor import get_global_reactor, initialize_global_reactor
 from hathor.reactor.reactor_protocol import ReactorProtocol
 
 __all__ = [
+    'initialize_global_reactor',
     'get_global_reactor',
     'ReactorProtocol',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,14 @@
-import asyncio
 import os
 import sys
 
-from twisted.internet import asyncioreactor
-
 from hathor.conf import UNITTESTS_SETTINGS_FILEPATH
+from hathor.reactor import initialize_global_reactor
 
 os.environ['HATHOR_CONFIG_YAML'] = os.environ.get('HATHOR_TEST_CONFIG_YAML', UNITTESTS_SETTINGS_FILEPATH)
 
 if sys.platform == 'win32':
-    # See: https://twistedmatrix.com/documents/current/api/twisted.internet.asyncioreactor.AsyncioSelectorReactor.html
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     # XXX: because rocksdb isn't available on Windows, we force using memory-storage for tests so most of them can run
     os.environ['HATHOR_TEST_MEMORY_STORAGE'] = 'true'
 
-asyncioreactor.install(asyncio.get_event_loop())
+# TODO: We should remove this call from the module level.
+initialize_global_reactor(use_asyncio_reactor=True)


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/888

### Motivation

Considering the general improvements we plan to make in the full node related to concurrent and parallel execution, using async/await and multiprocessing, it may be useful to interop with Python's native `asyncio`. Currently we used Twisted's default reactor, but they provide a reactor that has compatibility with asyncio: [AsyncioSelectorReactor](https://docs.twisted.org/en/stable/api/twisted.internet.asyncioreactor.AsyncioSelectorReactor.html). In theory, it is a drop-in replacement for what we're currently using.

This PR adds an experimental CLI option to enable this custom reactor, so we can test its usage in some full nodes for a while. Then, we'll have data to assess whether it's worth it using it as the default, in the future.

### Acceptance Criteria

- Add `--x-asyncio-reactor` CLI option to enable using the asyncio reactor.
- Update `get_global_reactor()` to add support for installing the asyncio reactor.
- Add reactor type to initial logs.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 