### PR TITLE
tests(verification): add missing assertions

### DIFF
--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -340,7 +340,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_sigops_output_wrapped.assert_called_once()
 
         # MergeMinedBlock methods
-        verify_pow_wrapped.assert_called_once()
+        verify_aux_pow_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify(self) -> None:
         block = self._get_valid_merge_mined_block()
@@ -389,7 +389,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_mandatory_signaling_wrapped.assert_called_once()
 
         # MergeMinedBlock methods
-        verify_pow_wrapped.assert_called_once()
+        verify_aux_pow_wrapped.assert_called_once()
 
     def test_merge_mined_block_validate_basic(self) -> None:
         block = self._get_valid_merge_mined_block()
@@ -484,7 +484,7 @@ class BaseVerificationTest(unittest.TestCase):
         verify_mandatory_signaling_wrapped.assert_called_once()
 
         # MergeMinedBlock methods
-        verify_pow_wrapped.assert_called_once()
+        verify_aux_pow_wrapped.assert_called_once()
 
     def test_transaction_verify_basic(self) -> None:
         tx = self._get_valid_tx()


### PR DESCRIPTION
### Motivation

I noticed some verification tests were incorrect by a missing assertion.

### Acceptance Criteria

- Fix wrong Mock used in assertions from `verify_pow_wrapped` to `verify_aux_pow_wrapped`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 