### PR TITLE
fix(events): fix initialization on existing event storage

### DIFF
--- a/hathor/event/model/event_data.py
+++ b/hathor/event/model/event_data.py
@@ -101,7 +101,7 @@ class TxData(BaseEventData, extra=Extra.ignore):
     hash: str
     nonce: Optional[int] = None
     timestamp: int
-    signal_bits: int
+    signal_bits: int | None
     version: int
     weight: float
     inputs: list['TxInput']


### PR DESCRIPTION
### Motivation

In v0.60.0 the `signal_bits` field was added to event's `TxData`, but that breaks when initializing with an existing event storage. That happened when trying to update the wallet service node.

### Acceptance Criteria

- Make event's `TxData.signal_bits` nullable.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 