### PR TITLE
feat(p2p): add ability to update peer_id.json with SIGUSR1

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import getpass
-import json
 import os
 import platform
 import sys
@@ -96,8 +95,7 @@ class CliBuilder:
         self.log = logger.new()
         self.reactor = reactor
 
-        peer_id = self.create_peer_id()
-
+        peer_id = PeerId.create_from_json_path(self._args.peer) if self._args.peer else PeerId()
         python = f'{platform.python_version()}-{platform.python_implementation()}'
 
         self.log.info(
@@ -367,7 +365,7 @@ class CliBuilder:
             self.log.warn('--memory-indexes is implied for memory storage or JSON storage')
 
         for description in self._args.listen:
-            p2p_manager.add_listen_address(description)
+            p2p_manager.add_listen_address_description(description)
 
         if self._args.peer_id_blacklist:
             self.log.info('with peer id blacklist', blacklist=self._args.peer_id_blacklist)
@@ -396,14 +394,6 @@ class CliBuilder:
                 sys.exit(-1)
             print('Hostname discovered and set to {}'.format(hostname))
         return hostname
-
-    def create_peer_id(self) -> PeerId:
-        if not self._args.peer:
-            peer_id = PeerId()
-        else:
-            data = json.load(open(self._args.peer, 'r'))
-            peer_id = PeerId.create_from_json(data)
-        return peer_id
 
     def create_wallet(self) -> BaseWallet:
         if self._args.wallet == 'hd':

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -265,9 +265,8 @@ class RunNode:
     def signal_usr1_handler(self, sig: int, frame: Any) -> None:
         """Called when USR1 signal is received."""
         try:
-            self.log.warn('USR1 received. Killing all connections...')
-            if self.manager and self.manager.connections:
-                self.manager.connections.disconnect_all_peers(force=True)
+            self.log.warn('USR1 received.')
+            self.manager.connections.reload_entrypoints_and_connections()
         except Exception:
             # see: https://docs.python.org/3/library/signal.html#note-on-signal-handlers-and-exceptions
             self.log.error('prevented exception from escaping the signal handler', exc_info=True)

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -423,6 +423,10 @@ class HathorSettings(NamedTuple):
     OLD_MAX_MERKLE_PATH_LENGTH: int = 12
     NEW_MAX_MERKLE_PATH_LENGTH: int = 20
 
+    # Maximum number of tx tips to accept in the initial phase of the mempool sync 1000 is arbitrary, but it should be
+    # more than enough for the forseeable future
+    MAX_MEMPOOL_RECEIVING_TIPS: int = 1000
+
     # Used to enable nano contracts.
     #
     # This should NEVER be enabled for mainnet and testnet, since both networks will

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -89,31 +89,33 @@ class HathorManager:
     # This is the interval to be used by the task to check if the node is synced
     CHECK_SYNC_STATE_INTERVAL = 30  # seconds
 
-    def __init__(self,
-                 reactor: Reactor,
-                 *,
-                 settings: HathorSettings,
-                 pubsub: PubSubManager,
-                 consensus_algorithm: ConsensusAlgorithm,
-                 daa: DifficultyAdjustmentAlgorithm,
-                 peer_id: PeerId,
-                 tx_storage: TransactionStorage,
-                 p2p_manager: ConnectionsManager,
-                 event_manager: EventManager,
-                 feature_service: FeatureService,
-                 bit_signaling_service: BitSignalingService,
-                 verification_service: VerificationService,
-                 cpu_mining_service: CpuMiningService,
-                 network: str,
-                 execution_manager: ExecutionManager,
-                 hostname: Optional[str] = None,
-                 wallet: Optional[BaseWallet] = None,
-                 capabilities: Optional[list[str]] = None,
-                 checkpoints: Optional[list[Checkpoint]] = None,
-                 rng: Optional[Random] = None,
-                 environment_info: Optional[EnvironmentInfo] = None,
-                 full_verification: bool = False,
-                 enable_event_queue: bool = False):
+    def __init__(
+        self,
+        reactor: Reactor,
+        *,
+        settings: HathorSettings,
+        pubsub: PubSubManager,
+        consensus_algorithm: ConsensusAlgorithm,
+        daa: DifficultyAdjustmentAlgorithm,
+        peer_id: PeerId,
+        tx_storage: TransactionStorage,
+        p2p_manager: ConnectionsManager,
+        event_manager: EventManager,
+        feature_service: FeatureService,
+        bit_signaling_service: BitSignalingService,
+        verification_service: VerificationService,
+        cpu_mining_service: CpuMiningService,
+        network: str,
+        execution_manager: ExecutionManager,
+        hostname: Optional[str] = None,
+        wallet: Optional[BaseWallet] = None,
+        capabilities: Optional[list[str]] = None,
+        checkpoints: Optional[list[Checkpoint]] = None,
+        rng: Optional[Random] = None,
+        environment_info: Optional[EnvironmentInfo] = None,
+        full_verification: bool = False,
+        enable_event_queue: bool = False,
+    ) -> None:
         """
         :param reactor: Twisted reactor which handles the mainloop and the events.
         :param peer_id: Id of this node.
@@ -1172,6 +1174,13 @@ class HathorManager:
     def get_cmd_path(self) -> Optional[str]:
         """Return the cmd path. If no cmd path is set, returns None."""
         return self._cmd_path
+
+    def set_hostname_and_reset_connections(self, new_hostname: str) -> None:
+        """Set the hostname and reset all connections."""
+        old_hostname = self.hostname
+        self.hostname = new_hostname
+        self.connections.update_hostname_entrypoints(old_hostname=old_hostname, new_hostname=self.hostname)
+        self.connections.disconnect_all_peers(force=True)
 
 
 class ParentTxs(NamedTuple):

--- a/hathor/p2p/utils.py
+++ b/hathor/p2p/utils.py
@@ -33,18 +33,18 @@ from hathor.p2p.peer_discovery import DNSPeerDiscovery
 from hathor.transaction.genesis import get_representation_for_all_genesis
 
 
-def discover_hostname() -> Optional[str]:
-    """ Try to discover your hostname. It is a synchonous operation and
+def discover_hostname(timeout: float | None = None) -> Optional[str]:
+    """ Try to discover your hostname. It is a synchronous operation and
     should not be called from twisted main loop.
     """
-    return discover_ip_ipify()
+    return discover_ip_ipify(timeout)
 
 
-def discover_ip_ipify() -> Optional[str]:
+def discover_ip_ipify(timeout: float | None = None) -> Optional[str]:
     """ Try to discover your IP address using ipify's api.
-    It is a synchonous operation and should not be called from twisted main loop.
+    It is a synchronous operation and should not be called from twisted main loop.
     """
-    response = requests.get('https://api.ipify.org')
+    response = requests.get('https://api.ipify.org', timeout=timeout)
     if response.ok:
         # It may be either an ipv4 or ipv6 in string format.
         ip = response.text

--- a/hathor/simulator/tx_generator.py
+++ b/hathor/simulator/tx_generator.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 from collections import deque
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, TypeAlias
 
 from structlog import get_logger
 
 from hathor.conf.get_settings import get_global_settings
 from hathor.simulator.utils import NoCandidatesError, gen_new_double_spending, gen_new_tx
+from hathor.transaction import Transaction
 from hathor.transaction.exceptions import RewardLocked
 from hathor.types import VertexId
 from hathor.util import Random
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+GenTxFunction: TypeAlias = Callable[['HathorManager', str, int], Transaction]
+
 
 class RandomTransactionGenerator:
     """ Generates random transactions without mining. It is supposed to be used
@@ -38,7 +41,8 @@ class RandomTransactionGenerator:
     MAX_LATEST_TRANSACTIONS_LEN = 10
 
     def __init__(self, manager: 'HathorManager', rng: Random, *,
-                 rate: float, hashpower: float, ignore_no_funds: bool = False):
+                 rate: float, hashpower: float, ignore_no_funds: bool = False,
+                 custom_gen_new_tx: GenTxFunction | None = None):
         """
         :param: rate: Number of transactions per second
         :param: hashpower: Number of hashes per second
@@ -58,6 +62,11 @@ class RandomTransactionGenerator:
         self.delayedcall = None
         self.log = logger.new()
         self.rng = rng
+        self.gen_new_tx: GenTxFunction
+        if custom_gen_new_tx is not None:
+            self.gen_new_tx = custom_gen_new_tx
+        else:
+            self.gen_new_tx = gen_new_tx
 
         # Most recent transactions generated here.
         # The lowest index has the most recent transaction.
@@ -115,7 +124,7 @@ class RandomTransactionGenerator:
 
         if not self.double_spending_only:
             try:
-                tx = gen_new_tx(self.manager, address, value)
+                tx = self.gen_new_tx(self.manager, address, value)
             except (InsufficientFunds, RewardLocked):
                 self.delayedcall = self.clock.callLater(0, self.schedule_next_transaction)
                 return

--- a/hathor/transaction/aux_pow.py
+++ b/hathor/transaction/aux_pow.py
@@ -18,6 +18,8 @@ from structlog import get_logger
 
 logger = get_logger()
 
+MAX_MERKLE_PATH_COUNT = 100
+
 
 class BitcoinAuxPow(NamedTuple):
     header_head: bytes  # 36 bytes
@@ -96,8 +98,11 @@ class BitcoinAuxPow(NamedTuple):
         coinbase_head = read_bytes(a)
         coinbase_tail = read_bytes(a)
         c = read_varint(a)
+        if c > MAX_MERKLE_PATH_COUNT:
+            raise ValueError(f'invalid merkle path count: {c} > {MAX_MERKLE_PATH_COUNT}')
         merkle_path = []
         for _ in range(c):
+            assert len(a) >= 32
             merkle_path.append(bytes(a[:32]))
             del a[:32]
         header_tail = read_nbytes(a, 12)

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -30,7 +30,7 @@ from structlog import get_logger
 
 import hathor
 from hathor.conf.get_settings import get_global_settings
-from hathor.types import TokenUid
+from hathor.types import TokenUid, VertexId
 
 if TYPE_CHECKING:
     import structlog
@@ -810,3 +810,23 @@ def calculate_min_significant_weight(score: float, tol: float) -> float:
     """ This function will return the min significant weight to increase score by tol.
     """
     return score + math.log2(2 ** tol - 1)
+
+
+def bytes_to_vertexid(data: bytes) -> VertexId:
+    # XXX: using raw string for the docstring so we can more easily write byte literals
+    r""" Function to validate bytes and return a VertexId, raises ValueError if not valid.
+
+    >>> bytes_to_vertexid(b'\0' * 32)
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    >>> bytes_to_vertexid(b'\0' * 31)
+    Traceback (most recent call last):
+    ...
+    ValueError: length must be exactly 32 bytes
+    >>> bytes_to_vertexid(b'\0' * 33)
+    Traceback (most recent call last):
+    ...
+    ValueError: length must be exactly 32 bytes
+    """
+    if len(data) != 32:
+        raise ValueError('length must be exactly 32 bytes')
+    return VertexId(data)

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -257,6 +257,94 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         self.assertEqual(manager1.tx_storage.get_vertices_count(), manager2.tx_storage.get_vertices_count())
         self.assertConsensusEqualSyncV2(manager1, manager2)
 
+    def test_receiving_tips_limit(self) -> None:
+        from hathor.manager import HathorManager
+        from hathor.transaction import Transaction
+        from hathor.wallet.base_wallet import WalletOutputInfo
+        from tests.utils import BURN_ADDRESS
+
+        manager1 = self.create_peer(enable_sync_v1=False, enable_sync_v2=True)
+        manager1.allow_mining_without_peers()
+
+        # Find 100 blocks.
+        miner1 = self.simulator.create_miner(manager1, hashpower=10e6)
+        miner1.start()
+        trigger: Trigger = StopAfterNMinedBlocks(miner1, quantity=100)
+        self.assertTrue(self.simulator.run(3 * 3600, trigger=trigger))
+        miner1.stop()
+
+        # Custom tx generator that generates tips
+        parents = manager1.get_new_tx_parents(manager1.tx_storage.latest_timestamp)
+
+        def custom_gen_new_tx(manager: HathorManager, _address: str, value: int, verify: bool = True) -> Transaction:
+            outputs = []
+            # XXX: burn address guarantees that this output will not be used as input for any following transactions
+            # XXX: reduce value to make sure we can generate more transactions, otherwise it will spend a linear random
+            #      percent from 1 to 100 of the available balance, this way it spends from 0.1% to 10%
+            outputs.append(WalletOutputInfo(address=BURN_ADDRESS, value=max(1, int(value / 10)), timelock=None))
+
+            assert manager.wallet is not None
+            tx = manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, manager.tx_storage)
+            tx.storage = manager.tx_storage
+
+            max_ts_spent_tx = max(tx.get_spent_tx(txin).timestamp for txin in tx.inputs)
+            tx.timestamp = max(max_ts_spent_tx + 1, int(manager.reactor.seconds()))
+
+            tx.weight = 1
+            # XXX: fixed parents is the final requirement to make all the generated new tips
+            tx.parents = parents
+            manager.cpu_mining_service.resolve(tx)
+            if verify:
+                manager.verification_service.verify(tx)
+            return tx
+
+        # Generate 100 tx-tips in mempool.
+        gen_tx1 = self.simulator.create_tx_generator(manager1, rate=3., hashpower=10e9, ignore_no_funds=True)
+        gen_tx1.gen_new_tx = custom_gen_new_tx
+        gen_tx1.start()
+        trigger = StopAfterNTransactions(gen_tx1, quantity=100)
+        self.simulator.run(3600, trigger=trigger)
+        self.assertGreater(manager1.tx_storage.get_vertices_count(), 100)
+        gen_tx1.stop()
+        assert manager1.tx_storage.indexes is not None
+        assert manager1.tx_storage.indexes.mempool_tips is not None
+        mempool_tips_count = len(manager1.tx_storage.indexes.mempool_tips.get())
+        # we should expect at the very least 30 tips
+        self.assertGreater(mempool_tips_count, 30)
+
+        # Create a new peer and run sync for a while (but stop before getting synced).
+        peer_id = PeerId()
+        builder2 = self.simulator.get_default_builder() \
+            .set_peer_id(peer_id) \
+            .disable_sync_v1() \
+            .enable_sync_v2() \
+
+        manager2 = self.simulator.create_peer(builder2)
+        conn12 = FakeConnection(manager1, manager2, latency=0.05)
+        self.simulator.add_connection(conn12)
+
+        # Let the connection start to sync.
+        self.simulator.run(1)
+
+        # Run until blocks are synced
+        sync2 = conn12.proto2.state.sync_agent
+        trigger = StopWhenTrue(sync2.is_synced)
+        self.assertTrue(self.simulator.run(300, trigger=trigger))
+
+        # Change manager2's max_running_time to check if it correctly closes the connection
+        # 10 < 30, so this should be strict enough that it will fail
+        sync2.max_receiving_tips = 10
+        self.assertIsNone(sync2._blk_streaming_server)
+        self.assertIsNone(sync2._tx_streaming_server)
+
+        # This should fail because the get tips should be rejected because it exceeds the limit
+        self.simulator.run(300)
+        # we should expect only the tips to be missing from the second node
+        self.assertEqual(manager1.tx_storage.get_vertices_count(),
+                         manager2.tx_storage.get_vertices_count() + mempool_tips_count)
+        # and also the second node should have aborted the connection
+        self.assertTrue(conn12.proto2.aborting)
+
     def _prepare_sync_v2_find_best_common_block_reorg(self) -> FakeConnection:
         manager1 = self.create_peer(enable_sync_v1=False, enable_sync_v2=True)
         manager1.allow_mining_without_peers()


### PR DESCRIPTION
### Motivation

Implement ability to update the full node public IP while the sync is running, as requested in the issue: resolves https://github.com/HathorNetwork/internal-issues/issues/261.

Here are the new ways of interacting with entrypoints and the hostname:

#### Sysctl `hostname` command

Get and manually set the full node's hostname. Entrypoints will automatically reflect this change, and connections will be reset.

#### Sysctl `refresh_auto_hostname` command

Automatically set the hostname to an auto discovered one. Entrypoints will automatically reflect this change, and connections will be reset.

#### Sysctl `reload_entrypoints_and_connections` command

Reload the `peer_id.json` file, replacing the entrypoints list with the new one. Then, connections will be reset.

#### `SIGUSR1` command

This is just a shortcut to the sysctl `reload_entrypoints_and_connections` command.

### Acceptance Criteria

- Remove `CliBuilder.create_peer_id()` and add `PeerId.create_from_json_path()`.
- Refactor `ConnectionsManager.listen()` so it uses the listen deferred and persists the listened addresses.
- Implement `ConnectionsManager.update_hostname_entrypoints()` and `reset_all_connections()`.
- Move `peer_id.json` file path to the `PeerId` class, with the `reload_entrypoints_from_source_file()` method.
- Add sysctl commands for getting/setting `hostname`, refreshing the auto hostname, and resetting all connections.
- Add `peer_id.json` reload in `SIGUSR1`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 