### PR TITLE
refactor(feature-activation): remove enable_usage

### DIFF
--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -135,12 +135,14 @@ def execute(args: Namespace) -> None:
                                                                       block.nonce, block.weight))
 
         try:
+            from unittest.mock import Mock
+
             from hathor.conf.get_settings import get_global_settings
             from hathor.daa import DifficultyAdjustmentAlgorithm
             from hathor.verification.verification_service import VerificationService, VertexVerifiers
             settings = get_global_settings()
             daa = DifficultyAdjustmentAlgorithm(settings=settings)
-            verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa)
+            verifiers = VertexVerifiers.create_defaults(settings=settings, daa=daa, feature_service=Mock())
             verification_service = VerificationService(verifiers=verifiers)
             verification_service.verify_without_storage(block)
         except HathorError:

--- a/hathor/conf/mainnet.py
+++ b/hathor/conf/mainnet.py
@@ -200,7 +200,6 @@ SETTINGS = HathorSettings(
         '000045ecbab77c9a8d819ff6d26893b9da2774eee5539f17d8fc2394f82b758e',
     ])),
     FEATURE_ACTIVATION=FeatureActivationSettings(
-        enable_usage=True,
         features={
             Feature.NOP_FEATURE_1: Criteria(
                 bit=0,

--- a/hathor/conf/mainnet.yml
+++ b/hathor/conf/mainnet.yml
@@ -181,7 +181,6 @@ SOFT_VOIDED_TX_IDS:
   - 000045ecbab77c9a8d819ff6d26893b9da2774eee5539f17d8fc2394f82b758e
 
 FEATURE_ACTIVATION:
-  enable_usage: true
   features:
     #### First Phased Testing features on mainnet ####
 

--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -56,7 +56,6 @@ SETTINGS = HathorSettings(
     ],
     FEATURE_ACTIVATION=FeatureActivationSettings(
         evaluation_interval=40_320,
-        enable_usage=True,
         default_threshold=30240,
         features={
             Feature.NOP_FEATURE_4: Criteria(

--- a/hathor/conf/testnet.yml
+++ b/hathor/conf/testnet.yml
@@ -38,7 +38,6 @@ CHECKPOINTS:
 
 FEATURE_ACTIVATION:
   evaluation_interval: 40_320
-  enable_usage: true
   default_threshold: 30_240 # 30240 = 75% of evaluation_interval (40320)
   features:
     #### Second Phased Testing features ####

--- a/hathor/feature_activation/settings.py
+++ b/hathor/feature_activation/settings.py
@@ -41,9 +41,6 @@ class Settings(BaseModel, validate_all=True):
     # neither their values changed, to preserve history.
     features: dict[Feature, Criteria] = {}
 
-    # Boolean indicating whether feature activation can be used.
-    enable_usage: bool = False
-
     @validator('default_threshold')
     def _validate_default_threshold(cls, default_threshold: int, values: dict[str, Any]) -> int:
         """Validates that the default_threshold is not greater than the evaluation_interval."""

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -1061,7 +1061,7 @@ class HathorManager:
 
     def _log_feature_states(self, vertex: BaseTransaction) -> None:
         """Log features states for a block. Used as part of the Feature Activation Phased Testing."""
-        if not self._settings.FEATURE_ACTIVATION.enable_usage or not isinstance(vertex, Block):
+        if not isinstance(vertex, Block):
             return
 
         feature_descriptions = self._feature_service.get_bits_description(block=vertex)

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -35,7 +35,7 @@ class BlockVerifier:
         *,
         settings: HathorSettings,
         daa: DifficultyAdjustmentAlgorithm,
-        feature_service: FeatureService | None = None
+        feature_service: FeatureService,
     ) -> None:
         self._settings = settings
         self._daa = daa
@@ -82,11 +82,6 @@ class BlockVerifier:
 
     def verify_mandatory_signaling(self, block: Block) -> None:
         """Verify whether this block is missing mandatory signaling for any feature."""
-        if not self._settings.FEATURE_ACTIVATION.enable_usage:
-            return
-
-        assert self._feature_service is not None
-
         signaling_state = self._feature_service.is_signaling_mandatory_features(block)
 
         match signaling_state:

--- a/hathor/verification/vertex_verifiers.py
+++ b/hathor/verification/vertex_verifiers.py
@@ -38,7 +38,7 @@ class VertexVerifiers(NamedTuple):
         *,
         settings: HathorSettings,
         daa: DifficultyAdjustmentAlgorithm,
-        feature_service: FeatureService | None = None,
+        feature_service: FeatureService,
     ) -> 'VertexVerifiers':
         """
         Create a VertexVerifiers instance using the default verifier for each vertex type,
@@ -60,7 +60,7 @@ class VertexVerifiers(NamedTuple):
         settings: HathorSettings,
         vertex_verifier: VertexVerifier,
         daa: DifficultyAdjustmentAlgorithm,
-        feature_service: FeatureService | None = None,
+        feature_service: FeatureService,
     ) -> 'VertexVerifiers':
         """
         Create a VertexVerifiers instance using a custom vertex_verifier.

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -59,7 +59,6 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         method calls to make sure we're executing it in the intended, most performatic way.
         """
         feature_settings = FeatureSettings(
-            enable_usage=True,
             evaluation_interval=4,
             max_signal_bits=4,
             default_threshold=3,
@@ -336,7 +335,6 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
 
     def test_reorg(self) -> None:
         feature_settings = FeatureSettings(
-            enable_usage=True,
             evaluation_interval=4,
             max_signal_bits=4,
             default_threshold=3,
@@ -551,7 +549,6 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
         Tests that feature states are correctly retrieved from an existing storage, so no recalculation is required.
         """
         feature_settings = FeatureSettings(
-            enable_usage=True,
             evaluation_interval=4,
             max_signal_bits=4,
             default_threshold=3,

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -138,24 +138,8 @@ def test_get_feature_activation_bit_value() -> None:
     assert block.get_feature_activation_bit_value(3) == 0
 
 
-@pytest.mark.parametrize(
-    'is_signaling_mandatory_features',
-    [BlockIsSignaling(), BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)]
-)
-def test_verify_must_signal_when_feature_activation_is_disabled(is_signaling_mandatory_features: bool) -> None:
-    settings = Mock(spec_set=HathorSettings)
-    settings.FEATURE_ACTIVATION.enable_usage = False
-    feature_service = Mock(spec_set=FeatureService)
-    feature_service.is_signaling_mandatory_features = Mock(return_value=is_signaling_mandatory_features)
-    verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())
-    block = Block()
-
-    verifier.verify_mandatory_signaling(block)
-
-
 def test_verify_must_signal() -> None:
     settings = Mock(spec_set=HathorSettings)
-    settings.FEATURE_ACTIVATION.enable_usage = True
     feature_service = Mock(spec_set=FeatureService)
     feature_service.is_signaling_mandatory_features = Mock(
         return_value=BlockIsMissingSignal(feature=Feature.NOP_FEATURE_1)
@@ -171,7 +155,6 @@ def test_verify_must_signal() -> None:
 
 def test_verify_must_not_signal() -> None:
     settings = Mock(spec_set=HathorSettings)
-    settings.FEATURE_ACTIVATION.enable_usage = True
     feature_service = Mock(spec_set=FeatureService)
     feature_service.is_signaling_mandatory_features = Mock(return_value=BlockIsSignaling())
     verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock())

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from hathor.conf import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
 from hathor.transaction.storage import TransactionMemoryStorage
@@ -30,7 +32,7 @@ class GenesisTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self._daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
-        verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=self._daa)
+        verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=self._daa, feature_service=Mock())
         self._verification_service = VerificationService(verifiers=verifiers)
         self.storage = TransactionMemoryStorage()
 

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.transaction import Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
@@ -11,7 +13,7 @@ class _BaseTest:
         def setUp(self) -> None:
             super().setUp()
             daa = DifficultyAdjustmentAlgorithm(settings=self._settings)
-            verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=daa)
+            verifiers = VertexVerifiers.create_defaults(settings=self._settings, daa=daa, feature_service=Mock())
             self._verification_service = VerificationService(verifiers=verifiers)
 
         def test_deserialize(self):


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/908

### Motivation

Since Feature Activation was enabled on mainnet on the previous PR, we can now remove the `enable_usage` setting, as its only purpose was making Feature Activation available on testnet but not mainnet.

### Acceptance Criteria

- Make `FeatureService` mandatory on `VertexVerifiers`.
- Remove `enable_usage` property from Feature Activation settings, and update code accordingly.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 