### PR TITLE
refactor(verification): move feature activation dependency

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -80,7 +80,7 @@ class BuildArtifacts(NamedTuple):
 
 
 _VertexVerifiersBuilder: TypeAlias = Callable[
-    [HathorSettingsType, DifficultyAdjustmentAlgorithm, FeatureService],
+    [HathorSettingsType, DifficultyAdjustmentAlgorithm],
     VertexVerifiers
 ]
 
@@ -509,7 +509,8 @@ class Builder:
     def _get_or_create_verification_service(self) -> VerificationService:
         if self._verification_service is None:
             verifiers = self._get_or_create_vertex_verifiers()
-            self._verification_service = VerificationService(verifiers=verifiers)
+            feature_service = self._get_or_create_feature_service()
+            self._verification_service = VerificationService(verifiers=verifiers, feature_service=feature_service)
 
         return self._verification_service
 
@@ -525,17 +526,12 @@ class Builder:
     def _get_or_create_vertex_verifiers(self) -> VertexVerifiers:
         if self._vertex_verifiers is None:
             settings = self._get_or_create_settings()
-            feature_service = self._get_or_create_feature_service()
             daa = self._get_or_create_daa()
 
             if self._vertex_verifiers_builder:
-                self._vertex_verifiers = self._vertex_verifiers_builder(settings, daa, feature_service)
+                self._vertex_verifiers = self._vertex_verifiers_builder(settings, daa)
             else:
-                self._vertex_verifiers = VertexVerifiers.create_defaults(
-                    settings=settings,
-                    daa=daa,
-                    feature_service=feature_service,
-                )
+                self._vertex_verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
 
         return self._vertex_verifiers
 

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -275,12 +275,8 @@ class CliBuilder:
 
         daa = DifficultyAdjustmentAlgorithm(settings=settings, test_mode=test_mode)
 
-        vertex_verifiers = VertexVerifiers.create_defaults(
-            settings=settings,
-            daa=daa,
-            feature_service=self.feature_service
-        )
-        verification_service = VerificationService(verifiers=vertex_verifiers)
+        vertex_verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
+        verification_service = VerificationService(verifiers=vertex_verifiers, feature_service=self.feature_service)
 
         cpu_mining_service = CpuMiningService()
 

--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -133,15 +133,13 @@ def execute(args: Namespace) -> None:
                                                                       block.nonce, block.weight))
 
         try:
-            from unittest.mock import Mock
-
             from hathor.conf.get_settings import get_global_settings
             from hathor.daa import DifficultyAdjustmentAlgorithm
             from hathor.verification.verification_service import VerificationService
             from hathor.verification.vertex_verifiers import VertexVerifiers
             settings = get_global_settings()
             daa = DifficultyAdjustmentAlgorithm(settings=settings)
-            verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa, feature_service=Mock())
+            verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
             verification_service = VerificationService(verifiers=verifiers)
             verification_service.verify_without_storage(block)
         except HathorError:

--- a/hathor/feature_activation/bit_signaling_service.py
+++ b/hathor/feature_activation/bit_signaling_service.py
@@ -163,7 +163,7 @@ class BitSignalingService:
 
     def _get_signaling_features(self, block: Block) -> dict[Feature, Criteria]:
         """Given a specific block, return all features that are in a signaling state for that block."""
-        feature_descriptions = self._feature_service.get_bits_description(block=block)
+        feature_descriptions = self._feature_service.get_feature_info(block=block)
         signaling_features = {
             feature: description.criteria
             for feature, description in feature_descriptions.items()

--- a/hathor/feature_activation/feature_service.py
+++ b/hathor/feature_activation/feature_service.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, TypeAlias
 
 from hathor.feature_activation.feature import Feature
-from hathor.feature_activation.model.feature_description import FeatureDescription
+from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
 
@@ -64,7 +64,7 @@ class FeatureService:
         height = block.get_height()
         offset_to_boundary = height % self._feature_settings.evaluation_interval
         remaining_blocks = self._feature_settings.evaluation_interval - offset_to_boundary - 1
-        descriptions = self.get_bits_description(block=block)
+        descriptions = self.get_feature_info(block=block)
 
         must_signal_features = (
             feature for feature, description in descriptions.items()
@@ -194,10 +194,10 @@ class FeatureService:
 
         raise ValueError(f'Unknown previous state: {previous_state}')
 
-    def get_bits_description(self, *, block: 'Block') -> dict[Feature, FeatureDescription]:
+    def get_feature_info(self, *, block: 'Block') -> dict[Feature, FeatureInfo]:
         """Returns the criteria definition and feature state for all features at a certain block."""
         return {
-            feature: FeatureDescription(
+            feature: FeatureInfo(
                 criteria=criteria,
                 state=self.get_state(block=block, feature=feature)
             )

--- a/hathor/feature_activation/model/feature_description.py
+++ b/hathor/feature_activation/model/feature_description.py
@@ -18,7 +18,7 @@ from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.model.feature_state import FeatureState
 
 
-class FeatureDescription(NamedTuple):
+class FeatureInfo(NamedTuple):
     """Represents all information related to one feature, that is, its criteria and state."""
     criteria: Criteria
     state: FeatureState

--- a/hathor/feature_activation/model/feature_state.py
+++ b/hathor/feature_activation/model/feature_state.py
@@ -42,3 +42,7 @@ class FeatureState(Enum):
         support it or not through bit signals is valid during those states.
         """
         return {FeatureState.STARTED, FeatureState.MUST_SIGNAL, FeatureState.LOCKED_IN}
+
+    def is_active(self) -> bool:
+        """Return whether the state is active."""
+        return self is FeatureState.ACTIVE

--- a/hathor/feature_activation/resources/feature.py
+++ b/hathor/feature_activation/resources/feature.py
@@ -68,7 +68,7 @@ class FeatureResource(Resource):
             return error.json_dumpb()
 
         signal_bits = []
-        feature_descriptions = self._feature_service.get_bits_description(block=block)
+        feature_descriptions = self._feature_service.get_feature_info(block=block)
 
         for feature, description in feature_descriptions.items():
             if description.state not in FeatureState.get_signaling_states():

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -24,7 +24,6 @@ from hathor.builder import BuildArtifacts, Builder
 from hathor.conf.get_settings import get_global_settings
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
-from hathor.feature_activation.feature_service import FeatureService
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
 from hathor.simulator.clock import HeapClock, MemoryReactorHeapClock
@@ -243,11 +242,7 @@ class Simulator:
         return True
 
 
-def _build_vertex_verifiers(
-    settings: HathorSettings,
-    daa: DifficultyAdjustmentAlgorithm,
-    feature_service: FeatureService
-) -> VertexVerifiers:
+def _build_vertex_verifiers(settings: HathorSettings, daa: DifficultyAdjustmentAlgorithm) -> VertexVerifiers:
     """
     A custom VertexVerifiers builder to be used by the simulator.
     """
@@ -255,5 +250,4 @@ def _build_vertex_verifiers(
         settings=settings,
         vertex_verifier=SimulatorVertexVerifier(settings=settings, daa=daa),
         daa=daa,
-        feature_service=feature_service,
     )

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -14,29 +14,25 @@
 
 from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
-from hathor.feature_activation.feature_service import FeatureService
+from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.transaction import MergeMinedBlock
 
 
 class MergeMinedBlockVerifier:
-    __slots__ = ('_settings', '_feature_service',)
+    __slots__ = ('_settings',)
 
-    def __init__(self, *, settings: HathorSettings, feature_service: FeatureService):
+    def __init__(self, *, settings: HathorSettings) -> None:
         self._settings = settings
-        self._feature_service = feature_service
 
-    def verify_aux_pow(self, block: MergeMinedBlock) -> None:
+    def verify_aux_pow(self, block: MergeMinedBlock, feature_info: dict[Feature, FeatureInfo]) -> None:
         """ Verify auxiliary proof-of-work (for merged mining).
         """
         assert block.aux_pow is not None
 
-        is_feature_active = self._feature_service.is_feature_active(
-            block=block,
-            feature=Feature.INCREASE_MAX_MERKLE_PATH_LENGTH
-        )
-        max_merkle_path_length = (
-            self._settings.NEW_MAX_MERKLE_PATH_LENGTH if is_feature_active
-            else self._settings.OLD_MAX_MERKLE_PATH_LENGTH
-        )
+        max_merkle_path_length = self._settings.OLD_MAX_MERKLE_PATH_LENGTH
+        merkle_path_info = feature_info.get(Feature.INCREASE_MAX_MERKLE_PATH_LENGTH)
+
+        if merkle_path_info and merkle_path_info.state.is_active():
+            max_merkle_path_length = self._settings.NEW_MAX_MERKLE_PATH_LENGTH
 
         block.aux_pow.verify(block.get_base_hash(), max_merkle_path_length)

--- a/hathor/verification/vertex_verifiers.py
+++ b/hathor/verification/vertex_verifiers.py
@@ -16,7 +16,6 @@ from typing import NamedTuple
 
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
-from hathor.feature_activation.feature_service import FeatureService
 from hathor.verification.block_verifier import BlockVerifier
 from hathor.verification.merge_mined_block_verifier import MergeMinedBlockVerifier
 from hathor.verification.token_creation_transaction_verifier import TokenCreationTransactionVerifier
@@ -33,13 +32,7 @@ class VertexVerifiers(NamedTuple):
     token_creation_tx: TokenCreationTransactionVerifier
 
     @classmethod
-    def create_defaults(
-        cls,
-        *,
-        settings: HathorSettings,
-        daa: DifficultyAdjustmentAlgorithm,
-        feature_service: FeatureService,
-    ) -> 'VertexVerifiers':
+    def create_defaults(cls, *, settings: HathorSettings, daa: DifficultyAdjustmentAlgorithm) -> 'VertexVerifiers':
         """
         Create a VertexVerifiers instance using the default verifier for each vertex type,
         from all required dependencies.
@@ -50,7 +43,6 @@ class VertexVerifiers(NamedTuple):
             settings=settings,
             vertex_verifier=vertex_verifier,
             daa=daa,
-            feature_service=feature_service
         )
 
     @classmethod
@@ -60,13 +52,12 @@ class VertexVerifiers(NamedTuple):
         settings: HathorSettings,
         vertex_verifier: VertexVerifier,
         daa: DifficultyAdjustmentAlgorithm,
-        feature_service: FeatureService,
     ) -> 'VertexVerifiers':
         """
         Create a VertexVerifiers instance using a custom vertex_verifier.
         """
-        block_verifier = BlockVerifier(settings=settings, daa=daa, feature_service=feature_service)
-        merge_mined_block_verifier = MergeMinedBlockVerifier(settings=settings, feature_service=feature_service)
+        block_verifier = BlockVerifier(settings=settings, daa=daa)
+        merge_mined_block_verifier = MergeMinedBlockVerifier(settings=settings)
         tx_verifier = TransactionVerifier(settings=settings, daa=daa)
         token_creation_tx_verifier = TokenCreationTransactionVerifier(settings=settings)
 

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -240,7 +240,7 @@ class VertexHandler:
         if not isinstance(vertex, Block):
             return
 
-        feature_descriptions = self._feature_service.get_bits_description(block=vertex)
+        feature_descriptions = self._feature_service.get_feature_info(block=vertex)
         state_by_feature = {
             feature.value: description.state.value
             for feature, description in feature_descriptions.items()

--- a/tests/feature_activation/test_bit_signaling_service.py
+++ b/tests/feature_activation/test_bit_signaling_service.py
@@ -20,7 +20,7 @@ from hathor.feature_activation.bit_signaling_service import BitSignalingService
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.criteria import Criteria
-from hathor.feature_activation.model.feature_description import FeatureDescription
+from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.transaction import Block
@@ -32,11 +32,11 @@ from hathor.transaction.storage import TransactionStorage
     [
         {},
         {
-            Feature.NOP_FEATURE_1: FeatureDescription(state=FeatureState.DEFINED, criteria=Mock())
+            Feature.NOP_FEATURE_1: FeatureInfo(state=FeatureState.DEFINED, criteria=Mock())
         },
         {
-            Feature.NOP_FEATURE_1: FeatureDescription(state=FeatureState.FAILED, criteria=Mock()),
-            Feature.NOP_FEATURE_2: FeatureDescription(state=FeatureState.ACTIVE, criteria=Mock())
+            Feature.NOP_FEATURE_1: FeatureInfo(state=FeatureState.FAILED, criteria=Mock()),
+            Feature.NOP_FEATURE_2: FeatureInfo(state=FeatureState.ACTIVE, criteria=Mock())
         }
     ]
 )
@@ -50,7 +50,7 @@ from hathor.transaction.storage import TransactionStorage
     ]
 )
 def test_generate_signal_bits_no_signaling_features(
-    features_description: dict[Feature, FeatureDescription],
+    features_description: dict[Feature, FeatureInfo],
     support_features: set[Feature],
     not_support_features: set[Feature]
 ) -> None:
@@ -74,7 +74,7 @@ def test_generate_signal_bits_signaling_features(
     expected_signal_bits: int,
 ) -> None:
     features_description = {
-        Feature.NOP_FEATURE_1: FeatureDescription(
+        Feature.NOP_FEATURE_1: FeatureInfo(
             state=FeatureState.STARTED,
             criteria=Criteria(
                 bit=0,
@@ -83,7 +83,7 @@ def test_generate_signal_bits_signaling_features(
                 version='0.0.0'
             )
         ),
-        Feature.NOP_FEATURE_2: FeatureDescription(
+        Feature.NOP_FEATURE_2: FeatureInfo(
             state=FeatureState.MUST_SIGNAL,
             criteria=Criteria(
                 bit=1,
@@ -92,7 +92,7 @@ def test_generate_signal_bits_signaling_features(
                 version='0.0.0'
             )
         ),
-        Feature.NOP_FEATURE_3: FeatureDescription(
+        Feature.NOP_FEATURE_3: FeatureInfo(
             state=FeatureState.LOCKED_IN,
             criteria=Criteria(
                 bit=3,
@@ -124,7 +124,7 @@ def test_generate_signal_bits_signaling_features_with_defaults(
     expected_signal_bits: int,
 ) -> None:
     features_description = {
-        Feature.NOP_FEATURE_1: FeatureDescription(
+        Feature.NOP_FEATURE_1: FeatureInfo(
             state=FeatureState.STARTED,
             criteria=Criteria(
                 bit=0,
@@ -134,7 +134,7 @@ def test_generate_signal_bits_signaling_features_with_defaults(
                 signal_support_by_default=True
             )
         ),
-        Feature.NOP_FEATURE_2: FeatureDescription(
+        Feature.NOP_FEATURE_2: FeatureInfo(
             state=FeatureState.MUST_SIGNAL,
             criteria=Criteria(
                 bit=1,
@@ -144,7 +144,7 @@ def test_generate_signal_bits_signaling_features_with_defaults(
                 signal_support_by_default=True
             )
         ),
-        Feature.NOP_FEATURE_3: FeatureDescription(
+        Feature.NOP_FEATURE_3: FeatureInfo(
             state=FeatureState.LOCKED_IN,
             criteria=Criteria(
                 bit=3,
@@ -161,12 +161,12 @@ def test_generate_signal_bits_signaling_features_with_defaults(
 
 
 def _test_generate_signal_bits(
-    features_description: dict[Feature, FeatureDescription],
+    features_description: dict[Feature, FeatureInfo],
     support_features: set[Feature],
     not_support_features: set[Feature]
 ) -> int:
     feature_service = Mock(spec_set=FeatureService)
-    feature_service.get_bits_description = lambda block: features_description
+    feature_service.get_feature_info = lambda block: features_description
 
     service = BitSignalingService(
         feature_settings=FeatureSettings(),
@@ -258,13 +258,13 @@ def test_non_signaling_features_warning(
     tx_storage = Mock(spec_set=TransactionStorage)
     tx_storage.get_best_block = lambda: best_block
 
-    def get_bits_description_mock(block: Block) -> dict[Feature, FeatureDescription]:
+    def get_feature_info_mock(block: Block) -> dict[Feature, FeatureInfo]:
         if block == best_block:
             return {}
         raise NotImplementedError
 
     feature_service = Mock(spec_set=FeatureService)
-    feature_service.get_bits_description = get_bits_description_mock
+    feature_service.get_feature_info = get_feature_info_mock
 
     service = BitSignalingService(
         feature_settings=FeatureSettings(),

--- a/tests/feature_activation/test_feature_service.py
+++ b/tests/feature_activation/test_feature_service.py
@@ -26,7 +26,7 @@ from hathor.feature_activation.feature_service import (
     FeatureService,
 )
 from hathor.feature_activation.model.criteria import Criteria
-from hathor.feature_activation.model.feature_description import FeatureDescription
+from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.transaction import Block, TransactionMetadata
@@ -561,7 +561,7 @@ def test_get_state_undefined_feature(block_mocks: list[Block], service: FeatureS
     assert result == FeatureState.DEFINED
 
 
-def test_get_bits_description(tx_storage: TransactionStorage) -> None:
+def test_get_feature_info(tx_storage: TransactionStorage) -> None:
     criteria_mock_1 = Criteria.construct(bit=Mock(), start_height=Mock(), timeout_height=Mock(), version=Mock())
     criteria_mock_2 = Criteria.construct(bit=Mock(), start_height=Mock(), timeout_height=Mock(), version=Mock())
     feature_settings = FeatureSettings.construct(
@@ -584,11 +584,11 @@ def test_get_bits_description(tx_storage: TransactionStorage) -> None:
         return states[feature]
 
     with patch('hathor.feature_activation.feature_service.FeatureService.get_state', get_state):
-        result = service.get_bits_description(block=Mock())
+        result = service.get_feature_info(block=Mock())
 
     expected = {
-        Feature.NOP_FEATURE_1: FeatureDescription(criteria_mock_1, FeatureState.STARTED),
-        Feature.NOP_FEATURE_2: FeatureDescription(criteria_mock_2, FeatureState.FAILED),
+        Feature.NOP_FEATURE_1: FeatureInfo(criteria_mock_1, FeatureState.STARTED),
+        Feature.NOP_FEATURE_2: FeatureInfo(criteria_mock_2, FeatureState.FAILED),
     }
 
     assert result == expected

--- a/tests/resources/feature/test_feature.py
+++ b/tests/resources/feature/test_feature.py
@@ -19,7 +19,7 @@ import pytest
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.criteria import Criteria
-from hathor.feature_activation.model.feature_description import FeatureDescription
+from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.resources.feature import FeatureResource
 from hathor.feature_activation.settings import Settings as FeatureSettings
@@ -58,9 +58,9 @@ def web():
 
     feature_service = Mock(spec_set=FeatureService)
     feature_service.get_state = Mock(side_effect=get_state)
-    feature_service.get_bits_description = Mock(return_value={
-        Feature.NOP_FEATURE_1: FeatureDescription(state=FeatureState.DEFINED, criteria=nop_feature_1_criteria),
-        Feature.NOP_FEATURE_2: FeatureDescription(state=FeatureState.LOCKED_IN, criteria=nop_feature_2_criteria),
+    feature_service.get_feature_info = Mock(return_value={
+        Feature.NOP_FEATURE_1: FeatureInfo(state=FeatureState.DEFINED, criteria=nop_feature_1_criteria),
+        Feature.NOP_FEATURE_2: FeatureInfo(state=FeatureState.LOCKED_IN, criteria=nop_feature_2_criteria),
     })
 
     feature_settings = FeatureSettings(

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -19,7 +19,7 @@ import pytest
 from hathor.conf.get_settings import get_global_settings
 from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
-from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling, FeatureService
+from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling
 from hathor.transaction import Block, TransactionMetadata
 from hathor.transaction.exceptions import BlockMustSignalError
 from hathor.transaction.storage import TransactionMemoryStorage, TransactionStorage
@@ -140,24 +140,16 @@ def test_get_feature_activation_bit_value() -> None:
 
 def test_verify_must_signal() -> None:
     settings = Mock(spec_set=HathorSettings)
-    feature_service = Mock(spec_set=FeatureService)
-    feature_service.is_signaling_mandatory_features = Mock(
-        return_value=BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)
-    )
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
-    block = Block()
+    verifier = BlockVerifier(settings=settings, daa=Mock())
 
     with pytest.raises(BlockMustSignalError) as e:
-        verifier.verify_mandatory_signaling(block)
+        verifier.verify_mandatory_signaling(BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1))
 
     assert str(e.value) == "Block must signal support for feature 'NOP_FEATURE_1' during MUST_SIGNAL phase."
 
 
 def test_verify_must_not_signal() -> None:
     settings = Mock(spec_set=HathorSettings)
-    feature_service = Mock(spec_set=FeatureService)
-    feature_service.is_signaling_mandatory_features = Mock(return_value=BlockIsSignaling())
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
-    block = Block()
+    verifier = BlockVerifier(settings=settings, daa=Mock())
 
-    verifier.verify_mandatory_signaling(block)
+    verifier.verify_mandatory_signaling(BlockIsSignaling())

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -32,7 +32,7 @@ class GenesisTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self._daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
-        verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=self._daa, feature_service=Mock())
+        verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=self._daa)
         self._verification_service = VerificationService(verifiers=verifiers)
         self.storage = TransactionMemoryStorage()
 

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -1,5 +1,3 @@
-from unittest.mock import Mock
-
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.transaction import Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
@@ -13,7 +11,7 @@ class _BaseTest:
         def setUp(self) -> None:
             super().setUp()
             daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
-            verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=daa, feature_service=Mock())
+            verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=daa)
             self._verification_service = VerificationService(verifiers=verifiers)
 
         def test_deserialize(self):

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -321,8 +321,6 @@ class BaseVerificationTest(unittest.TestCase):
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
-        verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
-
         with (
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
@@ -331,7 +329,6 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
             self.manager.verification_service.verify_without_storage(block)
 
@@ -345,9 +342,6 @@ class BaseVerificationTest(unittest.TestCase):
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
-
-        # MergeMinedBlock methods
-        verify_aux_pow_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify(self) -> None:
         block = self._get_valid_merge_mined_block()


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/983

### Motivation

Move the Feature Activation verification dependency to outside the verification method. This will be useful for Multiprocess Verification.

### Acceptance Criteria

- Rename `FeatureService.get_bits_description()` to `get_feature_info()`, and `FeatureDescription` to `FeatureInfo`.
- Change `BlockVerifier.verify_mandatory_signaling()` so it receives a pre-calculated signaling state, instead of calculating it itself with a `FeatureService`.
- Change `MergeMinedBlockVerifier.verify_aux_pow()` so it receives a pre-calculated `feature_info`, instead of calculating it itself with a `FeatureService`.
- **IMPORTANT:** move `verify_aux_pow()` verification from `verify_without_storage()` to `verify()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 