### PR TITLE
refactor: remove deprecated resource method from address history API

### DIFF
--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -197,7 +197,6 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         response_history = yield self.web_address_history.get(
             'thin_wallet/address_history', {
                 b'addresses[]': address.encode(),
-                b'paginate': b'true'
             }
         )
 
@@ -217,7 +216,6 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         response_history = yield self.web_address_history.get(
             'thin_wallet/address_history', {
                 b'addresses[]': address.encode(),
-                b'paginate': b'true'
             }
         )
 
@@ -248,7 +246,6 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         response_history = yield self.web_address_history.get(
             'thin_wallet/address_history', {
                 b'addresses[]': random_address.encode(),
-                b'paginate': b'true'
             }
         )
 
@@ -261,7 +258,6 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
             'thin_wallet/address_history', {
                 b'addresses[]': random_address.encode(),
                 b'hash': response_data['first_hash'].encode(),
-                b'paginate': b'true'
             }
         )
 


### PR DESCRIPTION
### Motivation

We deprecated the `address_history` API without `paginate=true` parameter on March 2020 (https://github.com/HathorNetwork/hathor-core/commit/a8ae6d86be8a04aaf8a7aae9b5ead1272303cad7). This API has low performance for addresses with many transactions and that's why it was deprecated. 

After many years, we are removing it to prevent someone from using it by mistake and consuming the full node's CPU.

### Acceptance Criteria

- Remove deprecated method resource from `address_history` API.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 