### PR TITLE
fix(resources): regression in address history endpoint

### DIFF
--- a/tests/resources/base_resource.py
+++ b/tests/resources/base_resource.py
@@ -53,8 +53,17 @@ class TestDummyRequest(DummyRequest):
 
         # Set request args
         args = args or {}
-        for k, v in args.items():
-            self.addArg(k, v)
+        if isinstance(args, dict):
+            for k, v in args.items():
+                self.addArg(k, v)
+        elif isinstance(args, list):
+            for k, v in args:
+                if k not in self.args:
+                    self.args[k] = [v]
+                else:
+                    self.args[k].append(v)
+        else:
+            raise TypeError(f'unsupported type {type(args)} for args')
 
     def json_value(self):
         return json_loadb(self.written[0])


### PR DESCRIPTION
### Motivation

After the release o v0.60.0 [a bug was reported](https://github.com/HathorNetwork/on-call-incidents/issues/173) in the address-history API. The bug was introduced after the optimizations in #978, reverting the PR makes the bug disappear.

### Acceptance Criteria

- Restore the correct behavior without undoing the optimizations
- Add a test that reproduces the issue 

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 