### PR TITLE
feat(sysctl): Add p2p.kill_connection to sysctl

### DIFF
--- a/hathor/sysctl/sysctl.py
+++ b/hathor/sysctl/sysctl.py
@@ -15,11 +15,14 @@
 from typing import Any, Callable, Iterator, NamedTuple, Optional
 
 from pydantic import validate_arguments
+from structlog import get_logger
 
 from hathor.sysctl.exception import SysctlEntryNotFound, SysctlReadOnlyEntry, SysctlWriteOnlyEntry
 
 Getter = Callable[[], Any]
 Setter = Callable[..., None]
+
+logger = get_logger()
 
 
 class SysctlCommand(NamedTuple):
@@ -33,6 +36,7 @@ class Sysctl:
     def __init__(self) -> None:
         self._children: dict[str, 'Sysctl'] = {}
         self._commands: dict[str, SysctlCommand] = {}
+        self.log = logger.new()
 
     def put_child(self, path: str, sysctl: 'Sysctl') -> None:
         """Add a child to the tree."""


### PR DESCRIPTION
### Motivation

We currently do not have the capacity to kill connections from sysctl. The only alternative is to kill all connections using SIGUSR1.

### Acceptance Criteria

1. Add `p2p.kill_connection` to sysctl. The expected behavior is to kill a connection with a given peer-id or to kill all connections if the provided peer-id is "*".

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 