### PR TITLE
feat(sysctl): Add sysctl tools for debugging

### DIFF
--- a/hathor/sysctl/core/manager.py
+++ b/hathor/sysctl/core/manager.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+import os
+import sys
+from typing import IO, Any, Optional
+
 from hathor.manager import HathorManager
-from hathor.sysctl.sysctl import Sysctl
+from hathor.sysctl.sysctl import Sysctl, signal_handler_safe
 
 
 class HathorManagerSysctl(Sysctl):
@@ -36,6 +41,31 @@ class HathorManagerSysctl(Sysctl):
             None,
             self.set_profiler_stop,
         )
+        self.register(
+            'pudb.set_trace.attach_tty',
+            None,
+            self.set_pudb_set_trace_attach_tty,
+        )
+        self.register(
+            'pudb.set_trace.create_tty',
+            None,
+            self.set_pudb_set_trace_create_tty,
+        )
+        self.register(
+            'pudb.status',
+            self.get_pudb_status,
+            None
+        )
+        self.register(
+            'pudb.stop',
+            None,
+            self.set_pudb_stop,
+        )
+        self.register(
+            'ipython.run.attach_tty',
+            None,
+            self.set_ipython_run,
+        )
 
     def get_profiler_status(self) -> tuple[int, float]:
         """Return (enabled, duration) as a profiler status.
@@ -49,10 +79,12 @@ class HathorManagerSysctl(Sysctl):
         duration = now - self.manager.profiler_last_start_time
         return (1, duration)
 
+    @signal_handler_safe
     def set_profiler_start(self, reset: bool) -> None:
         """Start the profiler. One can safely call start multiple times to reset it."""
         self.manager.start_profiler(reset=reset)
 
+    @signal_handler_safe
     def set_profiler_stop(self, save_to: str | None) -> None:
         """Stop the profiler and optionally dump the statistics to a file.
 
@@ -61,3 +93,146 @@ class HathorManagerSysctl(Sysctl):
         if not save_to:
             save_to = None
         self.manager.stop_profiler(save_to=save_to)
+
+    @signal_handler_safe
+    def set_pudb_set_trace_attach_tty(self, tty: str) -> None:
+        """Stop execution and open pudb in a given tty.
+
+        ATTENTION: This command can be destructive and the full node might not work after running it.
+
+        Open a new terminal. First, you need to get the path of the tty of the
+        terminal you want to debug from. To do that, use the standard unix
+        command `tty`. It will print something like `/dev/pts/3`.
+
+        Then you need to make sure that your terminal doesn't have a shell actively
+        reading and possibly capturing some of the input that should go to pudb.
+        To do that run a placeholder command that does nothing, such as `perl -MPOSIX -e pause`.
+        """
+        fp = open(tty, 'r+b', buffering=0)
+        term_size = os.get_terminal_size(fp.fileno())
+        self._run_pudb_set_trace(tty, fp, term_size=term_size)
+
+    @signal_handler_safe
+    def set_pudb_set_trace_create_tty(self, cols: int, rows: int) -> None:
+        """Stop execution and open pudb for debugging in a newly created tty.
+
+        ATTENTION: This command can be destructive and the full node might not work after running it.
+
+        You must provide the terminal size (cols, rows).
+
+        The newly created tty name will be printed in the logs. After you check the logs and get the name,
+        you can connect to it using `screen <ttyname>`.
+        """
+        import fcntl
+        import struct
+        import termios
+
+        # Some of these methods are not available in some operating system (e.g. Windows).
+        # This is a way to avoid mypy errors.
+        openpty = getattr(os, 'openpty', None)
+        ioctl = getattr(fcntl, 'ioctl', None)
+        ttyname = getattr(os, 'ttyname', None)
+        TIOCSWINSZ = getattr(termios, 'TIOCSWINSZ', None)
+
+        if openpty is None or ioctl is None or ttyname is None or TIOCSWINSZ is None:
+            self.log.warn('Error opening pudb. You can try to attach to a tty using `set_pudb_set_trace_attach_tty`.',
+                          openpty=openpty,
+                          ioctl=ioctl,
+                          ttyname=ttyname,
+                          TIOCSWINSZ=TIOCSWINSZ)
+            return
+
+        (term_master, term_slave) = openpty()
+
+        term_size = (cols, rows)
+        term_size_bytes = struct.pack("HHHH", term_size[1], term_size[0], 0, 0)
+        ioctl(term_master, TIOCSWINSZ, term_size_bytes)
+
+        tty_name = ttyname(term_slave)
+        fp = os.fdopen(term_master, 'wb+', buffering=0)
+
+        self._run_pudb_set_trace(tty_name, fp, term_size=term_size)
+
+    def _run_pudb_set_trace(self, tty: str, fp: IO[bytes], *, term_size: Optional[tuple[int, int]] = None) -> None:
+        from pudb.debugger import Debugger
+
+        self.log.warn('main loop paused; pudb.set_trace running', tty=tty)
+
+        tty_file = io.TextIOWrapper(fp)
+        kwargs: dict[str, Any] = {
+            'stdin': tty_file,
+            'stdout': tty_file,
+        }
+        if term_size is not None:
+            kwargs['term_size'] = term_size
+
+        if Debugger._current_debugger:
+            Debugger._current_debugger.pop()
+
+        dbg = Debugger(**kwargs)
+        dbg.set_trace(sys._getframe().f_back, paused=True)
+
+    def get_pudb_status(self) -> str:
+        """Return whether the pudb is running or not."""
+        from pudb.debugger import Debugger
+
+        if not Debugger._current_debugger:
+            return 'not running'
+
+        dbg = Debugger._current_debugger[0]
+        if dbg.ui.quit_event_loop:
+            return 'not running'
+
+        return 'running'
+
+    @signal_handler_safe
+    def set_pudb_stop(self) -> None:
+        """Stop pudb if it is running."""
+        from pudb.debugger import Debugger
+
+        if not Debugger._current_debugger:
+            return
+
+        dbg = Debugger._current_debugger[0]
+        dbg.set_quit()
+        dbg.ui.quit_event_loop = True
+
+    @signal_handler_safe
+    def set_ipython_run(self, tty: str) -> None:
+        """Stop execution and open an ipython shell in a given tty.
+
+        ATTENTION: This command can be destructive and the full node might not work after running it.
+
+        Open a new terminal. First, you need to get the path of the tty of the
+        terminal you want to debug from. To do that, use the standard unix
+        command `tty`. It will print something like `/dev/pts/3`.
+
+        Then you need to make sure that your terminal doesn't have a shell actively
+        reading and possibly capturing some of the input that should go to pudb.
+        To do that run a placeholder command that does nothing, such as `perl -MPOSIX -e pause`.
+        """
+        fp = open(tty, 'r+b', buffering=0)
+        tty_file = io.TextIOWrapper(fp)
+
+        old_stdin = sys.stdin
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+
+        sys.stdin = tty_file
+        sys.stdout = tty_file
+        sys.stderr = tty_file
+
+        self.log.warn('main loop paused; ipython running', tty=tty)
+
+        from IPython import start_ipython
+        user_ns: dict[str, Any] = {
+            'manager': self.manager,
+            'tx_storage': self.manager.tx_storage,
+        }
+        start_ipython(argv=[], user_ns=user_ns)
+
+        sys.stdin = old_stdin
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+
+        self.log.warn('main loop resumed')


### PR DESCRIPTION
### Motivation

Being able to stop the event loop for debugging is useful to get a better understanding of issues. This PR introduces two different sysctl commands: (i) pudb and (ii) ipython.

The pudb commands is a full-screen console debugger that allows us to run step-by-step and inspect the stack trace and its local variables. The event loop will be paused during its execution.

The ipython command will pause the event loop and open an ipython console so we can inspect the objects internal state and call methods.

In both cases, the event loop is resumed after the debugging is finished. But it's important to highlight that these tools might crash the full node so we should avoid using it on production.

These are experimental tools that will probably be improved in future PRs.

### Acceptance Criteria

1. Add command `core.pudb.set_trace.attach_tty` that runs a pudb console attached to a tty that already exists.
2. Add command `core.pudb.set_trace.create_tty` that runs a pudb console on a newly created tty. So user have to attach this tty in a terminal to get access to the console.
3. Add command `core.pudb.status` that returns whether pudb is running or not.
4. Add command `core.pudb.stop` that stops a pudb console and return the control to the event loop.
5. Add command `core.ipython.run.attach_tty` that runs an ipython console attached a tty that already exists.
6. All these new commands were decorated with `@signal_handler_safe`.
7. Decorate both `set_profiler_start` and `set_profiler_stop` with `@signal_handler_safe`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 