### PR TITLE
fix(reactor): fix reactor initialization on CLI tools

### DIFF
--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -44,7 +44,7 @@ def execute(args: Namespace) -> None:
     os.environ['HATHOR_CONFIG_YAML'] = UNITTESTS_SETTINGS_FILEPATH
     from hathor.cli.events_simulator.event_forwarding_websocket_factory import EventForwardingWebsocketFactory
     from hathor.cli.events_simulator.scenario import Scenario
-    from hathor.reactor import get_global_reactor
+    from hathor.reactor import initialize_global_reactor
     from hathor.simulator import Simulator
 
     try:
@@ -53,7 +53,7 @@ def execute(args: Namespace) -> None:
         possible_scenarios = [scenario.name for scenario in Scenario]
         raise ValueError(f'Invalid scenario "{args.scenario}". Choose one of {possible_scenarios}') from e
 
-    reactor = get_global_reactor()
+    reactor = initialize_global_reactor()
     log = logger.new()
     simulator = Simulator(args.seed)
     simulator.start()

--- a/hathor/cli/stratum_mining.py
+++ b/hathor/cli/stratum_mining.py
@@ -30,7 +30,7 @@ def create_parser() -> ArgumentParser:
 
 def execute(args: Namespace) -> None:
     from hathor.crypto.util import decode_address
-    from hathor.reactor import get_global_reactor
+    from hathor.reactor import initialize_global_reactor
     from hathor.stratum import StratumClient
     from hathor.wallet.exceptions import InvalidAddress
 
@@ -43,7 +43,7 @@ def execute(args: Namespace) -> None:
             print('The given address is invalid')
             sys.exit(-1)
 
-    reactor = get_global_reactor()
+    reactor = initialize_global_reactor()
     miner = StratumClient(proc_count=args.nproc, address=address, reactor=reactor)
     miner.start()
     point = TCP4ClientEndpoint(reactor, args.host, args.port)


### PR DESCRIPTION
### Motivation

There was a regression in one of the latest refactors related to reactors. The `get` function is being called in CLI tools instead of the `initialize` one, which would be correct.

### Acceptance Criteria

- Change `get_global_reactor()` to `initialize_global_reactor()` on CLI tools.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 