### PR TITLE
fix: sorting execution manager callbacks

### DIFF
--- a/hathor/execution_manager.py
+++ b/hathor/execution_manager.py
@@ -37,7 +37,7 @@ class ExecutionManager:
 
     def _run_on_crash_callbacks(self) -> None:
         """Run all registered on crash callbacks."""
-        callbacks = sorted(self._on_crash_callbacks, reverse=True)
+        callbacks = sorted(self._on_crash_callbacks, reverse=True, key=lambda item: item[0])
 
         for _, callback in callbacks:
             try:


### PR DESCRIPTION
### Motivation

The sorting of `ExecutionManager` callbacks would fail for callbacks with the same priority, as the `Callable`s in the second sorting field are not orderable.

### Acceptance Criteria

- Fix sorting of `ExecutionManager` callbacks.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 