### PR TITLE
feat(feature-activation): configure NOP features on mainnet

### DIFF
--- a/hathor/conf/mainnet.py
+++ b/hathor/conf/mainnet.py
@@ -14,6 +14,9 @@
 
 from hathor.checkpoint import Checkpoint as cp
 from hathor.conf.settings import HathorSettings
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.model.criteria import Criteria
+from hathor.feature_activation.settings import Settings as FeatureActivationSettings
 
 SETTINGS = HathorSettings(
     P2PKH_VERSION_BYTE=b'\x28',
@@ -196,4 +199,27 @@ SETTINGS = HathorSettings(
         '00004305882eb3eef6b45f025ff58eb7baa5ca35f7d6f42c8b085482b00474e6',
         '000045ecbab77c9a8d819ff6d26893b9da2774eee5539f17d8fc2394f82b758e',
     ])),
+    FEATURE_ACTIVATION=FeatureActivationSettings(
+        enable_usage=True,
+        features={
+            Feature.NOP_FEATURE_1: Criteria(
+                bit=0,
+                start_height=4_213_440,  # N (right now the best block is 4_161_800 on mainnet)
+                timeout_height=4_253_760,  # N + 2 * 20160 (2 weeks after the start)
+                minimum_activation_height=4_273_920,  # N + 3 * 20160 (3 weeks after the start)
+                lock_in_on_timeout=False,
+                version='0.59.0',
+                signal_support_by_default=True,
+            ),
+            Feature.NOP_FEATURE_2: Criteria(
+                bit=1,
+                start_height=4_193_280,  # N (right now the best block is 4_133_220 on mainnet)
+                timeout_height=4_253_760,  # N + 2 * 20160 (2 weeks after the start)
+                minimum_activation_height=0,
+                lock_in_on_timeout=False,
+                version='0.59.0',
+                signal_support_by_default=False,
+            )
+        }
+    )
 )

--- a/hathor/conf/mainnet.yml
+++ b/hathor/conf/mainnet.yml
@@ -179,3 +179,26 @@ SOFT_VOIDED_TX_IDS:
   - 000040db8e91bcdc1e65bc868e904345396a0bc4eb084694a72dbcc485555d80
   - 00004305882eb3eef6b45f025ff58eb7baa5ca35f7d6f42c8b085482b00474e6
   - 000045ecbab77c9a8d819ff6d26893b9da2774eee5539f17d8fc2394f82b758e
+
+FEATURE_ACTIVATION:
+  enable_usage: true
+  features:
+    #### First Phased Testing features on mainnet ####
+
+    NOP_FEATURE_1:
+      bit: 0
+      start_height: 4_213_440 # N (right now the best block is 4_161_800 on mainnet)
+      timeout_height: 4_253_760 # N + 2 * 20160 (2 weeks after the start)
+      minimum_activation_height: 4_273_920 # N + 3 * 20160 (3 weeks after the start)
+      lock_in_on_timeout: false
+      version: 0.59.0
+      signal_support_by_default: true
+
+    NOP_FEATURE_2:
+      bit: 1
+      start_height: 4_193_280 # N (right now the best block is 4_133_220 on mainnet)
+      timeout_height: 4_253_760 # N + 2 * 20160 (2 weeks after the start)
+      minimum_activation_height: 0
+      lock_in_on_timeout: false
+      version: 0.59.0
+      signal_support_by_default: false


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/903

### Motivation

Configure NOP features for Feature Activation on mainnet, so we can test the process there, according to the Phased Testing plan.

### Acceptance Criteria

- Enable Feature Activation usage on mainnet.
- Configure `NOP_FEATURE_1` and `NOP_FEATURE_2` on mainnet.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 