### PR TITLE
fix: add health endpoint to openapi

### DIFF
--- a/hathor/cli/openapi_files/register.py
+++ b/hathor/cli/openapi_files/register.py
@@ -36,6 +36,7 @@ def get_registered_resources() -> list[type[Resource]]:
     """
     import hathor.event.resources.event  # noqa: 401
     import hathor.feature_activation.resources.feature  # noqa: 401
+    import hathor.healthcheck.resources.healthcheck  # noqa: 401
     import hathor.p2p.resources  # noqa: 401
     import hathor.profiler.resources  # noqa: 401
     import hathor.stratum.resources  # noqa: 401


### PR DESCRIPTION
### Motivation

We need the `/health` endpoint to be included in the OpenAPI definitions that generate the Nginx config

### Acceptance Criteria

- The Nginx config should contain the `/health` endpoint when generated

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 