### PR TITLE
docs: fix OpenAPI url of cpu profiler endpoint

### DIFF
--- a/hathor/profiler/resources/cpu_profiler.py
+++ b/hathor/profiler/resources/cpu_profiler.py
@@ -102,7 +102,7 @@ class CPUProfilerResource(Resource):
 
 
 CPUProfilerResource.openapi = {
-    '/profiler': {
+    '/top': {
         'x-visibility': 'private',
         'get': {
             'operationId': 'cpu-profiler',


### PR DESCRIPTION
### Motivation

When going through the docs with @BrunoCampana we noticed that this endpoint wasn't showing up on the docs.

### Acceptance Criteria

- The correct endpoint for the "top API" (cpu profiler) is `/top` and the OpenAPI should use that, `/profiler` is used by a different endpoint and using it causes one to overshadow the other.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 