### PR TITLE
fix(util): division by zero when logging progress in some cases

### DIFF
--- a/hathor/util.py
+++ b/hathor/util.py
@@ -495,7 +495,11 @@ def _tx_progress(iter_tx: Iterator['BaseTransaction'], *, log: 'structlog.stdlib
             if total:
                 progress_ = count / total
                 elapsed_time = t_log - t_start
-                remaining_time = LogDuration(elapsed_time / progress_ - elapsed_time)
+                remaining_time: str | LogDuration
+                if progress_ == 0:
+                    remaining_time = '?'
+                else:
+                    remaining_time = LogDuration(elapsed_time / progress_ - elapsed_time)
                 log.info(
                     f'loading... {math.floor(progress_ * 100):2.0f}%',
                     progress=progress_,


### PR DESCRIPTION
### Motivation

When testing #938 I got a division by zero error. I haven't debugged if the situation is realistic, but either way it seems to be better to handle the case where the denominator is 0.

### Acceptance Criteria

- Handle the case where `progress_ == 0` by simply doing `remaining_time = '?'`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 