### PR TITLE
refactor(verification): externalize verification dependencies [part 2/2]

### DIFF
--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -120,7 +120,7 @@ class CreateTxResource(Resource):
         # need to run verify_inputs first to check if all inputs exist
         verifiers.tx.verify_inputs(tx, deps, skip_script=True)
         verifiers.vertex.verify_parents(tx, deps)
-        verifiers.tx.verify_sum(tx.get_complete_token_info())
+        verifiers.tx.verify_sum(deps)
 
 
 CreateTxResource.openapi = {

--- a/hathor/transaction/storage/simple_memory_storage.py
+++ b/hathor/transaction/storage/simple_memory_storage.py
@@ -25,11 +25,12 @@ class SimpleMemoryStorage:
     Instances of this class simply facilitate storing some data in memory, specifically for pre-fetched verification
     dependencies.
     """
-    __slots__ = ('_blocks', '_transactions',)
+    __slots__ = ('_blocks', '_transactions', '_best_block_tips')
 
     def __init__(self) -> None:
         self._blocks: dict[VertexId, BaseTransaction] = {}
         self._transactions: dict[VertexId, BaseTransaction] = {}
+        self._best_block_tips: list[VertexId] = []
 
     @property
     def _vertices(self) -> dict[VertexId, BaseTransaction]:
@@ -101,6 +102,12 @@ class SimpleMemoryStorage:
 
         raise NotImplementedError
 
+    def set_best_block_tips_from_storage(self, storage: TransactionStorage) -> None:
+        """Get the best block tips from a storage and save them in this instance."""
+        tips = storage.get_best_block_tips()
+        self.add_vertices_from_storage(storage, tips)
+        self._best_block_tips = tips
+
     def get_best_block_tips(self) -> list[VertexId]:
-        # TODO: Currently unused, will be implemented in a next PR.
-        raise NotImplementedError
+        """Return the best block saved in this instance."""
+        return self._best_block_tips

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -15,9 +15,9 @@
 from hathor.conf.settings import HathorSettings
 from hathor.transaction.exceptions import InvalidToken, TransactionDataError
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
-from hathor.transaction.transaction import TokenInfo
 from hathor.transaction.util import clean_token_string
-from hathor.types import TokenUid
+from hathor.util import not_none
+from hathor.verification.verification_dependencies import TransactionDependencies
 
 
 class TokenCreationTransactionVerifier:
@@ -26,7 +26,7 @@ class TokenCreationTransactionVerifier:
     def __init__(self, *, settings: HathorSettings) -> None:
         self._settings = settings
 
-    def verify_minted_tokens(self, tx: TokenCreationTransaction, token_dict: dict[TokenUid, TokenInfo]) -> None:
+    def verify_minted_tokens(self, tx: TokenCreationTransaction, tx_deps: TransactionDependencies) -> None:
         """ Besides all checks made on regular transactions, a few extra ones are made:
         - only HTR tokens on the inputs;
         - new tokens are actually being minted;
@@ -35,7 +35,7 @@ class TokenCreationTransactionVerifier:
         :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
         """
         # make sure tokens are being minted
-        token_info = token_dict[tx.hash]
+        token_info = tx_deps.token_info[not_none(tx.hash)]
         if token_info.amount <= 0:
             raise InvalidToken('Token creation transaction must mint new tokens')
 

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -35,9 +35,8 @@ from hathor.transaction.exceptions import (
     TooManySigOps,
     WeightError,
 )
-from hathor.transaction.transaction import TokenInfo
 from hathor.transaction.util import get_deposit_amount, get_withdraw_amount
-from hathor.types import TokenUid, VertexId
+from hathor.types import VertexId
 from hathor.verification.verification_dependencies import TransactionDependencies
 
 cpu = get_cpu_profiler()
@@ -206,7 +205,7 @@ class TransactionVerifier:
             if output.get_token_index() > len(tx.tokens):
                 raise InvalidToken('token uid index not available: index {}'.format(output.get_token_index()))
 
-    def verify_sum(self, token_dict: dict[TokenUid, TokenInfo]) -> None:
+    def verify_sum(self, tx_deps: TransactionDependencies) -> None:
         """Verify that the sum of outputs is equal of the sum of inputs, for each token. If sum of inputs
         and outputs is not 0, make sure inputs have mint/melt authority.
 
@@ -219,7 +218,7 @@ class TransactionVerifier:
         """
         withdraw = 0
         deposit = 0
-        for token_uid, token_info in token_dict.items():
+        for token_uid, token_info in tx_deps.token_info.items():
             if token_uid == self._settings.HATHOR_TOKEN_UID:
                 continue
 
@@ -241,7 +240,7 @@ class TransactionVerifier:
 
         # check whether the deposit/withdraw amount is correct
         htr_expected_amount = withdraw - deposit
-        htr_info = token_dict[self._settings.HATHOR_TOKEN_UID]
+        htr_info = tx_deps.token_info[self._settings.HATHOR_TOKEN_UID]
         if htr_info.amount != htr_expected_amount:
             raise InputOutputMismatch('HTR balance is different than expected. (amount={}, expected={})'.format(
                 htr_info.amount,

--- a/hathor/verification/verification_dependencies.py
+++ b/hathor/verification/verification_dependencies.py
@@ -22,7 +22,8 @@ from hathor.feature_activation.feature_service import BlockSignalingState, Featu
 from hathor.feature_activation.model.feature_description import FeatureInfo
 from hathor.transaction import Block
 from hathor.transaction.storage.simple_memory_storage import SimpleMemoryStorage
-from hathor.transaction.transaction import Transaction
+from hathor.transaction.transaction import TokenInfo, Transaction
+from hathor.types import TokenUid
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,17 +73,24 @@ class BlockDependencies(VertexDependencies):
         )
 
 
+@dataclass(frozen=True, slots=True)
 class TransactionDependencies(VertexDependencies):
     """A dataclass of dependencies necessary for transaction verification."""
+    token_info: dict[TokenUid, TokenInfo]
 
     @classmethod
     def create(cls, tx: Transaction) -> Self:
         """Create a transaction dependencies instance."""
         assert tx.storage is not None
+        token_info = tx.get_complete_token_info()
         simple_storage = SimpleMemoryStorage()
         spent_txs = [tx_input.tx_id for tx_input in tx.inputs]
         deps = tx.parents + spent_txs
 
         simple_storage.add_vertices_from_storage(tx.storage, deps)
+        simple_storage.set_best_block_tips_from_storage(tx.storage)
 
-        return cls(storage=simple_storage)
+        return cls(
+            storage=simple_storage,
+            token_info=token_info
+        )

--- a/tests/tx/test_tokens.py
+++ b/tests/tx/test_tokens.py
@@ -72,7 +72,7 @@ class BaseTokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx)
+            self.manager.verification_service.verifiers.tx.verify_output_token_indexes(tx)
 
         # with 1 token uid in list
         tx.tokens = [bytes.fromhex('0023be91834c973d6a6ddd1a0ae411807b7c8ef2a015afb5177ee64b666ce602')]
@@ -82,7 +82,7 @@ class BaseTokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx)
+            self.manager.verification_service.verifiers.tx.verify_output_token_indexes(tx)
 
         # try hathor authority UTXO
         output = TxOutput(value, script, 0b10000000)

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -88,8 +88,9 @@ class BaseTransactionTest(unittest.TestCase):
         public_bytes, signature = self.wallet.get_input_aux_data(data_to_sign, self.genesis_private_key)
         _input.data = P2PKH.create_input_data(public_bytes, signature)
 
+        deps = TransactionDependencies.create(tx)
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(tx.get_complete_token_info())
+            self._verifiers.tx.verify_sum(deps)
 
     def test_validation(self):
         # add 100 blocks and check that walking through get_next_block_best_chain yields the same blocks
@@ -540,7 +541,7 @@ class BaseTransactionTest(unittest.TestCase):
             self.manager.verification_service.verify(tx)
 
         with self.assertRaises(InexistentInput):
-            self._verifiers.tx.verify_inputs(tx, TransactionDependencies(SimpleMemoryStorage()))
+            self._verifiers.tx.verify_inputs(tx, TransactionDependencies(SimpleMemoryStorage(), Mock()))
 
     def test_tx_inputs_conflict(self):
         # the new tx inputs will try to spend the same output


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/859

### Motivation

Finish the refactor started in #859 (read its description for more info). After this PR, all verification dependencies are externalized and pre-calculated.

### Acceptance Criteria

- Add missing verification dependencies for transactions: token info and best block tips.
- Add new auxiliary methods to `SimpleMemoryStorage`.
- Update verifiers and `VerificationService` accordingly.
- Update `Transaction` methods related to token info to receive an optional `SimpleMemoryStorage`, which may be used to retrieve data.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 