### PR TITLE
refactor(mypy): unify hathor and test modules strictness [part VI/VI]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,21 +142,7 @@ module = [
     "hathor.consensus.*",
     "hathor.feature_activation.*",
     "hathor.event.*",
-    "hathor.verification.*"
-]
-strict_equality = true
-strict_concatenate = true
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_untyped_defs = true
-no_implicit_reexport = true
-warn_return_any = true
-# disallow_subclassing_any = true
-# disallow_untyped_calls = true
-
-# We also override to add disallow_untyped_defs for some specific test modules
-[[tool.mypy.overrides]]
-module = [
+    "hathor.verification.*",
     "tests.consensus.*",
     "tests.crypto.*",
     "tests.event.*",
@@ -168,7 +154,15 @@ module = [
     "tests.unittest",
     "tests.utils",
 ]
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_any_generics = true
 disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = true
+# disallow_subclassing_any = true
+# disallow_untyped_calls = true
 
 [tool.pydantic-mypy]
 init_typed = true

--- a/tests/consensus/test_consensus3.py
+++ b/tests/consensus/test_consensus3.py
@@ -79,7 +79,7 @@ class DoubleSpendingTestCase(unittest.TestCase):
             outputs = []
             outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
             outputs.append(WalletOutputInfo(decode_address(addr), 2*tx_fund.outputs[1].value, None))
-            tx5 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx2.timestamp+1)
+            tx5: Transaction = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx2.timestamp+1)
             tx5.weight = tx3.weight - tx1.weight + 0.1
             tx5.parents = [tx2.hash, tx4.hash]
             manager.cpu_mining_service.resolve(tx5)
@@ -174,7 +174,7 @@ class DoubleSpendingTestCase(unittest.TestCase):
             outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
             outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
             outputs.append(WalletOutputInfo(decode_address(addr), 2*tx_fund.outputs[2].value, None))
-            tx5 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx4.timestamp+1)
+            tx5: Transaction = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx4.timestamp+1)
             tx5.weight = 1
             tx5.parents = manager.get_new_tx_parents(tx5.timestamp)
             manager.cpu_mining_service.resolve(tx5)

--- a/tests/event/test_event_simulation_responses.py
+++ b/tests/event/test_event_simulation_responses.py
@@ -282,7 +282,7 @@ class BaseEventSimulationResponsesTest(BaseEventSimulationTester):
         # get response
         response = self._get_error_response()
 
-        assert response.type == InvalidRequestType.ACK_TOO_SMALL.value
+        assert str(response.type) == InvalidRequestType.ACK_TOO_SMALL.value
 
     def test_multiple_interactions(self) -> None:
         miner = self.simulator.create_miner(self.manager, hashpower=1e6)
@@ -333,7 +333,8 @@ class BaseEventSimulationResponsesTest(BaseEventSimulationTester):
         # get response
         response = self._get_error_response()
 
-        assert response.type == InvalidRequestType.ACK_TOO_SMALL.value  # ACK too small because we've already sent it
+        # ACK too small because we've already sent it
+        assert str(response.type) == InvalidRequestType.ACK_TOO_SMALL.value
 
         # new ack
         ack = AckRequest(type='ACK', window_size=4, ack_event_id=5)

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -25,12 +25,13 @@ from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.resources.feature import FeatureResource
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.simulator import FakeConnection
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.exceptions import BlockMustSignalError
 from hathor.util import not_none
 from tests import unittest
 from tests.resources.base_resource import StubSite
 from tests.simulation.base import SimulatorTestCase
-from tests.utils import HAS_ROCKSDB, add_new_blocks
+from tests.utils import HAS_ROCKSDB
 
 
 class BaseFeatureSimulationTest(SimulatorTestCase):
@@ -42,7 +43,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
     def _get_result(web_client: StubSite) -> dict[str, Any]:
         """Returns the feature activation api response."""
         response = web_client.get('feature')
-        result = response.result.json_value()
+        result: dict[str, Any] = response.result.json_value()
 
         del result['block_hash']  # we don't assert the block hash because it's not always the same
 

--- a/tests/feature_activation/test_mining_simulation.py
+++ b/tests/feature_activation/test_mining_simulation.py
@@ -143,7 +143,8 @@ class BaseMiningSimulationTest(SimulatorTestCase):
 
     def _get_signal_bits_from_get_block_template(self, web_client: StubSite) -> int:
         result = self._get_result(web_client)
-        return result['signal_bits']
+        signal_bits: int = result['signal_bits']
+        return signal_bits
 
     def _get_signal_bits_from_mining(self, web_client: StubSite) -> int:
         result = self._get_result(web_client)
@@ -153,13 +154,14 @@ class BaseMiningSimulationTest(SimulatorTestCase):
     @staticmethod
     def _get_result(web_client: StubSite) -> dict[str, Any]:
         response = web_client.get('')
-        return response.result.json_value()
+        result: dict[str, Any] = response.result.json_value()
+        return result
 
     def _get_last_ws_signal_bits(self, transport: StringTransport) -> int:
         messages = self._get_transport_messages(transport)
         assert len(messages) > 0
         last_message = messages[-1]
-        signal_bits = last_message['params'][0]['signal_bits']
+        signal_bits: int = last_message['params'][0]['signal_bits']
 
         return signal_bits
 

--- a/tests/feature_activation/test_settings.py
+++ b/tests/feature_activation/test_settings.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -56,7 +57,7 @@ from hathor.feature_activation.settings import FeatureInterval, Settings as Feat
         )
     ]
 )
-def test_valid_settings(features: dict) -> None:
+def test_valid_settings(features: dict[str, Any]) -> None:
     data = dict(features=features)
     FeatureSettings(**data)  # type: ignore[arg-type]
 
@@ -114,7 +115,7 @@ def test_valid_settings(features: dict) -> None:
         )
     ]
 )
-def test_conflicting_bits(features: list[dict]) -> None:
+def test_conflicting_bits(features: list[dict[str, Any]]) -> None:
     with pytest.raises(ValidationError) as e:
         data = dict(features=features)
         FeatureSettings(**data)  # type: ignore[arg-type]

--- a/tests/p2p/test_get_best_blockchain.py
+++ b/tests/p2p/test_get_best_blockchain.py
@@ -23,7 +23,7 @@ class BaseGetBestBlockchainTestCase(SimulatorTestCase):
         else:
             line = '{} {}\r\n'.format(cmd, payload)
 
-        return proto.dataReceived(line.encode('utf-8'))
+        proto.dataReceived(line.encode('utf-8'))
 
     def test_get_best_blockchain(self) -> None:
         manager1 = self.create_peer()

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -50,7 +50,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         else:
             line = '{} {}\r\n'.format(cmd, payload)
 
-        return proto.dataReceived(line.encode('utf-8'))
+        proto.dataReceived(line.encode('utf-8'))
 
     def _check_result_only_cmd(self, result: bytes, expected_cmd: bytes) -> None:
         cmd_list = []

--- a/tests/p2p/test_split_brain.py
+++ b/tests/p2p/test_split_brain.py
@@ -27,7 +27,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         wallet = HDWallet(gap_limit=2)
         wallet._manually_initialize()
 
-        manager = super().create_peer(network, wallet=wallet)
+        manager: HathorManager = super().create_peer(network, wallet=wallet)
         manager.daa.TEST_MODE = TestMode.TEST_ALL_WEIGHT
         # manager.avg_time_between_blocks = 64  # FIXME: This property is not defined. Fix this test.
 

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -36,7 +36,9 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         outputs.append(
             WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None))
 
-        tx = self.manager1.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager1.tx_storage)
+        tx: Transaction = self.manager1.wallet.prepare_transaction_compute_inputs(
+            Transaction, outputs, self.manager1.tx_storage
+        )
         tx.timestamp = int(self.clock.seconds())
         tx.storage = self.manager1.tx_storage
         tx.weight = 10
@@ -57,7 +59,7 @@ class BaseHathorSyncMethodsTestCase(unittest.TestCase):
         return txs
 
     def _add_new_block(self, propagate: bool = True) -> Block:
-        block = self.manager1.generate_mining_block()
+        block: Block = self.manager1.generate_mining_block()
         self.assertTrue(self.manager1.cpu_mining_service.resolve(block))
         self.manager1.verification_service.verify(block)
         self.manager1.on_new_tx(block, propagate_to_peers=propagate)

--- a/tests/p2p/test_sync_mempool.py
+++ b/tests/p2p/test_sync_mempool.py
@@ -28,7 +28,9 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
         outputs.append(
             WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None))
 
-        tx = self.manager1.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager1.tx_storage)
+        tx: Transaction = self.manager1.wallet.prepare_transaction_compute_inputs(
+            Transaction, outputs, self.manager1.tx_storage
+        )
         tx.timestamp = int(self.clock.seconds())
         tx.storage = self.manager1.tx_storage
         tx.weight = 10
@@ -49,7 +51,7 @@ class BaseHathorSyncMempoolTestCase(unittest.TestCase):
         return txs
 
     def _add_new_block(self, propagate: bool = True) -> Block:
-        block = self.manager1.generate_mining_block()
+        block: Block = self.manager1.generate_mining_block()
         self.assertTrue(self.manager1.cpu_mining_service.resolve(block))
         self.manager1.verification_service.verify(block)
         self.manager1.on_new_tx(block, propagate_to_peers=propagate)

--- a/tests/pubsub/test_pubsub2.py
+++ b/tests/pubsub/test_pubsub2.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import Mock, patch
 
 import pytest
@@ -78,7 +78,7 @@ def test_memory_reactor_clock_running_with_threading() -> None:
     pubsub = PubSubManager(reactor)
     handler = Mock()
 
-    def fake_call_from_thread(f: Callable) -> None:
+    def fake_call_from_thread(f: Callable[..., Any]) -> None:
         reactor.callLater(0, f)
 
     call_from_thread_mock = Mock(side_effect=fake_call_from_thread)

--- a/tests/resources/healthcheck/test_healthcheck.py
+++ b/tests/resources/healthcheck/test_healthcheck.py
@@ -6,9 +6,9 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 from hathor.healthcheck.resources.healthcheck import HealthcheckResource
 from hathor.manager import HathorManager
 from hathor.simulator import FakeConnection
+from hathor.simulator.utils import add_new_blocks
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
-from tests.utils import add_new_blocks
 
 
 class BaseHealthcheckReadinessTest(_BaseResourceTest._ResourceTest):

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -3,7 +3,7 @@ import secrets
 import shutil
 import tempfile
 import time
-from typing import Callable, Collection, Iterable, Iterator, Optional
+from typing import Any, Callable, Collection, Iterable, Iterator, Optional
 from unittest import main as ut_main
 
 from structlog import get_logger
@@ -121,7 +121,7 @@ class TestCase(unittest.TestCase):
         self.seed = secrets.randbits(64) if self.seed_config is None else self.seed_config
         self.log.info('set seed', seed=self.seed)
         self.rng = Random(self.seed)
-        self._pending_cleanups: list[Callable] = []
+        self._pending_cleanups: list[Callable[..., Any]] = []
         self._settings = get_global_settings()
 
     def tearDown(self) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -306,7 +306,8 @@ def request_server(
         response = requests.put(url, json=data)
     else:
         raise ValueError('Unsuported method')
-    return response.json()
+    json_response: dict[str, Any] = response.json()
+    return json_response
 
 
 def execute_mining(


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/974

### Motivation

This PR continues to improve the strictness of mypy in test modules. For more info see the first PR in this series, https://github.com/HathorNetwork/hathor-core/pull/969.

### Acceptance Criteria

- Unify the custom mypy override sections into a single one by updating test modules accordingly.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 