### PR TITLE
refactor(metadata): move metadata attributes to static metadata [part 2/12]

### DIFF
--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -215,7 +215,7 @@ class ResourcesBuilder:
             # mining
             (b'mining', MiningResource(self.manager), root),
             (b'getmininginfo', MiningInfoResource(self.manager), root),
-            (b'get_block_template', GetBlockTemplateResource(self.manager), root),
+            (b'get_block_template', GetBlockTemplateResource(self.manager, settings), root),
             (b'submit_block', SubmitBlockResource(self.manager), root),
             (b'tx_parents', TxParentsResource(self.manager), root),
             # /thin_wallet
@@ -281,7 +281,7 @@ class ResourcesBuilder:
                 (b'balance', BalanceResource(self.manager), wallet_resource),
                 (b'history', HistoryResource(self.manager), wallet_resource),
                 (b'address', AddressResource(self.manager), wallet_resource),
-                (b'send_tokens', SendTokensResource(self.manager), wallet_resource),
+                (b'send_tokens', SendTokensResource(self.manager, settings), wallet_resource),
                 (b'sign_tx', SignTxResource(self.manager), wallet_resource),
                 (b'unlock', UnlockWalletResource(self.manager), wallet_resource),
                 (b'lock', LockWalletResource(self.manager), wallet_resource),

--- a/hathor/consensus/poa/poa_block_producer.py
+++ b/hathor/consensus/poa/poa_block_producer.py
@@ -174,6 +174,7 @@ class PoaBlockProducer:
         from hathor.transaction.poa import PoaBlock
         block_templates = self.manager.get_block_templates(parent_block_hash=previous_block.hash)
         block = block_templates.generate_mining_block(self.manager.rng, cls=PoaBlock)
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         assert isinstance(block, PoaBlock)
 
         if block.get_height() <= self.manager.tx_storage.get_height_best_block():

--- a/hathor/feature_activation/feature_service.py
+++ b/hathor/feature_activation/feature_service.py
@@ -60,8 +60,8 @@ class FeatureService:
         Return whether a block is signaling features that are mandatory, that is, any feature currently in the
         MUST_SIGNAL phase.
         """
-        bit_counts = block.get_feature_activation_bit_counts()
-        height = block.get_height()
+        bit_counts = block.static_metadata.feature_activation_bit_counts
+        height = block.static_metadata.height
         offset_to_boundary = height % self._feature_settings.evaluation_interval
         remaining_blocks = self._feature_settings.evaluation_interval - offset_to_boundary - 1
         descriptions = self.get_bits_description(block=block)
@@ -95,7 +95,7 @@ class FeatureService:
         # All blocks within the same evaluation interval have the same state, that is, the state is only defined for
         # the block in each interval boundary. Therefore, we get the state of the previous boundary block or calculate
         # a new state if this block is a boundary block.
-        height = block.get_height()
+        height = block.static_metadata.height
         offset_to_boundary = height % self._feature_settings.evaluation_interval
         offset_to_previous_boundary = offset_to_boundary or self._feature_settings.evaluation_interval
         previous_boundary_height = height - offset_to_previous_boundary
@@ -139,7 +139,7 @@ class FeatureService:
         an AssertionError. Non-boundary blocks never calculate their own state, they get it from their parent block
         instead.
         """
-        height = boundary_block.get_height()
+        height = boundary_block.static_metadata.height
         criteria = self._feature_settings.features.get(feature)
         evaluation_interval = self._feature_settings.evaluation_interval
 
@@ -162,7 +162,7 @@ class FeatureService:
             # Get the count for this block's parent. Since this is a boundary block, its parent count represents the
             # previous evaluation interval count.
             parent_block = boundary_block.get_block_parent()
-            counts = parent_block.get_feature_activation_bit_counts()
+            counts = parent_block.static_metadata.feature_activation_bit_counts
             count = counts[criteria.bit]
             threshold = criteria.get_threshold(self._feature_settings)
 
@@ -209,8 +209,9 @@ class FeatureService:
         Given a block, return its ancestor at a specific height.
         Uses the height index if the block is in the best blockchain, or search iteratively otherwise.
         """
-        assert ancestor_height < block.get_height(), (
-            f"ancestor height must be lower than the block's height: {ancestor_height} >= {block.get_height()}"
+        assert ancestor_height < block.static_metadata.height, (
+            f"ancestor height must be lower than the block's height: "
+            f"{ancestor_height} >= {block.static_metadata.height}"
         )
 
         # It's possible that this method is called before the consensus runs for this block, therefore we do not know
@@ -219,7 +220,7 @@ class FeatureService:
         parent_metadata = parent_block.get_metadata()
         assert parent_metadata.validation.is_fully_connected(), 'The parent should always be fully validated.'
 
-        if parent_block.get_height() == ancestor_height:
+        if parent_block.static_metadata.height == ancestor_height:
             return parent_block
 
         if not parent_metadata.voided_by and (ancestor := self._tx_storage.get_block_by_height(ancestor_height)):
@@ -237,11 +238,11 @@ class FeatureService:
         # TODO: there are further optimizations to be done here, the latest common block height could be persisted in
         #  metadata, so we could still use the height index if the requested height is before that height.
         assert ancestor_height >= 0
-        assert block.get_height() - ancestor_height <= self._feature_settings.evaluation_interval, (
+        assert block.static_metadata.height - ancestor_height <= self._feature_settings.evaluation_interval, (
             'requested ancestor is deeper than the maximum allowed'
         )
         ancestor = block
-        while ancestor.get_height() > ancestor_height:
+        while ancestor.static_metadata.height > ancestor_height:
             ancestor = ancestor.get_block_parent()
 
         return ancestor

--- a/hathor/feature_activation/resources/feature.py
+++ b/hathor/feature_activation/resources/feature.py
@@ -89,7 +89,7 @@ class FeatureResource(Resource):
 
     def get_features(self) -> bytes:
         best_block = self.tx_storage.get_best_block()
-        bit_counts = best_block.get_feature_activation_bit_counts()
+        bit_counts = best_block.static_metadata.feature_activation_bit_counts
         features = []
 
         for feature, criteria in self._feature_settings.features.items():

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -449,7 +449,7 @@ class HathorManager:
             dt = LogDuration(t2 - t1)
             dcnt = cnt - cnt2
             tx_rate = '?' if dt == 0 else dcnt / dt
-            h = max(h, tx_meta.height or 0)
+            h = max(h, (tx.static_metadata.height if isinstance(tx, Block) else 0))
             if dt > 30:
                 ts_date = datetime.datetime.fromtimestamp(self.tx_storage.latest_timestamp)
                 if h == 0:
@@ -469,12 +469,10 @@ class HathorManager:
 
             try:
                 # TODO: deal with invalid tx
-                tx.calculate_height()
                 tx._update_parents_children_metadata()
 
                 if tx.can_validate_full():
                     tx.update_initial_metadata()
-                    tx.calculate_min_height()
                     if tx.is_genesis:
                         assert tx.validate_checkpoint(self.checkpoints)
                     assert self.verification_service.validate_full(
@@ -661,31 +659,32 @@ class HathorManager:
         for checkpoint in expected_checkpoints:
             # XXX: query the database from checkpoint.hash and verify what comes out
             try:
-                tx = self.tx_storage.get_transaction(checkpoint.hash)
+                block = self.tx_storage.get_block(checkpoint.hash)
             except TransactionDoesNotExist as e:
                 raise InitializationError(f'Expected checkpoint does not exist in database: {checkpoint}') from e
-            tx_meta = tx.get_metadata()
-            if tx_meta.height != checkpoint.height:
+            meta = block.get_metadata()
+            height = block.static_metadata.height
+            if height != checkpoint.height:
                 raise InitializationError(
-                    f'Expected checkpoint of hash {tx.hash_hex} to have height {checkpoint.height}, but instead it has'
-                    f'height {tx_meta.height}'
+                    f'Expected checkpoint of hash {block.hash_hex} to have height {checkpoint.height},'
+                    f'but instead it has height {height}'
                 )
-            if tx_meta.voided_by:
-                pretty_voided_by = list(i.hex() for i in tx_meta.voided_by)
+            if meta.voided_by:
+                pretty_voided_by = list(i.hex() for i in meta.voided_by)
                 raise InitializationError(
                     f'Expected checkpoint {checkpoint} to *NOT* be voided, but it is being voided by: '
                     f'{pretty_voided_by}'
                 )
             # XXX: query the height index from checkpoint.height and check that the hash matches
-            tx_hash = self.tx_storage.indexes.height.get(checkpoint.height)
-            if tx_hash is None:
+            block_hash = self.tx_storage.indexes.height.get(checkpoint.height)
+            if block_hash is None:
                 raise InitializationError(
                     f'Expected checkpoint {checkpoint} to be found in the height index, but it was not found'
                 )
-            if tx_hash != tx.hash:
+            if block_hash != block.hash:
                 raise InitializationError(
                     f'Expected checkpoint {checkpoint} to be found in the height index, but it instead the block with '
-                    f'hash {tx_hash.hex()} was found'
+                    f'hash {block_hash.hex()} was found'
                 )
 
     def get_new_tx_parents(self, timestamp: Optional[float] = None) -> list[VertexId]:

--- a/hathor/mining/block_template.py
+++ b/hathor/mining/block_template.py
@@ -80,7 +80,7 @@ class BlockTemplate(NamedTuple):
         block = cls(outputs=tx_outputs, parents=parents, timestamp=block_timestamp,
                     data=data or b'', storage=storage, weight=self.weight, signal_bits=self.signal_bits)
         if include_metadata:
-            block._metadata = TransactionMetadata(height=self.height, score=self.score)
+            block._metadata = TransactionMetadata(score=self.score)
         block.get_metadata(use_storage=False)
         return block
 

--- a/hathor/p2p/resources/mining_info.py
+++ b/hathor/p2p/resources/mining_info.py
@@ -49,8 +49,9 @@ class MiningInfoResource(Resource):
             self._settings.P2PKH_VERSION_BYTE.hex() + 'acbfb94571417423c1ed66f706730c4aea516ac5762cccb8'
         )
         block = self.manager.generate_mining_block(address=burn_address)
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
 
-        height = block.calculate_height() - 1
+        height = block.static_metadata.height - 1
         difficulty = max(int(Weight(block.weight).to_pdiff()), 1)
 
         parent = block.get_block_parent()

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -92,9 +92,8 @@ class StatusResource(Resource):
 
         best_block_tips = []
         for tip in self.manager.tx_storage.get_best_block_tips():
-            tx = self.manager.tx_storage.get_transaction(tip)
-            meta = tx.get_metadata()
-            best_block_tips.append({'hash': tx.hash_hex, 'height': meta.height})
+            block = self.manager.tx_storage.get_block(tip)
+            best_block_tips.append({'hash': block.hash_hex, 'height': block.static_metadata.height})
 
         best_block = self.manager.tx_storage.get_best_block()
         raw_best_blockchain = self.manager.tx_storage.get_n_height_tips(self._settings.DEFAULT_BEST_BLOCKCHAIN_BLOCKS)
@@ -122,7 +121,7 @@ class StatusResource(Resource):
                 'best_block_tips': best_block_tips,
                 'best_block': {
                     'hash': best_block.hash_hex,
-                    'height': best_block.get_metadata().height,
+                    'height': best_block.static_metadata.height,
                 },
                 'best_blockchain': best_blockchain,
             }

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -42,7 +42,7 @@ from hathor.transaction import BaseTransaction, Block, Transaction
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.transaction.vertex_parser import VertexParser
 from hathor.types import VertexId
-from hathor.util import collect_n, not_none
+from hathor.util import collect_n
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
@@ -846,7 +846,7 @@ class NodeBlockSync(SyncAgent):
         assert meta.validation.is_fully_connected()
         payload = BestBlockPayload(
             block=best_block.hash,
-            height=not_none(meta.height),
+            height=best_block.static_metadata.height,
         )
         self.send_message(ProtocolMessages.BEST_BLOCK, payload.json())
 

--- a/hathor/p2p/sync_v2/streamers.py
+++ b/hathor/p2p/sync_v2/streamers.py
@@ -296,8 +296,8 @@ class TransactionsStreamingServer(_StreamingServerBase):
         # Check if tx is confirmed by the `self.current_block` or any next block.
         assert cur_metadata.first_block is not None
         assert self.current_block is not None
-        first_block = self.tx_storage.get_transaction(cur_metadata.first_block)
-        if not_none(first_block.get_metadata().height) < not_none(self.current_block.get_metadata().height):
+        first_block = self.tx_storage.get_block(cur_metadata.first_block)
+        if not_none(first_block.static_metadata.height) < not_none(self.current_block.static_metadata.height):
             self.log.debug('skipping tx: out of current block')
             self.bfs.skip_neighbors(cur)
             return

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -674,6 +674,7 @@ class StratumProtocol(JSONRPC):
         data = data[:self._settings.BLOCK_DATA_MAX_SIZE]
         block = self.manager.generate_mining_block(data=data, address=self.miner_address,
                                                    merge_mined=self.merged_mining)
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         self.log.debug('prepared block for mining', block=block)
         return block
 

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -24,7 +24,7 @@ from enum import IntEnum
 from itertools import chain
 from math import inf, isfinite, log
 from struct import error as StructError, pack
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Iterator, Optional, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Iterator, Optional, TypeAlias, TypeVar
 
 from structlog import get_logger
 
@@ -280,14 +280,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
     def __hash__(self) -> int:
         return hash(self.hash)
-
-    @abstractmethod
-    def calculate_height(self) -> int:
-        raise NotImplementedError
-
-    @abstractmethod
-    def calculate_min_height(self) -> int:
-        raise NotImplementedError
 
     @property
     def hash(self) -> VertexId:
@@ -633,20 +625,12 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
             metadata = self.storage.get_metadata(self.hash)
             self._metadata = metadata
         if not metadata:
-            # FIXME: there is code that set use_storage=False but relies on correct height being calculated
-            #        which requires the use of a storage, this is a workaround that should be fixed, places where this
-            #        happens include generating new mining blocks and some tests
-            height = self.calculate_height() if self.storage else None
             score = self.weight if self.is_genesis else 0
-            min_height = 0 if self.is_genesis else None
-
             metadata = TransactionMetadata(
                 settings=self._settings,
                 hash=self._hash,
                 accumulated_weight=self.weight,
-                height=height,
                 score=score,
-                min_height=min_height
             )
             self._metadata = metadata
         if not metadata.hash:
@@ -671,8 +655,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
             self._metadata.validation = ValidationState.INITIAL
             self._metadata.voided_by = {self._settings.PARTIALLY_VALIDATED_ID}
         self._metadata._tx_ref = weakref.ref(self)
-
-        self._update_height_metadata()
 
         self.storage.save_transaction(self, only_metadata=True)
 
@@ -727,27 +709,11 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         It is called when a new transaction/block is received by HathorManager.
         """
-        self._update_height_metadata()
         self._update_parents_children_metadata()
-        self.update_reward_lock_metadata()
-        self._update_feature_activation_bit_counts()
         self._update_initial_accumulated_weight()
         if save:
             assert self.storage is not None
             self.storage.save_transaction(self, only_metadata=True)
-
-    def _update_height_metadata(self) -> None:
-        """Update the vertice height metadata."""
-        meta = self.get_metadata()
-        meta.height = self.calculate_height()
-
-    def update_reward_lock_metadata(self) -> None:
-        """Update the txs/block min_height metadata."""
-        metadata = self.get_metadata()
-        min_height = self.calculate_min_height()
-        if metadata.min_height is not None:
-            assert metadata.min_height == min_height
-        metadata.min_height = min_height
 
     def _update_parents_children_metadata(self) -> None:
         """Update the txs/block parent's children metadata."""
@@ -759,15 +725,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
             if self.hash not in metadata.children:
                 metadata.children.append(self.hash)
                 self.storage.save_transaction(parent, only_metadata=True)
-
-    def _update_feature_activation_bit_counts(self) -> None:
-        """Update the block's feature_activation_bit_counts."""
-        if not self.is_block:
-            return
-        from hathor.transaction import Block
-        assert isinstance(self, Block)
-        # This method lazily calculates and stores the value in metadata
-        cast(Block, self).get_feature_activation_bit_counts()
 
     def _update_initial_accumulated_weight(self) -> None:
         """Update the vertex initial accumulated_weight."""
@@ -911,22 +868,26 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         return self._static_metadata
 
     @abstractmethod
-    def init_static_metadata_from_storage(self, storage: 'TransactionStorage') -> None:
+    def init_static_metadata_from_storage(self, settings: HathorSettings, storage: 'TransactionStorage') -> None:
         """Initialize this vertex's static metadata using dependencies from a storage. This can be called multiple
-        times, provided the dependencies don't change."""
+        times, provided the dependencies don't change. Also, this must be fast, ideally O(1)."""
         raise NotImplementedError
 
     def set_static_metadata(self, static_metadata: StaticMetadataT | None) -> None:
         """Set this vertex's static metadata. After it's set, it can only be set again to the same value."""
-        assert not self._static_metadata or self._static_metadata == static_metadata, (
-            'trying to set static metadata with different values'
-        )
+        if self._static_metadata is not None:
+            assert self._static_metadata == static_metadata, 'trying to set static metadata with different values'
+            self.log.warn(
+                'redundant call on set_static_metadata', vertex_id=self.hash_hex, static_metadata=static_metadata
+            )
+
         self._static_metadata = static_metadata
 
 
 """
 Type aliases for easily working with `GenericVertex`. A `Vertex` is a superclass that includes all specific
-vertex subclasses, and a `BaseTransaction` is simply an alias to `Vertex` for backwards compatibility.
+vertex subclasses, and a `BaseTransaction` is simply an alias to `Vertex` for backwards compatibility (it can be
+removed in the future).
 """
 Vertex: TypeAlias = GenericVertex[VertexStaticMetadata]
 BaseTransaction: TypeAlias = Vertex

--- a/hathor/transaction/resources/decode_tx.py
+++ b/hathor/transaction/resources/decode_tx.py
@@ -16,6 +16,7 @@ import struct
 
 from hathor.api_util import Resource, get_args, get_missing_params_msg, parse_args, set_cors
 from hathor.cli.openapi_files.register import register_resource
+from hathor.conf.get_settings import get_global_settings
 from hathor.transaction.resources.transaction import get_tx_extra_data
 from hathor.util import json_dumpb
 
@@ -33,6 +34,7 @@ class DecodeTxResource(Resource):
     def __init__(self, manager):
         # Important to have the manager so we can know the tx_storage
         self.manager = manager
+        self._settings = get_global_settings()
 
     def render_GET(self, request):
         """ Get request /decode_tx/ that returns the tx decoded, if success
@@ -51,6 +53,7 @@ class DecodeTxResource(Resource):
         try:
             tx_bytes = bytes.fromhex(parsed['args']['hex_tx'])
             tx = self.manager.vertex_parser.deserialize(tx_bytes)
+            tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
             tx.storage = self.manager.tx_storage
             data = get_tx_extra_data(tx)
         except ValueError:

--- a/hathor/transaction/resources/transaction.py
+++ b/hathor/transaction/resources/transaction.py
@@ -28,6 +28,7 @@ from hathor.api_util import (
 )
 from hathor.cli.openapi_files.register import register_resource
 from hathor.conf.get_settings import get_global_settings
+from hathor.transaction import Block
 from hathor.transaction.base_transaction import BaseTransaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.util import json_dumpb
@@ -70,9 +71,9 @@ def get_tx_extra_data(
     # To get the updated accumulated weight just need to call the
     # TransactionAccumulatedWeightResource (/transaction_acc_weight)
 
-    if tx.is_block:
+    if isinstance(tx, Block):
         # For blocks we need to add the height
-        serialized['height'] = meta.height
+        serialized['height'] = tx.static_metadata.height
 
     # In the metadata we have the spent_outputs, that are the txs that spent the outputs for each index
     # However we need to send also which one of them is not voided

--- a/hathor/transaction/static_metadata.py
+++ b/hathor/transaction/static_metadata.py
@@ -12,15 +12,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 from abc import ABC
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from itertools import chain, starmap, zip_longest
+from operator import add
+from typing import TYPE_CHECKING, Callable
 
+from typing_extensions import Self
+
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.model.feature_state import FeatureState
+from hathor.types import VertexId
 from hathor.util import json_dumpb, json_loadb
 
 if TYPE_CHECKING:
-    from hathor.transaction import BaseTransaction
+    from hathor.conf.settings import HathorSettings
+    from hathor.transaction import BaseTransaction, Block, Transaction
+    from hathor.transaction.storage import TransactionStorage
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -32,6 +43,10 @@ class VertexStaticMetadata(ABC):
     This class is an abstract base class for all static metadata types that includes attributes common to all vertex
     types.
     """
+
+    # XXX: this is only used to defer the reward-lock verification from the transaction spending a reward to the first
+    # block that confirming this transaction, it is important to always have this set to be able to distinguish an old
+    # metadata (that does not have this calculated, from a tx with a new format that does have this calculated)
     min_height: int
 
     def to_bytes(self) -> bytes:
@@ -56,9 +71,185 @@ class VertexStaticMetadata(ABC):
 @dataclass(slots=True, frozen=True, kw_only=True)
 class BlockStaticMetadata(VertexStaticMetadata):
     height: int
+
+    # A list of feature activation bit counts.
+    # Each list index corresponds to a bit position, and its respective value is the rolling count of active bits from
+    # the previous boundary block up to this block, including it. LSB is on the left.
     feature_activation_bit_counts: list[int]
+
+    # A dict of features in the feature activation process and their respective state.
+    feature_states: dict[Feature, FeatureState]
+
+    @classmethod
+    def create_from_storage(cls, block: 'Block', settings: HathorSettings, storage: 'TransactionStorage') -> Self:
+        """Create a `BlockStaticMetadata` using dependencies provided by a storage."""
+        return cls.create(block, settings, storage.get_vertex)
+
+    @classmethod
+    def create(
+        cls,
+        block: 'Block',
+        settings: HathorSettings,
+        vertex_getter: Callable[[VertexId], 'BaseTransaction']
+    ) -> Self:
+        """Create a `BlockStaticMetadata` using dependencies provided by a `vertex_getter`.
+        This must be fast, ideally O(1)."""
+        height = cls._calculate_height(block, vertex_getter)
+        min_height = cls._calculate_min_height(block, vertex_getter)
+        feature_activation_bit_counts = cls._calculate_feature_activation_bit_counts(
+            block,
+            height,
+            settings,
+            vertex_getter,
+        )
+
+        return cls(
+            height=height,
+            min_height=min_height,
+            feature_activation_bit_counts=feature_activation_bit_counts,
+            feature_states={},  # This will be populated in the next PR
+        )
+
+    @staticmethod
+    def _calculate_height(block: 'Block', vertex_getter: Callable[[VertexId], 'BaseTransaction']) -> int:
+        """Return the height of the block, i.e., the number of blocks since genesis"""
+        if block.is_genesis:
+            return 0
+
+        from hathor.transaction import Block
+        parent_hash = block.get_block_parent_hash()
+        parent_block = vertex_getter(parent_hash)
+        assert isinstance(parent_block, Block)
+        return parent_block.static_metadata.height + 1
+
+    @staticmethod
+    def _calculate_min_height(block: 'Block', vertex_getter: Callable[[VertexId], 'BaseTransaction']) -> int:
+        """The minimum height the next block needs to have, basically the maximum min-height of this block's parents.
+        """
+        # maximum min-height of any parent tx
+        min_height = 0
+        for tx_hash in block.get_tx_parents():
+            tx = vertex_getter(tx_hash)
+            min_height = max(min_height, tx.static_metadata.min_height)
+
+        return min_height
+
+    @classmethod
+    def _calculate_feature_activation_bit_counts(
+        cls,
+        block: 'Block',
+        height: int,
+        settings: HathorSettings,
+        vertex_getter: Callable[[VertexId], 'BaseTransaction'],
+    ) -> list[int]:
+        """
+        Lazily calculates the feature_activation_bit_counts metadata attribute, which is a list of feature activation
+        bit counts. After it's calculated for the first time, it's persisted in block metadata and must not be changed.
+
+        Each list index corresponds to a bit position, and its respective value is the rolling count of active bits
+        from the previous boundary block up to this block, including it. LSB is on the left.
+        """
+        previous_counts = cls._get_previous_feature_activation_bit_counts(block, height, settings, vertex_getter)
+        bit_list = block._get_feature_activation_bit_list()
+
+        count_and_bit_pairs = zip_longest(previous_counts, bit_list, fillvalue=0)
+        updated_counts = starmap(add, count_and_bit_pairs)
+        return list(updated_counts)
+
+    @staticmethod
+    def _get_previous_feature_activation_bit_counts(
+        block: 'Block',
+        height: int,
+        settings: HathorSettings,
+        vertex_getter: Callable[[VertexId], 'BaseTransaction'],
+    ) -> list[int]:
+        """
+        Returns the feature_activation_bit_counts metadata attribute from the parent block,
+        or no previous counts if this is a boundary block.
+        """
+        evaluation_interval = settings.FEATURE_ACTIVATION.evaluation_interval
+        is_boundary_block = height % evaluation_interval == 0
+
+        if is_boundary_block:
+            return []
+
+        from hathor.transaction import Block
+        parent_hash = block.get_block_parent_hash()
+        parent_block = vertex_getter(parent_hash)
+        assert isinstance(parent_block, Block)
+
+        return parent_block.static_metadata.feature_activation_bit_counts
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class TransactionStaticMetadata(VertexStaticMetadata):
-    pass
+    @classmethod
+    def create_from_storage(cls, tx: 'Transaction', settings: HathorSettings, storage: 'TransactionStorage') -> Self:
+        """Create a `TransactionStaticMetadata` using dependencies provided by a storage."""
+        return cls.create(tx, settings, storage.get_vertex)
+
+    @classmethod
+    def create(
+        cls,
+        tx: 'Transaction',
+        settings: HathorSettings,
+        vertex_getter: Callable[[VertexId], 'BaseTransaction'],
+    ) -> Self:
+        """Create a `TransactionStaticMetadata` using dependencies provided by a `vertex_getter`.
+        This must be fast, ideally O(1)."""
+        min_height = cls._calculate_min_height(
+            tx,
+            settings,
+            vertex_getter=vertex_getter,
+        )
+
+        return cls(
+            min_height=min_height
+        )
+
+    @classmethod
+    def _calculate_min_height(
+        cls,
+        tx: 'Transaction',
+        settings: HathorSettings,
+        vertex_getter: Callable[[VertexId], 'BaseTransaction'],
+    ) -> int:
+        """Calculates the min height the first block confirming this tx needs to have for reward lock verification."""
+        if tx.is_genesis:
+            return 0
+
+        return max(
+            # 1) don't drop the min height of any parent tx or input tx
+            cls._calculate_inherited_min_height(tx, vertex_getter),
+            # 2) include the min height for any reward being spent
+            cls._calculate_my_min_height(tx, settings, vertex_getter),
+        )
+
+    @staticmethod
+    def _calculate_inherited_min_height(
+        tx: 'Transaction',
+        vertex_getter: Callable[[VertexId], 'BaseTransaction']
+    ) -> int:
+        """ Calculates min height inherited from any input or parent"""
+        min_height = 0
+        iter_parents = tx.get_tx_parents()
+        iter_inputs = (tx_input.tx_id for tx_input in tx.inputs)
+        for vertex_id in chain(iter_parents, iter_inputs):
+            vertex = vertex_getter(vertex_id)
+            min_height = max(min_height, vertex.static_metadata.min_height)
+        return min_height
+
+    @staticmethod
+    def _calculate_my_min_height(
+        tx: 'Transaction',
+        settings: HathorSettings,
+        vertex_getter: Callable[[VertexId], 'BaseTransaction'],
+    ) -> int:
+        """ Calculates min height derived from own spent block rewards"""
+        from hathor.transaction import Block
+        min_height = 0
+        for tx_input in tx.inputs:
+            spent_tx = vertex_getter(tx_input.tx_id)
+            if isinstance(spent_tx, Block):
+                min_height = max(min_height, spent_tx.static_metadata.height + settings.REWARD_SPEND_MIN_BLOCKS + 1)
+        return min_height

--- a/hathor/transaction/storage/cache_storage.py
+++ b/hathor/transaction/storage/cache_storage.py
@@ -15,6 +15,7 @@
 from collections import OrderedDict
 from typing import Any, Iterator, Optional
 
+from structlog.stdlib import BoundLogger
 from twisted.internet import threads
 from typing_extensions import override
 
@@ -22,7 +23,6 @@ from hathor.conf.settings import HathorSettings
 from hathor.indexes import IndexesManager
 from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction
-from hathor.transaction.static_metadata import VertexStaticMetadata
 from hathor.transaction.storage.migrations import MigrationState
 from hathor.transaction.storage.transaction_storage import BaseTransactionStorage
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope
@@ -170,10 +170,6 @@ class TransactionCacheStorage(BaseTransactionStorage):
     def _save_static_metadata(self, tx: BaseTransaction) -> None:
         self.store._save_static_metadata(tx)
 
-    @override
-    def _get_static_metadata(self, vertex: BaseTransaction) -> VertexStaticMetadata | None:
-        return self.store._get_static_metadata(vertex)
-
     def get_all_genesis(self) -> set[BaseTransaction]:
         return self.store.get_all_genesis()
 
@@ -255,3 +251,7 @@ class TransactionCacheStorage(BaseTransactionStorage):
 
     def flush(self):
         self._flush_to_storage(self.dirty_txs.copy())
+
+    @override
+    def migrate_static_metadata(self, log: BoundLogger) -> None:
+        return self.store.migrate_static_metadata(log)

--- a/hathor/transaction/storage/migrations/migrate_static_metadata.py
+++ b/hathor/transaction/storage/migrations/migrate_static_metadata.py
@@ -1,0 +1,67 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+
+from hathor.conf.get_settings import get_global_settings
+from hathor.transaction import Block, Transaction
+from hathor.transaction.static_metadata import BlockStaticMetadata, TransactionStaticMetadata
+from hathor.transaction.storage.migrations import BaseMigration
+from hathor.util import progress
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage import TransactionStorage
+
+logger = get_logger()
+
+
+class Migration(BaseMigration):
+    def skip_empty_db(self) -> bool:
+        return True
+
+    def get_db_name(self) -> str:
+        return 'migrate_static_metadata'
+
+    def run(self, storage: 'TransactionStorage') -> None:
+        """This migration takes attributes from existing vertex metadata and saves them as static metadata."""
+        log = logger.new()
+        settings = get_global_settings()
+
+        # First we migrate static metadata using the storage itself since it uses internal structures.
+        log.info('creating static metadata...')
+        storage.migrate_static_metadata(log)
+
+        # Now that static metadata is set, we can use the topological iterator normally
+        log.info('removing old metadata and validating...')
+        topological_iter = storage.topological_iterator()
+
+        for vertex in progress(topological_iter, log=log, total=None):
+            # We re-save the vertex's metadata so it's serialized with the new `to_bytes()` method, excluding fields
+            # that were migrated.
+            storage.save_transaction(vertex, only_metadata=True)
+
+            # We re-create the static metadata from scratch and compare it with the value that was created by the
+            # migration above, as a sanity check.
+            if isinstance(vertex, Block):
+                assert vertex.static_metadata == BlockStaticMetadata.create_from_storage(
+                    vertex, settings, storage
+                )
+            elif isinstance(vertex, Transaction):
+                assert vertex.static_metadata == TransactionStaticMetadata.create_from_storage(
+                    vertex, settings, storage
+                )
+            else:
+                raise NotImplementedError

--- a/hathor/transaction/storage/migrations/remove_first_nop_features.py
+++ b/hathor/transaction/storage/migrations/remove_first_nop_features.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from structlog import get_logger
 
 from hathor.conf.get_settings import get_global_settings
+from hathor.transaction import Block
 from hathor.transaction.storage.migrations import BaseMigration
 from hathor.util import progress
 
@@ -48,11 +49,10 @@ class Migration(BaseMigration):
         topological_iterator = storage.topological_iterator()
 
         for vertex in progress(topological_iterator, log=log, total=None):
-            if vertex.is_block:
+            if isinstance(vertex, Block):
                 meta = vertex.get_metadata()
-                assert meta.height is not None
                 # This is the start_height of the **second** Phased Testing, so we clear anything before it.
-                if meta.height < 3_386_880:
+                if vertex.static_metadata.height < 3_386_880:
                     meta.feature_states = None
 
                     storage.save_transaction(vertex, only_metadata=True)

--- a/hathor/transaction/transaction_metadata.py
+++ b/hathor/transaction/transaction_metadata.py
@@ -21,7 +21,7 @@ from hathor.conf.get_settings import get_global_settings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.transaction.validation_state import ValidationState
-from hathor.util import practically_equal
+from hathor.util import json_dumpb, json_loadb, practically_equal
 
 if TYPE_CHECKING:
     from weakref import ReferenceType  # noqa: F401
@@ -43,17 +43,7 @@ class TransactionMetadata:
     accumulated_weight: float
     score: float
     first_block: Optional[bytes]
-    height: Optional[int]
     validation: ValidationState
-    # XXX: this is only used to defer the reward-lock verification from the transaction spending a reward to the first
-    # block that confirming this transaction, it is important to always have this set to be able to distinguish an old
-    # metadata (that does not have this calculated, from a tx with a new format that does have this calculated)
-    min_height: Optional[int]
-
-    # A list of feature activation bit counts. Must only be used by Blocks, is None otherwise.
-    # Each list index corresponds to a bit position, and its respective value is the rolling count of active bits from
-    # the previous boundary block up to this block, including it. LSB is on the left.
-    feature_activation_bit_counts: Optional[list[int]]
 
     # A dict of features in the feature activation process and their respective state. Must only be used by Blocks,
     # is None otherwise. This is only used for caching, so it can be safely cleared up, as it would be recalculated
@@ -72,9 +62,6 @@ class TransactionMetadata:
         hash: Optional[bytes] = None,
         accumulated_weight: float = 0,
         score: float = 0,
-        height: Optional[int] = None,
-        min_height: Optional[int] = None,
-        feature_activation_bit_counts: Optional[list[int]] = None,
         settings: HathorSettings | None = None,
     ) -> None:
         from hathor.transaction.genesis import is_genesis
@@ -122,16 +109,8 @@ class TransactionMetadata:
         # If two blocks verify the same parent block and have the same score, both are valid.
         self.first_block = None
 
-        # Height
-        self.height = height
-
-        # Min height
-        self.min_height = min_height
-
         # Validation
         self.validation = ValidationState.INITIAL
-
-        self.feature_activation_bit_counts = feature_activation_bit_counts
 
         settings = settings or get_global_settings()
 
@@ -196,7 +175,7 @@ class TransactionMetadata:
             return False
         for field in ['hash', 'conflict_with', 'voided_by', 'received_by', 'children',
                       'accumulated_weight', 'twins', 'score', 'first_block', 'validation',
-                      'min_height', 'feature_activation_bit_counts', 'feature_states']:
+                      'feature_states']:
             if (getattr(self, field) or None) != (getattr(other, field) or None):
                 return False
 
@@ -229,9 +208,19 @@ class TransactionMetadata:
         data['twins'] = [x.hex() for x in self.twins]
         data['accumulated_weight'] = self.accumulated_weight
         data['score'] = self.score
-        data['height'] = self.height
-        data['min_height'] = self.min_height
-        data['feature_activation_bit_counts'] = self.feature_activation_bit_counts
+
+        vertex = self.get_tx()
+        data['min_height'] = vertex.static_metadata.min_height
+
+        from hathor.transaction import Block
+        if isinstance(vertex, Block):
+            data['height'] = vertex.static_metadata.height
+            data['feature_activation_bit_counts'] = vertex.static_metadata.feature_activation_bit_counts
+        else:
+            # TODO: This is kept here backwards compatibility with transactions,
+            #  but should be removed in the future.
+            data['height'] = 0
+            data['feature_activation_bit_counts'] = []
 
         if self.feature_states is not None:
             data['feature_states'] = {feature.value: state.value for feature, state in self.feature_states.items()}
@@ -247,8 +236,8 @@ class TransactionMetadata:
         data = self.to_json()
         first_block_height: Optional[int]
         if self.first_block is not None:
-            first_block = tx_storage.get_transaction(self.first_block)
-            first_block_height = first_block.get_metadata().height
+            first_block = tx_storage.get_block(self.first_block)
+            first_block_height = first_block.static_metadata.height
         else:
             first_block_height = None
         data['first_block_height'] = first_block_height
@@ -281,9 +270,6 @@ class TransactionMetadata:
 
         meta.accumulated_weight = data['accumulated_weight']
         meta.score = data.get('score', 0)
-        meta.height = data.get('height', 0)  # XXX: should we calculate the height if it's not defined?
-        meta.min_height = data.get('min_height')
-        meta.feature_activation_bit_counts = data.get('feature_activation_bit_counts', [])
 
         feature_states_raw = data.get('feature_states')
         if feature_states_raw:
@@ -300,6 +286,29 @@ class TransactionMetadata:
         meta.validation = ValidationState.from_name(_val_name) if _val_name is not None else ValidationState.INITIAL
 
         return meta
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> 'TransactionMetadata':
+        """Deserialize a TransactionMetadata instance from bytes."""
+        return cls.create_from_json(json_loadb(data))
+
+    def to_bytes(self) -> bytes:
+        """Serialize a TransactionMetadata instance to bytes. This should be used for storage."""
+        json_dict = self.to_json()
+
+        # The `to_json()` method includes these fields for backwards compatibility with APIs, but since they're not
+        # part of metadata, they should not be serialized.
+        if 'height' in json_dict:
+            del json_dict['height']
+        if 'min_height' in json_dict:
+            del json_dict['min_height']
+        if 'feature_activation_bit_counts' in json_dict:
+            del json_dict['feature_activation_bit_counts']
+        # TODO: This one has not been migrated yet, but will be in the next PR
+        # if 'feature_states' in json_dict:
+        #     del json_dict['feature_states']
+
+        return json_dumpb(json_dict)
 
     def clone(self) -> 'TransactionMetadata':
         """Return exact copy without sharing memory.

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -478,9 +478,9 @@ def _tx_progress(iter_tx: Iterator['BaseTransaction'], *, log: 'structlog.stdlib
             log.warn('iterator was slow to yield', took_sec=dt_next)
 
         # XXX: this is only informative and made to work with either partially/fully validated blocks/transactions
-        meta = tx.get_metadata()
-        if meta.height:
-            h = max(h, meta.height)
+        from hathor.transaction import Block
+        if isinstance(tx, Block):
+            h = max(h, tx.static_metadata.height)
         ts_tx = max(ts_tx, tx.timestamp)
 
         t_log = time.time()

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -43,11 +43,10 @@ class BlockVerifier:
 
     def verify_height(self, block: Block) -> None:
         """Validate that the block height is enough to confirm all transactions being confirmed."""
-        meta = block.get_metadata()
-        assert meta.height is not None
-        assert meta.min_height is not None
-        if meta.height < meta.min_height:
-            raise RewardLocked(f'Block needs {meta.min_height} height but has {meta.height}')
+        height = block.static_metadata.height
+        min_height = block.static_metadata.min_height
+        if height < min_height:
+            raise RewardLocked(f'Block needs {min_height} height but has {height}')
 
     def verify_weight(self, block: Block) -> None:
         """Validate minimum block difficulty."""

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -178,14 +178,13 @@ class TransactionVerifier:
         if info is not None:
             raise RewardLocked(f'Reward {info.block_hash.hex()} still needs {info.blocks_needed} to be unlocked.')
 
-        meta = tx.get_metadata()
-        assert meta.min_height is not None
+        min_height = tx.static_metadata.min_height
         # We use +1 here because a tx is valid if it can be confirmed by the next block
-        if best_height + 1 < meta.min_height:
+        if best_height + 1 < min_height:
             if assert_min_height_verification:
                 raise AssertionError('a new tx should never be invalid by its inherited min_height.')
             raise RewardLocked(
-                f'Tx {tx.hash_hex} has min_height={meta.min_height}, but the best_height={best_height}.'
+                f'Tx {tx.hash_hex} has min_height={min_height}, but the best_height={best_height}.'
             )
 
     def verify_number_of_inputs(self, tx: Transaction) -> None:

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -62,15 +62,19 @@ class VerificationService:
         *,
         skip_block_weight_verification: bool = False,
         sync_checkpoints: bool = False,
-        reject_locked_reward: bool = True
+        reject_locked_reward: bool = True,
+        init_static_metadata: bool = True,
     ) -> bool:
         """ Run full validations (these need access to all dependencies) and update the validation state.
 
         If no exception is raised, the ValidationState will end up as `FULL` or `CHECKPOINT_FULL` and return `True`.
         """
+        assert self._tx_storage is not None
         from hathor.transaction.transaction_metadata import ValidationState
 
         meta = vertex.get_metadata()
+        if init_static_metadata:
+            vertex.init_static_metadata_from_storage(self._settings, self._tx_storage)
 
         # skip full validation when it is a checkpoint
         if meta.validation.is_checkpoint():

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -153,8 +153,6 @@ class VertexHandler:
 
         if not metadata.validation.is_fully_connected():
             try:
-                # TODO: Remove this from here after a refactor in metadata initialization
-                vertex.update_reward_lock_metadata()
                 self._verification_service.validate_full(vertex, reject_locked_reward=reject_locked_reward)
             except HathorError as e:
                 if not fails_silently:
@@ -191,7 +189,8 @@ class VertexHandler:
         assert self._verification_service.validate_full(
             vertex,
             skip_block_weight_verification=True,
-            reject_locked_reward=reject_locked_reward
+            reject_locked_reward=reject_locked_reward,
+            init_static_metadata=False,
         )
         self._tx_storage.indexes.update(vertex)
         if self._tx_storage.indexes.mempool_tips:

--- a/hathor/wallet/resources/thin_wallet/send_tokens.py
+++ b/hathor/wallet/resources/thin_wallet/send_tokens.py
@@ -270,7 +270,7 @@ class SendTokensResource(Resource):
         if context.should_stop_mining_thread:
             raise CancelledError()
         context.tx.update_hash()
-        context.tx.update_reward_lock_metadata()
+        context.tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         self.manager.verification_service.verify(context.tx)
         return context
 

--- a/tests/feature_activation/test_feature_service.py
+++ b/tests/feature_activation/test_feature_service.py
@@ -82,6 +82,7 @@ def storage() -> TransactionStorage:
         block = Block(signal_bits=bits, parents=[parent.hash], storage=storage)
         block.update_hash()
         block.get_metadata().validation = ValidationState.FULL
+        block.init_static_metadata_from_storage(get_global_settings(), storage)
         storage.save_transaction(block)
         indexes.height.add_new(height, block.hash, block.timestamp)
 

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -228,7 +228,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             non_signaling_block = manager.generate_mining_block()
             manager.cpu_mining_service.resolve(non_signaling_block)
             non_signaling_block.signal_bits = 0b10
-            non_signaling_block.update_reward_lock_metadata()
+            non_signaling_block.init_static_metadata_from_storage(settings, manager.tx_storage)
 
             with pytest.raises(BlockMustSignalError):
                 manager.verification_service.verify(non_signaling_block)

--- a/tests/feature_activation/test_mining_simulation.py
+++ b/tests/feature_activation/test_mining_simulation.py
@@ -70,7 +70,7 @@ class BaseMiningSimulationTest(SimulatorTestCase):
         miner.start()
 
         # There are 3 resources available for miners, and all of them should contain the correct signal_bits
-        get_block_template_resource = GetBlockTemplateResource(manager)
+        get_block_template_resource = GetBlockTemplateResource(manager, settings)
         get_block_template_client = StubSite(get_block_template_resource)
 
         mining_resource = MiningResource(manager)

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -711,8 +711,8 @@ class SyncV2HathorSyncMethodsTestCase(unittest.SyncV2Params, BaseHathorSyncMetho
             conn.run_one_step(debug=False)
             self.clock.advance(0.1)
 
-        self.assertEqual(self.manager1.tx_storage.get_best_block().get_metadata().height, TOTAL_BLOCKS)
-        self.assertEqual(manager2.tx_storage.get_best_block().get_metadata().height, TOTAL_BLOCKS)
+        self.assertEqual(self.manager1.tx_storage.get_best_block().static_metadata.height, TOTAL_BLOCKS)
+        self.assertEqual(manager2.tx_storage.get_best_block().static_metadata.height, TOTAL_BLOCKS)
 
         node_sync1 = conn.proto1.state.sync_agent
         node_sync2 = conn.proto2.state.sync_agent

--- a/tests/poa/test_poa.py
+++ b/tests/poa/test_poa.py
@@ -26,6 +26,7 @@ from hathor.crypto.util import get_address_b58_from_public_key, get_private_key_
 from hathor.transaction import Block, TxOutput
 from hathor.transaction.exceptions import PoaValidationError
 from hathor.transaction.poa import PoaBlock
+from hathor.transaction.static_metadata import BlockStaticMetadata
 from hathor.verification.poa_block_verifier import PoaBlockVerifier
 
 
@@ -107,8 +108,14 @@ def test_verify_poa() -> None:
         weight=poa.BLOCK_WEIGHT_IN_TURN,
         parents=[b'parent1', b'parent2'],
     )
-    block._metadata = Mock()
-    block._metadata.height = 2
+    block.set_static_metadata(
+        BlockStaticMetadata(
+            min_height=0,
+            height=2,
+            feature_activation_bit_counts=[],
+            feature_states={},
+        )
+    )
 
     # Test no rewards
     block.outputs = [TxOutput(123, b'')]
@@ -190,7 +197,21 @@ def test_verify_poa() -> None:
     assert str(e.value) == 'block weight is 1.0, expected 2.0'
 
     # When we increment the height, the turn inverts
-    block._metadata.height += 1
+    block = PoaBlock(
+        storage=storage,
+        timestamp=153,
+        signal_bits=0b1010,
+        weight=poa.BLOCK_WEIGHT_IN_TURN,
+        parents=[b'parent1', b'parent2'],
+    )
+    block.set_static_metadata(
+        BlockStaticMetadata(
+            min_height=0,
+            height=3,
+            feature_activation_bit_counts=[],
+            feature_states={},
+        )
+    )
 
     # Test valid signature with two signers, in turn
     block.weight = poa.BLOCK_WEIGHT_IN_TURN

--- a/tests/poa/test_poa_verification.py
+++ b/tests/poa/test_poa_verification.py
@@ -64,7 +64,7 @@ class BasePoaVerificationTest(unittest.TestCase):
             ],
         )
         self.signer.sign_block(block)
-        block.update_reward_lock_metadata()
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         return block
 
     def test_poa_block_verify_basic(self) -> None:

--- a/tests/resources/transaction/test_mining.py
+++ b/tests/resources/transaction/test_mining.py
@@ -11,7 +11,7 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
 
     def setUp(self):
         super().setUp()
-        self.get_block_template = StubSite(mining.GetBlockTemplateResource(self.manager))
+        self.get_block_template = StubSite(mining.GetBlockTemplateResource(self.manager, self.manager._settings))
         self.submit_block = StubSite(mining.SubmitBlockResource(self.manager))
 
     @inlineCallbacks
@@ -38,9 +38,9 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'accumulated_weight': 1.0,
                 'score': 0,
                 'height': 1,
-                'min_height': None,
+                'min_height': 0,
                 'first_block': None,
-                'feature_activation_bit_counts': None
+                'feature_activation_bit_counts': [0, 0, 0, 0]
             },
             'tokens': [],
             'data': '',
@@ -71,9 +71,9 @@ class BaseMiningApiTest(_BaseResourceTest._ResourceTest):
                 'accumulated_weight': 1.0,
                 'score': 0,
                 'height': 1,
-                'min_height': None,
+                'min_height': 0,
                 'first_block': None,
-                'feature_activation_bit_counts': None
+                'feature_activation_bit_counts': [0, 0, 0, 0]
             },
             'tokens': [],
             'data': '',

--- a/tests/resources/transaction/test_pushtx.py
+++ b/tests/resources/transaction/test_pushtx.py
@@ -25,7 +25,7 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
     def setUp(self):
         super().setUp()
         self.web = StubSite(PushTxResource(self.manager))
-        self.web_tokens = StubSite(SendTokensResource(self.manager))
+        self.web_tokens = StubSite(SendTokensResource(self.manager, self._settings))
 
     def get_tx(self, inputs: Optional[list[WalletInputInfo]] = None,
                outputs: Optional[list[WalletOutputInfo]] = None) -> Transaction:
@@ -47,6 +47,7 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
         tx.timestamp = max(max_ts_spent_tx + 1, int(self.manager.reactor.seconds()))
         tx.parents = self.manager.get_new_tx_parents(tx.timestamp)
         self.manager.cpu_mining_service.resolve(tx)
+        tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         return tx
 
     def push_tx(self, data=None):

--- a/tests/resources/transaction/test_tx.py
+++ b/tests/resources/transaction/test_tx.py
@@ -3,6 +3,7 @@ from twisted.internet.defer import inlineCallbacks
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.transaction.resources import TransactionResource
+from hathor.transaction.static_metadata import TransactionStaticMetadata
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.validation_state import ValidationState
 from tests import unittest
@@ -31,7 +32,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
         dict_test['raw'] = genesis_tx.get_struct().hex()
         dict_test['nonce'] = str(dict_test['nonce'])
         if genesis_tx.is_block:
-            dict_test['height'] = genesis_tx.calculate_height()
+            dict_test['height'] = genesis_tx.static_metadata.height
         self.assertEqual(data_success['tx'], dict_test)
 
         # Test sending hash that does not exist
@@ -87,6 +88,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                   '0248b9e7d6a626f45dec86975b00f4dd53f84f1f0091125250b044e49023fbbd0f74f6093cdd2226fdff3e09a1000002be')
         tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
         tx.get_metadata().validation = ValidationState.FULL
+        tx.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx)
 
         tx_parent1_hex = ('0001010102001c382847d8440d05da95420bee2ebeb32bc437f82a9ae47b0745c8a29a7b0d001c382847d844'
@@ -99,6 +101,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           '8fb080f53a0c9c57ddb000000120')
         tx_parent1 = Transaction.create_from_struct(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
         tx_parent1.get_metadata().validation = ValidationState.FULL
+        tx_parent1.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx_parent1)
 
         tx_parent2_hex = ('0001000103001f16fe62e3433bcc74b262c11a1fa94fcb38484f4d8fb080f53a0c9c57ddb001006946304402'
@@ -111,6 +114,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           'd57709926b76e64763bf19c3f13eeac30000016d')
         tx_parent2 = Transaction.create_from_struct(bytes.fromhex(tx_parent2_hex), self.manager.tx_storage)
         tx_parent2.get_metadata().validation = ValidationState.FULL
+        tx_parent2.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx_parent2)
 
         tx_input_hex = ('0001010203007231eee3cb6160d95172a409d634d0866eafc8775f5729fff6a61e7850aba500b3ab76c5337b55'
@@ -126,6 +130,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                         'cfaf6e7ceb2ba91c9c84009c8174d4a46ebcc789d1989e3dec5b68cffeef239fd8cf86ef62728e2eacee000001b6')
         tx_input = Transaction.create_from_struct(bytes.fromhex(tx_input_hex), self.manager.tx_storage)
         tx_input.get_metadata().validation = ValidationState.FULL
+        tx_input.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx_input)
 
         # XXX: this is completely dependant on MemoryTokensIndex implementation, hence use_memory_storage=True
@@ -193,6 +198,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                   '5114256caacfb8f6dd13db33000020393')
         tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
         tx.get_metadata().validation = ValidationState.FULL
+        tx.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx)
 
         tx_parent1_hex = ('0001010203000023b318c91dcfd4b967b205dc938f9f5e2fd5114256caacfb8f6dd13db330000023b318c91dcfd'
@@ -208,6 +214,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                           'd13db3300038c3d3b69ce90bb88c0c4d6a87b9f0c349e5b10c9b7ce6714f996e512ac16400021261')
         tx_parent1 = Transaction.create_from_struct(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
         tx_parent1.get_metadata().validation = ValidationState.FULL
+        tx_parent1.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx_parent1)
 
         tx_parent2_hex = ('000201040000476810205cb3625d62897fcdad620e01d66649869329640f5504d77e960d01006a473045022100c'
@@ -222,6 +229,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
         tx_parent2_bytes = bytes.fromhex(tx_parent2_hex)
         tx_parent2 = TokenCreationTransaction.create_from_struct(tx_parent2_bytes, self.manager.tx_storage)
         tx_parent2.get_metadata().validation = ValidationState.FULL
+        tx_parent2.set_static_metadata(TransactionStaticMetadata(min_height=0))
         self.manager.tx_storage.save_transaction(tx_parent2)
 
         # Both inputs are the same as the last parent, so no need to manually add them
@@ -271,7 +279,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(data['meta']['first_block'], block.hash_hex)
 
         # now check that the first_block_height was correctly included
-        self.assertEqual(data['meta']['first_block_height'], block.get_metadata().height)
+        self.assertEqual(data['meta']['first_block_height'], block.static_metadata.height)
 
     @inlineCallbacks
     def test_get_many(self):
@@ -514,6 +522,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
                   '0248b9e7d6a626f45dec86975b00f4dd53f84f1f0091125250b044e49023fbbd0f74f6093cdd2226fdff3e09a1000002be')
         tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
         tx.set_validation(ValidationState.BASIC)
+        tx.set_static_metadata(TransactionStaticMetadata(min_height=0))
         with self.manager.tx_storage.allow_partially_validated_context():
             self.manager.tx_storage.save_transaction(tx)
 

--- a/tests/resources/transaction/test_utxo_search.py
+++ b/tests/resources/transaction/test_utxo_search.py
@@ -59,7 +59,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[:1]])
 
         # Success non-empty address with medium amount, will require more than one output
@@ -72,7 +72,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[4:1:-1]])
 
         # Success non-empty address with exact amount, will require all UTXOs
@@ -85,7 +85,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[::-1]])
 
         # Success non-empty address with excessive amount, will require all UTXOs, even if it's not enough
@@ -98,7 +98,7 @@ class BaseUtxoSearchTest(_BaseResourceTest._ResourceTest):
             'index': 0,
             'amount': 6400,
             'timelock': None,
-            'heightlock': b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+            'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[::-1]])
 
 

--- a/tests/resources/wallet/test_send_tokens.py
+++ b/tests/resources/wallet/test_send_tokens.py
@@ -17,7 +17,7 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
 
     def setUp(self):
         super().setUp()
-        self.web = StubSite(SendTokensResource(self.manager))
+        self.web = StubSite(SendTokensResource(self.manager, self._settings))
         self.web_mining = StubSite(MiningResource(self.manager))
         self.web_balance = StubSite(BalanceResource(self.manager))
         self.web_history = StubSite(HistoryResource(self.manager))
@@ -194,7 +194,7 @@ class BaseSendTokensTest(_BaseResourceTest._ResourceTest):
         self.assertFalse(data['success'])
 
     def test_error_request(self):
-        resource = SendTokensResource(self.manager)
+        resource = SendTokensResource(self.manager, self._settings)
         request = TestDummyRequest('POST', 'wallet/send_tokens', {})
 
         self.assertIsNotNone(request._finishedDeferreds)

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -21,8 +21,9 @@ from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling, FeatureService
 from hathor.indexes import MemoryIndexesManager
-from hathor.transaction import Block, TransactionMetadata
+from hathor.transaction import Block
 from hathor.transaction.exceptions import BlockMustSignalError
+from hathor.transaction.static_metadata import BlockStaticMetadata
 from hathor.transaction.storage import TransactionMemoryStorage, TransactionStorage
 from hathor.transaction.validation_state import ValidationState
 from hathor.util import not_none
@@ -33,7 +34,7 @@ def test_calculate_feature_activation_bit_counts_genesis():
     settings = get_global_settings()
     storage = TransactionMemoryStorage(settings=settings)
     genesis_block = storage.get_block(settings.GENESIS_BLOCK_HASH)
-    result = genesis_block.get_feature_activation_bit_counts()
+    result = genesis_block.static_metadata.feature_activation_bit_counts
 
     assert result == [0, 0, 0, 0]
 
@@ -64,9 +65,8 @@ def tx_storage() -> TransactionStorage:
         parent = not_none(storage.get_block_by_height(height - 1))
         block = Block(signal_bits=bits, parents=[parent.hash], storage=storage)
         block.update_hash()
-        meta = block.get_metadata()
-        meta.validation = ValidationState.FULL
-        meta.height = height
+        block.get_metadata().validation = ValidationState.FULL
+        block.init_static_metadata_from_storage(get_global_settings(), storage)
         storage.save_transaction(block)
         indexes.height.add_new(height, block.hash, block.timestamp)
 
@@ -94,20 +94,20 @@ def test_calculate_feature_activation_bit_counts(
     expected_counts: list[int]
 ) -> None:
     block = not_none(tx_storage.get_block_by_height(block_height))
-    assert block.get_feature_activation_bit_counts() == expected_counts
+    assert block.static_metadata.feature_activation_bit_counts == expected_counts
 
 
-def test_get_height():
-    block_hash = b'some_hash'
-    block_height = 10
-    metadata = TransactionMetadata(hash=block_hash, height=block_height)
+def test_get_height() -> None:
+    static_metadata = BlockStaticMetadata(
+        min_height=0,
+        height=10,
+        feature_activation_bit_counts=[],
+        feature_states={},
+    )
+    block = Block()
+    block.set_static_metadata(static_metadata)
 
-    storage = Mock(spec_set=TransactionStorage)
-    storage.get_metadata = Mock(side_effect=lambda _hash: metadata if _hash == block_hash else None)
-
-    block = Block(hash=block_hash, storage=storage)
-
-    assert block.get_height() == block_height
+    assert block.get_height() == 10
 
 
 @pytest.mark.parametrize(

--- a/tests/tx/test_blockchain.py
+++ b/tests/tx/test_blockchain.py
@@ -336,7 +336,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
 
     def test_block_height(self):
         genesis_block = self.genesis_blocks[0]
-        self.assertEqual(genesis_block.get_metadata().height, 0)
+        self.assertEqual(genesis_block.static_metadata.height, 0)
 
         manager = self.create_peer('testnet', tx_storage=self.tx_storage)
 
@@ -345,7 +345,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
 
         for i, block in enumerate(blocks):
             expected_height = i + 1
-            self.assertEqual(block.get_metadata().height, expected_height)
+            self.assertEqual(block.static_metadata.height, expected_height)
 
     def test_tokens_issued_per_block(self):
         manager = self.create_peer('testnet', tx_storage=self.tx_storage)
@@ -378,7 +378,7 @@ class BaseBlockchainTestCase(unittest.TestCase):
             outputs = block.outputs
             self.assertEqual(len(outputs), 1)
             output = outputs[0]
-            height = block.get_metadata().height
+            height = block.static_metadata.height
             self.assertEqual(output.value, manager.get_tokens_issued_per_block(height))
 
     def test_daa_sanity(self):

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -36,6 +36,7 @@ class BaseCacheStorageTest(unittest.TestCase):
         from hathor.transaction.validation_state import ValidationState
         tx = Transaction(nonce=nonce, storage=self.cache_storage)
         tx.update_hash()
+        tx.init_static_metadata_from_storage(self._settings, self.cache_storage)
         meta = TransactionMetadata(hash=tx.hash)
         meta.validation = ValidationState.FULL
         tx._metadata = meta

--- a/tests/tx/test_indexes.py
+++ b/tests/tx/test_indexes.py
@@ -307,7 +307,7 @@ class BaseIndexesTest(unittest.TestCase):
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[:1]
             ]
         )
@@ -322,7 +322,7 @@ class BaseIndexesTest(unittest.TestCase):
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[4:1:-1]
             ]
         )
@@ -337,7 +337,7 @@ class BaseIndexesTest(unittest.TestCase):
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[::-1]
             ]
         )
@@ -352,7 +352,7 @@ class BaseIndexesTest(unittest.TestCase):
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[::-1]
             ]
         )
@@ -464,7 +464,7 @@ class BaseIndexesTest(unittest.TestCase):
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                     ) for b in blocks
             ]
         )
@@ -536,7 +536,7 @@ class BaseIndexesTest(unittest.TestCase):
                     address=address,
                     amount=6400,
                     timelock=None,
-                    heightlock=b.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS,
+                    heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                     ) for b in blocks
             ]
         )

--- a/tests/tx/test_reward_lock.py
+++ b/tests/tx/test_reward_lock.py
@@ -39,7 +39,7 @@ class BaseTransactionTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(reward_block)
         self.assertTrue(self.manager.propagate_tx(reward_block))
         # XXX: calculate unlock height AFTER adding the block so the height is correctly calculated
-        unlock_height = reward_block.get_metadata().height + self._settings.REWARD_SPEND_MIN_BLOCKS + 1
+        unlock_height = reward_block.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS + 1
         return reward_block, unlock_height
 
     def _spend_reward_tx(self, manager, reward_block):
@@ -61,6 +61,7 @@ class BaseTransactionTest(unittest.TestCase):
         input_.data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx)
         tx.update_initial_metadata(save=False)
+        tx.init_static_metadata_from_storage(self._settings, self.tx_storage)
         return tx
 
     def test_classic_reward_lock(self):
@@ -70,14 +71,14 @@ class BaseTransactionTest(unittest.TestCase):
         # reward cannot be spent while not enough blocks are added
         for _ in range(self._settings.REWARD_SPEND_MIN_BLOCKS):
             tx = self._spend_reward_tx(self.manager, reward_block)
-            self.assertEqual(tx.get_metadata().min_height, unlock_height)
+            self.assertEqual(tx.static_metadata.min_height, unlock_height)
             with self.assertRaises(RewardLocked):
                 self.manager.verification_service.verify(tx)
             add_new_blocks(self.manager, 1, advance_clock=1)
 
         # now it should be spendable
         tx = self._spend_reward_tx(self.manager, reward_block)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         self.assertTrue(self.manager.propagate_tx(tx, fails_silently=False))
 
     def test_block_with_not_enough_height(self):
@@ -91,7 +92,7 @@ class BaseTransactionTest(unittest.TestCase):
         # XXX: this situation is impossible in practice, but we force it to test that when a block tries to confirm a
         #      transaction before it can the RewardLocked exception is raised
         tx = self._spend_reward_tx(self.manager, reward_block)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         self.assertTrue(self.manager.on_new_tx(tx, fails_silently=False, reject_locked_reward=False))
 
         # new block will try to confirm it and fail
@@ -113,7 +114,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         # add tx that spends the reward
         tx = self._spend_reward_tx(self.manager, reward_block)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         self.assertTrue(self.manager.on_new_tx(tx, fails_silently=False))
 
         # new block will be able to confirm it
@@ -130,7 +131,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         # add tx to mempool, must fail reward-lock verification
         tx = self._spend_reward_tx(self.manager, reward_block)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         with self.assertRaises(RewardLocked):
             self.manager.verification_service.verify(tx)
         with self.assertRaises(InvalidNewTransaction):
@@ -145,7 +146,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         # add tx that spends the reward, must not fail
         tx = self._spend_reward_tx(self.manager, reward_block)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         self.assertTrue(self.manager.on_new_tx(tx, fails_silently=False))
 
     def test_mempool_tx_invalid_after_reorg(self):
@@ -157,7 +158,7 @@ class BaseTransactionTest(unittest.TestCase):
 
         # add tx that spends the reward, must not fail
         tx = self._spend_reward_tx(self.manager, reward_block)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         self.assertTrue(self.manager.on_new_tx(tx, fails_silently=False))
 
         # re-org: replace last two blocks with one block, new height will be just one short of enough
@@ -203,7 +204,7 @@ class BaseTransactionTest(unittest.TestCase):
         tx = self._spend_reward_tx(self.manager, reward_block)
         tx.timestamp = blocks[-1].timestamp
         self.manager.cpu_mining_service.resolve(tx)
-        self.assertEqual(tx.get_metadata().min_height, unlock_height)
+        self.assertEqual(tx.static_metadata.min_height, unlock_height)
         with self.assertRaises(RewardLocked):
             self.manager.verification_service.verify(tx)
 

--- a/tests/tx/test_tokens.py
+++ b/tests/tx/test_tokens.py
@@ -112,7 +112,7 @@ class BaseTokenTest(unittest.TestCase):
         public_bytes, signature = wallet.get_input_aux_data(data_to_sign, wallet.get_private_key(self.address_b58))
         tx2.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx2)
-        tx2.update_reward_lock_metadata()
+        tx2.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         self.manager.verification_service.verify(tx2)
 
         # missing tokens

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -62,7 +62,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.block = Block(timestamp=previous_timestamp + 1, weight=12, outputs=[output], parents=block_parents,
                            nonce=100781, storage=self.tx_storage)
         self.manager.cpu_mining_service.resolve(self.block)
-        self.block.update_reward_lock_metadata()
+        self.block.init_static_metadata_from_storage(self._settings, self.tx_storage)
         self.manager.verification_service.verify(self.block)
         self.block.get_metadata().validation = ValidationState.FULL
 
@@ -81,6 +81,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
             parents=tx_parents, storage=self.tx_storage)
         self.manager.cpu_mining_service.resolve(self.tx)
         self.tx.get_metadata().validation = ValidationState.FULL
+        self.tx.init_static_metadata_from_storage(self._settings, self.tx_storage)
 
         # Disable weakref to test the internal methods. Otherwise, most methods return objects from weakref.
         self.tx_storage._disable_weakref()
@@ -374,6 +375,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
     def test_save_token_creation_tx(self):
         tx = create_tokens(self.manager, propagate=False)
         tx.get_metadata().validation = ValidationState.FULL
+        tx.init_static_metadata_from_storage(self._settings, self.tx_storage)
         self.validate_save(tx)
 
     def _validate_not_in_index(self, tx, index):

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -54,7 +54,7 @@ class BaseVerificationTest(unittest.TestCase):
                 self._settings.GENESIS_TX2_HASH
             ]
         )
-        block.update_reward_lock_metadata()
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         return block
 
     def _get_valid_merge_mined_block(self) -> MergeMinedBlock:
@@ -70,7 +70,7 @@ class BaseVerificationTest(unittest.TestCase):
                 self._settings.GENESIS_TX2_HASH
             ],
         )
-        block.update_reward_lock_metadata()
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         return block
 
     def _get_valid_tx(self) -> Transaction:
@@ -95,7 +95,7 @@ class BaseVerificationTest(unittest.TestCase):
                 self._settings.GENESIS_TX2_HASH,
             ]
         )
-        tx.update_reward_lock_metadata()
+        tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
 
         data_to_sign = tx.get_sighash_all()
         assert self.manager.wallet
@@ -108,7 +108,7 @@ class BaseVerificationTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
         assert self.manager.wallet
         tx = create_tokens(self.manager, self.manager.wallet.get_unused_address())
-        tx.update_reward_lock_metadata()
+        tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         return tx
 
     def test_block_verify_basic(self) -> None:

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -85,6 +85,7 @@ class BaseBasicWalletTest(unittest.TestCase):
         tx1.storage = self.storage
         tx1.update_hash()
         tx1.get_metadata().validation = ValidationState.FULL
+        tx1.init_static_metadata_from_storage(self._settings, self.storage)
         self.storage.save_transaction(tx1)
         w.on_new_tx(tx1)
         self.assertEqual(len(w.spent_txs), 1)
@@ -101,6 +102,7 @@ class BaseBasicWalletTest(unittest.TestCase):
         tx2.storage = self.storage
         tx2.update_hash()
         tx2.get_metadata().validation = ValidationState.FULL
+        tx2.init_static_metadata_from_storage(self._settings, self.storage)
         self.storage.save_transaction(tx2)
         w.on_new_tx(tx2)
         self.assertEqual(len(w.spent_txs), 2)
@@ -206,7 +208,7 @@ class BaseBasicWalletTest(unittest.TestCase):
         tx2.timestamp = tx.timestamp + 1
         tx2.parents = self.manager.get_new_tx_parents()
         self.manager.cpu_mining_service.resolve(tx2)
-        tx2.update_reward_lock_metadata()
+        tx2.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         self.manager.verification_service.verify(tx2)
 
         self.assertNotEqual(len(tx2.inputs), 0)

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -45,6 +45,7 @@ class BaseWalletHDTest(unittest.TestCase):
         tx1.storage = self.tx_storage
         tx1.get_metadata().validation = ValidationState.FULL
         self.wallet.on_new_tx(tx1)
+        tx1.init_static_metadata_from_storage(self._settings, self.tx_storage)
         self.tx_storage.save_transaction(tx1)
         self.assertEqual(len(self.wallet.spent_txs), 1)
         utxo = self.wallet.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((tx1.hash, 0))
@@ -63,6 +64,7 @@ class BaseWalletHDTest(unittest.TestCase):
         tx2.storage = self.tx_storage
         verifier.verify_script(tx=tx2, input_tx=tx2.inputs[0], spent_tx=tx1)
         tx2.get_metadata().validation = ValidationState.FULL
+        tx2.init_static_metadata_from_storage(self._settings, self.tx_storage)
         self.tx_storage.save_transaction(tx2)
         self.wallet.on_new_tx(tx2)
         self.assertEqual(len(self.wallet.spent_txs), 2)


### PR DESCRIPTION
### Motivation

This PR continues and completes the implementation for a working version of the static metadata refactor started in the previous PR, https://github.com/HathorNetwork/hathor-core/pull/1013. Read its description for more detailed information.

It moves the `height`, `min_height`, and `feature_activation_bit_counts` metadata attributes to the new static structure. The `feature_states` attribute will be migrated in the next PR.

As a consequence, it introduces several benefits for metadata handling, including:

- Blocks and Transactions now have separate types for their static metadata attributes, which are different. No more handling of non-existent attributes for different types, like setting `height=0` for transactions.
- All vertices are required to have static metadata set before they're saved to the storage, meaning when a vertex is retrieved from the storage, it's guaranteed to have static metadata. No need to perform updates and such.
- Static metadata can be interpreted more as attributes that are as constant and present as intrinsic vertex attributes, and less like dynamic metadata attributes (like `voided_by` and `validation`).

### Acceptance Criteria

- Remove `height`, `min_height`, and `feature_activation_bit_counts` attributes from metadata, moving them to static metadata.
  - Provide new equivalent metadata properties that are a forward from static metadata, for backwards compatibility.
  - Keep those properties in the `to_json()` method, for backwards compatibility with APIs and etc.
- Move some metadata-related methods from `BaseTransaction` and its subclasses to the static metadata dataclasses, and remove some that are not necessary anymore.
  - Changes were made so they do not depend on a storage anymore.
- Implement `create()` and `create_from_storage()` methods for static metadata dataclasses.
- Implement `migrate_static_metadata` Migration to move existing metadata attributes to the new static metadata structure.
- Changes in `TransactionStorage` and its subclasses:
  - Save static metadata in `save_transaction()` and retrieve/set it in `get_transaction()` and `get_all_transactions()`.
  - Remove `_validate_block_height_metadata()`.
  - Implement `iter_all_raw_metadata()` method used in the migration.
- Fix and update code and tests accordingly.

### Breaking Changes

- Before, all API calls that returned metadata included both a `height` and a `feature_activation_bit_counts` field for all vertices. For transactions, they were always falsy values (`0`, `None`, or `[]`). Now, they were removed from transactions and are only present for blocks.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 