### PR TITLE
refactor: create non-null hash property

### DIFF
--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -65,7 +65,6 @@ class TokenCreationTransaction(Transaction):
         """ When we update the hash, we also have to update the tokens uid list
         """
         super().update_hash()
-        assert self.hash is not None
         self.tokens = [self.hash]
 
     def get_funds_fields_from_struct(self, buf: bytes, *, verbose: VerboseCallback = None) -> bytes:
@@ -221,7 +220,6 @@ class TokenCreationTransaction(Transaction):
         token_dict = super()._get_token_info_from_inputs()
 
         # we add the created token's info to token_dict, as the creation tx allows for mint/melt
-        assert self.hash is not None
         token_dict[self.hash] = TokenInfo(0, True, True)
 
         return token_dict

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -360,7 +360,7 @@ class Transaction(BaseTransaction):
             tx = self.storage.get_transaction(tx_in.tx_id)
             meta = tx.get_metadata()
             spent_by = meta.get_output_spent_by(tx_in.index)
-            if spent_by and spent_by != self.hash:
+            if spent_by and spent_by != self._hash:
                 return True
         return False
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 import urllib.parse
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import Optional
 
 import requests
 from hathorlib.scripts import DataScript
@@ -378,7 +378,7 @@ def create_tokens(manager: 'HathorManager', address_b58: Optional[str] = None, m
         assert genesis_hash is not None
         deposit_input = [TxInput(genesis_hash, 0, b'')]
         change_output = TxOutput(genesis_block.outputs[0].value - deposit_amount, script, 0)
-        parents = [cast(bytes, tx.hash) for tx in genesis_txs]
+        parents = [tx.hash for tx in genesis_txs]
         timestamp = int(manager.reactor.seconds())
     else:
         total_reward = 0


### PR DESCRIPTION
### Motivation

Currently, the `BaseTransaction.hash` property is of type `Optional[bytes]`, which is pretty inconvenient considering the hash has (and should have) a value most times. For that, we have to use asserts in multiple places to guarantee the value is not `None`.

This PR renames the existing optional property to `_hash`, creating a new calculated `hash` property that performs the assert for us. By doing it like this, every place that already uses the existing `hash` property will continue to work (only a few places that rely on the possibility of the value being `None` had to be updated).

### Acceptance Criteria

- Rename current optional `BaseTransaction.hash` property to `_hash` and add new non-null `hash` property.
- Remove some unnecessary asserts.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 