### PR TITLE
feat(cli): Add --log-vertex-bytes for debugging

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -309,6 +309,7 @@ class CliBuilder:
             feature_service=self.feature_service,
             pubsub=pubsub,
             wallet=self.wallet,
+            log_vertex_bytes=self._args.log_vertex_bytes,
         )
 
         self.manager = HathorManager(

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -151,6 +151,8 @@ class RunNode:
         # XXX: this is temporary, should be added as a sysctl instead before merging
         parser.add_argument('--x-ipython-kernel', action='store_true',
                             help='Launch embedded IPython kernel for remote debugging')
+        parser.add_argument('--log-vertex-bytes', action='store_true',
+                            help='Log tx bytes for debugging')
         return parser
 
     def prepare(self, *, register_resources: bool = True) -> None:

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -79,3 +79,4 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     x_asyncio_reactor: bool
     x_ipython_kernel: bool
     nano_testnet: bool
+    log_vertex_bytes: bool

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -45,6 +45,7 @@ class VertexHandler:
         '_feature_service',
         '_pubsub',
         '_wallet',
+        '_log_vertex_bytes',
     )
 
     def __init__(
@@ -59,6 +60,7 @@ class VertexHandler:
         feature_service: FeatureService,
         pubsub: PubSubManager,
         wallet: BaseWallet | None,
+        log_vertex_bytes: bool = False,
     ) -> None:
         self._log = logger.new()
         self._reactor = reactor
@@ -70,6 +72,7 @@ class VertexHandler:
         self._feature_service = feature_service
         self._pubsub = pubsub
         self._wallet = wallet
+        self._log_vertex_bytes = log_vertex_bytes
 
     def on_new_vertex(
         self,
@@ -223,6 +226,8 @@ class VertexHandler:
             'time_from_now': tx.get_time_from_now(now),
             'validation': metadata.validation.name,
         }
+        if self._log_vertex_bytes:
+            kwargs['bytes'] = bytes(tx).hex()
         if tx.is_block:
             message = message_fmt.format('block')
             if isinstance(tx, Block):


### PR DESCRIPTION
### Motivation

We faced some difficulties replicating issue reports from developers. So this PR introduces a parameter to make replication easier just by sharing the full node log with us.

### Acceptance Criteria

- Add the `--log-vertex-bytes` parameter in the run_node cli.
- Add the `VertexHandler._log_vertex_bytes: bool` which defaults to false.
- Log the transaction bytes when this new option is enabled.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 