### PR TITLE
refactor(api): prevent duplicate tx earlier

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -908,6 +908,9 @@ class HathorManager:
                 max_output_script_size: int | None = None) -> None:
         """Used by all APIs that accept a new transaction (like push_tx)
         """
+        if self.tx_storage.transaction_exists(tx.hash):
+            raise InvalidNewTransaction('Transaction already exists {}'.format(tx.hash_hex))
+
         if max_output_script_size is None:
             max_output_script_size = self._settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE
 


### PR DESCRIPTION
### Motivation

This verification has to happen anyway and doing it earlier avoids wasting time with more expensive verifications.

### Acceptance Criteria

- Check for tx existence on `HathorManager.push_tx` directly before waiting for `HathorManger.on_new_tx` to do it.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 