### PR TITLE
refactor(mypy): add stricter rules to p2p tests [part IV/VI]

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -57,8 +57,8 @@ from hathor.reward_lock import is_spent_reward_locked
 from hathor.stratum import StratumFactory
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion, sum_weights
 from hathor.transaction.exceptions import TxValidationError
-from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
+from hathor.transaction.storage.transaction_storage import TransactionStorage
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope
 from hathor.types import Address, VertexId
 from hathor.util import EnvironmentInfo, LogDuration, Random, calculate_min_significant_weight, not_none

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -73,6 +73,7 @@ class TransactionStorage(ABC):
 
     pubsub: Optional[PubSubManager]
     indexes: Optional[IndexesManager]
+    _latest_n_height_tips: list[HeightInfo]
 
     log = get_logger()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ module = [
     "tests.event.*",
     "tests.execution_manager.*",
     "tests.feature_activation.*",
-#    "tests.p2p.*",
+    "tests.p2p.*",
     "tests.pubsub.*",
     "tests.simulation.*",
 ]

--- a/tests/p2p/netfilter/test_factory.py
+++ b/tests/p2p/netfilter/test_factory.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from twisted.internet.address import IPv4Address
 
 from hathor.p2p.netfilter import get_table
@@ -10,7 +12,7 @@ from tests.unittest import TestBuilder
 
 
 class NetfilterFactoryTest(unittest.TestCase):
-    def test_factory(self):
+    def test_factory(self) -> None:
         pre_conn = get_table('filter').get_chain('pre_conn')
 
         match = NetfilterMatchIPAddress('192.168.0.1/32')
@@ -20,7 +22,7 @@ class NetfilterFactoryTest(unittest.TestCase):
         builder = TestBuilder()
         artifacts = builder.build()
         wrapped_factory = artifacts.p2p_manager.server_factory
-        factory = NetfilterFactory(connections=None, wrappedFactory=wrapped_factory)
+        factory = NetfilterFactory(connections=Mock(), wrappedFactory=wrapped_factory)
 
         ret = factory.buildProtocol(IPv4Address('TCP', '192.168.0.1', 1234))
         self.assertIsNone(ret)

--- a/tests/p2p/netfilter/test_match.py
+++ b/tests/p2p/netfilter/test_match.py
@@ -22,7 +22,7 @@ class NetfilterNeverMatch(NetfilterMatch):
 
 
 class NetfilterMatchTest(unittest.TestCase):
-    def test_match_all(self):
+    def test_match_all(self) -> None:
         matcher = NetfilterMatchAll()
         context = NetfilterContext()
         self.assertTrue(matcher.match(context))
@@ -31,7 +31,7 @@ class NetfilterMatchTest(unittest.TestCase):
         json = matcher.to_json()
         self.assertEqual(json['type'], 'NetfilterMatchAll')
 
-    def test_never_match(self):
+    def test_never_match(self) -> None:
         matcher = NetfilterNeverMatch()
         context = NetfilterContext()
         self.assertFalse(matcher.match(context))
@@ -40,14 +40,14 @@ class NetfilterMatchTest(unittest.TestCase):
         json = matcher.to_json()
         self.assertEqual(json['type'], 'NetfilterNeverMatch')
 
-    def test_match_and_success(self):
+    def test_match_and_success(self) -> None:
         m1 = NetfilterMatchAll()
         m2 = NetfilterMatchAll()
         matcher = NetfilterMatchAnd(m1, m2)
         context = NetfilterContext()
         self.assertTrue(matcher.match(context))
 
-    def test_match_and_fail_01(self):
+    def test_match_and_fail_01(self) -> None:
         m1 = NetfilterNeverMatch()
         m2 = NetfilterMatchAll()
         matcher = NetfilterMatchAnd(m1, m2)
@@ -60,28 +60,28 @@ class NetfilterMatchTest(unittest.TestCase):
         self.assertEqual(json['match_params']['a']['type'], 'NetfilterNeverMatch')
         self.assertEqual(json['match_params']['b']['type'], 'NetfilterMatchAll')
 
-    def test_match_and_fail_10(self):
+    def test_match_and_fail_10(self) -> None:
         m1 = NetfilterMatchAll()
         m2 = NetfilterNeverMatch()
         matcher = NetfilterMatchAnd(m1, m2)
         context = NetfilterContext()
         self.assertFalse(matcher.match(context))
 
-    def test_match_and_fail_00(self):
+    def test_match_and_fail_00(self) -> None:
         m1 = NetfilterNeverMatch()
         m2 = NetfilterNeverMatch()
         matcher = NetfilterMatchAnd(m1, m2)
         context = NetfilterContext()
         self.assertFalse(matcher.match(context))
 
-    def test_match_or_success_11(self):
+    def test_match_or_success_11(self) -> None:
         m1 = NetfilterMatchAll()
         m2 = NetfilterMatchAll()
         matcher = NetfilterMatchOr(m1, m2)
         context = NetfilterContext()
         self.assertTrue(matcher.match(context))
 
-    def test_match_or_success_10(self):
+    def test_match_or_success_10(self) -> None:
         m1 = NetfilterMatchAll()
         m2 = NetfilterNeverMatch()
         matcher = NetfilterMatchOr(m1, m2)
@@ -94,21 +94,21 @@ class NetfilterMatchTest(unittest.TestCase):
         self.assertEqual(json['match_params']['a']['type'], 'NetfilterMatchAll')
         self.assertEqual(json['match_params']['b']['type'], 'NetfilterNeverMatch')
 
-    def test_match_or_success_01(self):
+    def test_match_or_success_01(self) -> None:
         m1 = NetfilterNeverMatch()
         m2 = NetfilterMatchAll()
         matcher = NetfilterMatchOr(m1, m2)
         context = NetfilterContext()
         self.assertTrue(matcher.match(context))
 
-    def test_match_or_fail_00(self):
+    def test_match_or_fail_00(self) -> None:
         m1 = NetfilterNeverMatch()
         m2 = NetfilterNeverMatch()
         matcher = NetfilterMatchOr(m1, m2)
         context = NetfilterContext()
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_empty_context(self):
+    def test_match_ip_address_empty_context(self) -> None:
         matcher = NetfilterMatchIPAddress('192.168.0.0/24')
         context = NetfilterContext()
         self.assertFalse(matcher.match(context))
@@ -118,7 +118,7 @@ class NetfilterMatchTest(unittest.TestCase):
         self.assertEqual(json['type'], 'NetfilterMatchIPAddress')
         self.assertEqual(json['match_params']['host'], '192.168.0.0/24')
 
-    def test_match_ip_address_ipv4_net(self):
+    def test_match_ip_address_ipv4_net(self) -> None:
         matcher = NetfilterMatchIPAddress('192.168.0.0/24')
         context = NetfilterContext(addr=IPv4Address('TCP', '192.168.0.10', 1234))
         self.assertTrue(matcher.match(context))
@@ -129,7 +129,7 @@ class NetfilterMatchTest(unittest.TestCase):
         context = NetfilterContext(addr=IPv4Address('TCP', '', 1234))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv4_ip(self):
+    def test_match_ip_address_ipv4_ip(self) -> None:
         matcher = NetfilterMatchIPAddress('192.168.0.1/32')
         context = NetfilterContext(addr=IPv4Address('TCP', '192.168.0.1', 1234))
         self.assertTrue(matcher.match(context))
@@ -138,24 +138,24 @@ class NetfilterMatchTest(unittest.TestCase):
         context = NetfilterContext(addr=IPv4Address('TCP', '', 1234))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv4_hostname(self):
+    def test_match_ip_address_ipv4_hostname(self) -> None:
         matcher = NetfilterMatchIPAddress('192.168.0.1/32')
-        context = NetfilterContext(addr=HostnameAddress('hathor.network', 80))
+        context = NetfilterContext(addr=HostnameAddress(b'hathor.network', 80))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv4_unix(self):
+    def test_match_ip_address_ipv4_unix(self) -> None:
         matcher = NetfilterMatchIPAddress('192.168.0.1/32')
         context = NetfilterContext(addr=UNIXAddress('/unix.sock'))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv4_ipv6(self):
+    def test_match_ip_address_ipv4_ipv6(self) -> None:
         matcher = NetfilterMatchIPAddress('192.168.0.1/32')
         context = NetfilterContext(addr=IPv6Address('TCP', '2001:db8::', 80))
         self.assertFalse(matcher.match(context))
         context = NetfilterContext(addr=IPv6Address('TCP', '', 80))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv6_net(self):
+    def test_match_ip_address_ipv6_net(self) -> None:
         matcher = NetfilterMatchIPAddress('2001:0db8:0:f101::/64')
         context = NetfilterContext(addr=IPv6Address('TCP', '2001:db8::8a2e:370:7334', 1234))
         self.assertFalse(matcher.match(context))
@@ -167,7 +167,7 @@ class NetfilterMatchTest(unittest.TestCase):
         self.assertEqual(json['type'], 'NetfilterMatchIPAddress')
         self.assertEqual(json['match_params']['host'], str(ip_network('2001:0db8:0:f101::/64')))
 
-    def test_match_ip_address_ipv6_ip(self):
+    def test_match_ip_address_ipv6_ip(self) -> None:
         matcher = NetfilterMatchIPAddress('2001:0db8:0:f101::1/128')
         context = NetfilterContext(addr=IPv6Address('TCP', '2001:db8:0:f101::1', 1234))
         self.assertTrue(matcher.match(context))
@@ -176,22 +176,22 @@ class NetfilterMatchTest(unittest.TestCase):
         context = NetfilterContext(addr=IPv6Address('TCP', '2001:db8:0:f101:2::7334', 1234))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv6_hostname(self):
+    def test_match_ip_address_ipv6_hostname(self) -> None:
         matcher = NetfilterMatchIPAddress('2001:0db8:0:f101::1/128')
-        context = NetfilterContext(addr=HostnameAddress('hathor.network', 80))
+        context = NetfilterContext(addr=HostnameAddress(b'hathor.network', 80))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv6_unix(self):
+    def test_match_ip_address_ipv6_unix(self) -> None:
         matcher = NetfilterMatchIPAddress('2001:0db8:0:f101::1/128')
         context = NetfilterContext(addr=UNIXAddress('/unix.sock'))
         self.assertFalse(matcher.match(context))
 
-    def test_match_ip_address_ipv6_ipv4(self):
+    def test_match_ip_address_ipv6_ipv4(self) -> None:
         matcher = NetfilterMatchIPAddress('2001:0db8:0:f101::1/128')
         context = NetfilterContext(addr=IPv4Address('TCP', '192.168.0.1', 1234))
         self.assertFalse(matcher.match(context))
 
-    def test_match_peer_id_empty_context(self):
+    def test_match_peer_id_empty_context(self) -> None:
         matcher = NetfilterMatchPeerId('123')
         context = NetfilterContext()
         self.assertFalse(matcher.match(context))
@@ -200,7 +200,7 @@ class NetfilterMatchTest(unittest.TestCase):
 class BaseNetfilterMatchTest(unittest.TestCase):
     __test__ = False
 
-    def test_match_peer_id(self):
+    def test_match_peer_id(self) -> None:
         network = 'testnet'
         peer_id1 = PeerId()
         peer_id2 = PeerId()

--- a/tests/p2p/netfilter/test_match_remote.py
+++ b/tests/p2p/netfilter/test_match_remote.py
@@ -6,7 +6,7 @@ from tests import unittest
 
 
 class NetfilterMatchRemoteTest(unittest.TestCase):
-    def test_match_ip(self):
+    def test_match_ip(self) -> None:
         matcher = NetfilterMatchIPAddressRemoteURL('test', self.clock, 'http://localhost:8080')
         context = NetfilterContext(addr=IPv4Address('TCP', '192.168.0.1', 1234))
         self.assertFalse(matcher.match(context))

--- a/tests/p2p/netfilter/test_tables.py
+++ b/tests/p2p/netfilter/test_tables.py
@@ -6,17 +6,17 @@ from tests import unittest
 
 
 class NetfilterTableTest(unittest.TestCase):
-    def test_default_table_filter(self):
+    def test_default_table_filter(self) -> None:
         tb_filter = get_table('filter')
         tb_filter.get_chain('pre_conn')
         tb_filter.get_chain('post_hello')
         tb_filter.get_chain('post_peerid')
 
-    def test_default_table_not_exists(self):
+    def test_default_table_not_exists(self) -> None:
         with self.assertRaises(KeyError):
             get_table('do-not-exists')
 
-    def test_add_get_chain(self):
+    def test_add_get_chain(self) -> None:
         mytable = NetfilterTable('mytable')
         mychain = NetfilterChain('mychain', NetfilterAccept())
         mytable.add_chain(mychain)

--- a/tests/p2p/netfilter/test_utils.py
+++ b/tests/p2p/netfilter/test_utils.py
@@ -4,7 +4,7 @@ from tests import unittest
 
 
 class NetfilterUtilsTest(unittest.TestCase):
-    def test_peer_id_blacklist(self):
+    def test_peer_id_blacklist(self) -> None:
         post_peerid = get_table('filter').get_chain('post_peerid')
 
         # Chain starts empty

--- a/tests/p2p/test_capabilities.py
+++ b/tests/p2p/test_capabilities.py
@@ -1,3 +1,4 @@
+from hathor.p2p.states import ReadyState
 from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 from hathor.p2p.sync_v2.agent import NodeBlockSync
 from hathor.simulator import FakeConnection
@@ -5,7 +6,7 @@ from tests import unittest
 
 
 class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase):
-    def test_capabilities(self):
+    def test_capabilities(self) -> None:
         network = 'testnet'
         manager1 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST])
         manager2 = self.create_peer(network, capabilities=[])
@@ -18,6 +19,8 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
             self.clock.advance(0.1)
 
         # Even if we don't have the capability we must connect because the whitelist url conf is None
+        assert isinstance(conn._proto1.state, ReadyState)
+        assert isinstance(conn._proto2.state, ReadyState)
         self.assertEqual(conn._proto1.state.state_name, 'READY')
         self.assertEqual(conn._proto2.state.state_name, 'READY')
         self.assertIsInstance(conn._proto1.state.sync_agent, NodeSyncTimestamp)
@@ -33,6 +36,8 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
             conn2.run_one_step(debug=True)
             self.clock.advance(0.1)
 
+        assert isinstance(conn2._proto1.state, ReadyState)
+        assert isinstance(conn2._proto2.state, ReadyState)
         self.assertEqual(conn2._proto1.state.state_name, 'READY')
         self.assertEqual(conn2._proto2.state.state_name, 'READY')
         self.assertIsInstance(conn2._proto1.state.sync_agent, NodeSyncTimestamp)
@@ -40,7 +45,7 @@ class SyncV1HathorCapabilitiesTestCase(unittest.SyncV1Params, unittest.TestCase)
 
 
 class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase):
-    def test_capabilities(self):
+    def test_capabilities(self) -> None:
         network = 'testnet'
         manager1 = self.create_peer(network, capabilities=[self._settings.CAPABILITY_WHITELIST,
                                                            self._settings.CAPABILITY_SYNC_VERSION])
@@ -54,6 +59,8 @@ class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase)
             self.clock.advance(0.1)
 
         # Even if we don't have the capability we must connect because the whitelist url conf is None
+        assert isinstance(conn._proto1.state, ReadyState)
+        assert isinstance(conn._proto2.state, ReadyState)
         self.assertEqual(conn._proto1.state.state_name, 'READY')
         self.assertEqual(conn._proto2.state.state_name, 'READY')
         self.assertIsInstance(conn._proto1.state.sync_agent, NodeBlockSync)
@@ -71,6 +78,8 @@ class SyncV2HathorCapabilitiesTestCase(unittest.SyncV2Params, unittest.TestCase)
             conn2.run_one_step(debug=True)
             self.clock.advance(0.1)
 
+        assert isinstance(conn2._proto1.state, ReadyState)
+        assert isinstance(conn2._proto2.state, ReadyState)
         self.assertEqual(conn2._proto1.state.state_name, 'READY')
         self.assertEqual(conn2._proto2.state.state_name, 'READY')
         self.assertIsInstance(conn2._proto1.state.sync_agent, NodeBlockSync)

--- a/tests/p2p/test_connections.py
+++ b/tests/p2p/test_connections.py
@@ -8,7 +8,7 @@ from tests.utils import run_server
 
 class ConnectionsTest(unittest.TestCase):
     @pytest.mark.skipif(sys.platform == 'win32', reason='run_server is very finicky on Windows')
-    def test_connections(self):
+    def test_connections(self) -> None:
         process = run_server()
         process2 = run_server(listen=8006, status=8086, bootstrap='tcp://127.0.0.1:8005')
         process3 = run_server(listen=8007, status=8087, bootstrap='tcp://127.0.0.1:8005')
@@ -17,7 +17,7 @@ class ConnectionsTest(unittest.TestCase):
         process2.terminate()
         process3.terminate()
 
-    def test_manager_connections(self):
+    def test_manager_connections(self) -> None:
         manager = self.create_peer('testnet', enable_sync_v1=True, enable_sync_v2=False)
 
         endpoint = 'tcp://127.0.0.1:8005'

--- a/tests/p2p/test_double_spending.py
+++ b/tests/p2p/test_double_spending.py
@@ -1,5 +1,9 @@
+from unittest.mock import Mock
+
 from hathor.crypto.util import decode_address
+from hathor.manager import HathorManager
 from hathor.simulator.utils import add_new_blocks
+from hathor.transaction import Transaction
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, add_new_tx
 
@@ -7,7 +11,7 @@ from tests.utils import add_blocks_unlock_reward, add_new_tx
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):
     __test__ = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.network = 'testnet'
@@ -16,7 +20,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.genesis = self.manager1.tx_storage.get_all_genesis()
         self.genesis_blocks = [tx for tx in self.genesis if tx.is_block]
 
-    def _add_new_transactions(self, manager, num_txs):
+    def _add_new_transactions(self, manager: HathorManager, num_txs: int) -> list[Transaction]:
         txs = []
         for _ in range(num_txs):
             address = self.get_address(0)
@@ -25,7 +29,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
             txs.append(tx)
         return txs
 
-    def test_simple_double_spending(self):
+    def test_simple_double_spending(self) -> None:
         add_new_blocks(self.manager1, 5, advance_clock=15)
         add_blocks_unlock_reward(self.manager1)
 
@@ -33,6 +37,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         from hathor.wallet.base_wallet import WalletOutputInfo
 
         address = self.get_address(0)
+        assert address is not None
         value = 500
 
         outputs = []
@@ -125,7 +130,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
 
         self.assertConsensusValid(self.manager1)
 
-    def test_double_spending_propagation(self):
+    def test_double_spending_propagation(self) -> None:
         blocks = add_new_blocks(self.manager1, 4, advance_clock=15)
         add_blocks_unlock_reward(self.manager1)
 
@@ -165,7 +170,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         outputs = [WalletOutputInfo(address=address, value=value, timelock=None),
                    WalletOutputInfo(address=address, value=tx_total_value - 500, timelock=None)]
         self.clock.advance(1)
-        inputs = [WalletInputInfo(i.tx_id, i.index, b'') for i in tx1.inputs]
+        inputs = [WalletInputInfo(i.tx_id, i.index, Mock()) for i in tx1.inputs]
         tx4 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs,
                                                                          outputs, self.manager1.tx_storage)
         tx4.weight = 5
@@ -186,7 +191,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
 
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 100
-        inputs = [WalletInputInfo(tx_id=tx1.hash, index=1, private_key=None)]
+        inputs = [WalletInputInfo(tx_id=tx1.hash, index=1, private_key=Mock())]
         outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
         self.clock.advance(1)
         tx2 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,
@@ -236,7 +241,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
 
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 500
-        inputs = [WalletInputInfo(tx_id=tx4.hash, index=0, private_key=None)]
+        inputs = [WalletInputInfo(tx_id=tx4.hash, index=0, private_key=Mock())]
         outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
         self.clock.advance(1)
         tx5 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs, force=True,
@@ -273,7 +278,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
 
         address = self.manager1.wallet.get_unused_address_bytes()
         value = blocks[3].outputs[0].value
-        inputs = [WalletInputInfo(tx_id=blocks[3].hash, index=0, private_key=None)]
+        inputs = [WalletInputInfo(tx_id=blocks[3].hash, index=0, private_key=Mock())]
         outputs = [WalletOutputInfo(address=address, value=value, timelock=None)]
         self.clock.advance(1)
         tx7 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,

--- a/tests/p2p/test_get_best_blockchain.py
+++ b/tests/p2p/test_get_best_blockchain.py
@@ -1,4 +1,4 @@
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.protocol import Protocol
 
 from hathor.indexes.height_index import HeightInfo
 from hathor.p2p.messages import ProtocolMessages
@@ -17,18 +17,15 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
 
     seed_config = 6
 
-    def _send_cmd(self, proto, cmd, payload=None):
+    def _send_cmd(self, proto: Protocol, cmd: str, payload: str | None = None) -> None:
         if not payload:
             line = '{}\r\n'.format(cmd)
         else:
             line = '{} {}\r\n'.format(cmd, payload)
 
-        if isinstance(line, str):
-            line = line.encode('utf-8')
+        return proto.dataReceived(line.encode('utf-8'))
 
-        return proto.dataReceived(line)
-
-    def test_get_best_blockchain(self):
+    def test_get_best_blockchain(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
         conn12 = FakeConnection(manager1, manager2, latency=0.05)
@@ -54,8 +51,8 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         # assert the protocol is in ReadyState
         state1 = protocol1.state
         state2 = protocol2.state
-        self.assertIsInstance(state1, ReadyState)
-        self.assertIsInstance(state2, ReadyState)
+        assert isinstance(state1, ReadyState)
+        assert isinstance(state2, ReadyState)
 
         # assert ReadyState commands
         self.assertIn(ProtocolMessages.GET_BEST_BLOCKCHAIN, state1.cmd_map)
@@ -81,10 +78,10 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertEqual(self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS, len(state1.peer_best_blockchain))
         self.assertEqual(self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS, len(state2.peer_best_blockchain))
 
-        self.assertIsInstance(state1.peer_best_blockchain[0], HeightInfo)
-        self.assertIsInstance(state2.peer_best_blockchain[0], HeightInfo)
+        assert isinstance(state1.peer_best_blockchain[0], HeightInfo)
+        assert isinstance(state2.peer_best_blockchain[0], HeightInfo)
 
-    def test_handle_get_best_blockchain(self):
+    def test_handle_get_best_blockchain(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
         conn12 = FakeConnection(manager1, manager2, latency=0.05)
@@ -101,13 +98,13 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertEqual(1, len(connected_peers1))
         protocol2 = connected_peers1[0]
         state2 = protocol2.state
-        self.assertIsInstance(state2, ReadyState)
+        assert isinstance(state2, ReadyState)
 
         connected_peers2 = list(manager2.connections.connected_peers.values())
         self.assertEqual(1, len(connected_peers2))
         protocol1 = connected_peers2[0]
         state1 = protocol1.state
-        self.assertIsInstance(state1, ReadyState)
+        assert isinstance(state1, ReadyState)
 
         # assert compliance with N blocks inside the boundaries
         state1.send_get_best_blockchain(n_blocks=1)
@@ -141,7 +138,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertEqual(1, len(connected_peers2))
         protocol1 = connected_peers2[0]
         state1 = protocol1.state
-        self.assertIsInstance(state1, ReadyState)
+        assert isinstance(state1, ReadyState)
 
         # assert param validation exception closes connection
         state1.handle_get_best_blockchain('invalid single value')
@@ -149,7 +146,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         # state1 is managed by manager2
         self.assertTrue(conn12.tr2.disconnecting)
 
-    def test_handle_best_blockchain(self):
+    def test_handle_best_blockchain(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
         conn12 = FakeConnection(manager1, manager2, latency=0.05)
@@ -160,19 +157,19 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertEqual(1, len(connected_peers1))
         protocol2 = connected_peers1[0]
         state2 = protocol2.state
-        self.assertIsInstance(state2, ReadyState)
+        assert isinstance(state2, ReadyState)
 
         connected_peers2 = list(manager2.connections.connected_peers.values())
         self.assertEqual(1, len(connected_peers2))
         protocol1 = connected_peers2[0]
         state1 = protocol1.state
-        self.assertIsInstance(state1, ReadyState)
+        assert isinstance(state1, ReadyState)
 
         self.assertFalse(conn12.tr1.disconnecting)
         self.simulator.run(60)
 
         # assert a valid blockchain keeps connections open
-        fake_blockchain = [
+        fake_blockchain: list[tuple[float, str]] = [
             (1, '0000000000000002eccfbca9bc06c449c01f37afb3cb49c04ee62921d9bcf9dc'),
             (2, '00000000000000006c846e182462a2cc437070288a486dfa21aa64bb373b8507'),
         ]
@@ -203,7 +200,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.simulator.run(60)
         self.assertTrue(conn12.tr2.disconnecting)
 
-    def test_node_without_get_best_blockchain_capability(self):
+    def test_node_without_get_best_blockchain_capability(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
 
@@ -232,10 +229,10 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
 
         # assert the peers don't engage in get_best_blockchain messages
         state2 = protocol2.state
-        self.assertIsInstance(state2, ReadyState)
+        assert isinstance(state2, ReadyState)
         self.assertIsNone(state2.lc_get_best_blockchain)
         state1 = protocol1.state
-        self.assertIsInstance(state1, ReadyState)
+        assert isinstance(state1, ReadyState)
         self.assertIsNone(state1.lc_get_best_blockchain)
 
         # assert the connections remains open
@@ -261,7 +258,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.simulator.run(60)
         self.assertTrue(conn12.tr2.disconnecting)
 
-    def test_best_blockchain_from_storage(self):
+    def test_best_blockchain_from_storage(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
         conn12 = FakeConnection(manager1, manager2, latency=0.05)
@@ -281,8 +278,8 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertTrue(block is memo_block)
 
         # cache miss if best block doesn't match
-        fake_block = HeightInfo(1, 'fake hash')
-        manager1._latest_n_height_tips = [fake_block]
+        fake_block = HeightInfo(1, b'fake hash')
+        # manager1._latest_n_height_tips = [fake_block]  # FIXME: This property is not defined. Fix this test.
         best_blockchain = manager1.tx_storage.get_n_height_tips(1)  # there is only the genesis block
         block = best_blockchain[0]
         # the memoized best_blockchain is skiped
@@ -309,7 +306,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         block = best_blockchain[0]
         self.assertTrue(block is memo_block)
 
-    def test_stop_looping_on_exit(self):
+    def test_stop_looping_on_exit(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
         conn12 = FakeConnection(manager1, manager2, latency=0.05)
@@ -320,18 +317,18 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertEqual(1, len(connected_peers1))
         protocol2 = connected_peers1[0]
         state2 = protocol2.state
-        self.assertIsInstance(state2, ReadyState)
+        assert isinstance(state2, ReadyState)
 
         connected_peers2 = list(manager2.connections.connected_peers.values())
         self.assertEqual(1, len(connected_peers2))
         protocol1 = connected_peers2[0]
         state1 = protocol1.state
-        self.assertIsInstance(state1, ReadyState)
+        assert isinstance(state1, ReadyState)
 
-        self.assertIsNotNone(state1.lc_get_best_blockchain)
+        assert state1.lc_get_best_blockchain is not None
         self.assertTrue(state1.lc_get_best_blockchain.running)
 
-        self.assertIsNotNone(state2.lc_get_best_blockchain)
+        assert state2.lc_get_best_blockchain is not None
         self.assertTrue(state2.lc_get_best_blockchain.running)
 
         state1.on_exit()
@@ -343,8 +340,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.assertIsNotNone(state2.lc_get_best_blockchain)
         self.assertFalse(state2.lc_get_best_blockchain.running)
 
-    @inlineCallbacks
-    def test_best_blockchain_from_status_resource(self):
+    async def test_best_blockchain_from_status_resource(self) -> None:
         manager1 = self.create_peer()
         manager2 = self.create_peer()
         conn12 = FakeConnection(manager1, manager2, latency=0.05)
@@ -353,7 +349,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
 
         # check /status before generate blocks
         self.web = StubSite(StatusResource(manager1))
-        response = yield self.web.get("status")
+        response = await self.web.get("status")
         data = response.json_value()
         connections = data.get('connections')
         self.assertEqual(len(connections['connected_peers']), 1)
@@ -385,7 +381,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         self.simulator.run(60)
 
         # check /status after mine blocks
-        response = yield self.web.get("status")
+        response = await self.web.get("status")
         data = response.json_value()
         connections = data.get('connections')
         self.assertEqual(len(connections['connected_peers']), 1)

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -2,7 +2,7 @@ from json import JSONDecodeError
 from typing import Optional
 from unittest.mock import Mock, patch
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.protocol import Protocol
 from twisted.python.failure import Failure
 
 from hathor.p2p.peer_id import PeerId
@@ -15,7 +15,7 @@ from tests import unittest
 class BaseHathorProtocolTestCase(unittest.TestCase):
     __test__ = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.network = 'testnet'
         self.peer_id1 = PeerId()
@@ -32,52 +32,49 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self.assertRegex(conn.peek_tr2_value(), regex2)
         conn.run_one_step()
 
-    def assertIsConnected(self, conn=None):
+    def assertIsConnected(self, conn: FakeConnection | None = None) -> None:
         if conn is None:
             conn = self.conn
         self.assertFalse(conn.tr1.disconnecting)
         self.assertFalse(conn.tr2.disconnecting)
 
-    def assertIsNotConnected(self, conn=None):
+    def assertIsNotConnected(self, conn: FakeConnection | None = None) -> None:
         if conn is None:
             conn = self.conn
         self.assertTrue(conn.tr1.disconnecting)
         self.assertTrue(conn.tr2.disconnecting)
 
-    def _send_cmd(self, proto, cmd, payload=None):
+    def _send_cmd(self, proto: Protocol, cmd: str, payload: str | None = None) -> None:
         if not payload:
             line = '{}\r\n'.format(cmd)
         else:
             line = '{} {}\r\n'.format(cmd, payload)
 
-        if isinstance(line, str):
-            line = line.encode('utf-8')
+        return proto.dataReceived(line.encode('utf-8'))
 
-        return proto.dataReceived(line)
-
-    def _check_result_only_cmd(self, result, expected_cmd):
+    def _check_result_only_cmd(self, result: bytes, expected_cmd: bytes) -> None:
         cmd_list = []
         for line in result.split(b'\r\n'):
             cmd, _, _ = line.partition(b' ')
             cmd_list.append(cmd)
         self.assertIn(expected_cmd, cmd_list)
 
-    def _check_cmd_and_value(self, result, expected):
+    def _check_cmd_and_value(self, result: bytes, expected: tuple[bytes, bytes]) -> None:
         result_list = []
         for line in result.split(b'\r\n'):
             cmd, _, data = line.partition(b' ')
             result_list.append((cmd, data))
         self.assertIn(expected, result_list)
 
-    def test_on_connect(self):
+    def test_on_connect(self) -> None:
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'HELLO')
 
-    def test_invalid_command(self):
+    def test_invalid_command(self) -> None:
         self._send_cmd(self.conn.proto1, 'INVALID-CMD')
         self.conn.proto1.state.handle_error('')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_rate_limit(self):
+    def test_rate_limit(self) -> None:
         hits = 1
         window = 60
 
@@ -99,7 +96,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self.conn.proto1.connections = None
         self.conn.proto1.on_disconnect(Failure(Exception()))
 
-    def test_invalid_size(self):
+    def test_invalid_size(self) -> None:
         self.conn.tr1.clear()
         cmd = b'HELLO '
         max_payload_bytes = HathorLineReceiver.MAX_LENGTH - len(cmd)
@@ -123,32 +120,32 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         line_length_exceeded_wrapped.assert_called_once()
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_invalid_payload(self):
+    def test_invalid_payload(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.conn.run_one_step()  # PEER-ID
         self.conn.run_one_step()  # READY
         with self.assertRaises(JSONDecodeError):
             self._send_cmd(self.conn.proto1, 'PEERS', 'abc')
 
-    def test_invalid_hello1(self):
+    def test_invalid_hello1(self) -> None:
         self.conn.tr1.clear()
         self._send_cmd(self.conn.proto1, 'HELLO')
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_invalid_hello2(self):
+    def test_invalid_hello2(self) -> None:
         self.conn.tr1.clear()
         self._send_cmd(self.conn.proto1, 'HELLO', 'invalid_payload')
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_invalid_hello3(self):
+    def test_invalid_hello3(self) -> None:
         self.conn.tr1.clear()
         self._send_cmd(self.conn.proto1, 'HELLO', '{}')
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_invalid_hello4(self):
+    def test_invalid_hello4(self) -> None:
         self.conn.tr1.clear()
         self._send_cmd(
             self.conn.proto1,
@@ -158,7 +155,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_invalid_hello5(self):
+    def test_invalid_hello5(self) -> None:
         # hello with clocks too far apart
         self.conn.tr1.clear()
         data = self.conn.proto2.state._get_hello_data()
@@ -171,14 +168,14 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_valid_hello(self):
+    def test_valid_hello(self) -> None:
         self.conn.run_one_step()  # HELLO
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'PEER-ID')
         self._check_result_only_cmd(self.conn.peek_tr2_value(), b'PEER-ID')
         self.assertFalse(self.conn.tr1.disconnecting)
         self.assertFalse(self.conn.tr2.disconnecting)
 
-    def test_invalid_same_peer_id(self):
+    def test_invalid_same_peer_id(self) -> None:
         manager3 = self.create_peer(self.network, peer_id=self.peer_id1)
         conn = FakeConnection(self.manager1, manager3)
         conn.run_one_step()  # HELLO
@@ -186,7 +183,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self._check_result_only_cmd(conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(conn.tr1.disconnecting)
 
-    def test_invalid_same_peer_id2(self):
+    def test_invalid_same_peer_id2(self) -> None:
         """
         We connect nodes 1-2 and 1-3. Nodes 2 and 3 have the same peer_id. The connections
         are established simultaneously, so we do not detect a peer id duplication in PEER_ID
@@ -246,7 +243,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         # connection is still up
         self.assertIsConnected(conn_alive)
 
-    def test_invalid_different_network(self):
+    def test_invalid_different_network(self) -> None:
         manager3 = self.create_peer(network='mainnet')
         conn = FakeConnection(self.manager1, manager3)
         conn.run_one_step()  # HELLO
@@ -254,23 +251,23 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self.assertTrue(conn.tr1.disconnecting)
         conn.run_one_step()  # ERROR
 
-    def test_send_invalid_unicode(self):
+    def test_send_invalid_unicode(self) -> None:
         # \xff is an invalid unicode.
         self.conn.proto1.dataReceived(b'\xff\r\n')
         self.assertTrue(self.conn.tr1.disconnecting)
 
-    def test_on_disconnect(self):
+    def test_on_disconnect(self) -> None:
         self.assertIn(self.conn.proto1, self.manager1.connections.handshaking_peers)
         self.conn.disconnect(Failure(Exception('testing')))
         self.assertNotIn(self.conn.proto1, self.manager1.connections.handshaking_peers)
 
-    def test_on_disconnect_after_hello(self):
+    def test_on_disconnect_after_hello(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.assertIn(self.conn.proto1, self.manager1.connections.handshaking_peers)
         self.conn.disconnect(Failure(Exception('testing')))
         self.assertNotIn(self.conn.proto1, self.manager1.connections.handshaking_peers)
 
-    def test_on_disconnect_after_peer_id(self):
+    def test_on_disconnect_after_peer_id(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.assertIn(self.conn.proto1, self.manager1.connections.handshaking_peers)
         # No peer id in the peer_storage (known_peers)
@@ -291,7 +288,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         # Peer id 2 removed from peer_storage (known_peers) after disconnection and after looping call
         self.assertNotIn(self.peer_id2.id, self.manager1.connections.peer_storage)
 
-    def test_idle_connection(self):
+    def test_idle_connection(self) -> None:
         self.clock.advance(self._settings.PEER_IDLE_TIMEOUT - 10)
         self.assertIsConnected(self.conn)
         self.clock.advance(15)
@@ -301,7 +298,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
 class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTestCase):
     __test__ = True
 
-    def test_two_connections(self):
+    def test_two_connections(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.conn.run_one_step()  # PEER-ID
         self.conn.run_one_step()  # READY
@@ -318,8 +315,7 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'PEERS')
         self.conn.run_one_step()
 
-    @inlineCallbacks
-    def test_get_data(self):
+    def test_get_data(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.conn.run_one_step()  # PEER-ID
         self.conn.run_one_step()  # READY
@@ -329,11 +325,11 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
         self.conn.run_one_step()  # TIPS
         self.assertIsConnected()
         missing_tx = '00000000228dfcd5dec1c9c6263f6430a5b4316bb9e3decb9441a6414bfd8697'
-        yield self._send_cmd(self.conn.proto1, 'GET-DATA', missing_tx)
+        self._send_cmd(self.conn.proto1, 'GET-DATA', missing_tx)
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'NOT-FOUND')
         self.conn.run_one_step()
 
-    def test_valid_hello_and_peer_id(self):
+    def test_valid_hello_and_peer_id(self) -> None:
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'HELLO')
         self._check_result_only_cmd(self.conn.peek_tr2_value(), b'HELLO')
         self.conn.run_one_step()  # HELLO
@@ -358,7 +354,7 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
         self.conn.run_one_step()  # TIPS
         self.assertIsConnected()
 
-    def test_send_ping(self):
+    def test_send_ping(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.conn.run_one_step()  # PEER-ID
         self.conn.run_one_step()  # READY
@@ -379,8 +375,7 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
             self.conn.run_one_step()
         self.assertEqual(self.clock.seconds(), self.conn.proto1.last_message)
 
-    @inlineCallbacks
-    def test_invalid_peer_id(self):
+    def test_invalid_peer_id(self) -> None:
         self.conn.run_one_step()  # HELLO
         self.conn.run_one_step()  # PEER-ID
         self.conn.run_one_step()  # READY
@@ -389,7 +384,7 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
         self.conn.run_one_step()  # PEERS
         self.conn.run_one_step()  # TIPS
         invalid_payload = {'id': '123', 'entrypoints': ['tcp://localhost:1234']}
-        yield self._send_cmd(self.conn.proto1, 'PEER-ID', json_dumps(invalid_payload))
+        self._send_cmd(self.conn.proto1, 'PEER-ID', json_dumps(invalid_payload))
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'ERROR')
         self.assertTrue(self.conn.tr1.disconnecting)
 
@@ -397,7 +392,7 @@ class SyncV1HathorProtocolTestCase(unittest.SyncV1Params, BaseHathorProtocolTest
 class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTestCase):
     __test__ = True
 
-    def test_two_connections(self):
+    def test_two_connections(self) -> None:
         self.assertAndStepConn(self.conn, b'^HELLO')
         self.assertAndStepConn(self.conn, b'^PEER-ID')
         self.assertAndStepConn(self.conn, b'^READY')
@@ -425,8 +420,7 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
 
         self.assertIsConnected()
 
-    @inlineCallbacks
-    def test_get_data(self):
+    def test_get_data(self) -> None:
         self.assertAndStepConn(self.conn, b'^HELLO')
         self.assertAndStepConn(self.conn, b'^PEER-ID')
         self.assertAndStepConn(self.conn, b'^READY')
@@ -442,11 +436,11 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
             'last_block_hash': missing_tx,
             'start_from': [self._settings.GENESIS_BLOCK_HASH.hex()]
         }
-        yield self._send_cmd(self.conn.proto1, 'GET-TRANSACTIONS-BFS', json_dumps(payload))
+        self._send_cmd(self.conn.proto1, 'GET-TRANSACTIONS-BFS', json_dumps(payload))
         self._check_result_only_cmd(self.conn.peek_tr1_value(), b'NOT-FOUND')
         self.conn.run_one_step()
 
-    def test_valid_hello_and_peer_id(self):
+    def test_valid_hello_and_peer_id(self) -> None:
         self.assertAndStepConn(self.conn, b'^HELLO')
         self.assertAndStepConn(self.conn, b'^PEER-ID')
         self.assertAndStepConn(self.conn, b'^READY')
@@ -477,7 +471,7 @@ class SyncV2HathorProtocolTestCase(unittest.SyncV2Params, BaseHathorProtocolTest
         self.assertAndStepConn(self.conn, b'^BEST-BLOCK')
         self.assertIsConnected()
 
-    def test_send_ping(self):
+    def test_send_ping(self) -> None:
         self.assertAndStepConn(self.conn, b'^HELLO')
         self.assertAndStepConn(self.conn, b'^PEER-ID')
         self.assertAndStepConn(self.conn, b'^READY')

--- a/tests/p2p/test_rate_limiter.py
+++ b/tests/p2p/test_rate_limiter.py
@@ -1,13 +1,14 @@
 from hathor.p2p.rate_limiter import RateLimiter
+from hathor.util import not_none
 from tests import unittest
 
 
 class RateLimiterTestCase(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.rate_limiter = RateLimiter(reactor=self.clock)
 
-    def test_limiter(self):
+    def test_limiter(self) -> None:
         key = 'test'
         self.rate_limiter.set_limit(key, 2, 2)
 
@@ -31,7 +32,7 @@ class RateLimiterTestCase(unittest.TestCase):
         self.assertTrue(self.rate_limiter.add_hit(key))
 
         # Get limit
-        self.assertEqual(self.rate_limiter.get_limit(key).max_hits, 2)
+        self.assertEqual(not_none(self.rate_limiter.get_limit(key)).max_hits, 2)
 
         # Unset limit
         self.rate_limiter.unset_limit(key)

--- a/tests/p2p/test_split_brain.py
+++ b/tests/p2p/test_split_brain.py
@@ -3,8 +3,10 @@ from mnemonic import Mnemonic
 
 from hathor.daa import TestMode
 from hathor.graphviz import GraphvizVisualizer
+from hathor.manager import HathorManager
 from hathor.simulator import FakeConnection
 from hathor.simulator.utils import add_new_block
+from hathor.util import not_none
 from hathor.wallet import HDWallet
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
@@ -13,7 +15,7 @@ from tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_n
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):
     __test__ = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         first_timestamp = self._settings.GENESIS_BLOCK_TIMESTAMP
@@ -21,13 +23,13 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
 
         self.network = 'testnet'
 
-    def create_peer(self, network, unlock_wallet=True):
+    def create_peer(self, network: str, unlock_wallet: bool = True) -> HathorManager:  # type: ignore[override]
         wallet = HDWallet(gap_limit=2)
         wallet._manually_initialize()
 
         manager = super().create_peer(network, wallet=wallet)
         manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
-        manager.avg_time_between_blocks = 64
+        # manager.avg_time_between_blocks = 64  # FIXME: This property is not defined. Fix this test.
 
         # Don't use it anywhere else. It is unsafe to generate mnemonic words like this.
         # It should be used only for testing purposes.
@@ -37,14 +39,14 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         return manager
 
     @pytest.mark.slow
-    def test_split_brain_plain(self):
+    def test_split_brain_plain(self) -> None:
         debug_pdf = False
 
         manager1 = self.create_peer(self.network, unlock_wallet=True)
-        manager1.avg_time_between_blocks = 3
+        # manager1.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         manager2 = self.create_peer(self.network, unlock_wallet=True)
-        manager2.avg_time_between_blocks = 3
+        # manager2.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         for _ in range(10):
             add_new_block(manager1, advance_clock=1)
@@ -100,12 +102,12 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertConsensusValid(manager2)
 
     @pytest.mark.slow
-    def test_split_brain_only_blocks_different_height(self):
+    def test_split_brain_only_blocks_different_height(self) -> None:
         manager1 = self.create_peer(self.network, unlock_wallet=True)
-        manager1.avg_time_between_blocks = 3
+        # manager1.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         manager2 = self.create_peer(self.network, unlock_wallet=True)
-        manager2.avg_time_between_blocks = 3
+        # manager2.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         for _ in range(10):
             add_new_block(manager1, advance_clock=1)
@@ -117,7 +119,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # Add one more block to manager1, so it's the winner chain
         add_new_block(manager1, advance_clock=1)
 
-        block_tip1 = manager1.tx_storage.indexes.height.get_tip()
+        block_tip1 = not_none(manager1.tx_storage.indexes).height.get_tip()
 
         self.assertConsensusValid(manager1)
         self.assertConsensusValid(manager2)
@@ -140,17 +142,17 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertConsensusValid(manager2)
         self.assertConsensusEqual(manager1, manager2)
 
-        self.assertEqual(block_tip1, manager1.tx_storage.indexes.height.get_tip())
-        self.assertEqual(block_tip1, manager2.tx_storage.indexes.height.get_tip())
+        self.assertEqual(block_tip1, not_none(manager1.tx_storage.indexes).height.get_tip())
+        self.assertEqual(block_tip1, not_none(manager2.tx_storage.indexes).height.get_tip())
 
     # XXX We must decide what to do when different chains have the same score
     # For now we are voiding everyone until the first common block
-    def test_split_brain_only_blocks_same_height(self):
+    def test_split_brain_only_blocks_same_height(self) -> None:
         manager1 = self.create_peer(self.network, unlock_wallet=True)
-        manager1.avg_time_between_blocks = 3
+        # manager1.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         manager2 = self.create_peer(self.network, unlock_wallet=True)
-        manager2.avg_time_between_blocks = 3
+        # manager2.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         for _ in range(10):
             add_new_block(manager1, advance_clock=1)
@@ -268,12 +270,12 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(len(manager2.tx_storage.get_best_block_tips()), 1)
         self.assertCountEqual(manager2.tx_storage.get_best_block_tips(), {new_block.hash})
 
-    def test_split_brain_only_blocks_bigger_score(self):
+    def test_split_brain_only_blocks_bigger_score(self) -> None:
         manager1 = self.create_peer(self.network, unlock_wallet=True)
-        manager1.avg_time_between_blocks = 3
+        # manager1.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         manager2 = self.create_peer(self.network, unlock_wallet=True)
-        manager2.avg_time_between_blocks = 3
+        # manager2.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
 
         # Start with 1 because of the genesis block
         manager2_blocks = 1
@@ -328,13 +330,13 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         # Assert that the consensus had the manager2 chain
         self.assertEqual(winners2_blocks, manager2_blocks)
 
-    def test_split_brain_no_double_spending(self):
+    def test_split_brain_no_double_spending(self) -> None:
         manager1 = self.create_peer(self.network, unlock_wallet=True)
-        manager1.avg_time_between_blocks = 3
+        # manager1.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
         manager1.connections.disable_rate_limiter()
 
         manager2 = self.create_peer(self.network, unlock_wallet=True)
-        manager2.avg_time_between_blocks = 3
+        # manager2.avg_time_between_blocks = 3  # FIXME: This property is not defined. Fix this test.
         manager2.connections.disable_rate_limiter()
 
         winner_blocks = 1

--- a/tests/p2p/test_split_brain2.py
+++ b/tests/p2p/test_split_brain2.py
@@ -10,7 +10,7 @@ class BaseHathorSyncMethodsTestCase(SimulatorTestCase):
     __test__ = False
 
     @pytest.mark.flaky(max_runs=3, min_passes=1)
-    def test_split_brain(self):
+    def test_split_brain(self) -> None:
         debug_pdf = False
 
         manager1 = self.create_peer()

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -5,7 +5,9 @@ from hathor.crypto.util import decode_address
 from hathor.p2p.protocol import PeerIdState
 from hathor.p2p.sync_version import SyncVersion
 from hathor.simulator import FakeConnection
+from hathor.transaction import Block, Transaction
 from hathor.transaction.storage.exceptions import TransactionIsNotABlock
+from hathor.util import not_none
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
 
@@ -13,7 +15,7 @@ from tests.utils import add_blocks_unlock_reward
 class BaseHathorSyncMethodsTestCase(unittest.TestCase):
     __test__ = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         # import sys
@@ -27,8 +29,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.genesis = self.manager1.tx_storage.get_all_genesis()
         self.genesis_blocks = [tx for tx in self.genesis if tx.is_block]
 
-    def _add_new_tx(self, address, value):
-        from hathor.transaction import Transaction
+    def _add_new_tx(self, address: str, value: int) -> Transaction:
         from hathor.wallet.base_wallet import WalletOutputInfo
 
         outputs = []
@@ -46,16 +47,16 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.clock.advance(10)
         return tx
 
-    def _add_new_transactions(self, num_txs):
+    def _add_new_transactions(self, num_txs: int) -> list[Transaction]:
         txs = []
         for _ in range(num_txs):
-            address = self.get_address(0)
+            address = not_none(self.get_address(0))
             value = self.rng.choice([5, 10, 50, 100, 120])
             tx = self._add_new_tx(address, value)
             txs.append(tx)
         return txs
 
-    def _add_new_block(self, propagate=True):
+    def _add_new_block(self, propagate: bool = True) -> Block:
         block = self.manager1.generate_mining_block()
         self.assertTrue(self.manager1.cpu_mining_service.resolve(block))
         self.manager1.verification_service.verify(block)
@@ -63,13 +64,13 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.clock.advance(10)
         return block
 
-    def _add_new_blocks(self, num_blocks, propagate=True):
+    def _add_new_blocks(self, num_blocks: int, propagate: bool = True) -> list[Block]:
         blocks = []
         for _ in range(num_blocks):
             blocks.append(self._add_new_block(propagate=propagate))
         return blocks
 
-    def test_get_blocks_before(self):
+    def test_get_blocks_before(self) -> None:
         genesis_block = self.genesis_blocks[0]
         result = self.manager1.tx_storage.get_blocks_before(genesis_block.hash)
         self.assertEqual(0, len(result))
@@ -88,7 +89,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
             expected_result = expected_result[::-1]
             self.assertEqual(result, expected_result)
 
-    def test_block_sync_only_genesis(self):
+    def test_block_sync_only_genesis(self) -> None:
         manager2 = self.create_peer(self.network)
         self.assertEqual(manager2.state, manager2.NodeState.READY)
 
@@ -102,7 +103,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(node_sync.synced_timestamp, node_sync.peer_timestamp)
         self.assertTipsEqual(self.manager1, manager2)
 
-    def test_block_sync_new_blocks(self):
+    def test_block_sync_new_blocks(self) -> None:
         self._add_new_blocks(15)
 
         manager2 = self.create_peer(self.network)
@@ -123,7 +124,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_block_sync_many_new_blocks(self):
+    def test_block_sync_many_new_blocks(self) -> None:
         self._add_new_blocks(150)
 
         manager2 = self.create_peer(self.network)
@@ -143,7 +144,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_block_sync_new_blocks_and_txs(self):
+    def test_block_sync_new_blocks_and_txs(self) -> None:
         self._add_new_blocks(25)
         self._add_new_transactions(3)
         self._add_new_blocks(4)
@@ -172,7 +173,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_tx_propagation_nat_peers(self):
+    def test_tx_propagation_nat_peers(self) -> None:
         """ manager1 <- manager2 <- manager3
         """
         self._add_new_blocks(25)
@@ -229,7 +230,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         self.assertConsensusValid(self.manager2)
         self.assertConsensusValid(self.manager3)
 
-    def test_check_sync_state(self):
+    def test_check_sync_state(self) -> None:
         """Tests if the LoopingCall to check the sync state works"""
         # Initially it should do nothing, since there is no recent activity
         self.manager1.check_sync_state()
@@ -249,7 +250,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
 class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMethodsTestCase):
     __test__ = True
 
-    def test_downloader(self):
+    def test_downloader(self) -> None:
         from hathor.p2p.sync_v1.agent import NodeSyncTimestamp
 
         blocks = self._add_new_blocks(3)
@@ -326,7 +327,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
         downloader.check_downloading_queue()
         self.assertEqual(len(downloader.downloading_deque), 0)
 
-    def _downloader_bug_setup(self):
+    def _downloader_bug_setup(self) -> None:
         """ This is an auxiliary method to setup a bug scenario."""
         from hathor.p2p.sync_version import SyncVersion
 
@@ -390,7 +391,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
         # by this point everything should be set to so we can trigger the bug, any issues that happen before this
         # comment are an issue in setting up the scenario, not related to the problem itself
 
-    def test_downloader_retry_reorder(self):
+    def test_downloader_retry_reorder(self) -> None:
         """ Reproduce the bug that causes a reorder in the downloader queue.
 
         The tracking issue for this bug is #465
@@ -454,7 +455,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
         # if the fix is applied, we would see tx_A in storage by this point
         self.assertTrue(self.manager_bug.tx_storage.transaction_exists(self.tx_A.hash))
 
-    def test_downloader_disconnect(self):
+    def test_downloader_disconnect(self) -> None:
         """ This is related to test_downloader_retry_reorder, but it basically tests the change in behavior instead.
 
         When a peer disconnects it should be immediately removed from the tx-detail's connections list.
@@ -474,7 +475,7 @@ class SyncV1HathorSyncMethodsTestCase(unittest.SyncV1Params, BaseHathorSyncMetho
 class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMethodsTestCase):
     __test__ = True
 
-    def test_sync_metadata(self):
+    def test_sync_metadata(self) -> None:
         # test if the synced peer will build all tx metadata correctly
 
         height = 0
@@ -519,7 +520,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             self.assertCountEqual(meta1.conflict_with or [], meta2.conflict_with or [])
             self.assertCountEqual(meta1.twins or [], meta2.twins or [])
 
-    def test_tx_propagation_nat_peers(self):
+    def test_tx_propagation_nat_peers(self) -> None:
         super().test_tx_propagation_nat_peers()
 
         node_sync1 = self.conn1.proto1.state.sync_agent
@@ -534,7 +535,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertEqual(node_sync2.peer_best_block.height, self.manager2.tx_storage.get_height_best_block())
         self.assertConsensusEqual(self.manager2, self.manager3)
 
-    def test_block_sync_new_blocks_and_txs(self):
+    def test_block_sync_new_blocks_and_txs(self) -> None:
         self._add_new_blocks(25)
         self._add_new_transactions(3)
         self._add_new_blocks(4)
@@ -563,7 +564,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_block_sync_many_new_blocks(self):
+    def test_block_sync_many_new_blocks(self) -> None:
         self._add_new_blocks(150)
 
         manager2 = self.create_peer(self.network)
@@ -584,7 +585,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_block_sync_new_blocks(self):
+    def test_block_sync_new_blocks(self) -> None:
         self._add_new_blocks(15)
 
         manager2 = self.create_peer(self.network)
@@ -605,7 +606,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_full_sync(self):
+    def test_full_sync(self) -> None:
         # 10 blocks
         blocks = self._add_new_blocks(10)
         # N blocks to unlock the reward
@@ -677,7 +678,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertEqual(len(manager2.tx_storage.indexes.mempool_tips.get()), 1)
         self.assertEqual(len(self.manager1.tx_storage.indexes.mempool_tips.get()), 1)
 
-    def test_block_sync_checkpoints(self):
+    def test_block_sync_checkpoints(self) -> None:
         TOTAL_BLOCKS = 30
         LAST_CHECKPOINT = 15
         FIRST_CHECKPOINT = LAST_CHECKPOINT // 2
@@ -718,7 +719,7 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
         self.assertConsensusValid(self.manager1)
         self.assertConsensusValid(manager2)
 
-    def test_block_sync_only_genesis(self):
+    def test_block_sync_only_genesis(self) -> None:
         manager2 = self.create_peer(self.network)
         self.assertEqual(manager2.state, manager2.NodeState.READY)
 

--- a/tests/p2p/test_sync_bridge.py
+++ b/tests/p2p/test_sync_bridge.py
@@ -5,7 +5,7 @@ from tests.simulation.base import SimulatorTestCase
 class MixedSyncRandomSimulatorTestCase(SimulatorTestCase):
     __test__ = True
 
-    def test_the_three_transacting_miners(self):
+    def test_the_three_transacting_miners(self) -> None:
         manager1 = self.create_peer(enable_sync_v1=True,  enable_sync_v2=False)
         manager2 = self.create_peer(enable_sync_v1=True,  enable_sync_v2=True)
         manager3 = self.create_peer(enable_sync_v1=False, enable_sync_v2=True)
@@ -44,7 +44,7 @@ class MixedSyncRandomSimulatorTestCase(SimulatorTestCase):
             # sync-v2 consensus test is more lenient (if sync-v1 assert passes sync-v2 assert will pass too)
             self.assertConsensusEqualSyncV2(manager_a, manager_b, strict_sync_v2_indexes=False)
 
-    def test_bridge_with_late_v2(self):
+    def test_bridge_with_late_v2(self) -> None:
         manager1 = self.create_peer(enable_sync_v1=True,  enable_sync_v2=False)
         manager2 = self.create_peer(enable_sync_v1=True,  enable_sync_v2=True)
         manager3 = self.create_peer(enable_sync_v1=False, enable_sync_v2=True)

--- a/tests/p2p/test_sync_enabled.py
+++ b/tests/p2p/test_sync_enabled.py
@@ -5,7 +5,7 @@ from tests.simulation.base import SimulatorTestCase
 
 
 class BaseRandomSimulatorTestCase(SimulatorTestCase):
-    def test_new_node_disabled(self):
+    def test_new_node_disabled(self) -> None:
         manager1 = self.create_peer()
         manager1.allow_mining_without_peers()
 
@@ -39,7 +39,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         v2 = list(manager2.tx_storage.get_all_transactions())
         self.assertEqual(3, len(v2))
 
-    def test_sync_rotate(self):
+    def test_sync_rotate(self) -> None:
         manager1 = self.create_peer()
         manager1.connections.MAX_ENABLED_SYNC = 3
         other_managers = [self.create_peer() for _ in range(15)]

--- a/tests/p2p/test_sync_mempool.py
+++ b/tests/p2p/test_sync_mempool.py
@@ -1,6 +1,8 @@
 from hathor.crypto.util import decode_address
 from hathor.graphviz import GraphvizVisualizer
 from hathor.simulator import FakeConnection
+from hathor.transaction import Block, Transaction
+from hathor.util import not_none
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward
 
@@ -8,7 +10,7 @@ from tests.utils import add_blocks_unlock_reward
 class BaseHathorSyncMempoolTestCase(unittest.TestCase):
     __test__ = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.network = 'testnet'
@@ -18,7 +20,7 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
         self.genesis = self.manager1.tx_storage.get_all_genesis()
         self.genesis_blocks = [tx for tx in self.genesis if tx.is_block]
 
-    def _add_new_tx(self, address, value):
+    def _add_new_tx(self, address: str, value: int) -> Transaction:
         from hathor.transaction import Transaction
         from hathor.wallet.base_wallet import WalletOutputInfo
 
@@ -37,16 +39,16 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
         self.clock.advance(10)
         return tx
 
-    def _add_new_transactions(self, num_txs):
+    def _add_new_transactions(self, num_txs: int) -> list[Transaction]:
         txs = []
         for _ in range(num_txs):
-            address = self.get_address(0)
+            address = not_none(self.get_address(0))
             value = self.rng.choice([5, 10, 50, 100, 120])
             tx = self._add_new_tx(address, value)
             txs.append(tx)
         return txs
 
-    def _add_new_block(self, propagate=True):
+    def _add_new_block(self, propagate: bool = True) -> Block:
         block = self.manager1.generate_mining_block()
         self.assertTrue(self.manager1.cpu_mining_service.resolve(block))
         self.manager1.verification_service.verify(block)
@@ -54,13 +56,13 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
         self.clock.advance(10)
         return block
 
-    def _add_new_blocks(self, num_blocks, propagate=True):
+    def _add_new_blocks(self, num_blocks: int, propagate: bool = True) -> list[Block]:
         blocks = []
         for _ in range(num_blocks):
             blocks.append(self._add_new_block(propagate=propagate))
         return blocks
 
-    def test_mempool_basic(self):
+    def test_mempool_basic(self) -> None:
         # 10 blocks
         self._add_new_blocks(2)
         # N blocks to unlock the reward
@@ -100,7 +102,7 @@ class SyncV1HathorSyncMempoolTestCase(unittest.SyncV1Params, BaseHathorSyncMempo
 class SyncV2HathorSyncMempoolTestCase(unittest.SyncV2Params, BaseHathorSyncMempoolTestCase):
     __test__ = True
 
-    def test_mempool_basic(self):
+    def test_mempool_basic(self) -> None:
         super().test_mempool_basic()
 
         # 3 genesis

--- a/tests/p2p/test_twin_tx.py
+++ b/tests/p2p/test_twin_tx.py
@@ -1,6 +1,7 @@
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
+from hathor.util import not_none
 from hathor.wallet.base_wallet import WalletOutputInfo
 from tests import unittest
 from tests.utils import add_blocks_unlock_reward, add_new_double_spending
@@ -9,16 +10,16 @@ from tests.utils import add_blocks_unlock_reward, add_new_double_spending
 class BaseTwinTransactionTestCase(unittest.TestCase):
     __test__ = False
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.network = 'testnet'
         self.manager = self.create_peer(self.network, unlock_wallet=True)
 
-    def test_twin_tx(self):
+    def test_twin_tx(self) -> None:
         add_new_blocks(self.manager, 5, advance_clock=15)
         add_blocks_unlock_reward(self.manager)
 
-        address = self.get_address(0)
+        address = not_none(self.get_address(0))
         value1 = 100
         value2 = 101
         value3 = 102

--- a/tests/p2p/test_whitelist.py
+++ b/tests/p2p/test_whitelist.py
@@ -17,7 +17,7 @@ settings = get_global_settings()
 
 class WhitelistTestCase(unittest.SyncV1Params, unittest.TestCase):
     @patch('hathor.p2p.states.peer_id.settings', new=settings._replace(ENABLE_PEER_WHITELIST=True))
-    def test_sync_v11_whitelist_no_no(self):
+    def test_sync_v11_whitelist_no_no(self) -> None:
         network = 'testnet'
 
         manager1 = self.create_peer(network)
@@ -39,7 +39,7 @@ class WhitelistTestCase(unittest.SyncV1Params, unittest.TestCase):
         self.assertTrue(conn.tr2.disconnecting)
 
     @patch('hathor.p2p.states.peer_id.settings', new=settings._replace(ENABLE_PEER_WHITELIST=True))
-    def test_sync_v11_whitelist_yes_no(self):
+    def test_sync_v11_whitelist_yes_no(self) -> None:
         network = 'testnet'
 
         manager1 = self.create_peer(network)
@@ -63,7 +63,7 @@ class WhitelistTestCase(unittest.SyncV1Params, unittest.TestCase):
         self.assertTrue(conn.tr2.disconnecting)
 
     @patch('hathor.p2p.states.peer_id.settings', new=settings._replace(ENABLE_PEER_WHITELIST=True))
-    def test_sync_v11_whitelist_yes_yes(self):
+    def test_sync_v11_whitelist_yes_yes(self) -> None:
         network = 'testnet'
 
         manager1 = self.create_peer(network)


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/972

### Motivation

This PR continues to improve the strictness of mypy in test modules. For more info see the first PR in this series, https://github.com/HathorNetwork/hathor-core/pull/969.

### Acceptance Criteria

- Add stricter mypy rules to `tests.p2p` module and update it to conform.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 