### PR TITLE
refactor(vertex-handler): modularize methods [part 2/2]

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -952,7 +952,7 @@ class HathorManager:
         :param fails_silently: if False will raise an exception when tx cannot be added
         :param propagate_to_peers: if True will relay the tx to other peers if it is accepted
         """
-        return self.vertex_handler.on_new_tx(
+        return self.vertex_handler.on_new_vertex(
             tx,
             quiet=quiet,
             fails_silently=fails_silently,


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/987

### Motivation

Modularize `on_new_tx()` as a prerequisite for the upcoming changes related to multiprocess verification, in order to create a new aysnc `on_new_tx()` (we should be able to duplicate the method without copying all code).

### Acceptance Criteria

- Rename `VertexHandler.on_new_tx()` to `on_new_vertex()`.
- Break `on_new_vertex()` into modularized methods, `_validate_vertex()`, `_save_and_run_consensus()`, and `_post_consensus()` (renamed from `tx_fully_validated()`).
- No behavior should change, only a couple unnecessary assertions were removed.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 