### PR TITLE
feat(feature-activation): configure new NOP features on mainnet

### DIFF
--- a/hathor/conf/mainnet.py
+++ b/hathor/conf/mainnet.py
@@ -203,7 +203,7 @@ SETTINGS = HathorSettings(
         features={
             Feature.NOP_FEATURE_1: Criteria(
                 bit=0,
-                start_height=4_213_440,  # N (right now the best block is 4_169_000 on mainnet)
+                start_height=4_213_440,  # N
                 timeout_height=4_253_760,  # N + 2 * 20160 (2 weeks after the start)
                 minimum_activation_height=4_273_920,  # N + 3 * 20160 (3 weeks after the start)
                 lock_in_on_timeout=False,
@@ -212,13 +212,31 @@ SETTINGS = HathorSettings(
             ),
             Feature.NOP_FEATURE_2: Criteria(
                 bit=1,
-                start_height=4_213_440,  # N (right now the best block is 4_169_000 on mainnet)
+                start_height=4_213_440,  # N
                 timeout_height=4_253_760,  # N + 2 * 20160 (2 weeks after the start)
                 minimum_activation_height=0,
                 lock_in_on_timeout=False,
                 version='0.59.0',
                 signal_support_by_default=False,
-            )
+            ),
+            Feature.NOP_FEATURE_3: Criteria(
+                bit=2,
+                start_height=4_273_920,  # N (on 2024/02/22, the best block is 4_251_000 on mainnet)
+                timeout_height=4_475_520,  # N + 10 * 20160 (10 weeks after the start)
+                minimum_activation_height=4_495_680,  # N + 11 * 20160 (11 weeks after the start)
+                lock_in_on_timeout=False,
+                version='0.59.0',
+                signal_support_by_default=True,
+            ),
+            Feature.NOP_FEATURE_4: Criteria(
+                bit=3,
+                start_height=4_273_920,  # N (on 2024/02/22, the best block is 4_251_000 on mainnet)
+                timeout_height=4_475_520,  # N + 10 * 20160 (10 weeks after the start)
+                minimum_activation_height=0,
+                lock_in_on_timeout=False,
+                version='0.59.0',
+                signal_support_by_default=False,
+            ),
         }
     )
 )

--- a/hathor/conf/mainnet.yml
+++ b/hathor/conf/mainnet.yml
@@ -186,7 +186,7 @@ FEATURE_ACTIVATION:
 
     NOP_FEATURE_1:
       bit: 0
-      start_height: 4_213_440 # N (right now the best block is 4_169_000 on mainnet)
+      start_height: 4_213_440 # N
       timeout_height: 4_253_760 # N + 2 * 20160 (2 weeks after the start)
       minimum_activation_height: 4_273_920 # N + 3 * 20160 (3 weeks after the start)
       lock_in_on_timeout: false
@@ -195,8 +195,28 @@ FEATURE_ACTIVATION:
 
     NOP_FEATURE_2:
       bit: 1
-      start_height: 4_213_440 # N (right now the best block is 4_169_000 on mainnet)
+      start_height: 4_213_440 # N
       timeout_height: 4_253_760 # N + 2 * 20160 (2 weeks after the start)
+      minimum_activation_height: 0
+      lock_in_on_timeout: false
+      version: 0.59.0
+      signal_support_by_default: false
+
+    #### Second Phased Testing features on mainnet ####
+
+    NOP_FEATURE_3:
+      bit: 2
+      start_height: 4_273_920 # N (on 2024/02/22, the best block is 4_251_000 on mainnet)
+      timeout_height: 4_475_520 # N + 10 * 20160 (10 weeks after the start)
+      minimum_activation_height: 4_495_680 # N + 11 * 20160 (11 weeks after the start)
+      lock_in_on_timeout: false
+      version: 0.59.0
+      signal_support_by_default: true
+
+    NOP_FEATURE_4:
+      bit: 3
+      start_height: 4_273_920 # N (on 2024/02/22, the best block is 4_251_000 on mainnet)
+      timeout_height: 4_475_520 # N + 10 * 20160 (10 weeks after the start)
       minimum_activation_height: 0
       lock_in_on_timeout: false
       version: 0.59.0


### PR DESCRIPTION
### Motivation

Since the miners did not update their nodes for the last test, we have to introduce new NOP features to test that bit signaling is working correctly.

The features are configured to start in approximately 1 week from now, and the voting period will last for 10 weeks, giving enough time for miners to udpate.

### Acceptance Criteria

- Configure NOP features for a new Feature Activation test on mainnet.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 