### PR TITLE
feat(cli): Add load_from_logs cli command to load blocks and transactions as they are found in a log dump

### DIFF
--- a/hathor/cli/load_from_logs.py
+++ b/hathor/cli/load_from_logs.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import sys
+from argparse import ArgumentParser, FileType
+
+from hathor.cli.run_node import RunNode
+
+
+class LoadFromLogs(RunNode):
+    def start_manager(self) -> None:
+        pass
+
+    def register_signal_handlers(self) -> None:
+        pass
+
+    @classmethod
+    def create_parser(cls) -> ArgumentParser:
+        parser = super().create_parser()
+        parser.add_argument('--log-dump', type=FileType('r', encoding='UTF-8'), default=sys.stdin, nargs='?',
+                            help='Where to read logs from, defaults to stdin.')
+        return parser
+
+    def prepare(self, *, register_resources: bool = True) -> None:
+        super().prepare(register_resources=False)
+
+    def run(self) -> None:
+        from hathor.transaction.base_transaction import tx_or_block_from_bytes
+
+        pattern = r'new (tx|block)    .*bytes=([^ ]*) '
+        pattern = r'new (tx|block)    .*bytes=([^ ]*) '
+        compiled_pattern = re.compile(pattern)
+
+        while True:
+            line_with_break = self._args.log_dump.readline()
+            if not line_with_break:
+                break
+            line = line_with_break.strip()
+
+            matches = compiled_pattern.findall(line)
+            if len(matches) == 0:
+                continue
+
+            assert len(matches) == 1
+            _, vertex_bytes_hex = matches[0]
+
+            vertex_bytes = bytes.fromhex(vertex_bytes_hex)
+            vertex = tx_or_block_from_bytes(vertex_bytes)
+            self.manager.on_new_tx(vertex)
+
+
+def main():
+    LoadFromLogs().run()

--- a/hathor/cli/main.py
+++ b/hathor/cli/main.py
@@ -35,6 +35,7 @@ class CliManager:
             db_export,
             db_import,
             generate_valid_words,
+            load_from_logs,
             merged_mining,
             mining,
             multisig_address,
@@ -91,6 +92,7 @@ class CliManager:
         self.add_cmd('dev', 'x-export', db_export, 'EXPERIMENTAL: Export database to a simple format.')
         self.add_cmd('dev', 'x-import', db_import, 'EXPERIMENTAL: Import database from exported format.')
         self.add_cmd('dev', 'replay-logs', replay_logs, 'EXPERIMENTAL: re-play json logs as console printted')
+        self.add_cmd('dev', 'load-from-logs', load_from_logs, 'Load vertices as they are found in a log dump')
 
     def add_cmd(self, group: str, cmd: str, module: ModuleType, short_description: Optional[str] = None) -> None:
         self.command_list[cmd] = module


### PR DESCRIPTION
### Motivation

This new command makes it easier to replay logs generated using `--log-vertex-bytes` (https://github.com/HathorNetwork/hathor-core/pull/1033).

I initially thought that we could replay even the timestamp by using a custom reactor and getting a tighter control of the time. But it was not needed yet for my debugging so I decided to postpone it to another PR.

### Acceptance Criteria

1. Add command `load_from_logs` that loads blocks and transactions as they are found in a log dump generated using `--log-vertex-bytes`. All vertices are processed in the same order as they appear in the log file.
2. The full node exits after the replay is complete.
3. All arguments from `run_node` are available so one can configure the environment where the replay will take place. A new required argument `--log-dump` was added to get the path of the log file that will be replayed.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 