### PR TITLE
refactor(storage): create StorageProtocol

### DIFF
--- a/hathor/reward_lock/__init__.py
+++ b/hathor/reward_lock/__init__.py
@@ -1,0 +1,21 @@
+#  Copyright 2024 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.reward_lock.reward_lock import get_spent_reward_locked_info, is_spent_reward_locked, iter_spent_rewards
+
+__all__ = [
+    'iter_spent_rewards',
+    'is_spent_reward_locked',
+    'get_spent_reward_locked_info',
+]

--- a/hathor/reward_lock/reward_lock.py
+++ b/hathor/reward_lock/reward_lock.py
@@ -1,0 +1,69 @@
+#  Copyright 2024 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING, Iterator, Optional
+
+from hathor.conf.get_settings import get_global_settings
+from hathor.transaction import Block
+from hathor.util import not_none
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage.vertex_storage_protocol import VertexStorageProtocol
+    from hathor.transaction.transaction import RewardLockedInfo, Transaction
+
+
+def iter_spent_rewards(tx: 'Transaction', storage: 'VertexStorageProtocol') -> Iterator[Block]:
+    """Iterate over all the rewards being spent, assumes tx has been verified."""
+    for input_tx in tx.inputs:
+        spent_tx = storage.get_vertex(input_tx.tx_id)
+        if spent_tx.is_block:
+            assert isinstance(spent_tx, Block)
+            yield spent_tx
+
+
+def is_spent_reward_locked(tx: 'Transaction') -> bool:
+    """ Check whether any spent reward is currently locked, considering only the block rewards spent by this tx
+    itself, and not the inherited `min_height`"""
+    return get_spent_reward_locked_info(tx, not_none(tx.storage)) is not None
+
+
+def get_spent_reward_locked_info(tx: 'Transaction', storage: 'VertexStorageProtocol') -> Optional['RewardLockedInfo']:
+    """Check if any input block reward is locked, returning the locked information if any, or None if they are all
+    unlocked."""
+    from hathor.transaction.transaction import RewardLockedInfo
+    for blk in iter_spent_rewards(tx, storage):
+        assert blk.hash is not None
+        needed_height = _spent_reward_needed_height(blk, storage)
+        if needed_height > 0:
+            return RewardLockedInfo(blk.hash, needed_height)
+    return None
+
+
+def _spent_reward_needed_height(block: Block, storage: 'VertexStorageProtocol') -> int:
+    """ Returns height still needed to unlock this `block` reward: 0 means it's unlocked."""
+    import math
+
+    # omitting timestamp to get the current best block, this will usually hit the cache instead of being slow
+    tips = storage.get_best_block_tips()
+    assert len(tips) > 0
+    best_height = math.inf
+    for tip in tips:
+        blk = storage.get_block(tip)
+        best_height = min(best_height, blk.get_height())
+    assert isinstance(best_height, int)
+    spent_height = block.get_height()
+    spend_blocks = best_height - spent_height
+    settings = get_global_settings()
+    needed_height = settings.REWARD_SPEND_MIN_BLOCKS - spend_blocks
+    return max(needed_height, 0)

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -45,6 +45,7 @@ from hathor.transaction.storage.migrations import (
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope, tx_allow_context
 from hathor.transaction.transaction import Transaction
 from hathor.transaction.transaction_metadata import TransactionMetadata
+from hathor.types import VertexId
 from hathor.util import not_none
 
 cpu = get_cpu_profiler()
@@ -1136,6 +1137,17 @@ class TransactionStorage(ABC):
 
         assert tx2.hash == self._settings.GENESIS_TX2_HASH
         return tx2
+
+    def get_parent_block(self, block: Block) -> Block:
+        return block.get_block_parent()
+
+    def get_vertex(self, vertex_id: VertexId) -> BaseTransaction:
+        return self.get_transaction(vertex_id)
+
+    def get_block(self, block_id: VertexId) -> Block:
+        block = self.get_vertex(block_id)
+        assert isinstance(block, Block)
+        return block
 
 
 class BaseTransactionStorage(TransactionStorage):

--- a/hathor/transaction/storage/vertex_storage_protocol.py
+++ b/hathor/transaction/storage/vertex_storage_protocol.py
@@ -1,0 +1,48 @@
+#  Copyright 2024 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from abc import abstractmethod
+from typing import Protocol
+
+from hathor.transaction import BaseTransaction, Block
+from hathor.types import VertexId
+
+
+class VertexStorageProtocol(Protocol):
+    """
+    This Protocol currently represents a subset of TransactionStorage methods. Its main use case is for verification
+    methods that can receive a RocksDB storage or an ephemeral simple memory storage.
+
+    Therefore, objects returned by this protocol may or may not have an `object.storage` pointer set.
+    """
+
+    @abstractmethod
+    def get_vertex(self, vertex_id: VertexId) -> BaseTransaction:
+        """Return a vertex from the storage."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_block(self, block_id: VertexId) -> Block:
+        """Return a block from the storage."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_parent_block(self, block: Block) -> Block:
+        """Get the parent block of a block."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_best_block_tips(self) -> list[VertexId]:
+        """Return a list of blocks that are heads in a best chain."""
+        raise NotImplementedError

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -15,6 +15,7 @@
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.profiler import get_cpu_profiler
+from hathor.reward_lock import get_spent_reward_locked_info
 from hathor.transaction import BaseTransaction, Transaction, TxInput
 from hathor.transaction.exceptions import (
     ConflictingInputs,
@@ -36,6 +37,7 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.transaction import TokenInfo
 from hathor.transaction.util import get_deposit_amount, get_withdraw_amount
 from hathor.types import TokenUid, VertexId
+from hathor.util import not_none
 
 cpu = get_cpu_profiler()
 
@@ -144,7 +146,7 @@ class TransactionVerifier:
     def verify_reward_locked(self, tx: Transaction) -> None:
         """Will raise `RewardLocked` if any reward is spent before the best block height is enough, considering only
         the block rewards spent by this tx itself, and not the inherited `min_height`."""
-        info = tx.get_spent_reward_locked_info()
+        info = get_spent_reward_locked_info(tx, not_none(tx.storage))
         if info is not None:
             raise RewardLocked(f'Reward {info.block_hash.hex()} still needs {info.blocks_needed} to be unlocked.')
 


### PR DESCRIPTION
### Motivation

To externalize storage dependencies from the verification process, we need to inject a storage into some methods used in verification, so it can either receive a `TransactionStorage` (rocksdb), or a simple memory storage that will be implemented in next PRs. To unify both of them in a single interface, a Python protocol is introduced, `StorageProtocol`.

### Acceptance Criteria

- Create `StorageProtocol`, a protocol for unifying a subset of storage methods.
- Add methods to `TransactionStorage` so it conforms to the `StorageProtocol`.
- Update DAA so its calculation depends on a `StorageProtocol`, and update usages accordingly.
- Update Reward Lock `Transaction` methods so they depend on a `StorageProtocol`, and update usages accordingly.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 