### PR TITLE
chore(cli): default to sync-v1 disabled

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -177,11 +177,11 @@ class CliBuilder:
 
         sync_choice: SyncChoice
         if self._args.sync_bridge:
-            self.log.warn('--sync-bridge is the default, this parameter has no effect')
             sync_choice = SyncChoice.BRIDGE
         elif self._args.sync_v1_only:
             sync_choice = SyncChoice.V1_ONLY
         elif self._args.sync_v2_only:
+            self.log.warn('--sync-v2-only is the default, this parameter has no effect')
             sync_choice = SyncChoice.V2_ONLY
         elif self._args.x_sync_bridge:
             self.log.warn('--x-sync-bridge is deprecated and will be removed, use --sync-bridge instead')
@@ -190,7 +190,8 @@ class CliBuilder:
             self.log.warn('--x-sync-v2-only is deprecated and will be removed, use --sync-v2-only instead')
             sync_choice = SyncChoice.V2_ONLY
         else:
-            sync_choice = SyncChoice.BRIDGE
+            # XXX: this is the default behavior when no parameter is given
+            sync_choice = SyncChoice.V2_ONLY
 
         enable_sync_v1: bool
         enable_sync_v2: bool

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -57,7 +57,7 @@ class BuilderTestCase(unittest.TestCase):
         self.assertIsInstance(manager.tx_storage.indexes, RocksDBIndexesManager)
         self.assertIsNone(manager.wallet)
         self.assertEqual('unittests', manager.network)
-        self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
+        self.assertFalse(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
         self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V2))
         self.assertFalse(self.resources_builder._built_prometheus)
         self.assertFalse(self.resources_builder._built_status)
@@ -103,7 +103,7 @@ class BuilderTestCase(unittest.TestCase):
 
     def test_sync_default(self):
         manager = self._build(['--memory-storage'])
-        self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
+        self.assertFalse(manager.connections.is_sync_version_enabled(SyncVersion.V1_1))
         self.assertTrue(manager.connections.is_sync_version_enabled(SyncVersion.V2))
 
     def test_sync_bridge(self):


### PR DESCRIPTION
### Motivation

As part of the sync-v2 roll out process we should have a release where sync-v1 is not enabled by default but is still fully supported.

### Acceptance Criteria

- Change the default behavior from having both sync-v1 and sync-v2 enabled to having only sync-v2 enabled but still allow sync-v1 to be enabled at runtime by default.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 