### PR TITLE
refactor(settings): remove some more calls to HathorSettings

### DIFF
--- a/tests/cli/test_multisig_spend.py
+++ b/tests/cli/test_multisig_spend.py
@@ -4,7 +4,6 @@ from io import StringIO
 from structlog.testing import capture_logs
 
 from hathor.cli.multisig_spend import create_parser, execute
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
@@ -13,8 +12,6 @@ from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
-
-settings = HathorSettings()
 
 
 class BaseMultiSigSpendTest(unittest.TestCase):
@@ -65,7 +62,10 @@ class BaseMultiSigSpendTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
         blocks_tokens = [sum(txout.value for txout in blk.outputs) for blk in blocks]
         available_tokens = sum(blocks_tokens)
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID], WalletBalance(0, available_tokens))
+        self.assertEqual(
+            self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
+            WalletBalance(0, available_tokens)
+        )
 
         # First we send tokens to a multisig address
         block_reward = blocks_tokens[0]
@@ -80,7 +80,7 @@ class BaseMultiSigSpendTest(unittest.TestCase):
         self.clock.advance(10)
 
         wallet_balance = WalletBalance(0, available_tokens - block_reward)
-        self.assertEqual(self.manager.wallet.balance[settings.HATHOR_TOKEN_UID], wallet_balance)
+        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID], wallet_balance)
 
         # Then we create a new tx that spends this tokens from multisig wallet
         tx = Transaction.create_from_struct(tx1.get_struct())

--- a/tests/cli/test_twin_tx.py
+++ b/tests/cli/test_twin_tx.py
@@ -5,7 +5,6 @@ import pytest
 from structlog.testing import capture_logs
 
 from hathor.cli.twin_tx import create_parser, execute
-from hathor.conf import HathorSettings
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TransactionMetadata
 from hathor.util import json_loadb
@@ -18,8 +17,6 @@ from tests.utils import (
     request_server,
     run_server,
 )
-
-settings = HathorSettings()
 
 
 class BaseTwinTxTest(unittest.TestCase):
@@ -93,7 +90,7 @@ class BaseTwinTxTest(unittest.TestCase):
         tx = response['tx']
 
         # Twin different weight and parents
-        host = 'http://localhost:8085/{}/'.format(settings.API_VERSION_PREFIX)
+        host = 'http://localhost:8085/{}/'.format(self._settings.API_VERSION_PREFIX)
         params = ['--url', host, '--hash', tx['hash'], '--parents', '--weight', '14']
         args = self.parser.parse_args(params)
 

--- a/tests/consensus/test_consensus.py
+++ b/tests/consensus/test_consensus.py
@@ -1,12 +1,9 @@
 from unittest.mock import MagicMock
 
-from hathor.conf import HathorSettings
 from hathor.simulator.utils import add_new_block, add_new_blocks, gen_new_tx
 from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
-
-settings = HathorSettings()
 
 
 class BaseConsensusTestCase(unittest.TestCase):
@@ -40,7 +37,7 @@ class BaseConsensusTestCase(unittest.TestCase):
 
         tx2 = manager.tx_storage.get_transaction(tx.hash)
         meta2 = tx2.get_metadata()
-        self.assertEqual({settings.CONSENSUS_FAIL_ID}, meta2.voided_by)
+        self.assertEqual({self._settings.CONSENSUS_FAIL_ID}, meta2.voided_by)
 
     def test_revert_block_high_weight(self):
         """ A conflict transaction will be propagated. At first, it will be voided.

--- a/tests/consensus/test_soft_voided.py
+++ b/tests/consensus/test_soft_voided.py
@@ -1,4 +1,3 @@
-from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterNTransactions
@@ -6,8 +5,6 @@ from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx
-
-settings = HathorSettings()
 
 
 class BaseSoftVoidedTestCase(SimulatorTestCase):
@@ -18,7 +15,7 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
             tx2 = tx.storage.get_transaction(h)
             tx2_meta = tx2.get_metadata()
             tx2_voided_by = tx2_meta.voided_by or set()
-            self.assertNotIn(settings.SOFT_VOIDED_ID, tx2_voided_by)
+            self.assertNotIn(self._settings.SOFT_VOIDED_ID, tx2_voided_by)
 
     def _run_test(self, simulator, soft_voided_tx_ids):
         manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids, simulator=simulator)
@@ -57,7 +54,7 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
 
         txA = manager2.tx_storage.get_transaction(txA_hash)
         metaA = txA.get_metadata()
-        self.assertEqual({settings.SOFT_VOIDED_ID, txA.hash}, metaA.voided_by)
+        self.assertEqual({self._settings.SOFT_VOIDED_ID, txA.hash}, metaA.voided_by)
         graphviz.labels[txA.hash] = 'txA'
 
         txB = add_custom_tx(manager2, [(txA, 0)])
@@ -123,8 +120,8 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
         for tx in manager1.tx_storage.get_all_transactions():
             meta = tx.get_metadata()
             voided_by = meta.voided_by or set()
-            if settings.SOFT_VOIDED_ID in voided_by:
-                self.assertTrue({settings.SOFT_VOIDED_ID, tx.hash}.issubset(voided_by))
+            if self._settings.SOFT_VOIDED_ID in voided_by:
+                self.assertTrue({self._settings.SOFT_VOIDED_ID, tx.hash}.issubset(voided_by))
 
         # Uncomment lines below to visualize the DAG and the blockchain.
         # dot = graphviz.dot()

--- a/tests/consensus/test_soft_voided2.py
+++ b/tests/consensus/test_soft_voided2.py
@@ -1,12 +1,9 @@
-from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import Simulator
 from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import BURN_ADDRESS, add_custom_tx
-
-settings = HathorSettings()
 
 
 class BaseConsensusSimulatorTestCase(SimulatorTestCase):
@@ -159,8 +156,8 @@ class BaseConsensusSimulatorTestCase(SimulatorTestCase):
         for tx in manager1.tx_storage.get_all_transactions():
             meta = tx.get_metadata()
             voided_by = meta.voided_by or set()
-            if settings.SOFT_VOIDED_ID in voided_by:
-                self.assertTrue({settings.SOFT_VOIDED_ID, tx.hash}.issubset(voided_by))
+            if self._settings.SOFT_VOIDED_ID in voided_by:
+                self.assertTrue({self._settings.SOFT_VOIDED_ID, tx.hash}.issubset(voided_by))
 
         txF1 = self.txF1_0
         txF2 = self.txF2_0

--- a/tests/consensus/test_soft_voided3.py
+++ b/tests/consensus/test_soft_voided3.py
@@ -1,4 +1,3 @@
-from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterNTransactions
@@ -6,8 +5,6 @@ from hathor.simulator.utils import gen_new_tx
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx, gen_custom_tx
-
-settings = HathorSettings()
 
 
 class BaseSoftVoidedTestCase(SimulatorTestCase):
@@ -18,7 +15,7 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
             tx2 = tx.storage.get_transaction(h)
             tx2_meta = tx2.get_metadata()
             tx2_voided_by = tx2_meta.voided_by or set()
-            self.assertNotIn(settings.SOFT_VOIDED_ID, tx2_voided_by)
+            self.assertNotIn(self._settings.SOFT_VOIDED_ID, tx2_voided_by)
 
     def _run_test(self, simulator, soft_voided_tx_ids):
         manager1 = self.create_peer(soft_voided_tx_ids=soft_voided_tx_ids, simulator=simulator)
@@ -60,7 +57,7 @@ class BaseSoftVoidedTestCase(SimulatorTestCase):
 
         txA = manager2.tx_storage.get_transaction(txA_hash)
         metaA = txA.get_metadata()
-        self.assertEqual({settings.SOFT_VOIDED_ID, txA.hash}, metaA.voided_by)
+        self.assertEqual({self._settings.SOFT_VOIDED_ID, txA.hash}, metaA.voided_by)
         graphviz.labels[txA.hash] = 'txA'
 
         txB = add_custom_tx(manager2, [(txA, 0)])

--- a/tests/consensus/test_soft_voided4.py
+++ b/tests/consensus/test_soft_voided4.py
@@ -1,4 +1,3 @@
-from hathor.conf import HathorSettings
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterNTransactions
@@ -6,8 +5,6 @@ from hathor.simulator.utils import gen_new_double_spending
 from tests import unittest
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import add_custom_tx
-
-settings = HathorSettings()
 
 
 class BaseSoftVoidedTestCase(SimulatorTestCase):

--- a/tests/crypto/test_util.py
+++ b/tests/crypto/test_util.py
@@ -3,7 +3,6 @@ import unittest
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import (
     decode_address,
     get_address_b58_from_public_key,
@@ -11,8 +10,6 @@ from hathor.crypto.util import (
     get_private_key_bytes,
     get_private_key_from_bytes,
 )
-
-settings = HathorSettings()
 
 
 class CryptoUtilTestCase(unittest.TestCase):

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -1,11 +1,8 @@
-from hathor.conf import HathorSettings
 from hathor.event.model.event_type import EventType
 from hathor.event.storage import EventMemoryStorage
 from hathor.simulator.utils import add_new_blocks
 from tests import unittest
 from tests.utils import BURN_ADDRESS, get_genesis_key
-
-settings = HathorSettings()
 
 
 class BaseEventReorgTest(unittest.TestCase):
@@ -27,10 +24,10 @@ class BaseEventReorgTest(unittest.TestCase):
         self.genesis_public_key = self.genesis_private_key.public_key()
 
     def test_reorg_events(self):
-        assert settings.REWARD_SPEND_MIN_BLOCKS == 10, 'this test was made with this hardcoded value in mind'
+        assert self._settings.REWARD_SPEND_MIN_BLOCKS == 10, 'this test was made with this hardcoded value in mind'
 
         # add some blocks
-        blocks = add_new_blocks(self.manager, settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
+        blocks = add_new_blocks(self.manager, self._settings.REWARD_SPEND_MIN_BLOCKS, advance_clock=1)
 
         # make a re-org
         self.log.debug('make reorg block')
@@ -49,13 +46,13 @@ class BaseEventReorgTest(unittest.TestCase):
 
         expected_events = [
             (EventType.LOAD_STARTED, {}),
-            (EventType.NEW_VERTEX_ACCEPTED, {'hash': settings.GENESIS_BLOCK_HASH.hex()}),
-            (EventType.NEW_VERTEX_ACCEPTED, {'hash': settings.GENESIS_TX1_HASH.hex()}),
-            (EventType.NEW_VERTEX_ACCEPTED, {'hash': settings.GENESIS_TX2_HASH.hex()}),
+            (EventType.NEW_VERTEX_ACCEPTED, {'hash': self._settings.GENESIS_BLOCK_HASH.hex()}),
+            (EventType.NEW_VERTEX_ACCEPTED, {'hash': self._settings.GENESIS_TX1_HASH.hex()}),
+            (EventType.NEW_VERTEX_ACCEPTED, {'hash': self._settings.GENESIS_TX2_HASH.hex()}),
             (EventType.LOAD_FINISHED, {}),
             (EventType.VERTEX_METADATA_CHANGED, {'hash': blocks[0].hash_hex}),
-            (EventType.VERTEX_METADATA_CHANGED, {'hash': settings.GENESIS_TX2_HASH.hex()}),
-            (EventType.VERTEX_METADATA_CHANGED, {'hash': settings.GENESIS_TX1_HASH.hex()}),
+            (EventType.VERTEX_METADATA_CHANGED, {'hash': self._settings.GENESIS_TX2_HASH.hex()}),
+            (EventType.VERTEX_METADATA_CHANGED, {'hash': self._settings.GENESIS_TX1_HASH.hex()}),
             (EventType.NEW_VERTEX_ACCEPTED, {'hash': blocks[0].hash_hex}),
             (EventType.VERTEX_METADATA_CHANGED, {'hash': blocks[1].hash_hex}),
             (EventType.NEW_VERTEX_ACCEPTED, {'hash': blocks[1].hash_hex}),

--- a/tests/feature_activation/test_feature_service.py
+++ b/tests/feature_activation/test_feature_service.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from hathor.conf import HathorSettings
+from hathor.conf.get_settings import get_global_settings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import (
     BlockIsMissingSignal,
@@ -35,7 +35,7 @@ from hathor.transaction.validation_state import ValidationState
 
 
 def _get_blocks_and_storage() -> tuple[list[Block], TransactionStorage]:
-    settings = HathorSettings()
+    settings = get_global_settings()
     genesis_hash = settings.GENESIS_BLOCK_HASH
     blocks: list[Block] = []
     feature_activation_bits = [

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -1,6 +1,5 @@
 from typing import Iterator
 
-from hathor.conf import HathorSettings
 from hathor.pubsub import PubSubManager
 from hathor.simulator.utils import add_new_block, add_new_blocks
 from hathor.transaction import BaseTransaction
@@ -8,8 +7,6 @@ from hathor.transaction.storage import TransactionMemoryStorage
 from tests import unittest
 from tests.unittest import TestBuilder
 from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
-
-settings = HathorSettings()
 
 
 class ModifiedTransactionMemoryStorage(TransactionMemoryStorage):

--- a/tests/p2p/test_capabilities.py
+++ b/tests/p2p/test_capabilities.py
@@ -1,16 +1,13 @@
-from hathor.conf import HathorSettings
 from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 from hathor.p2p.sync_v2.agent import NodeBlockSync
 from hathor.simulator import FakeConnection
 from tests import unittest
 
-settings = HathorSettings()
-
 
 class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase):
     def test_capabilities(self):
         network = 'testnet'
-        manager1 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST])
+        manager1 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST])
         manager2 = self.create_peer(network, capabilities=[])
 
         conn = FakeConnection(manager1, manager2)
@@ -26,8 +23,8 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
         self.assertIsInstance(conn._proto1.state.sync_agent, NodeSyncTimestamp)
         self.assertIsInstance(conn._proto2.state.sync_agent, NodeSyncTimestamp)
 
-        manager3 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST])
-        manager4 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST])
+        manager3 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST])
+        manager4 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST])
 
         conn2 = FakeConnection(manager3, manager4)
 
@@ -45,9 +42,9 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
 class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase):
     def test_capabilities(self):
         network = 'testnet'
-        manager1 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST,
-                                                           settings.CAPABILITY_SYNC_VERSION])
-        manager2 = self.create_peer(network, capabilities=[settings.CAPABILITY_SYNC_VERSION])
+        manager1 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST,
+                                                           self._settings.CAPABILITY_SYNC_VERSION])
+        manager2 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_SYNC_VERSION])
 
         conn = FakeConnection(manager1, manager2)
 
@@ -62,10 +59,10 @@ class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase)
         self.assertIsInstance(conn._proto1.state.sync_agent, NodeBlockSync)
         self.assertIsInstance(conn._proto2.state.sync_agent, NodeBlockSync)
 
-        manager3 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST,
-                                                           settings.CAPABILITY_SYNC_VERSION])
-        manager4 = self.create_peer(network, capabilities=[settings.CAPABILITY_WHITELIST,
-                                                           settings.CAPABILITY_SYNC_VERSION])
+        manager3 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST,
+                                                           self._settings.CAPABILITY_SYNC_VERSION])
+        manager4 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST,
+                                                           self._settings.CAPABILITY_SYNC_VERSION])
 
         conn2 = FakeConnection(manager3, manager4)
 

--- a/tests/p2p/test_get_best_blockchain.py
+++ b/tests/p2p/test_get_best_blockchain.py
@@ -1,6 +1,5 @@
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.conf import HathorSettings
 from hathor.indexes.height_index import HeightInfo
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.resources import StatusResource
@@ -12,8 +11,6 @@ from hathor.util import json_dumps
 from tests import unittest
 from tests.resources.base_resource import StubSite
 from tests.simulation.base import SimulatorTestCase
-
-settings = HathorSettings()
 
 
 class BaseGetBestBlockchainTestCase(SimulatorTestCase):
@@ -51,8 +48,8 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertIsNotNone(protocol2.capabilities)
 
         # assert the protocol has the GET_BEST_BLOCKCHAIN capability
-        self.assertIn(settings.CAPABILITY_GET_BEST_BLOCKCHAIN, protocol1.capabilities)
-        self.assertIn(settings.CAPABILITY_GET_BEST_BLOCKCHAIN, protocol2.capabilities)
+        self.assertIn(self._settings.CAPABILITY_GET_BEST_BLOCKCHAIN, protocol1.capabilities)
+        self.assertIn(self._settings.CAPABILITY_GET_BEST_BLOCKCHAIN, protocol2.capabilities)
 
         # assert the protocol is in ReadyState
         state1 = protocol1.state
@@ -81,8 +78,8 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         state1.send_get_best_blockchain()
         state2.send_get_best_blockchain()
         self.simulator.run(60)
-        self.assertEqual(settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS, len(state1.peer_best_blockchain))
-        self.assertEqual(settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS, len(state2.peer_best_blockchain))
+        self.assertEqual(self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS, len(state1.peer_best_blockchain))
+        self.assertEqual(self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS, len(state2.peer_best_blockchain))
 
         self.assertIsInstance(state1.peer_best_blockchain[0], HeightInfo)
         self.assertIsInstance(state2.peer_best_blockchain[0], HeightInfo)
@@ -211,8 +208,8 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         manager2 = self.create_peer()
 
         cababilities_without_get_best_blockchain = [
-            settings.CAPABILITY_WHITELIST,
-            settings.CAPABILITY_SYNC_VERSION,
+            self._settings.CAPABILITY_WHITELIST,
+            self._settings.CAPABILITY_SYNC_VERSION,
         ]
         manager2.capabilities = cababilities_without_get_best_blockchain
 
@@ -397,7 +394,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         # connected_peers
         # assert default peer_best_blockchain length
         peer_best_blockchain = connections['connected_peers'][0]['peer_best_blockchain']
-        self.assertEqual(len(peer_best_blockchain), settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS)
+        self.assertEqual(len(peer_best_blockchain), self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS)
 
         # assert a raw_height_info can be converted to HeightInfo
         try:
@@ -418,7 +415,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         # dag
         # assert default peer_best_blockchain length
         peer_best_blockchain = dag['best_blockchain']
-        self.assertEqual(len(peer_best_blockchain), settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS)
+        self.assertEqual(len(peer_best_blockchain), self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS)
 
         # assert a raw_height_info can be converted to HeightInfo
         try:

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -2,13 +2,10 @@ import os
 import shutil
 import tempfile
 
-from hathor.conf import HathorSettings
 from hathor.p2p.peer_id import InvalidPeerIdException, PeerId
 from hathor.p2p.peer_storage import PeerStorage
 from tests import unittest
 from tests.unittest import TestBuilder
-
-settings = HathorSettings()
 
 
 class PeerIdTest(unittest.TestCase):
@@ -134,13 +131,13 @@ class PeerIdTest(unittest.TestCase):
         p = PeerId()
         interval = p.retry_interval
         p.increment_retry_attempt(0)
-        self.assertEqual(settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER*interval, p.retry_interval)
+        self.assertEqual(self._settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER*interval, p.retry_interval)
         self.assertEqual(interval, p.retry_timestamp)
 
         # when retry_interval is already 180
-        p.retry_interval = settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 10
+        p.retry_interval = self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 10
         p.increment_retry_attempt(0)
-        self.assertEqual(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL, p.retry_interval)
+        self.assertEqual(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL, p.retry_interval)
 
         # reset
         p.reset_retry_timestamp()
@@ -180,27 +177,27 @@ class PeerIdTest(unittest.TestCase):
         peer.increment_retry_attempt(0)
         self.assertFalse(peer.can_retry(retry_interval))
 
-        retry_interval *= settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER
+        retry_interval *= self._settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER
         self.assertFalse(peer.can_retry(retry_interval - 1))
         self.assertTrue(peer.can_retry(retry_interval))
         self.assertTrue(peer.can_retry(retry_interval))
 
         # Retry until we reach max retry interval.
-        while peer.retry_interval < settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL:
+        while peer.retry_interval < self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL:
             peer.increment_retry_attempt(0)
         # We need to call it once more because peer.retry_interval is always one step behind.
         peer.increment_retry_attempt(0)
 
         # Confirm we are at the max retry interval.
-        self.assertFalse(peer.can_retry(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
-        self.assertTrue(peer.can_retry(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
-        self.assertTrue(peer.can_retry(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
+        self.assertFalse(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
+        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
+        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
 
         # It shouldn't change with another retry.
         peer.increment_retry_attempt(0)
-        self.assertFalse(peer.can_retry(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
-        self.assertTrue(peer.can_retry(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
-        self.assertTrue(peer.can_retry(settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
+        self.assertFalse(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
+        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
+        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
 
         # Finally, reset it.
         peer.reset_retry_timestamp()

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -5,14 +5,11 @@ from unittest.mock import Mock, patch
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 
-from hathor.conf import HathorSettings
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.protocol import HathorLineReceiver, HathorProtocol
 from hathor.simulator import FakeConnection
 from hathor.util import json_dumps
 from tests import unittest
-
-settings = HathorSettings()
 
 
 class BaseHathorProtocolTestCase(unittest.TestCase):
@@ -165,7 +162,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         # hello with clocks too far apart
         self.conn.tr1.clear()
         data = self.conn.proto2.state._get_hello_data()
-        data['timestamp'] = data['timestamp'] + settings.MAX_FUTURE_TIMESTAMP_ALLOWED/2 + 1
+        data['timestamp'] = data['timestamp'] + self._settings.MAX_FUTURE_TIMESTAMP_ALLOWED/2 + 1
         self._send_cmd(
             self.conn.proto1,
             'HELLO',
@@ -295,7 +292,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self.assertNotIn(self.peer_id2.id, self.manager1.connections.peer_storage)
 
     def test_idle_connection(self):
-        self.clock.advance(settings.PEER_IDLE_TIMEOUT - 10)
+        self.clock.advance(self._settings.PEER_IDLE_TIMEOUT - 10)
         self.assertIsConnected(self.conn)
         self.clock.advance(15)
         self.assertIsNotConnected(self.conn)
@@ -443,7 +440,7 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
         payload = {
             'first_block_hash': missing_tx,
             'last_block_hash': missing_tx,
-            'start_from': [settings.GENESIS_BLOCK_HASH.hex()]
+            'start_from': [self._settings.GENESIS_BLOCK_HASH.hex()]
         }
         yield self._send_cmd(self.conn.proto1, 'GET-TRANSACTIONS-BFS', json_dumps(payload))
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'NOT-FOUND')

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -1,7 +1,6 @@
 from twisted.python.failure import Failure
 
 from hathor.checkpoint import Checkpoint as cp
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.p2p.protocol import PeerIdState
 from hathor.p2p.sync_version import SyncVersion
@@ -9,8 +8,6 @@ from hathor.simulator import FakeConnection
 from hathor.transaction.storage.exceptions import TransactionIsNotABlock
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
-
-settings = HathorSettings()
 
 
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):
@@ -425,7 +422,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
         # disconnect and wait for the download of tx_A to timeout but not yet the download of tx_B
         self.conn1.disconnect(Failure(Exception('testing')))
         self.conn2.disconnect(Failure(Exception('testing')))
-        self.clock.advance(settings.GET_DATA_TIMEOUT - 10.0)
+        self.clock.advance(self._settings.GET_DATA_TIMEOUT - 10.0)
 
         # reconnect peer_X and peer_Y
         self.conn1 = FakeConnection(self.manager_bug, self.manager1)

--- a/tests/p2p/test_sync_rate_limiter.py
+++ b/tests/p2p/test_sync_rate_limiter.py
@@ -154,11 +154,8 @@ class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, SimulatorTestCase):
         sync1.send_tips()
         self.assertEqual(len(sync1._send_tips_call_later), 0)
 
-        from hathor.conf import HathorSettings
-        settings = HathorSettings()
-
-        # add delayed calls to the the maximum
-        max_delayed_calls = settings.MAX_GET_TIPS_DELAYED_CALLS
+        # add delayed calls to the maximum
+        max_delayed_calls = self._settings.MAX_GET_TIPS_DELAYED_CALLS
         for count in range(max_delayed_calls):
             sync1.send_tips()
 

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -5,7 +5,6 @@ import pytest
 from twisted.internet.defer import inlineCallbacks, succeed
 from twisted.python.failure import Failure
 
-from hathor.conf import HathorSettings
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.sync_v2.agent import _HeightInfo
@@ -20,8 +19,6 @@ from hathor.simulator.trigger import (
 from hathor.transaction.storage.traversal import DFSWalk
 from tests.simulation.base import SimulatorTestCase
 from tests.utils import HAS_ROCKSDB
-
-settings = HathorSettings()
 
 
 class BaseRandomSimulatorTestCase(SimulatorTestCase):

--- a/tests/resources/test_mining_info.py
+++ b/tests/resources/test_mining_info.py
@@ -1,12 +1,9 @@
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.conf import HathorSettings
 from hathor.p2p.resources import MiningInfoResource
 from hathor.simulator.utils import add_new_blocks
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-
-settings = HathorSettings()
 
 
 class BaseGetMiningInfoTest(_BaseResourceTest._ResourceTest):
@@ -54,15 +51,15 @@ class BaseGetMiningInfoTest(_BaseResourceTest._ResourceTest):
         response = yield self.web.get("mined_tokens")
         data = response.json_value()
         self.assertEqual(data['blocks'], 5)
-        self.assertEqual(data['mined_tokens'], 5*settings.INITIAL_TOKENS_PER_BLOCK)
+        self.assertEqual(data['mined_tokens'], 5*self._settings.INITIAL_TOKENS_PER_BLOCK)
 
-        add_new_blocks(self.manager, settings.BLOCKS_PER_HALVING + 15, advance_clock=1)
-        mined_tokens = (settings.BLOCKS_PER_HALVING * settings.INITIAL_TOKENS_PER_BLOCK +
-                        20 * settings.INITIAL_TOKENS_PER_BLOCK // 2)
+        add_new_blocks(self.manager, self._settings.BLOCKS_PER_HALVING + 15, advance_clock=1)
+        mined_tokens = (self._settings.BLOCKS_PER_HALVING * self._settings.INITIAL_TOKENS_PER_BLOCK +
+                        20 * self._settings.INITIAL_TOKENS_PER_BLOCK // 2)
 
         response = yield self.web.get("mined_tokens")
         data = response.json_value()
-        self.assertEqual(data['blocks'], settings.BLOCKS_PER_HALVING + 20)
+        self.assertEqual(data['blocks'], self._settings.BLOCKS_PER_HALVING + 20)
         self.assertEqual(data['mined_tokens'], mined_tokens)
 
 

--- a/tests/resources/transaction/test_mempool.py
+++ b/tests/resources/transaction/test_mempool.py
@@ -1,13 +1,10 @@
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.conf import HathorSettings
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import MempoolResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward, add_new_transactions
-
-settings = HathorSettings()
 
 
 class BaseMempoolTest(_BaseResourceTest._ResourceTest):
@@ -57,12 +54,12 @@ class BaseMempoolTest(_BaseResourceTest._ResourceTest):
         add_new_blocks(self.manager, 1, advance_clock=1)
 
         # Add more than api limit and check truncated return
-        add_new_transactions(self.manager, settings.MEMPOOL_API_TX_LIMIT + 1, advance_clock=1)
+        add_new_transactions(self.manager, self._settings.MEMPOOL_API_TX_LIMIT + 1, advance_clock=1)
         response5 = yield self.web.get("mempool")
         data5 = response5.json_value()
         self.assertTrue(data5['success'])
         # default limit is 100
-        self.assertEqual(len(data5['transactions']), settings.MEMPOOL_API_TX_LIMIT)
+        self.assertEqual(len(data5['transactions']), self._settings.MEMPOOL_API_TX_LIMIT)
 
 
 class SyncV1MempoolTest(unittest.SyncV1Params, BaseMempoolTest):

--- a/tests/resources/transaction/test_pushtx.py
+++ b/tests/resources/transaction/test_pushtx.py
@@ -2,7 +2,6 @@ from typing import Generator, Optional
 
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput
@@ -14,8 +13,6 @@ from hathor.wallet.resources import SendTokensResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward, add_tx_with_data_script, create_tokens
-
-settings = HathorSettings()
 
 
 class BasePushTxTest(_BaseResourceTest._ResourceTest):
@@ -184,7 +181,7 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
         tx = self.get_tx()
 
         # Invalid tx (output script is too long)
-        tx.outputs[0].script = b'*' * (settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1)
+        tx.outputs[0].script = b'*' * (self._settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1)
         self.manager.cpu_mining_service.resolve(tx)
         tx_hex = tx.get_struct().hex()
         response = yield self.push_tx({'hex_tx': tx_hex})
@@ -254,7 +251,7 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
 
         # Now we set this tx2 as voided and try to push a tx3 that spends tx2
         tx_meta = tx2.get_metadata()
-        tx_meta.voided_by = {settings.SOFT_VOIDED_ID}
+        tx_meta.voided_by = {self._settings.SOFT_VOIDED_ID}
         self.manager.tx_storage.save_transaction(tx2, only_metadata=True)
 
         # Try to push again with soft voided id as voided by

--- a/tests/resources/transaction/test_utxo_search.py
+++ b/tests/resources/transaction/test_utxo_search.py
@@ -1,14 +1,11 @@
 from twisted.internet.defer import inlineCallbacks
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import UtxoSearchResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward
-
-settings = HathorSettings()
 
 
 class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
@@ -62,7 +59,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[:1]])
 
         # Success non-empty address with medium amount, will require more than one output
@@ -75,7 +72,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[4:1:-1]])
 
         # Success non-empty address with exact amount, will require all UTXOs
@@ -88,7 +85,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[::-1]])
 
         # Success non-empty address with excessive amount, will require all UTXOs, even if it's not enough
@@ -101,7 +98,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[::-1]])
 
 

--- a/tests/test_memory_reactor_clock.py
+++ b/tests/test_memory_reactor_clock.py
@@ -16,6 +16,8 @@ from twisted.internet.testing import MemoryReactorClock
 
 
 class TestMemoryReactorClock(MemoryReactorClock):
+    __test__ = False
+
     def run(self):
         """
         We have to override MemoryReactor.run() because the original Twisted implementation weirdly calls stop() inside


### PR DESCRIPTION
### Motivation

Continue with settings refactors. Part 2 of https://github.com/HathorNetwork/hathor-core/pull/920.

### Acceptance Criteria

- Remove some calls to `HathorSettings()`, changing them to `get_global_settings()`.
- Add `__test__ = False` to `TestMemoryReactorClock` as it was incorrectly being collected by pytest.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 