### PR TITLE
refactor(indexes): Optimize RocksDBAddressIndex to handle pagination in O(log n)

### DIFF
--- a/hathor/indexes/address_index.py
+++ b/hathor/indexes/address_index.py
@@ -92,8 +92,11 @@ class AddressIndex(TxGroupIndex[str]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_sorted_from_address(self, address: str, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+    def get_sorted_from_address(self, address: str, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         """ Get a sorted list of transaction hashes of an address
+
+        The parameter tx_start means the transaction from which the iterator will start, and it is used for pagination.
+        When it's None it means that the iterator will start from the beginning.
         """
         raise NotImplementedError
 

--- a/hathor/indexes/address_index.py
+++ b/hathor/indexes/address_index.py
@@ -95,8 +95,8 @@ class AddressIndex(TxGroupIndex[str]):
     def get_sorted_from_address(self, address: str, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         """ Get a sorted list of transaction hashes of an address
 
-        The parameter tx_start means the transaction from which the iterator will start, and it is used for pagination.
-        When it's None it means that the iterator will start from the beginning.
+        `tx_start` serves as a pagination marker, indicating the starting position for the iteration.
+        When tx_start is None, the iteration begins from the initial element.
         """
         raise NotImplementedError
 

--- a/hathor/indexes/address_index.py
+++ b/hathor/indexes/address_index.py
@@ -92,7 +92,7 @@ class AddressIndex(TxGroupIndex[str]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_sorted_from_address(self, address: str) -> list[bytes]:
+    def get_sorted_from_address(self, address: str, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         """ Get a sorted list of transaction hashes of an address
         """
         raise NotImplementedError

--- a/hathor/indexes/memory_address_index.py
+++ b/hathor/indexes/memory_address_index.py
@@ -49,8 +49,8 @@ class MemoryAddressIndex(MemoryTxGroupIndex[str], AddressIndex):
     def get_from_address(self, address: str) -> list[bytes]:
         return list(self._get_from_key(address))
 
-    def get_sorted_from_address(self, address: str, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
-        return self._get_sorted_from_key(address, tx)
+    def get_sorted_from_address(self, address: str, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        return self._get_sorted_from_key(address, tx_start)
 
     def is_address_empty(self, address: str) -> bool:
         return self._is_key_empty(address)

--- a/hathor/indexes/memory_address_index.py
+++ b/hathor/indexes/memory_address_index.py
@@ -49,8 +49,8 @@ class MemoryAddressIndex(MemoryTxGroupIndex[str], AddressIndex):
     def get_from_address(self, address: str) -> list[bytes]:
         return list(self._get_from_key(address))
 
-    def get_sorted_from_address(self, address: str) -> list[bytes]:
-        return list(self._get_sorted_from_key(address))
+    def get_sorted_from_address(self, address: str, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        return self._get_sorted_from_key(address, tx)
 
     def is_address_empty(self, address: str) -> bool:
         return self._is_key_empty(address)

--- a/hathor/indexes/memory_tx_group_index.py
+++ b/hathor/indexes/memory_tx_group_index.py
@@ -14,7 +14,7 @@
 
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Iterable, Sized, TypeVar
+from typing import Iterable, Optional, Sized, TypeVar
 
 from structlog import get_logger
 
@@ -63,8 +63,15 @@ class MemoryTxGroupIndex(TxGroupIndex[KT]):
         for _, h in self.index[key]:
             yield h
 
-    def _get_sorted_from_key(self, key: KT) -> Iterable[bytes]:
-        return [h for _, h in sorted(self.index[key])]
+    def _get_sorted_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        sorted_elements = sorted(self.index[key])
+        found = False
+        for _, h in sorted_elements:
+            if tx and h == tx.hash:
+                found = True
+
+            if found or not tx:
+                yield h
 
     def _is_key_empty(self, key: KT) -> bool:
         return not bool(self.index[key])

--- a/hathor/indexes/memory_tx_group_index.py
+++ b/hathor/indexes/memory_tx_group_index.py
@@ -63,14 +63,14 @@ class MemoryTxGroupIndex(TxGroupIndex[KT]):
         for _, h in self.index[key]:
             yield h
 
-    def _get_sorted_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+    def _get_sorted_from_key(self, key: KT, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         sorted_elements = sorted(self.index[key])
         found = False
         for _, h in sorted_elements:
-            if tx and h == tx.hash:
+            if tx_start and h == tx_start.hash:
                 found = True
 
-            if found or not tx:
+            if found or not tx_start:
                 yield h
 
     def _is_key_empty(self, key: KT) -> bool:

--- a/hathor/indexes/rocksdb_address_index.py
+++ b/hathor/indexes/rocksdb_address_index.py
@@ -66,8 +66,8 @@ class RocksDBAddressIndex(RocksDBTxGroupIndex[str], AddressIndex, RocksDBIndexUt
     def get_from_address(self, address: str) -> list[bytes]:
         return list(self._get_from_key(address))
 
-    def get_sorted_from_address(self, address: str) -> list[bytes]:
-        return list(self._get_sorted_from_key(address))
+    def get_sorted_from_address(self, address: str, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        return self._get_sorted_from_key(address, tx)
 
     def is_address_empty(self, address: str) -> bool:
         return self._is_key_empty(address)

--- a/hathor/indexes/rocksdb_address_index.py
+++ b/hathor/indexes/rocksdb_address_index.py
@@ -66,8 +66,8 @@ class RocksDBAddressIndex(RocksDBTxGroupIndex[str], AddressIndex, RocksDBIndexUt
     def get_from_address(self, address: str) -> list[bytes]:
         return list(self._get_from_key(address))
 
-    def get_sorted_from_address(self, address: str, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
-        return self._get_sorted_from_key(address, tx)
+    def get_sorted_from_address(self, address: str, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        return self._get_sorted_from_key(address, tx_start)
 
     def is_address_empty(self, address: str) -> bool:
         return self._is_key_empty(address)

--- a/hathor/indexes/rocksdb_tx_group_index.py
+++ b/hathor/indexes/rocksdb_tx_group_index.py
@@ -108,9 +108,15 @@ class RocksDBTxGroupIndex(TxGroupIndex[KT], RocksDBIndexUtils):
             self._db.delete((self._cf, self._to_rocksdb_key(key, tx)))
 
     def _get_from_key(self, key: KT) -> Iterable[bytes]:
+        return self._util_get_from_key(key)
+
+    def _get_sorted_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        return self._util_get_from_key(key, tx)
+
+    def _util_get_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         self.log.debug('seek to', key=key)
         it = self._db.iterkeys(self._cf)
-        it.seek(self._to_rocksdb_key(key))
+        it.seek(self._to_rocksdb_key(key, tx))
         for _cf, rocksdb_key in it:
             key2, _, tx_hash = self._from_rocksdb_key(rocksdb_key)
             if key2 != key:
@@ -118,9 +124,6 @@ class RocksDBTxGroupIndex(TxGroupIndex[KT], RocksDBIndexUtils):
             self.log.debug('seek found', tx=tx_hash.hex())
             yield tx_hash
         self.log.debug('seek end')
-
-    def _get_sorted_from_key(self, key: KT) -> Iterable[bytes]:
-        return self._get_from_key(key)
 
     def _is_key_empty(self, key: KT) -> bool:
         self.log.debug('seek to', key=key)

--- a/hathor/indexes/rocksdb_tx_group_index.py
+++ b/hathor/indexes/rocksdb_tx_group_index.py
@@ -110,8 +110,8 @@ class RocksDBTxGroupIndex(TxGroupIndex[KT], RocksDBIndexUtils):
     def _get_from_key(self, key: KT) -> Iterable[bytes]:
         return self._util_get_from_key(key)
 
-    def _get_sorted_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
-        return self._util_get_from_key(key, tx)
+    def _get_sorted_from_key(self, key: KT, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        return self._util_get_from_key(key, tx_start)
 
     def _util_get_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         self.log.debug('seek to', key=key)

--- a/hathor/indexes/tx_group_index.py
+++ b/hathor/indexes/tx_group_index.py
@@ -49,8 +49,12 @@ class TxGroupIndex(BaseIndex, Generic[KT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_sorted_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
-        """Get all transactions that have a given key, sorted by timestamp."""
+    def _get_sorted_from_key(self, key: KT, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
+        """Get all transactions that have a given key, sorted by timestamp.
+
+        The parameter tx_start means the transaction from which the iterator will start, and it is used for pagination.
+        When it's None it means that the iterator will start from the beginning.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/hathor/indexes/tx_group_index.py
+++ b/hathor/indexes/tx_group_index.py
@@ -52,8 +52,8 @@ class TxGroupIndex(BaseIndex, Generic[KT]):
     def _get_sorted_from_key(self, key: KT, tx_start: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         """Get all transactions that have a given key, sorted by timestamp.
 
-        The parameter tx_start means the transaction from which the iterator will start, and it is used for pagination.
-        When it's None it means that the iterator will start from the beginning.
+        `tx_start` serves as a pagination marker, indicating the starting position for the iteration.
+        When tx_start is None, the iteration begins from the initial element.
         """
         raise NotImplementedError
 

--- a/hathor/indexes/tx_group_index.py
+++ b/hathor/indexes/tx_group_index.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import Generic, Iterable, Sized, TypeVar
+from typing import Generic, Iterable, Optional, Sized, TypeVar
 
 from structlog import get_logger
 
@@ -49,7 +49,7 @@ class TxGroupIndex(BaseIndex, Generic[KT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_sorted_from_key(self, key: KT) -> Iterable[bytes]:
+    def _get_sorted_from_key(self, key: KT, tx: Optional[BaseTransaction] = None) -> Iterable[bytes]:
         """Get all transactions that have a given key, sorted by timestamp."""
         raise NotImplementedError
 

--- a/hathor/wallet/resources/thin_wallet/address_history.py
+++ b/hathor/wallet/resources/thin_wallet/address_history.py
@@ -186,8 +186,7 @@ class AddressHistoryResource(Resource):
                         'message': 'Hash {} is not a transaction hash.'.format(ref_hash)
                     })
 
-            # In rocksdb we can get an iterator directly from the hash
-            # sent in the ref_hash
+            # The address index returns an iterable that starts at `tx`.
             hashes = addresses_index.get_sorted_from_address(address, tx)
             did_break = False
             for tx_hash in hashes:

--- a/hathor/wallet/resources/thin_wallet/address_history.py
+++ b/hathor/wallet/resources/thin_wallet/address_history.py
@@ -21,6 +21,7 @@ from hathor.api_util import Resource, get_args, get_missing_params_msg, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.conf.get_settings import get_global_settings
 from hathor.crypto.util import decode_address
+from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.util import json_dumpb, json_loadb
 from hathor.wallet.exceptions import InvalidAddress
 
@@ -166,12 +167,6 @@ class AddressHistoryResource(Resource):
 
         history = []
         seen: set[bytes] = set()
-        # XXX In this algorithm we need to sort all transactions of an address
-        # and find one specific (in case of a pagination request)
-        # so if this address has many txs, this could become slow
-        # I've done some tests with 10k txs in one address and the request
-        # returned in less than 50ms, so we will move forward with it for now
-        # but this could be improved in the future
         for idx, address in enumerate(addresses):
             try:
                 decode_address(address)
@@ -181,31 +176,29 @@ class AddressHistoryResource(Resource):
                     'message': 'The address {} is invalid'.format(address)
                 })
 
-            hashes = addresses_index.get_sorted_from_address(address)
-            start_index = 0
-            if ref_hash_bytes and idx == 0:
-                # It's not the first request, so we must continue from the hash
-                # but we do it only for the first address
+            tx = None
+            if ref_hash_bytes:
                 try:
-                    # Find index where the hash is
-                    start_index = hashes.index(ref_hash_bytes)
-                except ValueError:
-                    # ref_hash is not in the list
+                    tx = self.manager.tx_storage.get_transaction(ref_hash_bytes)
+                except TransactionDoesNotExist:
                     return json_dumpb({
                         'success': False,
-                        'message': 'Hash {} is not a transaction from the address {}.'.format(ref_hash, address)
+                        'message': 'Hash {} is not a transaction hash.'.format(ref_hash)
                     })
 
-            # Slice the hashes array from the start_index
-            to_iterate = hashes[start_index:]
+            # In rocksdb we can get an iterator directly from the hash
+            # sent in the ref_hash
+            hashes = addresses_index.get_sorted_from_address(address, tx)
             did_break = False
-            for index, tx_hash in enumerate(to_iterate):
+            for tx_hash in hashes:
                 if total_added == self._settings.MAX_TX_ADDRESSES_HISTORY:
                     # If already added the max number of elements possible, then break
                     # I need to add this if at the beginning of the loop to handle the case
                     # when the first tx of the address exceeds the limit, so we must return
                     # that the next request should start in the first tx of this address
                     did_break = True
+                    # Saving the first tx hash for the next request
+                    first_hash = tx_hash.hex()
                     break
 
                 if tx_hash not in seen:
@@ -216,6 +209,8 @@ class AddressHistoryResource(Resource):
                         # It's important to validate also the maximum number of inputs and outputs because some txs
                         # are really big and the response payload becomes too big
                         did_break = True
+                        # Saving the first tx hash for the next request
+                        first_hash = tx_hash.hex()
                         break
 
                     seen.add(tx_hash)
@@ -226,10 +221,8 @@ class AddressHistoryResource(Resource):
             if did_break:
                 # We stopped in the middle of the txs of this address
                 # So we return that we still have more data to send
-                break_index = start_index + index
                 has_more = True
                 # The hash to start the search and which address this hash belongs
-                first_hash = hashes[break_index].hex()
                 first_address = address
                 break
 

--- a/tests/tx/test_indexes.py
+++ b/tests/tx/test_indexes.py
@@ -631,7 +631,7 @@ class BaseIndexesTest(unittest.TestCase):
         address = self.get_address(10)
         assert address is not None
         self.assertTrue(addresses_indexes.is_address_empty(address))
-        self.assertEqual(addresses_indexes.get_sorted_from_address(address), [])
+        self.assertEqual(list(addresses_indexes.get_sorted_from_address(address)), [])
 
     def test_addresses_index_last(self):
         """
@@ -653,7 +653,7 @@ class BaseIndexesTest(unittest.TestCase):
         # XXX: this artificial address should major (be greater byte-wise) any possible "natural" address
         address = '\x7f' * 34
         self.assertTrue(addresses_indexes.is_address_empty(address))
-        self.assertEqual(addresses_indexes.get_sorted_from_address(address), [])
+        self.assertEqual(list(addresses_indexes.get_sorted_from_address(address)), [])
 
         # XXX: since we didn't add any multisig address, this is guaranteed to be reach the tail end of the index
         assert self._settings.P2PKH_VERSION_BYTE[0] < self._settings.MULTISIG_VERSION_BYTE[0]
@@ -666,7 +666,7 @@ class BaseIndexesTest(unittest.TestCase):
         assert address is not None
 
         self.assertTrue(addresses_indexes.is_address_empty(address))
-        self.assertEqual(addresses_indexes.get_sorted_from_address(address), [])
+        self.assertEqual(list(addresses_indexes.get_sorted_from_address(address)), [])
 
     def test_height_index(self):
         from hathor.indexes.height_index import HeightInfo


### PR DESCRIPTION
### Motivation

We had some users with wallets that had many transactions in single addresses, then the API request `address_history` got really slow.

More details [here](https://github.com/HathorNetwork/internal-issues/issues/256)

### Acceptance Criteria

- Add parameter in the `get_sorted_from_key` method of tx group index to find the first tx to return the iterator from.
- Refactor address history API to remove O(n) operation and use rocksdb tree to find tx with hash and improve performance.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 