### PR TITLE
feat(merged-mining): configure new max merkle path length on mainnet

### DIFF
--- a/hathor/conf/mainnet.py
+++ b/hathor/conf/mainnet.py
@@ -237,6 +237,18 @@ SETTINGS = HathorSettings(
                 version='0.59.0',
                 signal_support_by_default=False,
             ),
+            Feature.INCREASE_MAX_MERKLE_PATH_LENGTH: Criteria(
+                bit=0,
+                # N = 4_475_520
+                # Expected to be reached around Monday, 2024-05-13 17:31:03 GMT
+                # Right now the best block is 4_463_619 at Thursday, 2024-05-09 14:20:33 GMT
+                start_height=4_475_520,
+                timeout_height=4_798_080,  # N + 16 * 20160 (16 weeks after the start)
+                minimum_activation_height=4_636_800,  # N + 8 * 20160 (8 weeks after the start)
+                lock_in_on_timeout=False,
+                version='0.60.0',
+                signal_support_by_default=True,
+            ),
         }
     )
 )

--- a/hathor/conf/mainnet.yml
+++ b/hathor/conf/mainnet.yml
@@ -221,3 +221,17 @@ FEATURE_ACTIVATION:
       lock_in_on_timeout: false
       version: 0.59.0
       signal_support_by_default: false
+
+    #### Actual features ####
+
+    INCREASE_MAX_MERKLE_PATH_LENGTH:
+      bit: 0
+      # N = 4_475_520
+      # Expected to be reached around Monday, 2024-05-13 17:31:03 GMT
+      # Right now the best block is 4_463_619 at Thursday, 2024-05-09 14:20:33 GMT
+      start_height: 4_475_520
+      timeout_height: 4_798_080  # N + 16 * 20160 (16 weeks after the start)
+      minimum_activation_height: 4_636_800  # N + 8 * 20160 (8 weeks after the start)
+      lock_in_on_timeout: false
+      version: 0.60.0
+      signal_support_by_default: true


### PR DESCRIPTION
### Motivation

We're ready to introduce this upgrade on the mainnet.

### Acceptance Criteria

- Set up the max-merkle-path increase on the mainnet

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 