### PR TITLE
refactor(metadata): add validation property

### DIFF
--- a/tests/resources/transaction/test_mining.py
+++ b/tests/resources/transaction/test_mining.py
@@ -32,7 +32,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'received_by': [],
                 'children': [],
                 'conflict_with': [],
-                'voided_by': [],
+                'voided_by': [self._settings.PARTIALLY_VALIDATED_ID.hex()],
                 'twins': [],
                 'validation': 'initial',
                 'accumulated_weight': 1.0,
@@ -65,7 +65,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'received_by': [],
                 'children': [],
                 'conflict_with': [],
-                'voided_by': [],
+                'voided_by': [self._settings.PARTIALLY_VALIDATED_ID.hex()],
                 'twins': [],
                 'validation': 'initial',  # FIXME: change to 'full' when validations are enabled
                 'accumulated_weight': 1.0,

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -208,7 +208,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.validate_save(self.tx)
 
     def test_pre_save_validation_invalid_tx_1(self):
-        self.tx.get_metadata().validation = ValidationState.BASIC
+        self.tx.get_metadata()._validation = ValidationState.BASIC
         with self.assertRaises(AssertionError):
             # XXX: avoid using validate_save because an exception could be raised for other reasons
             self.tx_storage.save_transaction(self.tx)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -119,6 +119,7 @@ class BaseBasicWalletTest(unittest.TestCase):
         out = WalletOutputInfo(decode_address(key.address), BLOCK_REWARD, timelock=None)
         tx = w.prepare_transaction(Transaction, inputs=[], outputs=[out])
         tx.update_hash()
+        tx.get_metadata().voided_by = None
         w.on_new_tx(tx)
         utxo = w.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((tx.hash, 0))
         self.assertIsNotNone(utxo)


### PR DESCRIPTION
### Motivation

What was the motivation for the changes in this PR?

### Acceptance Criteria

- Update `TransactionMetadata.__init__()` so it is initialized with `PARTIALLY_VALIDATED_ID` in its `voided_by`.
- Rename `TransactionMetadata.validation` to a private `_validation`, creating a getter and setter called `validation` for compatibility with current code.
- Move metadata logic related to updating its `voided_by` when its `validation` is changed from `BaseTransaction` to `TransactionMetadata`, including it in the newly created property setter.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 