### PR TITLE
fix: Fix slow tx processing on some edge cases

### DIFF
--- a/hathor/consensus/transaction_consensus.py
+++ b/hathor/consensus/transaction_consensus.py
@@ -235,7 +235,12 @@ class TransactionConsensusAlgorithm:
             conflict_tx = cast(Transaction, tx.storage.get_transaction(h))
             conflict_tx_meta = conflict_tx.get_metadata()
             if conflict_tx_meta.voided_by:
-                self.mark_as_voided(conflict_tx)
+                if conflict_tx_meta.first_block is not None:
+                    # do nothing
+                    assert bool(self.context.consensus.soft_voided_tx_ids & conflict_tx_meta.voided_by)
+                    self.log.info('skipping soft voided conflict', conflict_tx=conflict_tx.hash_hex)
+                else:
+                    self.mark_as_voided(conflict_tx)
 
         # Finally, check our conflicts.
         meta = tx.get_metadata()


### PR DESCRIPTION
### Motivation

We got this issue during the QA of hathor-core v0.59.0-rc1. This is triggered when a node does a sync from scratch using sync-v2 and, later on, switches to sync-v1. The sync-v1 works properly but the processing of some transactions get considerably slower.

Fixes https://github.com/HathorNetwork/internal-issues/issues/246.

### Acceptance Criteria

1. Stop marking transactions confirmed by the best blockchain as voided during conflict resolution. Notice that this edge case only occurs when the conflicting transaction is soft voided and is confirmed by the best blockchain.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 