### PR TITLE
feat(feature-activation): implement bit signaling sysctl

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -71,6 +71,7 @@ class BuildArtifacts(NamedTuple):
     consensus: ConsensusAlgorithm
     tx_storage: TransactionStorage
     feature_service: FeatureService
+    bit_signaling_service: BitSignalingService
     indexes: Optional[IndexesManager]
     wallet: Optional[BaseWallet]
     rocksdb_storage: Optional[RocksDBStorage]
@@ -247,6 +248,7 @@ class Builder:
             rocksdb_storage=self._rocksdb_storage,
             stratum_factory=stratum_factory,
             feature_service=feature_service,
+            bit_signaling_service=bit_signaling_service
         )
 
         return self.artifacts

--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 from hathor.builder import BuildArtifacts
-from hathor.sysctl import ConnectionsManagerSysctl, HathorManagerSysctl, Sysctl, WebsocketManagerSysctl
+from hathor.sysctl import (
+    ConnectionsManagerSysctl,
+    FeatureActivationSysctl,
+    HathorManagerSysctl,
+    Sysctl,
+    WebsocketManagerSysctl,
+)
 
 
 class SysctlBuilder:
@@ -25,7 +31,11 @@ class SysctlBuilder:
     def build(self) -> Sysctl:
         """Build the sysctl tree."""
         root = Sysctl()
-        root.put_child('core', HathorManagerSysctl(self.artifacts.manager))
+
+        core = HathorManagerSysctl(self.artifacts.manager)
+        core.put_child('features', FeatureActivationSysctl(self.artifacts.bit_signaling_service))
+
+        root.put_child('core', core)
         root.put_child('p2p', ConnectionsManagerSysctl(self.artifacts.p2p_manager))
 
         ws_factory = self.artifacts.manager.metrics.websocket_factory

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -221,7 +221,8 @@ class RunNode:
             wallet=self.manager.wallet,
             rocksdb_storage=getattr(builder, 'rocksdb_storage', None),
             stratum_factory=self.manager.stratum_factory,
-            feature_service=self.manager._feature_service
+            feature_service=self.manager._feature_service,
+            bit_signaling_service=self.manager._bit_signaling_service,
         )
 
     def start_sentry_if_possible(self) -> None:

--- a/hathor/sysctl/__init__.py
+++ b/hathor/sysctl/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from hathor.sysctl.core.manager import HathorManagerSysctl
+from hathor.sysctl.feature_activation.manager import FeatureActivationSysctl
 from hathor.sysctl.p2p.manager import ConnectionsManagerSysctl
 from hathor.sysctl.sysctl import Sysctl
 from hathor.sysctl.websocket.manager import WebsocketManagerSysctl
@@ -22,4 +23,5 @@ __all__ = [
     'ConnectionsManagerSysctl',
     'HathorManagerSysctl',
     'WebsocketManagerSysctl',
+    'FeatureActivationSysctl',
 ]

--- a/hathor/sysctl/feature_activation/manager.py
+++ b/hathor/sysctl/feature_activation/manager.py
@@ -1,0 +1,72 @@
+#  Copyright 2024 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.feature_activation.bit_signaling_service import BitSignalingService
+from hathor.feature_activation.feature import Feature
+from hathor.sysctl.sysctl import Sysctl
+
+
+class FeatureActivationSysctl(Sysctl):
+    def __init__(self, bit_signaling_service: BitSignalingService) -> None:
+        super().__init__()
+        self._bit_signaling_service = bit_signaling_service
+
+        self.register(
+            path='supported_features',
+            getter=self.get_support_features,
+            setter=None,
+        )
+        self.register(
+            path='not_supported_features',
+            getter=self.get_not_support_features,
+            setter=None,
+        )
+        self.register(
+            path='signaling_features',
+            getter=self.get_signaling_features,
+            setter=None,
+        )
+        self.register(
+            path='add_support',
+            getter=None,
+            setter=self.add_feature_support,
+        )
+        self.register(
+            path='remove_support',
+            getter=None,
+            setter=self.remove_feature_support,
+        )
+
+    def get_support_features(self) -> list[str]:
+        """Get a list of feature names with enabled support."""
+        return [feature.value for feature in self._bit_signaling_service.get_support_features()]
+
+    def get_not_support_features(self) -> list[str]:
+        """Get a list of feature names with disabled support."""
+        return [feature.value for feature in self._bit_signaling_service.get_not_support_features()]
+
+    def add_feature_support(self, *features: str) -> None:
+        """Explicitly add support for a feature by enabling its signaling bit."""
+        for feature in features:
+            self._bit_signaling_service.add_feature_support(Feature[feature])
+
+    def remove_feature_support(self, *features: str) -> None:
+        """Explicitly remove support for a feature by disabling its signaling bit."""
+        for feature in features:
+            self._bit_signaling_service.remove_feature_support(Feature[feature])
+
+    def get_signaling_features(self) -> list[str]:
+        """Get a list of feature names that are currently in a signaling state."""
+        features = self._bit_signaling_service.get_best_block_signaling_features().keys()
+        return [feature.value for feature in features]

--- a/tests/sysctl/test_feature_activation.py
+++ b/tests/sysctl/test_feature_activation.py
@@ -1,0 +1,38 @@
+#  Copyright 2024 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest.mock import Mock
+
+from hathor.feature_activation.bit_signaling_service import BitSignalingService
+from hathor.feature_activation.feature import Feature
+from hathor.sysctl import FeatureActivationSysctl
+
+
+def test_feature_activation_sysctl() -> None:
+    bit_signaling_service_mock = Mock(spec_set=BitSignalingService)
+    sysctl = FeatureActivationSysctl(bit_signaling_service_mock)
+
+    bit_signaling_service_mock.get_support_features = Mock(return_value=[Feature.NOP_FEATURE_1, Feature.NOP_FEATURE_2])
+    bit_signaling_service_mock.get_not_support_features = Mock(return_value=[Feature.NOP_FEATURE_3])
+    bit_signaling_service_mock.get_best_block_signaling_features = Mock(return_value={Feature.NOP_FEATURE_1: Mock()})
+
+    assert sysctl.get('supported_features') == ['NOP_FEATURE_1', 'NOP_FEATURE_2']
+    assert sysctl.get('not_supported_features') == ['NOP_FEATURE_3']
+    assert sysctl.get('signaling_features') == ['NOP_FEATURE_1']
+
+    sysctl.unsafe_set('add_support', 'NOP_FEATURE_3')
+    bit_signaling_service_mock.add_feature_support.assert_called_once_with(Feature.NOP_FEATURE_3)
+
+    sysctl.unsafe_set('remove_support', 'NOP_FEATURE_1')
+    bit_signaling_service_mock.remove_feature_support.assert_called_once_with(Feature.NOP_FEATURE_1)


### PR DESCRIPTION
## Motivation

Add sysctl commands to control Feature Activation bit signaling without having to restart the full node (previously, this was only available through CLI options). The commands are the following:

#### `core.features.supported_features`

Return features that are explicitly enabled. Read-only.

#### `core.features.not_supported_features`

Return features that are explicitly disabled. Read-only.

####  `core.features.signaling_features`

Return which feature are currently in a signaling phase. Read-only.

#### `core.features.add_support`

Add support for a feature. Write-only.

#### `core.features.remove_support`

Remove support for a feature. Write-only.

### Example

```bash
$ nc -U /tmp/hathor.sock
core.features.signaling_features
["NOP_FEATURE_5"]
core.features.remove_support="NOP_FEATURE_5"
core.features.not_supported_features
["NOP_FEATURE_5"]
core.features.supported_features
[]
core.features.add_support="NOP_FEATURE_5"
core.features.not_support_features
[]
core.features.supported_features
["NOP_FEATURE_5"]
```

Then, the bits in the block template will be changed accordingly.

## Acceptance Criteria

- Add `core.features` sysctl command group with the following subcommands: `supported_features`, `not_supported_features`, `signaling_features`, `add_support`, and `remove_support`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 