### PR TITLE
feat(feature-activation): decrease mainnet evaluation interval to 1 week

### DIFF
--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -55,6 +55,7 @@ SETTINGS = HathorSettings(
         cp(1_600_000, bytes.fromhex('00000000060adfdfd7d488d4d510b5779cf35a3c50df7bcff941fbb6957be4d2')),
     ],
     FEATURE_ACTIVATION=FeatureActivationSettings(
+        evaluation_interval=40_320,
         enable_usage=True,
         default_threshold=30240,
         features={

--- a/hathor/conf/testnet.yml
+++ b/hathor/conf/testnet.yml
@@ -37,6 +37,7 @@ CHECKPOINTS:
   1_600_000: 00000000060adfdfd7d488d4d510b5779cf35a3c50df7bcff941fbb6957be4d2
 
 FEATURE_ACTIVATION:
+  evaluation_interval: 40_320
   enable_usage: true
   default_threshold: 30_240 # 30240 = 75% of evaluation_interval (40320)
   features:

--- a/hathor/feature_activation/settings.py
+++ b/hathor/feature_activation/settings.py
@@ -26,15 +26,15 @@ class Settings(BaseModel, validate_all=True):
     """Feature Activation settings."""
 
     # The number of blocks in the feature activation evaluation interval.
-    # Equivalent to 14 days (40320 * 30 seconds = 14 days)
-    evaluation_interval: PositiveInt = 40320
+    # Equivalent to 1 week (20160 * 30 seconds = 1 week)
+    evaluation_interval: PositiveInt = 20_160
 
     # The number of bits used in the first byte of a block's version field. The 4 left-most bits are not used.
     max_signal_bits: int = Field(ge=1, le=8, default=4)
 
     # Specifies the default minimum number of blocks per evaluation interval required to activate a feature.
     # Usually calculated from a percentage of evaluation_interval.
-    default_threshold: NonNegativeInt = 36288  # 36288 = 90% of evaluation_interval (40320)
+    default_threshold: NonNegativeInt = 18_144  # 18144 = 90% of evaluation_interval (20160)
 
     # Dictionary of Feature enum to Criteria definition for all features that participate in the feature activation
     # process for a network, past or future, activated or not. Features should NOT be removed from this list, and


### PR DESCRIPTION
### Motivation

Decrease the Feature Activation Evaluation Interval from 2 weeks to 1 week, to decrease the time to release new features.

### Acceptance Criteria

- Change the default Feature Activation settings value of Evaluation Interval from 2 weeks to 1 week.
- Update the testnet Evaluation Interval value to keep it 2 weeks (this is necessary since we're currently running tests on testnet, but after that, we can also use 1 week for testnet).

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 