### PR TITLE
fix: health endpoint when using --x-asyncio-reactor

### DIFF
--- a/hathor/healthcheck/resources/healthcheck.py
+++ b/hathor/healthcheck/resources/healthcheck.py
@@ -74,6 +74,7 @@ class HealthcheckResource(Resource):
         healthcheck = Healthcheck(name='hathor-core', components=[sync_component])
 
         # The asyncio loop will be running in case the option --x-asyncio-reactor is used
+        # XXX: We should remove this if when the asyncio reactor becomes the default and the only option
         if asyncio.get_event_loop().is_running():
             future = asyncio.ensure_future(healthcheck.run())
             deferred = Deferred.fromFuture(future)

--- a/hathor/healthcheck/resources/healthcheck.py
+++ b/hathor/healthcheck/resources/healthcheck.py
@@ -1,6 +1,16 @@
 import asyncio
 
-from healthcheck import Healthcheck, HealthcheckCallbackResponse, HealthcheckInternalComponent, HealthcheckStatus
+from healthcheck import (
+    Healthcheck,
+    HealthcheckCallbackResponse,
+    HealthcheckInternalComponent,
+    HealthcheckResponse,
+    HealthcheckStatus,
+)
+from twisted.internet.defer import Deferred, succeed
+from twisted.python.failure import Failure
+from twisted.web.http import Request
+from twisted.web.server import NOT_DONE_YET
 
 from hathor.api_util import Resource, get_arg_default, get_args
 from hathor.cli.openapi_files.register import register_resource
@@ -24,6 +34,28 @@ class HealthcheckResource(Resource):
     def __init__(self, manager: HathorManager):
         self.manager = manager
 
+    def _render_error(self, failure: Failure, request: Request) -> None:
+        request.setResponseCode(500)
+        request.write(json_dumpb({
+            'status': 'fail',
+            'reason': f'Internal Error: {failure.getErrorMessage()}',
+            'traceback': failure.getTraceback()
+        }))
+        request.finish()
+
+    def _render_success(self, result: HealthcheckResponse, request: Request) -> None:
+        raw_args = get_args(request)
+        strict_status_code = get_arg_default(raw_args, 'strict_status_code', '0') == '1'
+
+        if strict_status_code:
+            request.setResponseCode(200)
+        else:
+            status_code = result.get_http_status_code()
+            request.setResponseCode(status_code)
+
+        request.write(json_dumpb(result.to_json()))
+        request.finish()
+
     def render_GET(self, request):
         """ GET request /health/
             Returns the health status of the fullnode
@@ -34,24 +66,25 @@ class HealthcheckResource(Resource):
 
             :rtype: string (json)
         """
-        raw_args = get_args(request)
-        strict_status_code = get_arg_default(raw_args, 'strict_status_code', '0') == '1'
-
         sync_component = HealthcheckInternalComponent(
             name='sync',
         )
         sync_component.add_healthcheck(lambda: sync_healthcheck(self.manager))
 
         healthcheck = Healthcheck(name='hathor-core', components=[sync_component])
-        status = asyncio.get_event_loop().run_until_complete(healthcheck.run())
 
-        if strict_status_code:
-            request.setResponseCode(200)
+        # The asyncio loop will be running in case the option --x-asyncio-reactor is used
+        if asyncio.get_event_loop().is_running():
+            future = asyncio.ensure_future(healthcheck.run())
+            deferred = Deferred.fromFuture(future)
         else:
-            status_code = status.get_http_status_code()
-            request.setResponseCode(status_code)
+            status = asyncio.get_event_loop().run_until_complete(healthcheck.run())
+            deferred = succeed(status)
 
-        return json_dumpb(status.to_json())
+        deferred.addCallback(self._render_success, request)
+        deferred.addErrback(self._render_error, request)
+
+        return NOT_DONE_YET
 
 
 HealthcheckResource.openapi = {

--- a/tests/resources/healthcheck/test_healthcheck.py
+++ b/tests/resources/healthcheck/test_healthcheck.py
@@ -1,6 +1,7 @@
+import asyncio
 from unittest.mock import ANY
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import Deferred, inlineCallbacks
 
 from hathor.healthcheck.resources.healthcheck import HealthcheckResource
 from hathor.manager import HathorManager
@@ -38,6 +39,56 @@ class BaseHealthcheckReadinessTest(_BaseResourceTest._ResourceTest):
                 }]
             }
         })
+
+    def test_with_running_asyncio_loop(self):
+        """Test with a running asyncio loop.
+
+           This is a simulation of how this endpoint should behave in production when the
+           --x-asyncio-reactor is provided to hathor-core, because this causes the reactor to run
+           an asyncio loop.
+        """
+        # This deferred will be used solely to make sure the test doesn't finish before the async code
+        done = Deferred()
+
+        def set_done(_):
+            done.callback(None)
+
+        def set_done_fail(failure):
+            done.errback(failure)
+
+        # This will be called from inside the async method to perform the web request
+        # while a running asyncio loop is present
+        @inlineCallbacks
+        def get_health():
+            response = yield self.web.get('/health')
+            return response.json_value()
+
+        async def run():
+            data = get_health()
+            # When the request is done, we make sure the response is as expected
+            data.addCallback(self.assertEqual, {
+                'status': 'fail',
+                'description': ANY,
+                'checks': {
+                    'sync': [{
+                        'componentType': 'internal',
+                        'componentName': 'sync',
+                        'status': 'fail',
+                        'output': HathorManager.UnhealthinessReason.NO_RECENT_ACTIVITY,
+                        'time': ANY
+                    }]
+                }
+            })
+            # We succeed the "done" deferred if everything is ok
+            data.addCallback(set_done)
+            # We fail the "done" deferred if something goes wrong. This includes the assertion above failing.
+            data.addErrback(set_done_fail)
+
+        # This will make sure we have a running asyncio loop
+        asyncio.get_event_loop().run_until_complete(run())
+
+        # Return the deferred so the test doesn't finish before the async code
+        return done
 
     @inlineCallbacks
     def test_strict_status_code(self):


### PR DESCRIPTION
### Motivation

In case the `--x-asyncio-reactor` option was used to run hathor-core, we would get the following error when sending requests to `/v1a/health`:

```
 Traceback (most recent call last):
File "/usr/local/lib/python3.10/site-packages/twisted/web/server.py", line 227, in process
self.render(resrc)
File "/usr/local/lib/python3.10/site-packages/twisted/web/server.py", line 292, in render
body = resrc.render(self)
File "/usr/local/lib/python3.10/site-packages/twisted/web/resource.py", line 268, in render
return m(request)
File "/usr/local/lib/python3.10/site-packages/hathor/healthcheck/resources/healthcheck.py", line 46, in render_GET
status = asyncio.get_event_loop().run_until_complete(healthcheck.run())
File "/usr/local/lib/python3.10/asyncio/base_events.py", line 625, in run_until_complete
self._check_running()
File "/usr/local/lib/python3.10/asyncio/base_events.py", line 584, in _check_running
raise RuntimeError('This event loop is already running')
RuntimeError: This event loop is already running
```

The reason for this is that basically Twisted would be running its own asyncio event loop already, so we couldn't run another one.

### Acceptance Criteria

- We should detect whether there is a running event loop and act accordingly. If there is, we just schedule a task on it. If there isn't, we create a new one to run the healthcheck logic.
- We should now use Deferred's callbacks in this endpoint to handle the response. With them, it becomes easier to adapt to both situations (having a running event loop or not).

### Useful References Consulted
- https://github.com/twisted/twisted/issues/11841
- https://github.com/twisted/twisted/pull/11890#issuecomment-1615953196


### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 