### PR TITLE
feat(sysctl): Add core module with profiler commands to sysctl

### DIFF
--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from hathor.builder import BuildArtifacts
-from hathor.sysctl import ConnectionsManagerSysctl, Sysctl, WebsocketManagerSysctl
+from hathor.sysctl import ConnectionsManagerSysctl, HathorManagerSysctl, Sysctl, WebsocketManagerSysctl
 
 
 class SysctlBuilder:
@@ -25,6 +25,7 @@ class SysctlBuilder:
     def build(self) -> Sysctl:
         """Build the sysctl tree."""
         root = Sysctl()
+        root.put_child('core', HathorManagerSysctl(self.artifacts.manager))
         root.put_child('p2p', ConnectionsManagerSysctl(self.artifacts.p2p_manager))
 
         ws_factory = self.artifacts.manager.metrics.websocket_factory

--- a/hathor/sysctl/core/__init__.py
+++ b/hathor/sysctl/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Hathor Labs
+# Copyright 2024 Hathor Labs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from hathor.sysctl.core.manager import HathorManagerSysctl
-from hathor.sysctl.p2p.manager import ConnectionsManagerSysctl
-from hathor.sysctl.sysctl import Sysctl
-from hathor.sysctl.websocket.manager import WebsocketManagerSysctl
-
-__all__ = [
-    'Sysctl',
-    'ConnectionsManagerSysctl',
-    'HathorManagerSysctl',
-    'WebsocketManagerSysctl',
-]

--- a/hathor/sysctl/core/manager.py
+++ b/hathor/sysctl/core/manager.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathor.manager import HathorManager
+from hathor.sysctl.sysctl import Sysctl
+
+
+class HathorManagerSysctl(Sysctl):
+    def __init__(self, manager: HathorManager) -> None:
+        super().__init__()
+
+        self.manager = manager
+        self.register(
+            'profiler.status',
+            self.get_profiler_status,
+            None
+        )
+        self.register(
+            'profiler.start',
+            None,
+            self.set_profiler_start,
+        )
+        self.register(
+            'profiler.stop',
+            None,
+            self.set_profiler_stop,
+        )
+
+    def get_profiler_status(self) -> tuple[int, float]:
+        """Return (enabled, duration) as a profiler status.
+
+        enabled: 0 means disabled / 1 means enabled.
+        duration: time in seconds since the profiler has been started.
+        """
+        if not self.manager.is_profiler_running:
+            return (0, 0)
+        now = self.manager.reactor.seconds()
+        duration = now - self.manager.profiler_last_start_time
+        return (1, duration)
+
+    def set_profiler_start(self, reset: bool) -> None:
+        """Start the profiler. One can safely call start multiple times to reset it."""
+        self.manager.start_profiler(reset=reset)
+
+    def set_profiler_stop(self, save_to: str | None) -> None:
+        """Stop the profiler and optionally dump the statistics to a file.
+
+        An empty save_to will skip the dump.
+        """
+        if not save_to:
+            save_to = None
+        self.manager.stop_profiler(save_to=save_to)

--- a/tests/sysctl/test_core.py
+++ b/tests/sysctl/test_core.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, Mock, call
+
+from hathor.sysctl import HathorManagerSysctl
+from tests.simulation.base import SimulatorTestCase
+
+
+class HathorManagerSysctlTestCase(SimulatorTestCase):
+    __test__ = True
+    _enable_sync_v1 = True
+    _enable_sync_v2 = True
+
+    def test_profiler(self):
+        manager = self.create_peer()
+        sysctl = HathorManagerSysctl(manager)
+
+        status = sysctl.get('profiler.status')
+        self.assertEqual(status, (0, 0))
+
+        manager.start_profiler = Mock(wraps=manager.start_profiler)
+        self.assertEqual(manager.start_profiler.call_count, 0)
+        sysctl.set('profiler.start', False)
+        self.assertEqual(manager.start_profiler.call_count, 1)
+
+        manager.reactor.advance(100)
+        status = sysctl.get('profiler.status')
+        self.assertEqual(status, (1, 100))
+
+        manager.stop_profiler = Mock(wraps=manager.stop_profiler)
+        manager.profiler = MagicMock()  # prevents a call to profiler.dump_stats()
+        self.assertEqual(manager.stop_profiler.call_count, 0)
+        sysctl.set('profiler.stop', '/path/to/dump')
+        self.assertEqual(manager.stop_profiler.call_count, 1)
+        self.assertEqual(manager.stop_profiler.call_args, call(save_to='/path/to/dump',))
+
+        status = sysctl.get('profiler.status')
+        self.assertEqual(status, (0, 0))


### PR DESCRIPTION
### Motivation

We currently must use an HTTP API to start and stop a global profiler. Such an API might not be accessible due to networking issues so having the ability to do it through sysctl becomes relevant.

### Acceptance Criteria

1. Create commands `core.profiler.status`, `core.profiler.start`, and `core.profiler.stop` in sysctl.
2. Add `HathorManagerSysctl` which handles all these commands.
3. Add `HathorManager.is_profiler_running` to keep track whether the profiler is running or not.
4. Add `HathorManager.profiler_last_start_time` to be able to calculate how long the profiler has been running.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 