### PR TITLE
fix(indexes): efficient rocksdb mempool-tips initialization

### DIFF
--- a/hathor/indexes/manager.py
+++ b/hathor/indexes/manager.py
@@ -348,7 +348,6 @@ class RocksDBIndexesManager(IndexesManager):
             self.utxo = RocksDBUtxoIndex(self._db)
 
     def enable_mempool_index(self) -> None:
-        from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
+        from hathor.indexes.rocksdb_mempool_tips_index import RocksDBMempoolTipsIndex
         if self.mempool_tips is None:
-            # XXX: use of RocksDBMempoolTipsIndex is very slow and was suspended
-            self.mempool_tips = MemoryMempoolTipsIndex()
+            self.mempool_tips = RocksDBMempoolTipsIndex(self._db)


### PR DESCRIPTION
### Motivation

When we made sync-v2 always available, even when not enabled, it implied having to initialize the mempool-tips index, but its RocksDB implementation had been disabled for having a very slow initialization but using a memory index has the downside of always initializing the index on every start.

The mempool is defined as the set of transactions that don't have a `first_block` and are not voided, the mempool-tips index only stores only the mempool transactions that are "tips" (in the sense that all the other transactions can be reached by traversing to the left), the practical definition is the set of all transactions that don't have a `first_block`, don't have a non-voided child and don't have a non-voided spent_output (that is, they aren't literal "tips" because they can have children or spent outputs, as long as those are voided).

Before this PR, the initialization was implemented as simply processing all transactions in topological order the same way they would be if a node received them from the network, with the disadvantage that the it would almost always cache miss due to how the update has to load transactions "to the right" of the iteration loop, making it very slow.

This PR simplifies the loading by looking at the `first_block`, `children`, `spent_outputs` and `voided_by` metadata fields to determine if a transaction is in the mempool and only adding it to the index if it is, instead of adding and removing transactions.

### Acceptance Criteria

- Optimize `MemoryTipsIndex.init_loop_step` by restricting the scope and making it only add transactions without a first_block, children or spent outputs.
- Use the RocksDB implementation when RocksDB indexes are being used.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 