### PR TITLE
fix(indexes): Fix wrong order in MemoryTxGroupIndex

### DIFF
--- a/hathor/indexes/memory_tx_group_index.py
+++ b/hathor/indexes/memory_tx_group_index.py
@@ -31,7 +31,7 @@ class MemoryTxGroupIndex(TxGroupIndex[KT]):
     """Memory implementation of the TxGroupIndex. This class is abstract and cannot be used directly.
     """
 
-    index: defaultdict[KT, set[bytes]]
+    index: defaultdict[KT, set[tuple[int, bytes]]]
 
     def __init__(self) -> None:
         self.force_clear()
@@ -40,7 +40,7 @@ class MemoryTxGroupIndex(TxGroupIndex[KT]):
         self.index = defaultdict(set)
 
     def _add_tx(self, key: KT, tx: BaseTransaction) -> None:
-        self.index[key].add(not_none(tx.hash))
+        self.index[key].add((tx.timestamp, not_none(tx.hash)))
 
     @abstractmethod
     def _extract_keys(self, tx: BaseTransaction) -> Iterable[KT]:
@@ -57,13 +57,14 @@ class MemoryTxGroupIndex(TxGroupIndex[KT]):
         assert tx.hash is not None
 
         for key in self._extract_keys(tx):
-            self.index[key].discard(tx.hash)
+            self.index[key].discard((tx.timestamp, tx.hash))
 
     def _get_from_key(self, key: KT) -> Iterable[bytes]:
-        yield from self.index[key]
+        for _, h in self.index[key]:
+            yield h
 
     def _get_sorted_from_key(self, key: KT) -> Iterable[bytes]:
-        return sorted(self.index[key])
+        return [h for _, h in sorted(self.index[key])]
 
     def _is_key_empty(self, key: KT) -> bool:
         return not bool(self.index[key])


### PR DESCRIPTION
### Motivation

`MemoryTxGroupIndex._get_sorted_from_key()` is returning transactions in the wrong order. The correct order is sorted by (timestamp, hash) but it is actually only sorting by hash.

### Acceptance Criteria

1. Replace `set[bytes]` to `set[tuple[int, bytes]]` so we can simply sort before returning the results.
2. Fix `_get_sorted_from_key()` sorting the tuple but returning only the hashes.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 