### PR TITLE
refactor(metadata): pre-refactors for migrating feature states to static metadata [part 3/12]

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -535,10 +535,7 @@ class Builder:
         if self._feature_service is None:
             settings = self._get_or_create_settings()
             tx_storage = self._get_or_create_tx_storage()
-            self._feature_service = FeatureService(
-                feature_settings=settings.FEATURE_ACTIVATION,
-                tx_storage=tx_storage
-            )
+            self._feature_service = FeatureService(settings=settings, tx_storage=tx_storage)
 
         return self._feature_service
 
@@ -549,7 +546,7 @@ class Builder:
             feature_service = self._get_or_create_feature_service()
             feature_storage = self._get_or_create_feature_storage()
             self._bit_signaling_service = BitSignalingService(
-                feature_settings=settings.FEATURE_ACTIVATION,
+                settings=settings,
                 feature_service=feature_service,
                 tx_storage=tx_storage,
                 support_features=self._support_features,

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -149,7 +149,7 @@ class CliBuilder:
             else:
                 indexes = RocksDBIndexesManager(self.rocksdb_storage)
 
-            kwargs = {}
+            kwargs: dict[str, Any] = {}
             if not self._args.cache:
                 # We should only pass indexes if cache is disabled. Otherwise,
                 # only TransactionCacheStorage should have indexes.
@@ -268,13 +268,10 @@ class CliBuilder:
             self.log.info('--x-enable-event-queue flag provided. '
                           'The events detected by the full node will be stored and can be retrieved by clients')
 
-        self.feature_service = FeatureService(
-            feature_settings=settings.FEATURE_ACTIVATION,
-            tx_storage=tx_storage
-        )
+        self.feature_service = FeatureService(settings=settings, tx_storage=tx_storage)
 
         bit_signaling_service = BitSignalingService(
-            feature_settings=settings.FEATURE_ACTIVATION,
+            settings=settings,
             feature_service=self.feature_service,
             tx_storage=tx_storage,
             support_features=self._args.signal_support,

--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -237,7 +237,7 @@ class ResourcesBuilder:
             (
                 b'feature',
                 FeatureResource(
-                    feature_settings=settings.FEATURE_ACTIVATION,
+                    settings=settings,
                     feature_service=self._feature_service,
                     tx_storage=self.manager.tx_storage
                 ),

--- a/hathor/feature_activation/model/feature_info.py
+++ b/hathor/feature_activation/model/feature_info.py
@@ -18,7 +18,7 @@ from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.model.feature_state import FeatureState
 
 
-class FeatureDescription(NamedTuple):
+class FeatureInfo(NamedTuple):
     """Represents all information related to one feature, that is, its criteria and state."""
     criteria: Criteria
     state: FeatureState

--- a/hathor/feature_activation/model/feature_state.py
+++ b/hathor/feature_activation/model/feature_state.py
@@ -12,10 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from enum import Enum
+from enum import Enum, unique
 
 
-class FeatureState(Enum):
+@unique
+class FeatureState(str, Enum):
     """
     Possible states a feature can be in, for each block.
 
@@ -34,6 +35,10 @@ class FeatureState(Enum):
     LOCKED_IN = 'LOCKED_IN'
     ACTIVE = 'ACTIVE'
     FAILED = 'FAILED'
+
+    def is_active(self) -> bool:
+        """Return whether the state is active."""
+        return self is FeatureState.ACTIVE
 
     @staticmethod
     def get_signaling_states() -> set['FeatureState']:

--- a/hathor/feature_activation/resources/feature.py
+++ b/hathor/feature_activation/resources/feature.py
@@ -18,10 +18,10 @@ from twisted.web.http import Request
 
 from hathor.api_util import Resource, set_cors
 from hathor.cli.openapi_files.register import register_resource
+from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.feature_state import FeatureState
-from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.transaction import Block
 from hathor.transaction.storage import TransactionStorage
 from hathor.utils.api import ErrorResponse, QueryParams, Response
@@ -36,12 +36,12 @@ class FeatureResource(Resource):
     def __init__(
         self,
         *,
-        feature_settings: FeatureSettings,
+        settings: HathorSettings,
         feature_service: FeatureService,
         tx_storage: TransactionStorage
     ) -> None:
         super().__init__()
-        self._feature_settings = feature_settings
+        self._feature_settings = settings.FEATURE_ACTIVATION
         self._feature_service = feature_service
         self.tx_storage = tx_storage
 
@@ -68,17 +68,17 @@ class FeatureResource(Resource):
             return error.json_dumpb()
 
         signal_bits = []
-        feature_descriptions = self._feature_service.get_bits_description(block=block)
+        feature_infos = self._feature_service.get_feature_infos(block=block)
 
-        for feature, description in feature_descriptions.items():
-            if description.state not in FeatureState.get_signaling_states():
+        for feature, feature_info in feature_infos.items():
+            if feature_info.state not in FeatureState.get_signaling_states():
                 continue
 
             block_feature = GetBlockFeatureResponse(
-                bit=description.criteria.bit,
-                signal=block.get_feature_activation_bit_value(description.criteria.bit),
+                bit=feature_info.criteria.bit,
+                signal=block.get_feature_activation_bit_value(feature_info.criteria.bit),
                 feature=feature,
-                feature_state=description.state.name
+                feature_state=feature_info.state.name
             )
 
             signal_bits.append(block_feature)
@@ -90,10 +90,12 @@ class FeatureResource(Resource):
     def get_features(self) -> bytes:
         best_block = self.tx_storage.get_best_block()
         bit_counts = best_block.static_metadata.feature_activation_bit_counts
+        feature_infos = self._feature_service.get_feature_infos(block=best_block)
         features = []
 
-        for feature, criteria in self._feature_settings.features.items():
-            state = self._feature_service.get_state(block=best_block, feature=feature)
+        for feature, feature_info in feature_infos.items():
+            state = feature_info.state
+            criteria = feature_info.criteria
             threshold_count = criteria.get_threshold(self._feature_settings)
             threshold_percentage = threshold_count / self._feature_settings.evaluation_interval
             acceptance_percentage = None

--- a/hathor/transaction/__init__.py
+++ b/hathor/transaction/__init__.py
@@ -19,6 +19,7 @@ from hathor.transaction.base_transaction import (
     TxInput,
     TxOutput,
     TxVersion,
+    Vertex,
     sum_weights,
 )
 from hathor.transaction.block import Block
@@ -29,6 +30,7 @@ from hathor.transaction.transaction_metadata import TransactionMetadata
 __all__ = [
     'Transaction',
     'BitcoinAuxPow',
+    'Vertex',
     'BaseTransaction',
     'Block',
     'MergeMinedBlock',

--- a/hathor/transaction/static_metadata.py
+++ b/hathor/transaction/static_metadata.py
@@ -14,9 +14,7 @@
 
 from __future__ import annotations
 
-import dataclasses
 from abc import ABC
-from dataclasses import dataclass
 from itertools import chain, starmap, zip_longest
 from operator import add
 from typing import TYPE_CHECKING, Callable
@@ -26,7 +24,8 @@ from typing_extensions import Self
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.types import VertexId
-from hathor.util import json_dumpb, json_loadb
+from hathor.util import json_loadb
+from hathor.utils.pydantic import BaseModel
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -34,8 +33,7 @@ if TYPE_CHECKING:
     from hathor.transaction.storage import TransactionStorage
 
 
-@dataclass(slots=True, frozen=True, kw_only=True)
-class VertexStaticMetadata(ABC):
+class VertexStaticMetadata(ABC, BaseModel):
     """
     Static Metadata represents vertex attributes that are not intrinsic to the vertex data, but can be calculated from
     only the vertex itself and its dependencies, and whose values never change.
@@ -48,10 +46,6 @@ class VertexStaticMetadata(ABC):
     # block that confirming this transaction, it is important to always have this set to be able to distinguish an old
     # metadata (that does not have this calculated, from a tx with a new format that does have this calculated)
     min_height: int
-
-    def to_bytes(self) -> bytes:
-        """Convert this static metadata instance to a json bytes representation."""
-        return json_dumpb(dataclasses.asdict(self))
 
     @classmethod
     def from_bytes(cls, data: bytes, *, target: 'BaseTransaction') -> 'VertexStaticMetadata':
@@ -68,7 +62,6 @@ class VertexStaticMetadata(ABC):
         raise NotImplementedError
 
 
-@dataclass(slots=True, frozen=True, kw_only=True)
 class BlockStaticMetadata(VertexStaticMetadata):
     height: int
 
@@ -181,7 +174,6 @@ class BlockStaticMetadata(VertexStaticMetadata):
         return parent_block.static_metadata.feature_activation_bit_counts
 
 
-@dataclass(slots=True, frozen=True, kw_only=True)
 class TransactionStaticMetadata(VertexStaticMetadata):
     @classmethod
     def create_from_storage(cls, tx: 'Transaction', settings: HathorSettings, storage: 'TransactionStorage') -> Self:

--- a/hathor/transaction/storage/rocksdb_storage.py
+++ b/hathor/transaction/storage/rocksdb_storage.py
@@ -113,7 +113,7 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
 
     @override
     def _save_static_metadata(self, tx: 'BaseTransaction') -> None:
-        self._db.put((self._cf_static_meta, tx.hash), tx.static_metadata.to_bytes())
+        self._db.put((self._cf_static_meta, tx.hash), tx.static_metadata.json_dumpb())
 
     def _load_static_metadata(self, vertex: 'BaseTransaction') -> None:
         """Set vertex static metadata loaded from what's saved in this storage."""
@@ -272,4 +272,4 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
                 )
 
             # Save it manually to the CF
-            self._db.put((self._cf_static_meta, vertex_id), static_metadata.to_bytes())
+            self._db.put((self._cf_static_meta, vertex_id), static_metadata.json_dumpb())

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing_extensions import assert_never
+
 from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import BlockIsMissingSignal, BlockIsSignaling, FeatureService
@@ -93,5 +95,4 @@ class BlockVerifier:
                     f"Block must signal support for feature '{feature.value}' during MUST_SIGNAL phase."
                 )
             case _:
-                # TODO: This will be changed to assert_never() so mypy can check it.
-                raise NotImplementedError
+                assert_never(signaling_state)

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -194,6 +194,7 @@ class VerificationService:
         self.verifiers.block.verify_mandatory_signaling(block)
 
     def _verify_merge_mined_block(self, block: MergeMinedBlock) -> None:
+        self.verifiers.merge_mined_block.verify_aux_pow(block)
         self._verify_block(block)
 
     def _verify_poa_block(self, block: PoaBlock) -> None:
@@ -274,7 +275,6 @@ class VerificationService:
         self._verify_without_storage_base_block(block)
 
     def _verify_without_storage_merge_mined_block(self, block: MergeMinedBlock) -> None:
-        self.verifiers.merge_mined_block.verify_aux_pow(block)
         self._verify_without_storage_block(block)
 
     def _verify_without_storage_poa_block(self, block: PoaBlock) -> None:

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -228,10 +228,10 @@ class VertexHandler:
         if tx.is_block:
             message = message_fmt.format('block')
             if isinstance(tx, Block):
-                feature_descriptions = self._feature_service.get_bits_description(block=tx)
+                feature_infos = self._feature_service.get_feature_infos(block=tx)
                 feature_states = {
-                    feature.value: description.state.value
-                    for feature, description in feature_descriptions.items()
+                    feature.value: info.state.value
+                    for feature, info in feature_infos.items()
                 }
                 kwargs['_height'] = tx.get_height()
                 kwargs['feature_states'] = feature_states

--- a/tests/feature_activation/test_bit_signaling_service.py
+++ b/tests/feature_activation/test_bit_signaling_service.py
@@ -16,11 +16,12 @@ from unittest.mock import Mock
 
 import pytest
 
+from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.bit_signaling_service import BitSignalingService
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.criteria import Criteria
-from hathor.feature_activation.model.feature_description import FeatureDescription
+from hathor.feature_activation.model.feature_info import FeatureInfo
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.transaction import Block
@@ -28,15 +29,15 @@ from hathor.transaction.storage import TransactionStorage
 
 
 @pytest.mark.parametrize(
-    'features_description',
+    'features_infos',
     [
         {},
         {
-            Feature.NOP_FEATURE_1: FeatureDescription(state=FeatureState.DEFINED, criteria=Mock())
+            Feature.NOP_FEATURE_1: FeatureInfo(state=FeatureState.DEFINED, criteria=Mock())
         },
         {
-            Feature.NOP_FEATURE_1: FeatureDescription(state=FeatureState.FAILED, criteria=Mock()),
-            Feature.NOP_FEATURE_2: FeatureDescription(state=FeatureState.ACTIVE, criteria=Mock())
+            Feature.NOP_FEATURE_1: FeatureInfo(state=FeatureState.FAILED, criteria=Mock()),
+            Feature.NOP_FEATURE_2: FeatureInfo(state=FeatureState.ACTIVE, criteria=Mock())
         }
     ]
 )
@@ -50,11 +51,11 @@ from hathor.transaction.storage import TransactionStorage
     ]
 )
 def test_generate_signal_bits_no_signaling_features(
-    features_description: dict[Feature, FeatureDescription],
+    features_infos: dict[Feature, FeatureInfo],
     support_features: set[Feature],
     not_support_features: set[Feature]
 ) -> None:
-    signal_bits = _test_generate_signal_bits(features_description, support_features, not_support_features)
+    signal_bits = _test_generate_signal_bits(features_infos, support_features, not_support_features)
 
     assert signal_bits == 0
 
@@ -74,7 +75,7 @@ def test_generate_signal_bits_signaling_features(
     expected_signal_bits: int,
 ) -> None:
     features_description = {
-        Feature.NOP_FEATURE_1: FeatureDescription(
+        Feature.NOP_FEATURE_1: FeatureInfo(
             state=FeatureState.STARTED,
             criteria=Criteria(
                 bit=0,
@@ -83,7 +84,7 @@ def test_generate_signal_bits_signaling_features(
                 version='0.0.0'
             )
         ),
-        Feature.NOP_FEATURE_2: FeatureDescription(
+        Feature.NOP_FEATURE_2: FeatureInfo(
             state=FeatureState.MUST_SIGNAL,
             criteria=Criteria(
                 bit=1,
@@ -92,7 +93,7 @@ def test_generate_signal_bits_signaling_features(
                 version='0.0.0'
             )
         ),
-        Feature.NOP_FEATURE_3: FeatureDescription(
+        Feature.NOP_FEATURE_3: FeatureInfo(
             state=FeatureState.LOCKED_IN,
             criteria=Criteria(
                 bit=3,
@@ -123,8 +124,8 @@ def test_generate_signal_bits_signaling_features_with_defaults(
     not_support_features: set[Feature],
     expected_signal_bits: int,
 ) -> None:
-    features_description = {
-        Feature.NOP_FEATURE_1: FeatureDescription(
+    feature_infos = {
+        Feature.NOP_FEATURE_1: FeatureInfo(
             state=FeatureState.STARTED,
             criteria=Criteria(
                 bit=0,
@@ -134,7 +135,7 @@ def test_generate_signal_bits_signaling_features_with_defaults(
                 signal_support_by_default=True
             )
         ),
-        Feature.NOP_FEATURE_2: FeatureDescription(
+        Feature.NOP_FEATURE_2: FeatureInfo(
             state=FeatureState.MUST_SIGNAL,
             criteria=Criteria(
                 bit=1,
@@ -144,7 +145,7 @@ def test_generate_signal_bits_signaling_features_with_defaults(
                 signal_support_by_default=True
             )
         ),
-        Feature.NOP_FEATURE_3: FeatureDescription(
+        Feature.NOP_FEATURE_3: FeatureInfo(
             state=FeatureState.LOCKED_IN,
             criteria=Criteria(
                 bit=3,
@@ -155,21 +156,23 @@ def test_generate_signal_bits_signaling_features_with_defaults(
         )
     }
 
-    signal_bits = _test_generate_signal_bits(features_description, support_features, not_support_features)
+    signal_bits = _test_generate_signal_bits(feature_infos, support_features, not_support_features)
 
     assert signal_bits == expected_signal_bits
 
 
 def _test_generate_signal_bits(
-    features_description: dict[Feature, FeatureDescription],
+    feature_infos: dict[Feature, FeatureInfo],
     support_features: set[Feature],
     not_support_features: set[Feature]
 ) -> int:
+    settings = Mock(spec_set=HathorSettings)
+    settings.FEATURE_ACTIVATION = FeatureSettings()
     feature_service = Mock(spec_set=FeatureService)
-    feature_service.get_bits_description = lambda block: features_description
+    feature_service.get_feature_infos = lambda block: feature_infos
 
     service = BitSignalingService(
-        feature_settings=FeatureSettings(),
+        settings=settings,
         feature_service=feature_service,
         tx_storage=Mock(),
         support_features=support_features,
@@ -212,7 +215,7 @@ def test_support_intersection_validation(
 ) -> None:
     with pytest.raises(ValueError) as e:
         BitSignalingService(
-            feature_settings=Mock(),
+            settings=Mock(),
             feature_service=Mock(),
             tx_storage=Mock(),
             support_features=support_features,
@@ -252,22 +255,25 @@ def test_non_signaling_features_warning(
     not_support_features: set[Feature],
     non_signaling_features: set[str],
 ) -> None:
+    settings = Mock(spec_set=HathorSettings)
+    settings.FEATURE_ACTIVATION = FeatureSettings()
+
     best_block = Mock(spec_set=Block)
     best_block.get_height = Mock(return_value=123)
     best_block.hash_hex = 'abc'
     tx_storage = Mock(spec_set=TransactionStorage)
     tx_storage.get_best_block = lambda: best_block
 
-    def get_bits_description_mock(block: Block) -> dict[Feature, FeatureDescription]:
+    def get_feature_infos_mock(block: Block) -> dict[Feature, FeatureInfo]:
         if block == best_block:
             return {}
         raise NotImplementedError
 
     feature_service = Mock(spec_set=FeatureService)
-    feature_service.get_bits_description = get_bits_description_mock
+    feature_service.get_feature_infos = get_feature_infos_mock
 
     service = BitSignalingService(
-        feature_settings=FeatureSettings(),
+        settings=settings,
         feature_service=feature_service,
         tx_storage=tx_storage,
         support_features=support_features,
@@ -290,7 +296,7 @@ def test_non_signaling_features_warning(
 
 def test_on_must_signal_not_supported() -> None:
     service = BitSignalingService(
-        feature_settings=Mock(),
+        settings=Mock(),
         feature_service=Mock(),
         tx_storage=Mock(),
         support_features=set(),
@@ -306,7 +312,7 @@ def test_on_must_signal_not_supported() -> None:
 
 def test_on_must_signal_supported() -> None:
     service = BitSignalingService(
-        feature_settings=Mock(),
+        settings=Mock(),
         feature_service=Mock(),
         tx_storage=Mock(),
         support_features=set(),

--- a/tests/feature_activation/test_feature_service.py
+++ b/tests/feature_activation/test_feature_service.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hathor.conf.get_settings import get_global_settings
+from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import (
     BlockIsMissingSignal,
@@ -25,7 +26,7 @@ from hathor.feature_activation.feature_service import (
     FeatureService,
 )
 from hathor.feature_activation.model.criteria import Criteria
-from hathor.feature_activation.model.feature_description import FeatureDescription
+from hathor.feature_activation.model.feature_info import FeatureInfo
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.indexes import MemoryIndexesManager
@@ -35,9 +36,7 @@ from hathor.transaction.validation_state import ValidationState
 from hathor.util import not_none
 
 
-@pytest.fixture
-def storage() -> TransactionStorage:
-    settings = get_global_settings()
+def get_storage(settings: HathorSettings, *, up_to_height: int) -> TransactionStorage:
     indexes = MemoryIndexesManager()
     storage = TransactionMemoryStorage(indexes=indexes, settings=settings)
     feature_activation_bits = [
@@ -75,40 +74,34 @@ def storage() -> TransactionStorage:
         0b0000,
     ]
 
-    for height, bits in enumerate(feature_activation_bits):
+    for height, bits in enumerate(feature_activation_bits[:up_to_height + 1]):
         if height == 0:
             continue
         parent = not_none(storage.get_block_by_height(height - 1))
         block = Block(signal_bits=bits, parents=[parent.hash], storage=storage)
         block.update_hash()
         block.get_metadata().validation = ValidationState.FULL
-        block.init_static_metadata_from_storage(get_global_settings(), storage)
+        block.init_static_metadata_from_storage(settings, storage)
         storage.save_transaction(block)
         indexes.height.add_new(height, block.hash, block.timestamp)
 
     return storage
 
 
-@pytest.fixture
-def feature_settings() -> FeatureSettings:
-    return FeatureSettings(
+def get_settings(*, features: dict[Feature, Criteria]) -> HathorSettings:
+    feature_settings = FeatureSettings.construct(
         evaluation_interval=4,
-        default_threshold=3
+        default_threshold=3,
+        features=features,
     )
+    settings = get_global_settings()._replace(FEATURE_ACTIVATION=feature_settings)
+    return settings
 
 
-@pytest.fixture
-def service(feature_settings: FeatureSettings, storage: TransactionStorage) -> FeatureService:
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
-    service.bit_signaling_service = Mock()
-
-    return service
-
-
-def test_get_state_genesis(storage: TransactionStorage, service: FeatureService) -> None:
+def test_get_state_genesis() -> None:
+    settings = get_settings(features={})
+    storage = get_storage(settings, up_to_height=0)
+    service = FeatureService(settings=settings, tx_storage=storage)
     block = not_none(storage.get_block_by_height(0))
     result = service.get_state(block=block, feature=Mock())
 
@@ -116,9 +109,14 @@ def test_get_state_genesis(storage: TransactionStorage, service: FeatureService)
 
 
 @pytest.mark.parametrize('block_height', [0, 1, 2, 3])
-def test_get_state_first_interval(storage: TransactionStorage, service: FeatureService, block_height: int) -> None:
+def test_get_state_first_interval(block_height: int) -> None:
+    settings = get_settings(features={
+        Feature.NOP_FEATURE_1: Mock()
+    })
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     block = not_none(storage.get_block_by_height(block_height))
-    result = service.get_state(block=block, feature=Mock())
+    result = service.get_state(block=block, feature=Feature.NOP_FEATURE_1)
 
     assert result == FeatureState.DEFINED
 
@@ -132,27 +130,18 @@ def test_get_state_first_interval(storage: TransactionStorage, service: FeatureS
         (8, FeatureState.DEFINED)
     ]
 )
-def test_get_state_from_defined(
-    storage: TransactionStorage,
-    block_height: int,
-    start_height: int,
-    expected_state: FeatureState
-) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
-            Feature.NOP_FEATURE_1: Criteria.construct(
-                bit=Mock(),
-                start_height=start_height,
-                timeout_height=Mock(),
-                version=Mock()
-            )
-        }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+def test_get_state_from_defined(block_height: int, start_height: int, expected_state: FeatureState) -> None:
+    features = {
+        Feature.NOP_FEATURE_1: Criteria.construct(
+            bit=Mock(),
+            start_height=start_height,
+            timeout_height=Mock(),
+            version=Mock()
+        )
+    }
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -164,13 +153,10 @@ def test_get_state_from_defined(
 @pytest.mark.parametrize('block_height', [12, 13, 14, 15, 16, 17])
 @pytest.mark.parametrize('timeout_height', [8, 12])
 def test_get_state_from_started_to_failed(
-    storage: TransactionStorage,
     block_height: int,
     timeout_height: int,
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -179,11 +165,9 @@ def test_get_state_from_started_to_failed(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -195,13 +179,10 @@ def test_get_state_from_started_to_failed(
 @pytest.mark.parametrize('block_height', [8, 9, 10, 11])
 @pytest.mark.parametrize('timeout_height', [8, 12])
 def test_get_state_from_started_to_must_signal_on_timeout(
-    storage: TransactionStorage,
     block_height: int,
     timeout_height: int,
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -210,11 +191,9 @@ def test_get_state_from_started_to_must_signal_on_timeout(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -227,7 +206,6 @@ def test_get_state_from_started_to_must_signal_on_timeout(
 @pytest.mark.parametrize('block_height', [8, 9, 10, 11])
 @pytest.mark.parametrize('default_threshold', [0, 1, 2, 3])
 def test_get_state_from_started_to_locked_in_on_default_threshold(
-    storage: TransactionStorage,
     block_height: int,
     default_threshold: int
 ) -> None:
@@ -244,10 +222,9 @@ def test_get_state_from_started_to_locked_in_on_default_threshold(
             )
         }
     )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_global_settings()._replace(FEATURE_ACTIVATION=feature_settings)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -259,13 +236,10 @@ def test_get_state_from_started_to_locked_in_on_default_threshold(
 @pytest.mark.parametrize('block_height', [8, 9, 10, 11])
 @pytest.mark.parametrize('custom_threshold', [0, 1, 2, 3])
 def test_get_state_from_started_to_locked_in_on_custom_threshold(
-    storage: TransactionStorage,
     block_height: int,
     custom_threshold: int
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=1,
                 start_height=0,
@@ -274,11 +248,9 @@ def test_get_state_from_started_to_locked_in_on_custom_threshold(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -297,14 +269,11 @@ def test_get_state_from_started_to_locked_in_on_custom_threshold(
     ]
 )
 def test_get_state_from_started_to_started(
-    storage: TransactionStorage,
     block_height: int,
     lock_in_on_timeout: bool,
     timeout_height: int,
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -313,11 +282,9 @@ def test_get_state_from_started_to_started(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -328,12 +295,9 @@ def test_get_state_from_started_to_started(
 
 @pytest.mark.parametrize('block_height', [12, 13, 14, 15])
 def test_get_state_from_must_signal_to_locked_in(
-    storage: TransactionStorage,
     block_height: int,
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -342,11 +306,9 @@ def test_get_state_from_must_signal_to_locked_in(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -358,13 +320,10 @@ def test_get_state_from_must_signal_to_locked_in(
 @pytest.mark.parametrize('block_height', [16, 17, 18, 19])
 @pytest.mark.parametrize('minimum_activation_height', [0, 4, 8, 12, 16])
 def test_get_state_from_locked_in_to_active(
-    storage: TransactionStorage,
     block_height: int,
     minimum_activation_height: int,
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -374,11 +333,9 @@ def test_get_state_from_locked_in_to_active(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -390,13 +347,10 @@ def test_get_state_from_locked_in_to_active(
 @pytest.mark.parametrize('block_height', [16, 17, 18, 19])
 @pytest.mark.parametrize('minimum_activation_height', [17, 20, 100])
 def test_get_state_from_locked_in_to_locked_in(
-    storage: TransactionStorage,
     block_height: int,
     minimum_activation_height: int,
 ) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -406,11 +360,9 @@ def test_get_state_from_locked_in_to_locked_in(
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -420,10 +372,8 @@ def test_get_state_from_locked_in_to_locked_in(
 
 
 @pytest.mark.parametrize('block_height', [20, 21, 22, 23])
-def test_get_state_from_active(storage: TransactionStorage, block_height: int) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+def test_get_state_from_active(block_height: int) -> None:
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -432,11 +382,9 @@ def test_get_state_from_active(storage: TransactionStorage, block_height: int) -
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -446,10 +394,8 @@ def test_get_state_from_active(storage: TransactionStorage, block_height: int) -
 
 
 @pytest.mark.parametrize('block_height', [16, 17, 18, 19])
-def test_caching_mechanism(storage: TransactionStorage, block_height: int) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+def test_is_feature_active(block_height: int) -> None:
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=3,
                 start_height=0,
@@ -458,41 +404,10 @@ def test_caching_mechanism(storage: TransactionStorage, block_height: int) -> No
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(feature_settings=feature_settings, tx_storage=storage)
-    service.bit_signaling_service = Mock()
-    block = not_none(storage.get_block_by_height(block_height))
-    calculate_new_state_mock = Mock(wraps=service._calculate_new_state)
-
-    with patch.object(FeatureService, '_calculate_new_state', calculate_new_state_mock):
-        result1 = service.get_state(block=block, feature=Feature.NOP_FEATURE_1)
-
-        assert result1 == FeatureState.ACTIVE
-        assert calculate_new_state_mock.call_count == 4
-
-        calculate_new_state_mock.reset_mock()
-        result2 = service.get_state(block=block, feature=Feature.NOP_FEATURE_1)
-
-        assert result2 == FeatureState.ACTIVE
-        assert calculate_new_state_mock.call_count == 0
-
-
-@pytest.mark.parametrize('block_height', [16, 17, 18, 19])
-def test_is_feature_active(storage: TransactionStorage, block_height: int) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
-            Feature.NOP_FEATURE_1: Criteria.construct(
-                bit=3,
-                start_height=0,
-                timeout_height=8,
-                lock_in_on_timeout=True,
-                version=Mock()
-            )
-        }
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
     service = FeatureService(
-        feature_settings=feature_settings,
+        settings=settings,
         tx_storage=storage
     )
     service.bit_signaling_service = Mock()
@@ -504,10 +419,8 @@ def test_is_feature_active(storage: TransactionStorage, block_height: int) -> No
 
 
 @pytest.mark.parametrize('block_height', [12, 13, 14, 15])
-def test_get_state_from_failed(storage: TransactionStorage, block_height: int) -> None:
-    feature_settings = FeatureSettings.construct(
-        evaluation_interval=4,
-        features={
+def test_get_state_from_failed(block_height: int) -> None:
+    features = {
             Feature.NOP_FEATURE_1: Criteria.construct(
                 bit=Mock(),
                 start_height=0,
@@ -515,11 +428,9 @@ def test_get_state_from_failed(storage: TransactionStorage, block_height: int) -
                 version=Mock()
             )
         }
-    )
-    service = FeatureService(
-        feature_settings=feature_settings,
-        tx_storage=storage
-    )
+    settings = get_settings(features=features)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -528,24 +439,26 @@ def test_get_state_from_failed(storage: TransactionStorage, block_height: int) -
     assert result == FeatureState.FAILED
 
 
-def test_get_state_undefined_feature(storage: TransactionStorage, service: FeatureService) -> None:
+def test_get_state_undefined_feature() -> None:
+    settings = get_settings(features={})
+    storage = get_storage(settings, up_to_height=10)
     block = not_none(storage.get_block_by_height(10))
+    service = FeatureService(settings=settings, tx_storage=storage)
     result = service.get_state(block=block, feature=Feature.NOP_FEATURE_1)
 
     assert result == FeatureState.DEFINED
 
 
-def test_get_bits_description(storage: TransactionStorage) -> None:
+def test_get_feature_info() -> None:
     criteria_mock_1 = Criteria.construct(bit=Mock(), start_height=Mock(), timeout_height=Mock(), version=Mock())
     criteria_mock_2 = Criteria.construct(bit=Mock(), start_height=Mock(), timeout_height=Mock(), version=Mock())
-    feature_settings = FeatureSettings.construct(
-        features={
-            Feature.NOP_FEATURE_1: criteria_mock_1,
-            Feature.NOP_FEATURE_2: criteria_mock_2
-        }
-    )
+    settings = get_settings(features={
+        Feature.NOP_FEATURE_1: criteria_mock_1,
+        Feature.NOP_FEATURE_2: criteria_mock_2
+    })
+    storage = get_storage(settings, up_to_height=0)
     service = FeatureService(
-        feature_settings=feature_settings,
+        settings=settings,
         tx_storage=storage
     )
     service.bit_signaling_service = Mock()
@@ -558,11 +471,11 @@ def test_get_bits_description(storage: TransactionStorage) -> None:
         return states[feature]
 
     with patch('hathor.feature_activation.feature_service.FeatureService.get_state', get_state):
-        result = service.get_bits_description(block=Mock())
+        result = service.get_feature_infos(block=Mock())
 
     expected = {
-        Feature.NOP_FEATURE_1: FeatureDescription(criteria_mock_1, FeatureState.STARTED),
-        Feature.NOP_FEATURE_2: FeatureDescription(criteria_mock_2, FeatureState.FAILED),
+        Feature.NOP_FEATURE_1: FeatureInfo(criteria_mock_1, FeatureState.STARTED),
+        Feature.NOP_FEATURE_2: FeatureInfo(criteria_mock_2, FeatureState.FAILED),
     }
 
     assert result == expected
@@ -578,13 +491,10 @@ def test_get_bits_description(storage: TransactionStorage) -> None:
         (0, 0),
     ]
 )
-def test_get_ancestor_at_height_invalid(
-    feature_settings: FeatureSettings,
-    storage: TransactionStorage,
-    block_height: int,
-    ancestor_height: int
-) -> None:
-    service = FeatureService(feature_settings=feature_settings, tx_storage=storage)
+def test_get_ancestor_at_height_invalid(block_height: int, ancestor_height: int) -> None:
+    settings = get_settings(features={})
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 
@@ -600,26 +510,26 @@ def test_get_ancestor_at_height_invalid(
     ['block_height', 'ancestor_height'],
     [
         (21, 20),
-        (21, 10),
-        (21, 0),
-        (15, 10),
-        (15, 0),
+        (21, 18),
+        (21, 17),
+        (15, 12),
+        (15, 11),
         (1, 0),
     ]
 )
-def test_get_ancestor_at_height(
-    feature_settings: FeatureSettings,
-    storage: TransactionStorage,
-    block_height: int,
-    ancestor_height: int
-) -> None:
-    service = FeatureService(feature_settings=feature_settings, tx_storage=storage)
-    service.bit_signaling_service = Mock()
+def test_get_ancestor_at_height(block_height: int, ancestor_height: int) -> None:
+    settings = get_settings(features={})
+    storage = get_storage(settings, up_to_height=block_height)
     block = not_none(storage.get_block_by_height(block_height))
 
     get_block_by_height_wrapped = Mock(wraps=storage.get_block_by_height)
     with patch.object(storage, 'get_block_by_height', get_block_by_height_wrapped):
-        result = service._get_ancestor_at_height(block=block, ancestor_height=ancestor_height)
+        service = FeatureService(settings=settings, tx_storage=storage)
+        service.bit_signaling_service = Mock()
+        result = service._get_ancestor_at_height(
+            block=block,
+            ancestor_height=ancestor_height
+        )
 
         assert get_block_by_height_wrapped.call_count == (
             0 if block_height - ancestor_height <= 1 else 1
@@ -634,19 +544,17 @@ def test_get_ancestor_at_height(
         (21, 20),
         (21, 18),
         (15, 12),
-        (15, 10),
+        (15, 11),
         (1, 0),
     ]
 )
-def test_get_ancestor_at_height_voided(
-    feature_settings: FeatureSettings,
-    storage: TransactionStorage,
-    block_height: int,
-    ancestor_height: int
-) -> None:
-    service = FeatureService(feature_settings=feature_settings, tx_storage=storage)
+def test_get_ancestor_at_height_voided(block_height: int, ancestor_height: int) -> None:
+    settings = get_settings(features={})
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
+
     parent_block = not_none(storage.get_block_by_height(block_height - 1))
     parent_block.get_metadata().voided_by = {b'some'}
 
@@ -686,7 +594,6 @@ def test_get_ancestor_at_height_voided(
     ]
 )
 def test_check_must_signal(
-    storage: TransactionStorage,
     bit: int,
     threshold: int,
     block_height: int,
@@ -705,7 +612,9 @@ def test_check_must_signal(
             )
         }
     )
-    service = FeatureService(feature_settings=feature_settings, tx_storage=storage)
+    settings = get_global_settings()._replace(FEATURE_ACTIVATION=feature_settings)
+    storage = get_storage(settings, up_to_height=block_height)
+    service = FeatureService(settings=settings, tx_storage=storage)
     service.bit_signaling_service = Mock()
     block = not_none(storage.get_block_by_height(block_height))
 

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -82,7 +82,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         manager = artifacts.manager
 
         feature_resource = FeatureResource(
-            feature_settings=feature_settings,
+            settings=settings,
             feature_service=feature_service,
             tx_storage=artifacts.tx_storage
         )
@@ -358,7 +358,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
         manager = artifacts.manager
 
         feature_resource = FeatureResource(
-            feature_settings=feature_settings,
+            settings=settings,
             feature_service=feature_service,
             tx_storage=artifacts.tx_storage
         )
@@ -573,7 +573,7 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
         manager1 = artifacts1.manager
 
         feature_resource = FeatureResource(
-            feature_settings=feature_settings,
+            settings=settings,
             feature_service=feature_service1,
             tx_storage=artifacts1.tx_storage
         )
@@ -626,7 +626,7 @@ class BaseRocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
         feature_service = artifacts2.feature_service
 
         feature_resource = FeatureResource(
-            feature_settings=feature_settings,
+            settings=settings,
             feature_service=feature_service,
             tx_storage=artifacts2.tx_storage
         )

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -342,8 +342,6 @@ class BaseVerificationTest(unittest.TestCase):
         verify_data_wrapped = Mock(wraps=self.verifiers.block.verify_data)
         verify_sigops_output_wrapped = Mock(wraps=self.verifiers.vertex.verify_sigops_output)
 
-        verify_aux_pow_wrapped = Mock(wraps=self.verifiers.merge_mined_block.verify_aux_pow)
-
         with (
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
@@ -352,7 +350,6 @@ class BaseVerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
-            patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
             self.manager.verification_service.verify_without_storage(block)
 
@@ -366,9 +363,6 @@ class BaseVerificationTest(unittest.TestCase):
         verify_number_of_outputs_wrapped.assert_called_once()
         verify_data_wrapped.assert_called_once()
         verify_sigops_output_wrapped.assert_called_once()
-
-        # MergeMinedBlock methods
-        verify_aux_pow_wrapped.assert_called_once()
 
     def test_merge_mined_block_verify(self) -> None:
         block = self._get_valid_merge_mined_block()


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1014

---

### Motivation

Continuing with the static metadata refactor introduced in PRs https://github.com/HathorNetwork/hathor-core/pull/1013 and https://github.com/HathorNetwork/hathor-core/pull/1014, the next step is to move the `feature_states` attribute from metadata to static metadata.

This was initially implemented in PR https://github.com/HathorNetwork/hathor-core/pull/1015, which turned out to be too large, so it was divided into 3 PRs: this one, https://github.com/HathorNetwork/hathor-core/pull/1017, and https://github.com/HathorNetwork/hathor-core/pull/1018. The latter is the one that actually moves the `feature_states` attribute, and the first two PRs perform simple refactors that were either necessary or small improvements.

Therefore, this PR simply performs some pre-refactors to debloat the main PR.

### Acceptance Criteria

- **IMPORTANT:** move `verify_aux_pow()` verification from `verify_without_storage()` to `verify()`.
- Rename `FeatureService.get_bits_description()` to `get_feature_infos()`, and `FeatureDescription` to `FeatureInfo`.
- Change `FeatureService._get_ancestor_at_height()` to assert that a block exists in the height index when it must.
- Update the `FeatureState` enum to be a unique string enum, like `Feature` (this will be important for serialization), and implement `is_active()`.
- Change static metadata dataclasses to `BaseModel`s instead, which will be necessary for (de)serialization.
- Other smaller improvements.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 