### PR TITLE
feat(cli): improve handling of SIGQUIT and SIGINT

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -140,7 +140,7 @@ class HathorManager:
         self.reactor = reactor
         add_system_event_trigger = getattr(self.reactor, 'addSystemEventTrigger', None)
         if add_system_event_trigger is not None:
-            add_system_event_trigger('after', 'shutdown', self.stop)
+            add_system_event_trigger('after', 'shutdown', self.try_stop)
 
         self.state: Optional[HathorManager.NodeState] = None
         self.profiler: Optional[Any] = None
@@ -314,6 +314,10 @@ class HathorManager:
 
         # Start running
         self.tx_storage.start_running_manager()
+
+    def try_stop(self) -> None:
+        if self.is_started:
+            self.stop()
 
     def stop(self) -> Deferred:
         if not self.is_started:


### PR DESCRIPTION
### Motivation

Before this change we had these two not directly related but of similar nature:

- sending two SIGINT (Ctrl+C) in a row, could (depending on the timing) cause the second one to fail because the node is already existing
- sending a SIGQUIT causes the node to quit "abruptly" and not able to resume

### Acceptance Criteria

- Introduce `HathorManager.try_stop` which does not fail if it's called multiple times, and use it for `SIGINT` and `SIGQUIT`
- Add explicit handler for `SIGQUIT` and make sure to stop the reactor

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 