### PR TITLE
fix(feature-activation): add missing metadata migration

### DIFF
--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -707,6 +707,7 @@ class BaseTransaction(ABC):
         self._update_height_metadata()
         self._update_parents_children_metadata()
         self._update_reward_lock_metadata()
+        self._update_feature_activation_bit_counts()
         if save:
             assert self.storage is not None
             self.storage.save_transaction(self, only_metadata=True)
@@ -731,6 +732,15 @@ class BaseTransaction(ABC):
             if self.hash not in metadata.children:
                 metadata.children.append(self.hash)
                 self.storage.save_transaction(parent, only_metadata=True)
+
+    def _update_feature_activation_bit_counts(self) -> None:
+        """Update the block's feature_activation_bit_counts."""
+        if not self.is_block:
+            return
+        from hathor.transaction import Block
+        assert isinstance(self, Block)
+        # This method lazily calculates and stores the value in metadata
+        self.get_feature_activation_bit_counts()
 
     def update_timestamp(self, now: int) -> None:
         """Update this tx's timestamp

--- a/hathor/transaction/storage/migrations/add_feature_activation_bit_counts_metadata2.py
+++ b/hathor/transaction/storage/migrations/add_feature_activation_bit_counts_metadata2.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from structlog import get_logger
 
 from hathor.transaction.storage.migrations import BaseMigration
+from hathor.util import progress
 
 if TYPE_CHECKING:
     from hathor.transaction.storage import TransactionStorage
@@ -29,9 +30,12 @@ class Migration(BaseMigration):
         return True
 
     def get_db_name(self) -> str:
-        return 'add_feature_activation_bit_counts_metadata'
+        return 'add_feature_activation_bit_counts_metadata2'
 
     def run(self, storage: 'TransactionStorage') -> None:
-        # We can skip this migration as it will run again in `add_feature_activation_bit_counts_metadata2`.
         log = logger.new()
-        log.info('Skipping unnecessary migration.')
+        topological_iterator = storage.topological_iterator()
+
+        for vertex in progress(topological_iterator, log=log, total=None):
+            if vertex.is_block:
+                vertex.update_initial_metadata()

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -39,6 +39,7 @@ from hathor.transaction.storage.migrations import (
     BaseMigration,
     MigrationState,
     add_feature_activation_bit_counts_metadata,
+    add_feature_activation_bit_counts_metadata2,
     add_min_height_metadata,
     remove_first_nop_features,
 )
@@ -89,7 +90,8 @@ class TransactionStorage(ABC):
     _migration_factories: list[type[BaseMigration]] = [
         add_min_height_metadata.Migration,
         add_feature_activation_bit_counts_metadata.Migration,
-        remove_first_nop_features.Migration
+        remove_first_nop_features.Migration,
+        add_feature_activation_bit_counts_metadata2.Migration,
     ]
 
     _migrations: list[BaseMigration]


### PR DESCRIPTION
### Motivation

The feature activation bit counts metadata would be empty causing a max recursion error due to a change caused by https://github.com/HathorNetwork/hathor-core/pull/785.

### Acceptance Criteria

- Add bit counts calculation in `update_initial_metadata()`.
- Add `add_feature_activation_bit_counts_metadata2` migration.
- Change `add_feature_activation_bit_counts_metadata` migration so it does nothing.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 