### PR TITLE
fix: catch update_reward_lock_metadata exceptions

### DIFF
--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -150,9 +150,9 @@ class VertexHandler:
             return False
 
         if not metadata.validation.is_fully_connected():
-            # TODO: Remove this from here after a refactor in metadata initialization
-            vertex.update_reward_lock_metadata()
             try:
+                # TODO: Remove this from here after a refactor in metadata initialization
+                vertex.update_reward_lock_metadata()
                 self._verification_service.validate_full(vertex, reject_locked_reward=reject_locked_reward)
             except HathorError as e:
                 if not fails_silently:


### PR DESCRIPTION
### Motivation

Correctly handle exceptions raised by `update_reward_lock_metadata()`.

### Acceptance Criteria

- Move `update_reward_lock_metadata()` call to inside the `validate_full()` try block.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 