### PR TITLE
refactor(p2p): split hathor.p2p.peer_discovery into separate modules

### DIFF
--- a/hathor/p2p/peer_discovery/__init__.py
+++ b/hathor/p2p/peer_discovery/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .bootstrap import BootstrapPeerDiscovery
+from .dns import DNSPeerDiscovery
+from .peer_discovery import PeerDiscovery
+
+__all__ = [
+    'PeerDiscovery',
+    'BootstrapPeerDiscovery',
+    'DNSPeerDiscovery',
+]

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+
+from structlog import get_logger
+from typing_extensions import override
+
+from .peer_discovery import PeerDiscovery
+
+logger = get_logger()
+
+
+class BootstrapPeerDiscovery(PeerDiscovery):
+    """ It implements a bootstrap peer discovery, which receives a static list of peers.
+    """
+
+    def __init__(self, descriptions: list[str]):
+        """
+        :param descriptions: Descriptions of peers to connect to.
+        """
+        super().__init__()
+        self.log = logger.new()
+        self.descriptions = descriptions
+
+    @override
+    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
+        for description in self.descriptions:
+            connect_to(description)

--- a/hathor/p2p/peer_discovery/dns.py
+++ b/hathor/p2p/peer_discovery/dns.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Hathor Labs
+# Copyright 2024 Hathor Labs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import socket
-from abc import ABC, abstractmethod
 from typing import Callable
 
 from structlog import get_logger
@@ -22,39 +21,9 @@ from twisted.names.client import lookupAddress, lookupText
 from twisted.names.dns import Record_A, Record_TXT, RRHeader
 from typing_extensions import override
 
+from .peer_discovery import PeerDiscovery
+
 logger = get_logger()
-
-
-class PeerDiscovery(ABC):
-    """ Base class to implement peer discovery strategies.
-    """
-
-    @abstractmethod
-    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
-        """ This method must discover the peers and call `connect_to` for each of them.
-
-        :param connect_to: Function which will be called for each discovered peer.
-        :type connect_to: function
-        """
-        raise NotImplementedError
-
-
-class BootstrapPeerDiscovery(PeerDiscovery):
-    """ It implements a bootstrap peer discovery, which receives a static list of peers.
-    """
-
-    def __init__(self, descriptions: list[str]):
-        """
-        :param descriptions: Descriptions of peers to connect to.
-        """
-        super().__init__()
-        self.log = logger.new()
-        self.descriptions = descriptions
-
-    @override
-    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
-        for description in self.descriptions:
-            connect_to(description)
 
 
 class DNSPeerDiscovery(PeerDiscovery):

--- a/hathor/p2p/peer_discovery/peer_discovery.py
+++ b/hathor/p2p/peer_discovery/peer_discovery.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+
+class PeerDiscovery(ABC):
+    """ Base class to implement peer discovery strategies.
+    """
+
+    @abstractmethod
+    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
+        """ This method must discover the peers and call `connect_to` for each of them.
+
+        :param connect_to: Function which will be called for each discovered peer.
+        :type connect_to: function
+        """
+        raise NotImplementedError


### PR DESCRIPTION
### Motivation

The `hathor.p2p.peer_discovery` module aggregates the abstraction and implementations, it could be split to make future implementations cleaner to review.

### Acceptance Criteria

- Split `hathor.p2p.peer_discovery` into the following submodules: `peer_discovery` (abstraction), `dns` (DNS implementation), `bootstrap` (bootstrap implementation), expose everything the same way they were being exposed before.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 