### PR TITLE
feat(cli): mark sync-v2 parameters as safe and deprecate --x-* ones

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -158,8 +158,17 @@ class CliBuilder:
 
         hostname = self.get_hostname()
         network = settings.NETWORK_NAME
-        enable_sync_v1 = not self._args.x_sync_v2_only
-        enable_sync_v2 = self._args.x_sync_v2_only or self._args.x_sync_bridge
+
+        arg_sync_v2_only = self._args.x_sync_v2_only or self._args.sync_v2_only
+        if self._args.x_sync_v2_only:
+            self.log.warn('--x-sync-v2-only is deprecated and will be removed, use --sync-v2-only instead')
+
+        arg_sync_bridge = self._args.x_sync_bridge or self._args.sync_bridge
+        if self._args.x_sync_bridge:
+            self.log.warn('--x-sync-bridge is deprecated and will be removed, use --sync-bridge instead')
+
+        enable_sync_v1 = not arg_sync_v2_only
+        enable_sync_v2 = arg_sync_v2_only or arg_sync_bridge
 
         pubsub = PubSubManager(reactor)
 

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -108,6 +108,11 @@ class RunNode:
                             help='Enable support for running both sync protocols. DO NOT ENABLE, IT WILL BREAK.')
         v2args.add_argument('--x-sync-v2-only', action='store_true',
                             help='Disable support for running sync-v1. DO NOT ENABLE, IT WILL BREAK.')
+        # XXX: new safe arguments along side the unsafe --x- arguments so transition is easier
+        v2args.add_argument('--sync-bridge', action='store_true',
+                            help='Enable support for running both sync protocols.')
+        v2args.add_argument('--sync-v2-only', action='store_true',
+                            help='Disable support for running sync-v1.')
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
         parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -65,6 +65,8 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     enable_crash_api: bool
     x_sync_bridge: bool
     x_sync_v2_only: bool
+    sync_bridge: bool
+    sync_v2_only: bool
     x_localhost_only: bool
     x_rocksdb_indexes: bool
     x_enable_event_queue: bool


### PR DESCRIPTION
### Motivation

On the previous release sync-v2 was available as "experimental" and was marked as "unsafe", our tests showed it ran really well, so in this release it is being marked as "safe", making it more user friendly to enable.

### Acceptance Criteria

- `--x-sync-v2-only` and `--x-sync-bridge` are still accepted but give a warning saying they're deprecated and will be removed in a later release (possibly `v0.60.0`)
- `--sync-v2-only` and `--sync-bridge` are added and have the same meaning as the `--x-*` variants.
  - internally they are mutually exclusive flags also with the `--x-*` variants, meaning `--x-sync-v2-only` and `--sync-v2-only` can't be used at the same time, and as long as one of them is true, the value used is true

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 