### PR TITLE
feat(cli): Use SIGUSR2 to run sysctl commands

### DIFF
--- a/hathor/sysctl/p2p/manager.py
+++ b/hathor/sysctl/p2p/manager.py
@@ -17,7 +17,7 @@ import os
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.sync_version import SyncVersion
 from hathor.sysctl.exception import SysctlException
-from hathor.sysctl.sysctl import Sysctl
+from hathor.sysctl.sysctl import Sysctl, signal_handler_safe
 
 
 def parse_text(text: str) -> list[str]:
@@ -162,6 +162,7 @@ class ConnectionsManagerSysctl(Sysctl):
         """Return the maximum number of peers running sync simultaneously."""
         return self.connections.MAX_ENABLED_SYNC
 
+    @signal_handler_safe
     def set_max_enabled_sync(self, value: int) -> None:
         """Change the maximum number of peers running sync simultaneously."""
         if value < 0:
@@ -179,6 +180,7 @@ class ConnectionsManagerSysctl(Sysctl):
         """Return the list of ENABLED sync versions."""
         return sorted(map(pretty_sync_version, self.connections.get_enabled_sync_versions()))
 
+    @signal_handler_safe
     def set_enabled_sync_versions(self, sync_versions: list[str]) -> None:
         """Set the list of ENABLED sync versions."""
         new_sync_versions = set(map(parse_sync_version, sync_versions))
@@ -202,6 +204,7 @@ class ConnectionsManagerSysctl(Sysctl):
         """Disable the given sync version."""
         self.connections.disable_sync_version(sync_version)
 
+    @signal_handler_safe
     def set_kill_connection(self, peer_id: str, force: bool = False) -> None:
         """Kill connection with peer_id or kill all connections if peer_id == '*'."""
         if peer_id == '*':

--- a/tests/sysctl/test_p2p.py
+++ b/tests/sysctl/test_p2p.py
@@ -17,28 +17,28 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         connections._sync_rotate_if_needed = MagicMock()
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 0)
 
-        sysctl.set('max_enabled_sync', 10)
+        sysctl.unsafe_set('max_enabled_sync', 10)
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 1)
         self.assertEqual(connections.MAX_ENABLED_SYNC, 10)
         self.assertEqual(sysctl.get('max_enabled_sync'), 10)
 
-        sysctl.set('max_enabled_sync', 10)
+        sysctl.unsafe_set('max_enabled_sync', 10)
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 1)
         self.assertEqual(connections.MAX_ENABLED_SYNC, 10)
         self.assertEqual(sysctl.get('max_enabled_sync'), 10)
 
-        sysctl.set('max_enabled_sync', 5)
+        sysctl.unsafe_set('max_enabled_sync', 5)
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 2)
         self.assertEqual(connections.MAX_ENABLED_SYNC, 5)
         self.assertEqual(sysctl.get('max_enabled_sync'), 5)
 
-        sysctl.set('max_enabled_sync', 0)
+        sysctl.unsafe_set('max_enabled_sync', 0)
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 3)
         self.assertEqual(connections.MAX_ENABLED_SYNC, 0)
         self.assertEqual(sysctl.get('max_enabled_sync'), 0)
 
         with self.assertRaises(SysctlException):
-            sysctl.set('max_enabled_sync', -1)
+            sysctl.unsafe_set('max_enabled_sync', -1)
 
     def test_global_rate_limiter_send_tips(self):
         manager = self.create_peer()
@@ -47,29 +47,29 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
 
         path = 'rate_limit.global.send_tips'
 
-        sysctl.set(path, (10, 4))
+        sysctl.unsafe_set(path, (10, 4))
         limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
         self.assertEqual(limit, (10, 4))
         self.assertEqual(sysctl.get(path), (10, 4))
 
-        sysctl.set(path, (15, 5))
+        sysctl.unsafe_set(path, (15, 5))
         limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
         self.assertEqual(limit, (15, 5))
         self.assertEqual(sysctl.get(path), (15, 5))
 
-        sysctl.set(path, (0, 0))
+        sysctl.unsafe_set(path, (0, 0))
         limit = connections.rate_limiter.get_limit(connections.GlobalRateLimiter.SEND_TIPS)
         self.assertEqual(limit, None)
         self.assertEqual(sysctl.get(path), (0, 0))
 
         with self.assertRaises(SysctlException):
-            sysctl.set(path, (-1, 1))
+            sysctl.unsafe_set(path, (-1, 1))
 
         with self.assertRaises(SysctlException):
-            sysctl.set(path, (1, -1))
+            sysctl.unsafe_set(path, (1, -1))
 
         with self.assertRaises(SysctlException):
-            sysctl.set(path, (-1, -1))
+            sysctl.unsafe_set(path, (-1, -1))
 
     def test_force_sync_rotate(self):
         manager = self.create_peer()
@@ -79,7 +79,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         connections._sync_rotate_if_needed = MagicMock()
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 0)
 
-        sysctl.set('force_sync_rotate', ())
+        sysctl.unsafe_set('force_sync_rotate', ())
         self.assertEqual(connections._sync_rotate_if_needed.call_count, 1)
         self.assertEqual(connections._sync_rotate_if_needed.call_args.kwargs, {'force': True})
 
@@ -88,23 +88,23 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         connections = manager.connections
         sysctl = ConnectionsManagerSysctl(connections)
 
-        sysctl.set('sync_update_interval', 10)
+        sysctl.unsafe_set('sync_update_interval', 10)
         self.assertEqual(connections.lc_sync_update_interval, 10)
         self.assertEqual(sysctl.get('sync_update_interval'), 10)
 
         with self.assertRaises(SysctlException):
-            sysctl.set('sync_update_interval', -1)
+            sysctl.unsafe_set('sync_update_interval', -1)
 
     def test_always_enable_sync(self):
         manager = self.create_peer()
         connections = manager.connections
         sysctl = ConnectionsManagerSysctl(connections)
 
-        sysctl.set('always_enable_sync', ['peer-1', 'peer-2'])
+        sysctl.unsafe_set('always_enable_sync', ['peer-1', 'peer-2'])
         self.assertEqual(connections.always_enable_sync, {'peer-1', 'peer-2'})
         self.assertEqual(set(sysctl.get('always_enable_sync')), {'peer-1', 'peer-2'})
 
-        sysctl.set('always_enable_sync', [])
+        sysctl.unsafe_set('always_enable_sync', [])
         self.assertEqual(connections.always_enable_sync, set())
         self.assertEqual(sysctl.get('always_enable_sync'), [])
 
@@ -119,7 +119,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
             fp.write('\n'.join(content))
             fp.close()
 
-            sysctl.set('always_enable_sync.readtxt', file_path)
+            sysctl.unsafe_set('always_enable_sync.readtxt', file_path)
             self.assertEqual(connections.always_enable_sync, set(content))
             self.assertEqual(set(sysctl.get('always_enable_sync')), set(content))
 
@@ -144,11 +144,11 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         sysctl = ConnectionsManagerSysctl(connections)
 
         self.assertEqual(sysctl.get('enabled_sync_versions'), self._default_enabled_sync_versions())
-        sysctl.set('enabled_sync_versions', ['v1', 'v2'])
+        sysctl.unsafe_set('enabled_sync_versions', ['v1', 'v2'])
         self.assertEqual(sysctl.get('enabled_sync_versions'), ['v1', 'v2'])
-        sysctl.set('enabled_sync_versions', ['v2'])
+        sysctl.unsafe_set('enabled_sync_versions', ['v2'])
         self.assertEqual(sysctl.get('enabled_sync_versions'), ['v2'])
-        sysctl.set('enabled_sync_versions', ['v1'])
+        sysctl.unsafe_set('enabled_sync_versions', ['v1'])
         self.assertEqual(sysctl.get('enabled_sync_versions'), ['v1'])
 
     def test_kill_all_connections(self):
@@ -158,7 +158,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
 
         p2p_manager.disconnect_all_peers = MagicMock()
         self.assertEqual(p2p_manager.disconnect_all_peers.call_count, 0)
-        sysctl.set('kill_connection', '*')
+        sysctl.unsafe_set('kill_connection', '*')
         self.assertEqual(p2p_manager.disconnect_all_peers.call_count, 1)
 
     def test_kill_one_connection(self):
@@ -170,7 +170,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         conn = MagicMock()
         p2p_manager.connected_peers[peer_id] = conn
         self.assertEqual(conn.disconnect.call_count, 0)
-        sysctl.set('kill_connection', peer_id)
+        sysctl.unsafe_set('kill_connection', peer_id)
         self.assertEqual(conn.disconnect.call_count, 1)
 
     def test_kill_connection_unknown_peer_id(self):
@@ -179,7 +179,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         sysctl = ConnectionsManagerSysctl(p2p_manager)
 
         with self.assertRaises(SysctlException):
-            sysctl.set('kill_connection', 'unknown-peer-id')
+            sysctl.unsafe_set('kill_connection', 'unknown-peer-id')
 
 
 class SyncV1RandomSimulatorTestCase(unittest.SyncV1Params, BaseRandomSimulatorTestCase):

--- a/tests/sysctl/test_sysctl.py
+++ b/tests/sysctl/test_sysctl.py
@@ -97,34 +97,34 @@ class SysctlTest(unittest.TestCase):
     ##############
 
     def test_set_int(self) -> None:
-        self.root.set('net.max_connections', 3)
-        setter = cast(MagicMock, self.root._get_setter('net.max_connections'))
+        self.root.unsafe_set('net.max_connections', 3)
+        setter = cast(MagicMock, self.root.get_setter('net.max_connections'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual((3,), setter.call_args.args)
 
     def test_set_str(self) -> None:
-        self.root.set('core.loglevel', 'debug')
-        setter = cast(MagicMock, self.root._get_setter('core.loglevel'))
+        self.root.unsafe_set('core.loglevel', 'debug')
+        setter = cast(MagicMock, self.root.get_setter('core.loglevel'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual(('debug',), setter.call_args.args)
 
     def test_set_readonly(self) -> None:
         with self.assertRaises(SysctlReadOnlyEntry):
-            self.root.set('net.readonly', 0.50)
+            self.root.unsafe_set('net.readonly', 0.50)
 
     def test_set_tuple(self) -> None:
-        self.root.set('net.rate_limit', (8, 2))
-        setter = cast(MagicMock, self.root._get_setter('net.rate_limit'))
+        self.root.unsafe_set('net.rate_limit', (8, 2))
+        setter = cast(MagicMock, self.root.get_setter('net.rate_limit'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual((8, 2), setter.call_args.args)
 
     def test_set_unknown(self) -> None:
         with self.assertRaises(SysctlEntryNotFound):
-            self.root.set('net.unknown', 1)
+            self.root.unsafe_set('net.unknown', 1)
 
     def test_set_writeonly(self) -> None:
-        self.root.set('core.writeonly', 1)
-        setter = cast(MagicMock, self.root._get_setter('core.writeonly'))
+        self.root.unsafe_set('core.writeonly', 1)
+        setter = cast(MagicMock, self.root.get_setter('core.writeonly'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual((1,), setter.call_args.args)
 
@@ -193,13 +193,13 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_set_int(self) -> None:
         self.proto.lineReceived(b'net.max_connections=3')
-        setter = cast(MagicMock, self.root._get_setter('net.max_connections'))
+        setter = cast(MagicMock, self.root.get_setter('net.max_connections'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual((3,), setter.call_args.args)
 
     def test_proto_set_str(self) -> None:
         self.proto.lineReceived(b'core.loglevel="debug"')
-        setter = cast(MagicMock, self.root._get_setter('core.loglevel'))
+        setter = cast(MagicMock, self.root.get_setter('core.loglevel'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual(('debug',), setter.call_args.args)
 
@@ -213,13 +213,13 @@ class SysctlTest(unittest.TestCase):
 
     def test_proto_set_tuple(self) -> None:
         self.proto.lineReceived(b'net.rate_limit=8, 2')
-        setter = cast(MagicMock, self.root._get_setter('net.rate_limit'))
+        setter = cast(MagicMock, self.root.get_setter('net.rate_limit'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual((8, 2), setter.call_args.args)
 
     def test_proto_set_writeonly(self) -> None:
         self.proto.lineReceived(b'core.writeonly=1')
-        setter = cast(MagicMock, self.root._get_setter('core.writeonly'))
+        setter = cast(MagicMock, self.root.get_setter('core.writeonly'))
         self.assertEqual(1, setter.call_count)
         self.assertEqual((1,), setter.call_args.args)
 

--- a/tests/sysctl/test_websocket.py
+++ b/tests/sysctl/test_websocket.py
@@ -9,36 +9,36 @@ class WebsocketSysctlTestCase(unittest.TestCase):
         ws_factory = HathorAdminWebsocketFactory()
         sysctl = WebsocketManagerSysctl(ws_factory)
 
-        sysctl.set('max_subs_addrs_conn', 10)
+        sysctl.unsafe_set('max_subs_addrs_conn', 10)
         self.assertEqual(ws_factory.max_subs_addrs_conn, 10)
         self.assertEqual(sysctl.get('max_subs_addrs_conn'), 10)
 
-        sysctl.set('max_subs_addrs_conn', 0)
+        sysctl.unsafe_set('max_subs_addrs_conn', 0)
         self.assertEqual(ws_factory.max_subs_addrs_conn, 0)
         self.assertEqual(sysctl.get('max_subs_addrs_conn'), 0)
 
-        sysctl.set('max_subs_addrs_conn', -1)
+        sysctl.unsafe_set('max_subs_addrs_conn', -1)
         self.assertIsNone(ws_factory.max_subs_addrs_conn)
         self.assertEqual(sysctl.get('max_subs_addrs_conn'), -1)
 
         with self.assertRaises(SysctlException):
-            sysctl.set('max_subs_addrs_conn', -2)
+            sysctl.unsafe_set('max_subs_addrs_conn', -2)
 
     def test_max_subs_addrs_empty(self):
         ws_factory = HathorAdminWebsocketFactory()
         sysctl = WebsocketManagerSysctl(ws_factory)
 
-        sysctl.set('max_subs_addrs_empty', 10)
+        sysctl.unsafe_set('max_subs_addrs_empty', 10)
         self.assertEqual(ws_factory.max_subs_addrs_empty, 10)
         self.assertEqual(sysctl.get('max_subs_addrs_empty'), 10)
 
-        sysctl.set('max_subs_addrs_empty', 0)
+        sysctl.unsafe_set('max_subs_addrs_empty', 0)
         self.assertEqual(ws_factory.max_subs_addrs_empty, 0)
         self.assertEqual(sysctl.get('max_subs_addrs_empty'), 0)
 
-        sysctl.set('max_subs_addrs_empty', -1)
+        sysctl.unsafe_set('max_subs_addrs_empty', -1)
         self.assertIsNone(ws_factory.max_subs_addrs_empty)
         self.assertEqual(sysctl.get('max_subs_addrs_empty'), -1)
 
         with self.assertRaises(SysctlException):
-            sysctl.set('max_subs_addrs_empty', -2)
+            sysctl.unsafe_set('max_subs_addrs_empty', -2)


### PR DESCRIPTION
### Motivation

Sometimes the CPU is so high that sysctl become irresponsive. So this PR adds another method to send command to sysctl.


### Acceptance Criteria

1. Handle SIGUSR2 on cli `run_node`.
2. Create a named pipe to receive a list of sysctl commands, one per line.
3. Execute the sysctl commands and log their results.
4. The named pipe will be created at the data directory if it exists. Otherwise, a temporary folder will be created.
5. Add decorator `@signal_handler_safe` to mark setters as safe to be executed during a signal handling.
6. Add `require_signal_handler_safe: bool = False` to the `SysctlRunner.run()` method.
7. Rename `_get_getter()` and `_set_setter()` to `get_getter()` and `set_setter()` on `Sysctl`.
8. Rename `set()` to `unsafe_set()` on `Sysctl`. It also updates the docstring to explain that it is unsafe to call this method directly.
9. Mark `max_enabled_sync`, `enabled_sync_versions` and `kill_connection` as signal handler safe on `ConnectionsManagerSysctl`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 