### PR TITLE
chore: fix codecov coverage upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,5 +101,7 @@ jobs:
       - name: Run tests
         run: poetry run make tests
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: matrix.python == 3.11 && startsWith(matrix.os, 'ubuntu')
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation

Codecov's upload task on CI broke, it used to be unstable so we suspected that was the case but apparently it is now required to use a token.

### Acceptance Criteria

- Add a secret token to the repo's settings
- Add CI config to expose the token to codecov's upload task

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 