### PR TITLE
feat(cli): add argument to make sync-v1 unavailable

### DIFF
--- a/hathor/builder/__init__.py
+++ b/hathor/builder/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.builder.builder import BuildArtifacts, Builder
+from hathor.builder.builder import BuildArtifacts, Builder, SyncSupportLevel
 from hathor.builder.cli_builder import CliBuilder
 from hathor.builder.resources_builder import ResourcesBuilder
 
@@ -21,4 +21,5 @@ __all__ = [
     'Builder',
     'CliBuilder',
     'ResourcesBuilder',
+    'SyncSupportLevel',
 ]

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -131,6 +131,8 @@ class RunNode:
                                help='Enable running both sync protocols.')
         sync_args.add_argument('--sync-v1-only', action='store_true', help='Disable support for running sync-v2.')
         sync_args.add_argument('--sync-v2-only', action='store_true', help='Disable support for running sync-v1.')
+        sync_args.add_argument('--x-remove-sync-v1', action='store_true', help='Make sync-v1 unavailable, thus '
+                               'impossible to be enable in runtime.')
         sync_args.add_argument('--x-sync-v2-only', action='store_true', help=SUPPRESS)  # old argument
         sync_args.add_argument('--x-sync-bridge', action='store_true', help=SUPPRESS)  # old argument
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -65,6 +65,7 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     enable_crash_api: bool
     x_sync_bridge: bool
     x_sync_v2_only: bool
+    x_remove_sync_v1: bool
     sync_bridge: bool
     sync_v1_only: bool
     sync_v2_only: bool

--- a/tests/simulation/base.py
+++ b/tests/simulation/base.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from hathor.builder import SyncSupportLevel
 from hathor.manager import HathorManager
 from hathor.simulator import Simulator
 from hathor.types import VertexId
@@ -41,13 +42,15 @@ class SimulatorTestCase(unittest.TestCase):
                                                       'the test class or pass `enable_sync_v2` by argument')
             enable_sync_v2 = self._enable_sync_v2
         assert enable_sync_v1 or enable_sync_v2, 'enable at least one sync version'
+        sync_v1_support = SyncSupportLevel.ENABLED if enable_sync_v1 else SyncSupportLevel.DISABLED
+        sync_v2_support = SyncSupportLevel.ENABLED if enable_sync_v2 else SyncSupportLevel.DISABLED
         if simulator is None:
             simulator = self.simulator
 
         builder = simulator.get_default_builder() \
             .set_peer_id(self.get_random_peer_id_from_pool(rng=simulator.rng)) \
             .set_soft_voided_tx_ids(soft_voided_tx_ids) \
-            .set_enable_sync_v1(enable_sync_v1) \
-            .set_enable_sync_v2(enable_sync_v2)
+            .set_sync_v1_support(sync_v1_support) \
+            .set_sync_v2_support(sync_v2_support)
 
         return simulator.create_peer(builder)

--- a/tests/simulation/test_simulator_itself.py
+++ b/tests/simulation/test_simulator_itself.py
@@ -1,5 +1,6 @@
 import pytest
 
+from hathor.builder import SyncSupportLevel
 from hathor.manager import HathorManager
 from hathor.p2p.peer_id import PeerId
 from hathor.simulator import FakeConnection, Simulator
@@ -54,11 +55,13 @@ class BaseSimulatorSelfTestCase(unittest.TestCase):
                                                       'the test class or pass `enable_sync_v2` by argument')
             enable_sync_v2 = self._enable_sync_v2
         assert enable_sync_v1 or enable_sync_v2, 'enable at least one sync version'
+        sync_v1_support = SyncSupportLevel.ENABLED if enable_sync_v1 else SyncSupportLevel.DISABLED
+        sync_v2_support = SyncSupportLevel.ENABLED if enable_sync_v2 else SyncSupportLevel.DISABLED
 
         builder = simulator.get_default_builder() \
             .set_peer_id(self.get_random_peer_id_from_pool()) \
-            .set_enable_sync_v1(enable_sync_v1) \
-            .set_enable_sync_v2(enable_sync_v2)
+            .set_sync_v1_support(sync_v1_support) \
+            .set_sync_v2_support(sync_v2_support)
 
         return simulator.create_peer(builder)
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -87,6 +87,8 @@ class TestBuilder(Builder):
     def __init__(self) -> None:
         super().__init__()
         self.set_network('testnet')
+        # default builder has sync-v2 enabled for tests
+        self.enable_sync_v2()
 
     def build(self) -> BuildArtifacts:
         artifacts = super().build()


### PR DESCRIPTION
### Motivation

In preparation to phase-out sync-v1, we would benefit from having a method for starting the node without sync-v1 indexes. This PR does not go into the details of which index is used, it only makes it possible to start with a node where sync-v1 is "not available" as opposed to just "disabled"; "not available" means it cannot be enabled in runtime.

### Acceptance Criteria

- Refactor the builder/cli to make it clear to understand how each sync protocol is enabled or made available
- Add `--x-remove-sync-v1` CLI option to make sync-v1 unavailable from the start

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 