### PR TITLE
chore(cli): make sync-bridge the default

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -174,7 +174,10 @@ class CliBuilder:
 
         sync_choice: SyncChoice
         if self._args.sync_bridge:
+            self.log.warn('--sync-bridge is the default, this parameter has no effect')
             sync_choice = SyncChoice.BRIDGE
+        elif self._args.sync_v1_only:
+            sync_choice = SyncChoice.V1_ONLY
         elif self._args.sync_v2_only:
             sync_choice = SyncChoice.V2_ONLY
         elif self._args.x_sync_bridge:
@@ -183,8 +186,8 @@ class CliBuilder:
         elif self._args.x_sync_v2_only:
             self.log.warn('--x-sync-v2-only is deprecated and will be removed, use --sync-v2-only instead')
             sync_choice = SyncChoice.V2_ONLY
-        else:  # default
-            sync_choice = SyncChoice.V1_ONLY
+        else:
+            sync_choice = SyncChoice.BRIDGE
 
         enable_sync_v1: bool
         enable_sync_v2: bool

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -129,6 +129,7 @@ class RunNode:
         sync_args = parser.add_mutually_exclusive_group()
         sync_args.add_argument('--sync-bridge', action='store_true',
                                help='Enable running both sync protocols.')
+        sync_args.add_argument('--sync-v1-only', action='store_true', help='Disable support for running sync-v2.')
         sync_args.add_argument('--sync-v2-only', action='store_true', help='Disable support for running sync-v1.')
         sync_args.add_argument('--x-sync-v2-only', action='store_true', help=SUPPRESS)  # old argument
         sync_args.add_argument('--x-sync-bridge', action='store_true', help=SUPPRESS)  # old argument

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -66,6 +66,7 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     x_sync_bridge: bool
     x_sync_v2_only: bool
     sync_bridge: bool
+    sync_v1_only: bool
     sync_v2_only: bool
     x_localhost_only: bool
     x_rocksdb_indexes: bool

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -58,7 +58,7 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsNone(manager.wallet)
         self.assertEqual('unittests', manager.network)
         self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
-        self.assertFalse(manager.connections.is_sync_version_enabled(SyncVersion.V2))
+        self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V2))
         self.assertFalse(self.resources_builder._built_prometheus)
         self.assertFalse(self.resources_builder._built_status)
         self.assertFalse(manager._enable_event_queue)
@@ -104,7 +104,7 @@ class BuilderTestCase(unittest.TestCase):
     def test_sync_default(self):
         manager = self._build(['--memory-storage'])
         self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
-        self.assertFalse(manager.connections.is_sync_version_enabled(SyncVersion.V2))
+        self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V2))
 
     def test_sync_bridge(self):
         manager = self._build(['--memory-storage', '--x-sync-bridge'])
@@ -125,6 +125,11 @@ class BuilderTestCase(unittest.TestCase):
         manager = self._build(['--memory-storage', '--sync-v2-only'])
         self.assertFalse(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
         self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V2))
+
+    def test_sync_v1_only(self):
+        manager = self._build(['--memory-storage', '--sync-v1-only'])
+        self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
+        self.assertFalse(manager.connections.is_sync_version_enabled(SyncVersion.V2))
 
     def test_keypair_wallet(self):
         manager = self._build(['--memory-storage', '--wallet', 'keypair'])


### PR DESCRIPTION
### Motivation

The current default of only enabling `sync-v1` is proving to be taxing on CPU, while `sync-v2` has been running very well on tests and seems stable enough. Defaulting to bridge mode allows for the best connectivity (connecting to updated and outdated nodes) and will gradually and naturally improve along with nodes being updated.

### Acceptance Criteria

- Add new cli option `--x-sync-v1-only`
- Make the default be sync bridge (sync-v1 and sync-v2 enabled)
- Tweak some warnings accordingly
- Adapt tests to the new defaults and the new cli option

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 