### PR TITLE
refactor(settings): remove some calls to HathorSettings

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -395,10 +395,6 @@ class HathorSettings(NamedTuple):
     # Identifier used in metadata's voided_by to mark a tx as partially validated.
     PARTIALLY_VALIDATED_ID: bytes = b'pending-validation'
 
-    EVENT_API_DEFAULT_BATCH_SIZE: int = 100
-
-    EVENT_API_MAX_BATCH_SIZE: int = 1000
-
     # Maximum number of sync running simultaneously.
     MAX_ENABLED_SYNC: int = 16
 

--- a/hathor/event/resources/event.py
+++ b/hathor/event/resources/event.py
@@ -19,12 +19,12 @@ from pydantic import Field, NonNegativeInt
 
 from hathor.api_util import Resource, set_cors
 from hathor.cli.openapi_files.register import register_resource
-from hathor.conf import HathorSettings
 from hathor.event import EventManager
 from hathor.event.model.base_event import BaseEvent
 from hathor.utils.api import ErrorResponse, QueryParams, Response
 
-settings = HathorSettings()
+EVENT_API_DEFAULT_BATCH_SIZE: int = 100
+EVENT_API_MAX_BATCH_SIZE: int = 1000
 
 
 @register_resource
@@ -66,7 +66,7 @@ class EventResource(Resource):
 
 class GetEventsParams(QueryParams):
     last_ack_event_id: Optional[NonNegativeInt]
-    size: int = Field(default=settings.EVENT_API_DEFAULT_BATCH_SIZE, ge=0, le=settings.EVENT_API_MAX_BATCH_SIZE)
+    size: int = Field(default=EVENT_API_DEFAULT_BATCH_SIZE, ge=0, le=EVENT_API_MAX_BATCH_SIZE)
 
 
 class GetEventsResponse(Response):

--- a/tests/resources/wallet/test_search_address.py
+++ b/tests/resources/wallet/test_search_address.py
@@ -1,6 +1,5 @@
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.scripts import parse_address_script
@@ -8,8 +7,6 @@ from hathor.wallet.resources.thin_wallet import AddressBalanceResource, AddressS
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward, create_tokens
-
-settings = HathorSettings()
 
 
 class BaseSearchAddressTest(_BaseResourceTest._ResourceTest):
@@ -108,12 +105,12 @@ class BaseSearchAddressTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
         self.assertTrue(data['success'])
         # Genesis - token deposit + blocks mined
-        HTR_value = settings.GENESIS_TOKENS - 1 + (settings.INITIAL_TOKENS_PER_BLOCK * 5)
+        HTR_value = self._settings.GENESIS_TOKENS - 1 + (self._settings.INITIAL_TOKENS_PER_BLOCK * 5)
         self.assertEqual(data['total_transactions'], 6)  # 5 blocks mined + token creation tx
-        self.assertIn(settings.HATHOR_TOKEN_UID.hex(), data['tokens_data'])
+        self.assertIn(self._settings.HATHOR_TOKEN_UID.hex(), data['tokens_data'])
         self.assertIn(self.token_uid.hex(), data['tokens_data'])
-        self.assertEqual(HTR_value, data['tokens_data'][settings.HATHOR_TOKEN_UID.hex()]['received'])
-        self.assertEqual(0, data['tokens_data'][settings.HATHOR_TOKEN_UID.hex()]['spent'])
+        self.assertEqual(HTR_value, data['tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['received'])
+        self.assertEqual(0, data['tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['spent'])
         self.assertEqual(100, data['tokens_data'][self.token_uid.hex()]['received'])
         self.assertEqual(0, data['tokens_data'][self.token_uid.hex()]['spent'])
 

--- a/tests/tx/test_indexes.py
+++ b/tests/tx/test_indexes.py
@@ -1,6 +1,5 @@
 import pytest
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator.utils import add_new_block, add_new_blocks
@@ -10,8 +9,6 @@ from hathor.util import iwindows
 from hathor.wallet import Wallet
 from tests import unittest
 from tests.utils import HAS_ROCKSDB, add_blocks_unlock_reward, add_custom_tx, add_new_tx, get_genesis_key
-
-settings = HathorSettings()
 
 
 class BaseIndexesTest(unittest.TestCase):
@@ -140,7 +137,7 @@ class BaseIndexesTest(unittest.TestCase):
         from hathor.indexes.utxo_index import UtxoIndexItem
         from tests.utils import GENESIS_ADDRESS_B58
 
-        HTR_UID = settings.HATHOR_TOKEN_UID
+        HTR_UID = self._settings.HATHOR_TOKEN_UID
 
         assert self.tx_storage.indexes is not None
         utxo_index = self.tx_storage.indexes.utxo
@@ -149,35 +146,35 @@ class BaseIndexesTest(unittest.TestCase):
         expected_genesis_utxos = [
             UtxoIndexItem(
                 token_uid=HTR_UID,
-                tx_id=settings.GENESIS_BLOCK_HASH,
+                tx_id=self._settings.GENESIS_BLOCK_HASH,
                 index=0,
                 address=GENESIS_ADDRESS_B58,
-                amount=settings.GENESIS_TOKENS,
+                amount=self._settings.GENESIS_TOKENS,
                 timelock=None,
-                heightlock=settings.REWARD_SPEND_MIN_BLOCKS,
+                heightlock=self._settings.REWARD_SPEND_MIN_BLOCKS,
             ),
         ]
 
         # height just not enough should be empty
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=settings.HATHOR_TOKEN_UID,
-                                       target_amount=settings.GENESIS_TOKEN_UNITS,
-                                       target_height=settings.REWARD_SPEND_MIN_BLOCKS - 1)),
+            list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
+                                       target_amount=self._settings.GENESIS_TOKEN_UNITS,
+                                       target_height=self._settings.REWARD_SPEND_MIN_BLOCKS - 1)),
             [],
         )
 
         # height is now enough
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=settings.HATHOR_TOKEN_UID,
-                                       target_amount=settings.GENESIS_TOKEN_UNITS,
-                                       target_height=settings.REWARD_SPEND_MIN_BLOCKS)),
+            list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
+                                       target_amount=self._settings.GENESIS_TOKEN_UNITS,
+                                       target_height=self._settings.REWARD_SPEND_MIN_BLOCKS)),
             expected_genesis_utxos,
         )
 
         # otherwise we can leave out the height and it should give the utxos
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=settings.HATHOR_TOKEN_UID,
-                                       target_amount=settings.GENESIS_TOKEN_UNITS)),
+            list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
+                                       target_amount=self._settings.GENESIS_TOKEN_UNITS)),
             expected_genesis_utxos,
         )
 
@@ -200,7 +197,7 @@ class BaseIndexesTest(unittest.TestCase):
             actual = list(utxo_index.iter_utxos(address=address, target_amount=9999999))
             expected = [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx_id,
                     index=index,
                     address=address,
@@ -304,13 +301,13 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=1)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[:1]
             ]
         )
@@ -319,13 +316,13 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=6500)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[4:1:-1]
             ]
         )
@@ -334,13 +331,13 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=25600)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[::-1]
             ]
         )
@@ -349,13 +346,13 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=30000)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[::-1]
             ]
         )
@@ -394,7 +391,7 @@ class BaseIndexesTest(unittest.TestCase):
             print('check target_amount =', target_amount)
             expected = [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx.hash,
                     index=1,
                     address=address,
@@ -416,11 +413,11 @@ class BaseIndexesTest(unittest.TestCase):
             self.assertEqual(actual, expected)
 
         # now check that at most 255 utxos will be returned when we check for a large enough amount
-        max_outputs = settings.MAX_NUM_OUTPUTS
+        max_outputs = self._settings.MAX_NUM_OUTPUTS
         actual = list(utxo_index.iter_utxos(address=address, target_amount=sum(range(301))))
         expected = [
             UtxoIndexItem(
-                token_uid=settings.HATHOR_TOKEN_UID,
+                token_uid=self._settings.HATHOR_TOKEN_UID,
                 tx_id=tx.hash,
                 index=1,
                 address=address,
@@ -461,13 +458,13 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=1)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                     ) for b in blocks
             ]
         )
@@ -499,7 +496,7 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address1, target_amount=6400)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=0,
                     address=address1,
@@ -533,13 +530,13 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=1)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                     ) for b in blocks
             ]
         )
@@ -571,7 +568,7 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address1, target_amount=transfer_value)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=1,
                     address=address1,
@@ -586,7 +583,7 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=change_value)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=0,
                     address=address,
@@ -603,7 +600,7 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address1, target_amount=1)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=1,
                     address=address1,
@@ -618,7 +615,7 @@ class BaseIndexesTest(unittest.TestCase):
             list(utxo_index.iter_utxos(address=address, target_amount=1)),
             [
                 UtxoIndexItem(
-                    token_uid=settings.HATHOR_TOKEN_UID,
+                    token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=0,
                     address=address,
@@ -659,7 +656,7 @@ class BaseIndexesTest(unittest.TestCase):
         self.assertEqual(addresses_indexes.get_sorted_from_address(address), [])
 
         # XXX: since we didn't add any multisig address, this is guaranteed to be reach the tail end of the index
-        assert settings.P2PKH_VERSION_BYTE[0] < settings.MULTISIG_VERSION_BYTE[0]
+        assert self._settings.P2PKH_VERSION_BYTE[0] < self._settings.MULTISIG_VERSION_BYTE[0]
 
         # generating a multisig address:
         address = generate_multisig_address(generate_multisig_redeem_script(2, [
@@ -676,7 +673,7 @@ class BaseIndexesTest(unittest.TestCase):
 
         # make height 100
         H = 100
-        blocks = add_new_blocks(self.manager, H - settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=15)
+        blocks = add_new_blocks(self.manager, H - self._settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=15)
         height_index = self.manager.tx_storage.indexes.height
         self.assertEqual(height_index.get_height_tip(), HeightInfo(100, blocks[-1].hash))
         self.assertEqual(height_index.get_n_height_tips(1), [HeightInfo(100, blocks[-1].hash)])

--- a/tests/tx/test_indexes2.py
+++ b/tests/tx/test_indexes2.py
@@ -3,14 +3,11 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import pytest
 
-from hathor.conf import HathorSettings
 from tests import unittest
 from tests.utils import HAS_ROCKSDB
 
 if TYPE_CHECKING:  # pragma: no cover
     import rocksdb
-
-settings = HathorSettings()
 
 
 class FakeTransaction(NamedTuple):
@@ -25,7 +22,7 @@ class SimpleIndexesTestCase(unittest.TestCase):
         # how many transactions will be generated on the same timestamp before increasing it by 1
         self.transactions = []
         repetitions = [1, 1, 10, 10, 10, 2, 1, 0, 0, 5, 5, 5, 0, 1, 1, 10, 10, 10, 1, 2, 3, 1, 100, 100, 1, 100, 0, 1]
-        ts = settings.GENESIS_BLOCK_TIMESTAMP
+        ts = self._settings.GENESIS_BLOCK_TIMESTAMP
         for rep in repetitions:
             for _ in range(rep):
                 tx = FakeTransaction(self.rng.randbytes(32), ts)

--- a/tests/tx/test_mining.py
+++ b/tests/tx/test_mining.py
@@ -1,13 +1,10 @@
 from typing import Any
 
-from hathor.conf import HathorSettings
 from hathor.mining import BlockTemplate
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Block, sum_weights
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
-
-settings = HathorSettings()
 
 
 class BaseMiningTest(unittest.TestCase):
@@ -45,10 +42,10 @@ class BaseMiningTest(unittest.TestCase):
 
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
-            reward=settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
+            reward=self._settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
-            timestamp_min=settings.GENESIS_BLOCK_TIMESTAMP + 3,
+            timestamp_min=self._settings.GENESIS_BLOCK_TIMESTAMP + 3,
             timestamp_max=timestamp_max,  # no limit for next block after genesis
             # parents=[tx.hash for tx in self.genesis_blocks + self.genesis_txs],
             parents=block_templates[0].parents,
@@ -68,13 +65,13 @@ class BaseMiningTest(unittest.TestCase):
         self.assertEqual(len(block_templates), 1)
 
         timestamp_max = min(
-            blocks[-1].timestamp + settings.MAX_DISTANCE_BETWEEN_BLOCKS - 1,
+            blocks[-1].timestamp + self._settings.MAX_DISTANCE_BETWEEN_BLOCKS - 1,
             int(manager.reactor.seconds()) + self._settings.MAX_FUTURE_TIMESTAMP_ALLOWED
         )
 
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
-            reward=settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
+            reward=self._settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=blocks[-1].timestamp + 1,

--- a/tests/tx/test_multisig.py
+++ b/tests/tx/test_multisig.py
@@ -1,6 +1,5 @@
 import base58
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address, get_private_key_from_bytes, get_public_key_bytes_compressed
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
@@ -10,8 +9,6 @@ from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
-
-settings = HathorSettings()
 
 
 class BaseMultisigTestCase(unittest.TestCase):
@@ -58,7 +55,7 @@ class BaseMultisigTestCase(unittest.TestCase):
         # Adding funds to the wallet
         blocks = add_new_blocks(self.manager, 2, advance_clock=15)
         add_blocks_unlock_reward(self.manager)
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, sum(blk.outputs[0].value for blk in blocks)))
 
         first_block_amount = blocks[0].outputs[0].value
@@ -77,7 +74,7 @@ class BaseMultisigTestCase(unittest.TestCase):
         self.manager.propagate_tx(tx1)
         self.clock.advance(10)
 
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, first_block_amount))
 
         # Then we create a new tx that spends this tokens from multisig wallet
@@ -126,7 +123,7 @@ class BaseMultisigTestCase(unittest.TestCase):
         # Now we propagate the correct
         self.assertTrue(self.manager.propagate_tx(tx))
 
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, first_block_amount + 300))
 
         # Testing the MultiSig class methods

--- a/tests/tx/test_reward_lock.py
+++ b/tests/tx/test_reward_lock.py
@@ -1,6 +1,5 @@
 import pytest
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import get_address_from_public_key
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
@@ -10,8 +9,6 @@ from hathor.transaction.storage import TransactionMemoryStorage
 from hathor.wallet import Wallet
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, get_genesis_key
-
-settings = HathorSettings()
 
 
 class BaseTransactionTest(unittest.TestCase):
@@ -41,7 +38,7 @@ class BaseTransactionTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(reward_block)
         self.assertTrue(self.manager.propagate_tx(reward_block))
         # XXX: calculate unlock height AFTER adding the block so the height is correctly calculated
-        unlock_height = reward_block.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS + 1
+        unlock_height = reward_block.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS + 1
         return reward_block, unlock_height
 
     def _spend_reward_tx(self, manager, reward_block):
@@ -70,7 +67,7 @@ class BaseTransactionTest(unittest.TestCase):
         reward_block, unlock_height = self._add_reward_block()
 
         # reward cannot be spent while not enough blocks are added
-        for _ in range(settings.REWARD_SPEND_MIN_BLOCKS):
+        for _ in range(self._settings.REWARD_SPEND_MIN_BLOCKS):
             tx = self._spend_reward_tx(self.manager, reward_block)
             self.assertEqual(tx.get_metadata().min_height, unlock_height)
             with self.assertRaises(RewardLocked):
@@ -87,7 +84,7 @@ class BaseTransactionTest(unittest.TestCase):
         reward_block, unlock_height = self._add_reward_block()
 
         # add one less block than needed
-        add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS - 1, advance_clock=1)
+        add_new_blocks(self.manager, self._settings.REWARD_SPEND_MIN_BLOCKS - 1, advance_clock=1)
 
         # add tx bypassing reward-lock verification
         # XXX: this situation is impossible in practice, but we force it to test that when a block tries to confirms a
@@ -105,7 +102,7 @@ class BaseTransactionTest(unittest.TestCase):
         reward_block, unlock_height = self._add_reward_block()
 
         # add just enough blocks
-        add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
+        add_new_blocks(self.manager, self._settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
 
         # add tx that spends the reward
         tx = self._spend_reward_tx(self.manager, reward_block)
@@ -122,7 +119,7 @@ class BaseTransactionTest(unittest.TestCase):
         reward_block, unlock_height = self._add_reward_block()
 
         # add one less block than needed
-        add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS - 1, advance_clock=1)
+        add_new_blocks(self.manager, self._settings.REWARD_SPEND_MIN_BLOCKS - 1, advance_clock=1)
 
         # add tx to mempool, must fail reward-lock verification
         tx = self._spend_reward_tx(self.manager, reward_block)
@@ -137,7 +134,7 @@ class BaseTransactionTest(unittest.TestCase):
         reward_block, unlock_height = self._add_reward_block()
 
         # add just enough blocks
-        add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
+        add_new_blocks(self.manager, self._settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
 
         # add tx that spends the reward, must not fail
         tx = self._spend_reward_tx(self.manager, reward_block)
@@ -149,7 +146,7 @@ class BaseTransactionTest(unittest.TestCase):
         reward_block, unlock_height = self._add_reward_block()
 
         # add just enough blocks
-        blocks = add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
+        blocks = add_new_blocks(self.manager, self._settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
 
         # add tx that spends the reward, must not fail
         tx = self._spend_reward_tx(self.manager, reward_block)

--- a/tests/tx/test_timelock.py
+++ b/tests/tx/test_timelock.py
@@ -1,4 +1,3 @@
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
@@ -6,8 +5,6 @@ from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutp
 from hathor.wallet.exceptions import InsufficientFunds
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
-
-settings = HathorSettings()
 
 
 class BaseTimelockTransactionTestCase(unittest.TestCase):
@@ -45,7 +42,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx1)
         self.manager.propagate_tx(tx1)
 
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(500, sum(blocks_tokens) - 500))
 
         self.clock.advance(1)
@@ -64,7 +61,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx2)
         propagated = self.manager.propagate_tx(tx2)
 
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(500, sum(blocks_tokens) - 500))
         self.assertFalse(propagated)
 
@@ -83,7 +80,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         tx3.timestamp = int(self.clock.seconds())
         self.manager.cpu_mining_service.resolve(tx3)
         propagated = self.manager.propagate_tx(tx3, False)
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(500, sum(blocks_tokens) - 500 - 700))
         self.assertTrue(propagated)
         self.clock.advance(1)
@@ -103,7 +100,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         tx4.timestamp = int(self.clock.seconds())
         self.manager.cpu_mining_service.resolve(tx4)
         propagated = self.manager.propagate_tx(tx4, False)
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(500, sum(blocks_tokens[:3])))
         self.assertTrue(propagated)
 
@@ -111,7 +108,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         tx2.timestamp = int(self.clock.seconds())
         self.manager.cpu_mining_service.resolve(tx2)
         propagated = self.manager.propagate_tx(tx2, False)
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, sum(blocks_tokens[:3])))
         self.assertTrue(propagated)
 
@@ -136,7 +133,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         self.manager.propagate_tx(tx1)
         self.clock.advance(1)
 
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(blocks_tokens[0], 0))
 
         outputs = [WalletOutputInfo(address=decode_address(address), value=blocks_tokens[0], timelock=None)]
@@ -153,7 +150,7 @@ class BaseTimelockTransactionTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx2)
         self.manager.propagate_tx(tx2)
 
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, blocks_tokens[0]))
 
 

--- a/tests/tx/test_tokens.py
+++ b/tests/tx/test_tokens.py
@@ -2,7 +2,6 @@ from struct import error as StructError
 
 import pytest
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.indexes.tokens_index import TokenUtxoInfo
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
@@ -12,8 +11,6 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.util import get_deposit_amount, get_withdraw_amount, int_to_bytes
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, add_new_double_spending, create_tokens, get_genesis_key
-
-settings = HathorSettings()
 
 
 class BaseTokenTest(unittest.TestCase):
@@ -453,30 +450,30 @@ class BaseTokenTest(unittest.TestCase):
         tx = create_tokens(self.manager, self.address_b58)
 
         # max token name length
-        tx.token_name = 'a' * settings.MAX_LENGTH_TOKEN_NAME
+        tx.token_name = 'a' * self._settings.MAX_LENGTH_TOKEN_NAME
         update_tx(tx)
         self.manager.verification_service.verify(tx)
 
         # max token symbol length
-        tx.token_symbol = 'a' * settings.MAX_LENGTH_TOKEN_SYMBOL
+        tx.token_symbol = 'a' * self._settings.MAX_LENGTH_TOKEN_SYMBOL
         update_tx(tx)
         self.manager.verification_service.verify(tx)
 
         # long token name
-        tx.token_name = 'a' * (settings.MAX_LENGTH_TOKEN_NAME + 1)
+        tx.token_name = 'a' * (self._settings.MAX_LENGTH_TOKEN_NAME + 1)
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
             self.manager.verification_service.verify(tx)
 
         # long token symbol
         tx.token_name = 'ValidName'
-        tx.token_symbol = 'a' * (settings.MAX_LENGTH_TOKEN_SYMBOL + 1)
+        tx.token_symbol = 'a' * (self._settings.MAX_LENGTH_TOKEN_SYMBOL + 1)
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
             self.manager.verification_service.verify(tx)
 
         # Hathor token name
-        tx.token_name = settings.HATHOR_TOKEN_NAME
+        tx.token_name = self._settings.HATHOR_TOKEN_NAME
         tx.token_symbol = 'TST'
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
@@ -484,7 +481,7 @@ class BaseTokenTest(unittest.TestCase):
 
         # Hathor token symbol
         tx.token_name = 'Test'
-        tx.token_symbol = settings.HATHOR_TOKEN_SYMBOL
+        tx.token_symbol = self._settings.HATHOR_TOKEN_SYMBOL
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
             self.manager.verification_service.verify(tx)

--- a/tests/wallet/test_balance_update.py
+++ b/tests/wallet/test_balance_update.py
@@ -1,4 +1,3 @@
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
@@ -7,8 +6,6 @@ from hathor.wallet.base_wallet import SpentTx, UnspentTx, WalletBalance, WalletI
 from hathor.wallet.exceptions import PrivateKeyNotFound
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, create_tokens
-
-settings = HathorSettings()
 
 
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):
@@ -47,7 +44,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # Tx2 is twin with tx1 but less acc weight, so it will get voided
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         # Change of parents only, so it's a twin.
@@ -68,7 +65,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta2.voided_by, {tx2.hash})
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         # Voided wallet history
@@ -94,7 +91,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # Tx2 is twin with tx1 with equal acc weight, so both will get voided
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         # Change of parents only, so it's a twin.
@@ -115,14 +112,14 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta2.voided_by, {tx2.hash})
 
         # Balance changed
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, sum(self.blocks_tokens[:3])))
 
     def test_balance_update3(self):
         # Tx2 is twin with tx1 with higher acc weight, so tx1 will get voided
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         # Change of parents only, so it's a twin.
@@ -144,7 +141,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta2.voided_by, None)
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
     def test_balance_update4(self):
@@ -154,7 +151,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.reactor.advance(1)
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         address = self.manager.wallet.get_unused_address_bytes()
@@ -199,7 +196,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta3.voided_by, {tx3.hash})
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
     def test_balance_update5(self):
@@ -210,7 +207,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.clock.advance(1)
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         address = self.manager.wallet.get_unused_address_bytes()
@@ -243,7 +240,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta3.twins, [self.tx1.hash])
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
     def test_balance_update6(self):
@@ -253,7 +250,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.reactor.advance(1)
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         # Change of parents only, so it's a twin.
@@ -280,7 +277,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.run_to_completion()
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance - 100))
 
     def test_balance_update7(self):
@@ -290,7 +287,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.reactor.advance(1)
 
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         address = self.manager.wallet.get_unused_address_bytes()
@@ -324,12 +321,12 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta3.twins, [self.tx1.hash])
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
     def test_balance_update_twin_tx(self):
         # Start balance
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
         wallet_address = self.manager.wallet.get_unused_address()
@@ -387,7 +384,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta5.voided_by, {tx5.hash})
 
         # Balance is the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID],
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
                          WalletBalance(0, self.initial_balance))
 
     def test_tokens_balance(self):
@@ -405,7 +402,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # initial hathor balance
         # we don't consider HTR balance 0 because we transfer genesis tokens to this
         # wallet during token creation
-        hathor_balance = self.manager.wallet.balance[settings.HATHOR_TOKEN_UID]
+        hathor_balance = self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID]
 
         # transfer token to another wallet and check balance again
         parents = self.manager.get_new_tx_parents()
@@ -435,9 +432,9 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # verify balance
         self.assertEqual(self.manager.wallet.balance[token_id], WalletBalance(0, amount - 30))
         # hathor balance remains the same
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID], hathor_balance)
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID], hathor_balance)
 
-        balances_per_address = self.manager.wallet.get_balance_per_address(settings.HATHOR_TOKEN_UID)
+        balances_per_address = self.manager.wallet.get_balance_per_address(self._settings.HATHOR_TOKEN_UID)
         self.assertEqual(hathor_balance.available, sum(x for x in balances_per_address.values()))
 
 

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -1,4 +1,3 @@
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_block
 from hathor.transaction import Transaction
@@ -7,8 +6,6 @@ from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutp
 from hathor.wallet.exceptions import InsufficientFunds
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
-
-settings = HathorSettings()
 
 
 class BaseWalletHDTest(unittest.TestCase):
@@ -33,9 +30,9 @@ class BaseWalletHDTest(unittest.TestCase):
         out = WalletOutputInfo(decode_address(new_address), self.TOKENS, timelock=None)
         block = add_new_block(self.manager)
         self.manager.verification_service.verify(block)
-        utxo = self.wallet.unspent_txs[settings.HATHOR_TOKEN_UID].get((block.hash, 0))
+        utxo = self.wallet.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((block.hash, 0))
         self.assertIsNotNone(utxo)
-        self.assertEqual(self.wallet.balance[settings.HATHOR_TOKEN_UID], WalletBalance(0, self.BLOCK_TOKENS))
+        self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.BLOCK_TOKENS))
 
         # create transaction spending this value, but sending to same wallet
         add_blocks_unlock_reward(self.manager)
@@ -50,9 +47,9 @@ class BaseWalletHDTest(unittest.TestCase):
         self.wallet.on_new_tx(tx1)
         self.tx_storage.save_transaction(tx1)
         self.assertEqual(len(self.wallet.spent_txs), 1)
-        utxo = self.wallet.unspent_txs[settings.HATHOR_TOKEN_UID].get((tx1.hash, 0))
+        utxo = self.wallet.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((tx1.hash, 0))
         self.assertIsNotNone(utxo)
-        self.assertEqual(self.wallet.balance[settings.HATHOR_TOKEN_UID], WalletBalance(0, self.TOKENS))
+        self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.TOKENS))
 
         # pass inputs and outputs to prepare_transaction, but not the input keys
         # spend output last transaction
@@ -69,7 +66,7 @@ class BaseWalletHDTest(unittest.TestCase):
         self.tx_storage.save_transaction(tx2)
         self.wallet.on_new_tx(tx2)
         self.assertEqual(len(self.wallet.spent_txs), 2)
-        self.assertEqual(self.wallet.balance[settings.HATHOR_TOKEN_UID], WalletBalance(0, self.TOKENS))
+        self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.TOKENS))
 
         # Test getting more unused addresses than the gap limit
         for i in range(3):

--- a/tests/websocket/test_websocket.py
+++ b/tests/websocket/test_websocket.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.testing import StringTransport
 
-from hathor.conf import HathorSettings
 from hathor.pubsub import EventArguments, HathorEvents
 from hathor.util import json_dumpb, json_dumps, json_loadb
 from hathor.wallet.base_wallet import SpentTx, UnspentTx, WalletBalance
@@ -12,8 +11,6 @@ from hathor.websocket import WebsocketStatsResource
 from hathor.websocket.factory import HathorAdminWebsocketFactory, HathorAdminWebsocketProtocol
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-
-settings = HathorSettings()
 
 
 class BaseWebsocketTest(_BaseResourceTest._ResourceTest):
@@ -82,7 +79,7 @@ class BaseWebsocketTest(_BaseResourceTest._ResourceTest):
         self.factory.connections.add(self.protocol)
         self.protocol.state = HathorAdminWebsocketProtocol.STATE_OPEN
         self.manager.pubsub.publish(HathorEvents.WALLET_BALANCE_UPDATED,
-                                    balance={settings.HATHOR_TOKEN_UID: WalletBalance(10, 20)})
+                                    balance={self._settings.HATHOR_TOKEN_UID: WalletBalance(10, 20)})
         self.run_to_completion()
         value = self._decode_value(self.transport.value())
         self.assertEqual(value['balance']['locked'], 10)


### PR DESCRIPTION
### Motivation

Continue with settings refactors.

### Acceptance Criteria

- Remove some calls to `HathorSettings()`, changing them to `get_global_settings()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 