### PR TITLE
fix(feature-activation): fix get ancestor

### DIFF
--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -19,7 +19,6 @@ import pytest
 
 from hathor.builder import Builder
 from hathor.conf.get_settings import get_global_settings
-from hathor.feature_activation import feature_service as feature_service_module
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.criteria import Criteria
@@ -88,11 +87,11 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         web_client = StubSite(feature_resource)
 
         calculate_new_state_mock = Mock(wraps=feature_service._calculate_new_state)
-        get_ancestor_iteratively_mock = Mock(wraps=feature_service_module._get_ancestor_iteratively)
+        get_ancestor_iteratively_mock = Mock(wraps=feature_service._get_ancestor_iteratively)
 
         with (
             patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock),
-            patch.object(feature_service_module, '_get_ancestor_iteratively', get_ancestor_iteratively_mock)
+            patch.object(FeatureService, '_get_ancestor_iteratively', get_ancestor_iteratively_mock),
         ):
             # at the beginning, the feature is DEFINED:
             add_new_blocks(manager, 10)
@@ -578,11 +577,11 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
         web_client = StubSite(feature_resource)
 
         calculate_new_state_mock = Mock(wraps=feature_service1._calculate_new_state)
-        get_ancestor_iteratively_mock = Mock(wraps=feature_service_module._get_ancestor_iteratively)
+        get_ancestor_iteratively_mock = Mock(wraps=feature_service1._get_ancestor_iteratively)
 
         with (
             patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock),
-            patch.object(feature_service_module, '_get_ancestor_iteratively', get_ancestor_iteratively_mock)
+            patch.object(FeatureService, '_get_ancestor_iteratively', get_ancestor_iteratively_mock),
         ):
             assert artifacts1.tx_storage.get_vertices_count() == 3  # genesis vertices in the storage
 
@@ -631,11 +630,11 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
         web_client = StubSite(feature_resource)
 
         calculate_new_state_mock = Mock(wraps=feature_service._calculate_new_state)
-        get_ancestor_iteratively_mock = Mock(wraps=feature_service_module._get_ancestor_iteratively)
+        get_ancestor_iteratively_mock = Mock(wraps=feature_service._get_ancestor_iteratively)
 
         with (
             patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock),
-            patch.object(feature_service_module, '_get_ancestor_iteratively', get_ancestor_iteratively_mock)
+            patch.object(FeatureService, '_get_ancestor_iteratively', get_ancestor_iteratively_mock),
         ):
             # the new storage starts populated
             assert artifacts2.tx_storage.get_vertices_count() == 67


### PR DESCRIPTION
### Motivation

I noticed there was a bug in the `_get_ancestor_at_height()` method of Feature Activation. It receives a block and an ancestor height, and returns the ancestor block with that height. In current code, it checks whether the block is voided, and if it's not, it's in the best blockchain, so we can use the height index. Otherwise, it would iterate over all parents using `block.get_block_parent()`, which is less performatic than using the index.

The issue is that this method may be called _before_ the consensus runs for this block. This means that we do not know if the block is part of the best blockchain, and checking `not meta.voided_by` is wrong. This PR fixes this issue simply by forwarding the existing rule to the first parent block, which is guaranteed to have gone through the consensus already.

This indicates that it would be beneficial to refactor metadata in a way that this bug would not be possible. We shouldn't be able to check `meta.voided_by` for a vertex that hasn't been through the consensus. We should have different metadata types depending on the state of the vertex.

**Note:** Even if the loop ends up running, which happens only once for each Evaluation Interval (1 week) and only if the block is not in the best chain, it's not that slow. I've tested it informally inside a running local testnet node, with `20160` iterations (the maximum possible):

![Screenshot 2024-01-19 at 14 22 03](https://github.com/HathorNetwork/hathor-core/assets/1757957/2465452e-9369-48f1-a7a9-abeeafeeb03c)

### Acceptance Criteria

- Change the `_get_ancestor_at_height()` method so it gets the ancestor from the first parent block, instead of from the block itself.
- Change the `_get_ancestor_iteratively()` function to a method to add an assertion.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 