### PR TITLE
feat(side-dag): implement gen_keys CLI command

### DIFF
--- a/hathor/cli/generate_poa_keys.py
+++ b/hathor/cli/generate_poa_keys.py
@@ -1,0 +1,49 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import sys
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKeyWithSerialization
+
+
+def main():
+    from hathor.cli.util import create_parser
+    from hathor.crypto.util import (
+        get_address_b58_from_public_key,
+        get_private_key_bytes,
+        get_public_key_bytes_compressed,
+    )
+    parser = create_parser()
+    parser.add_argument('--config-yaml', type=str, help='Configuration yaml filepath')
+    args = parser.parse_args(sys.argv[1:])
+    if not args.config_yaml:
+        raise Exception('`--config-yaml` is required')
+    # We have to set the config file because the `get_address_b58_from_public_key()` call below accesses it indirectly
+    # to use the version bytes.
+    os.environ['HATHOR_CONFIG_YAML'] = args.config_yaml
+
+    private_key = ec.generate_private_key(ec.SECP256K1())
+    public_key = private_key.public_key()
+    assert isinstance(private_key, EllipticCurvePrivateKeyWithSerialization)
+
+    data = dict(
+        private_key_hex=get_private_key_bytes(private_key=private_key).hex(),
+        public_key_hex=get_public_key_bytes_compressed(public_key=public_key).hex(),
+        address=get_address_b58_from_public_key(public_key=public_key),
+    )
+
+    print(json.dumps(data, indent=4))

--- a/hathor/cli/main.py
+++ b/hathor/cli/main.py
@@ -34,6 +34,7 @@ class CliManager:
         from . import (
             db_export,
             db_import,
+            generate_poa_keys,
             generate_valid_words,
             load_from_logs,
             merged_mining,
@@ -71,6 +72,8 @@ class CliManager:
             from . import top
             self.add_cmd('hathor', 'top', top, 'CPU profiler viewer')
         self.add_cmd('side-dag', 'run_node_with_side_dag', side_dag, 'Run a side-dag')
+        self.add_cmd('side-dag', 'gen_poa_keys', generate_poa_keys, 'Generate a private/public key pair and its '
+                                                                    'address to be used in Proof-of-Authority')
         self.add_cmd('docs', 'generate_openapi_json', openapi_json, 'Generate OpenAPI json for API docs')
         self.add_cmd('multisig', 'gen_multisig_address', multisig_address, 'Generate a new multisig address')
         self.add_cmd('multisig', 'spend_multisig_output', multisig_spend, 'Generate tx that spends a multisig output')


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1039

### Motivation

Implement a new CLI command to generate private/public keys to be used in Proof-of-Authority signing. 

### Acceptance Criteria

- Implement `gen_poa_keys` CLI command.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 