### PR TITLE
fix: improve unnecessary alerts

### DIFF
--- a/hathor/p2p/sync_v1/downloader.py
+++ b/hathor/p2p/sync_v1/downloader.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from structlog import get_logger
 from twisted.internet import defer
 from twisted.internet.defer import Deferred
+from twisted.python.failure import Failure
 
 from hathor.conf.get_settings import get_global_settings
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
@@ -238,10 +239,10 @@ class Downloader:
         """
         self.retry(tx_id)
 
-    def on_error(self, result: Any) -> None:
+    def on_error(self, failure: Failure) -> None:
         """ Errback for downloading deferred.
         """
-        self.log.error('failed to download tx', err=result)
+        self.log.error('failed to download tx', err=failure, traceback=failure.getTraceback())
 
     def on_new_tx(self, tx: 'BaseTransaction') -> None:
         """ This is called when a new transaction arrives.


### PR DESCRIPTION
### Motivation

The `failed to download tx` alerts currently spams our on-call engineer unnecessarily. There are two places where this can happen, and both generate alerts for different reasons ([1a](https://hathor.app.opsgenie.com/alert/detail/594a1544-4d01-422f-ac7a-f6093fd4b673-1709097028412/details), [1b](https://hathor.app.opsgenie.com/alert/detail/5c023dab-27e7-46a7-89fd-c6f4f691410e-1709061530497/details), [1c](https://hathor.app.opsgenie.com/alert/detail/1d427242-fe89-451a-a699-edabbb228030-1708976131712/details) and [2a](https://hathor.app.opsgenie.com/alert/detail/a0a6691b-4da0-45b9-a6bb-e814e409c07f-1709097027440/details), [2b](https://hathor.app.opsgenie.com/alert/detail/af4cb3ed-1486-4d7d-b2b4-8bfb6b261bfd-1709075260033/details)).

This PR prevents alerts caused by Twisted's `CancelledError` in case 1, which are not necessary. For case 2, we simply improve the logs to understand its root cause in a future release.

### Acceptance Criteria

- Remove logging of `CancelledError` and add traceback to logs.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 