### PR TITLE
feat: add first_block to the to_json_extended method of base transaction class

### DIFF
--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -820,13 +820,12 @@ class BaseTransaction(ABC):
             'parents': [],
         }
 
-        if not self.is_block:
-            # A nano contract tx must be confirmed by one block at least
-            # to be considered "executed"
-            if meta.first_block is not None:
-                ret['first_block'] = meta.first_block.hex()
-            else:
-                ret['first_block'] = None
+        # A nano contract tx must be confirmed by one block at least
+        # to be considered "executed"
+        if meta.first_block is not None:
+            ret['first_block'] = meta.first_block.hex()
+        else:
+            ret['first_block'] = None
 
         for parent in self.parents:
             ret['parents'].append(parent.hex())

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -820,6 +820,14 @@ class BaseTransaction(ABC):
             'parents': [],
         }
 
+        if not self.is_block:
+            # A nano contract tx must be confirmed by one block at least
+            # to be considered "executed"
+            if meta.first_block is not None:
+                ret['first_block'] = meta.first_block.hex()
+            else:
+                ret['first_block'] = None
+
         for parent in self.parents:
             ret['parents'].append(parent.hex())
 

--- a/hathor/transaction/resources/dashboard.py
+++ b/hathor/transaction/resources/dashboard.py
@@ -192,7 +192,9 @@ DashboardTransactionResource.openapi = {
                                                         'script': 'dqkUixvdsajkV6vO+9Jjgjbaheqn016IrA=='
                                                     }
                                                 ],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': ('000005af290a55b079014a0be3246479'
+                                                                'e84eeb635f02010dbf3e5f3414a85bbb')
                                             },
                                             {
                                                 'tx_id': ('00035e46a20d0ecbda0dc6fdcaa243e9'
@@ -213,7 +215,9 @@ DashboardTransactionResource.openapi = {
                                                         'script': 'dqkUdNQbj29Md1xsAYinK+RsDJCCB7eIrA=='
                                                     }
                                                 ],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': ('000005af290a55b079014a0be3246479'
+                                                                'e84eeb635f02010dbf3e5f3414a85bbb')
                                             },
                                             {
                                                 'tx_id': ('000133cc80b625b1babbd454edc3474e'
@@ -234,7 +238,8 @@ DashboardTransactionResource.openapi = {
                                                         'script': 'dqkU0AoLEAX+1b36s+VyaMc9bkj/5byIrA=='
                                                     }
                                                 ],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': None
                                             }
                                         ]
                                     }

--- a/hathor/transaction/resources/dashboard.py
+++ b/hathor/transaction/resources/dashboard.py
@@ -152,7 +152,8 @@ DashboardTransactionResource.openapi = {
                                                 ],
                                                 'inputs': [],
                                                 'outputs': [],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': None,
                                             },
                                             {
                                                 'tx_id': ('00002b3be4e3876e67b5e090d76dcd71'
@@ -166,7 +167,9 @@ DashboardTransactionResource.openapi = {
                                                 ],
                                                 'inputs': [],
                                                 'outputs': [],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': ('000005af290a55b079014a0be3246479'
+                                                                'e84eeb635f02010dbf3e5f3414a85bbb')
                                             }
                                         ],
                                         'blocks': [

--- a/hathor/transaction/resources/transaction.py
+++ b/hathor/transaction/resources/transaction.py
@@ -465,6 +465,7 @@ TransactionResource.openapi = {
                                                 ],
                                                 'tokens': [],
                                                 'height': 12345,
+                                                'first_block': None
                                             },
                                             {
                                                 'tx_id': ('00000b8792cb13e8adb51cc7d866541f'
@@ -496,7 +497,9 @@ TransactionResource.openapi = {
                                                         'script': 'dqkUjjPg+zwG6JDe901I0ybQxcAPrAuIrA=='
                                                     }
                                                 ],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': ('000005af290a55b079014a0be3246479'
+                                                                'e84eeb635f02010dbf3e5f3414a85bbb')
                                             }
                                         ],
                                         'has_more': True

--- a/hathor/wallet/resources/thin_wallet/address_history.py
+++ b/hathor/wallet/resources/thin_wallet/address_history.py
@@ -321,8 +321,10 @@ AddressHistoryResource.openapi = {
                                                             },
                                                         "token": "00"
                                                         }
-                                                    ]
-                                                }
+                                                    ],
+                                                "first_block": ("000005af290a55b079014a0be3246479"
+                                                                "e84eeb635f02010dbf3e5f3414a85bbb")
+                                            }
                                         ]
                                     }
                                 },

--- a/hathor/wallet/resources/thin_wallet/token_history.py
+++ b/hathor/wallet/resources/thin_wallet/token_history.py
@@ -243,7 +243,8 @@ TokenHistoryResource.openapi = {
                                                         'script': 'dqkUjjPg+zwG6JDe901I0ybQxcAPrAuIrA=='
                                                     }
                                                 ],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': None
                                             },
                                             {
                                                 'tx_id': ('00000b8792cb13e8adb51cc7d866541f'
@@ -276,7 +277,9 @@ TokenHistoryResource.openapi = {
                                                         'script': 'dqkUjjPg+zwG6JDe901I0ybQxcAPrAuIrA=='
                                                     }
                                                 ],
-                                                'tokens': []
+                                                'tokens': [],
+                                                'first_block': ('000005af290a55b079014a0be3246479'
+                                                                'e84eeb635f02010dbf3e5f3414a85bbb')
                                             }
                                         ],
                                         'has_more': True


### PR DESCRIPTION
### Motivation

Wallet Mobile needs the ability to show a nano contract transaction "status" in the token's transaction details modal, but this "status" requires to know if a nano contract transaction was already confirmed by a block of not, thus the `first_block` as a first citizen of a transaction.

### Acceptance Criteria

- It should add `first_block` to the `to_json_extended` to BaseTransaction for transactions.
- It should update documentation in the following resources:
  - `/dashboard_tx`
  - `/transaction`
  - `/thin_wallet/address_history`
  - `/thin_wallet/token_history`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 
