### PR TITLE
chore(ci): update default Python version used on docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # before changing these variables, make sure the tag $PYTHON-alpine$ALPINE exists first
 # list of valid tags hese: https://hub.docker.com/_/python
-ARG PYTHON=3.10
+ARG PYTHON=3.11
 ARG DEBIAN=bullseye
 
 # stage-0: copy pyproject.toml/poetry.lock and install the production set of dependencies

--- a/extras/github/test_docker.py
+++ b/extras/github/test_docker.py
@@ -3,6 +3,10 @@ import unittest
 
 from extras.github.docker import prep_base_version, prep_tags
 
+DEFAULT_PYTHON_VERSION = '3.11'
+NON_DEFAULT_PYTHON_VERSION = '3.10'
+
+
 class DockerWorkflowTest(unittest.TestCase):
     def setUp(self):
         os.environ.update({
@@ -17,7 +21,7 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
             'MATRIX_PYTHON_IMPL': 'python',
-            'MATRIX_PYTHON_VERSION': '3.10',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': '',
             'SECRETS_GHCR_IMAGE': '',
         })
@@ -32,7 +36,7 @@ class DockerWorkflowTest(unittest.TestCase):
         output = prep_tags(os.environ, base_version, is_release_candidate)
 
         self.assertEqual(output['slack-notification-version'], base_version)
-        self.assertEqual(output['version'], base_version + '-python3.10')
+        self.assertEqual(output['version'], base_version + f'-python{DEFAULT_PYTHON_VERSION}')
         self.assertEqual(output['login-dockerhub'], 'false')
         self.assertEqual(output['login-ghcr'], 'false')
         self.assertEqual(output['tags'], 'dont-push--local-only')
@@ -47,7 +51,7 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
             'MATRIX_PYTHON_IMPL': 'python',
-            'MATRIX_PYTHON_VERSION': '3.10',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
         })
@@ -62,12 +66,12 @@ class DockerWorkflowTest(unittest.TestCase):
         output = prep_tags(os.environ, base_version, is_release_candidate)
 
         self.assertEqual(output['slack-notification-version'], base_version)
-        self.assertEqual(output['version'], base_version + '-python3.10')
+        self.assertEqual(output['version'], base_version + f'-python{DEFAULT_PYTHON_VERSION}')
         self.assertEqual(output['login-dockerhub'], 'true')
         self.assertEqual(output['login-ghcr'], 'false')
         self.assertEqual(len(output['tags'].split(',')), 2)
         self.assertIn('mock_image:nightly-55629a7d', output['tags'].split(','))
-        self.assertIn('mock_image:nightly-55629a7d-python3.10', output['tags'].split(','))
+        self.assertIn(f'mock_image:nightly-55629a7d-python{DEFAULT_PYTHON_VERSION}', output['tags'].split(','))
         self.assertEqual(output['push'], 'true')
         self.assertEqual(output['dockerfile'], 'Dockerfile')
 
@@ -80,7 +84,7 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
             'MATRIX_PYTHON_IMPL': 'python',
-            'MATRIX_PYTHON_VERSION': '3.11',
+            'MATRIX_PYTHON_VERSION': NON_DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
         })
@@ -110,7 +114,7 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
             'MATRIX_PYTHON_IMPL': 'python',
-            'MATRIX_PYTHON_VERSION': '3.10',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
         })
@@ -140,7 +144,7 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
             'MATRIX_PYTHON_IMPL': 'python',
-            'MATRIX_PYTHON_VERSION': '3.10',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
         })
@@ -155,12 +159,12 @@ class DockerWorkflowTest(unittest.TestCase):
         output = prep_tags(os.environ, base_version, is_release_candidate)
 
         self.assertEqual(output['slack-notification-version'], base_version)
-        self.assertEqual(output['version'], base_version + '-python3.10')
+        self.assertEqual(output['version'], base_version + f'-python{DEFAULT_PYTHON_VERSION}')
         self.assertEqual(output['login-dockerhub'], 'true')
         self.assertEqual(output['login-ghcr'], 'false')
         self.assertEqual(len(output['tags'].split(',')), 4)
-        self.assertIn('mock_image:v0.53-python3.10', output['tags'].split(','))
-        self.assertIn('mock_image:v0.53.0-python3.10', output['tags'].split(','))
+        self.assertIn(f'mock_image:v0.53-python{DEFAULT_PYTHON_VERSION}', output['tags'].split(','))
+        self.assertIn(f'mock_image:v0.53.0-python{DEFAULT_PYTHON_VERSION}', output['tags'].split(','))
         self.assertIn('mock_image:v0.53.0', output['tags'].split(','))
         self.assertIn('mock_image:latest', output['tags'].split(','))
         self.assertEqual(output['push'], 'true')


### PR DESCRIPTION
### Motivation

The default has been 3.10 for a while now and it's the lowest supported version, meanwhile 3.11 has some useful performance improvements.

### Acceptance Criteria

- Change the default Python version used on Docker images from 3.10 to 3.11

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 