### PR TITLE
feat(p2p): persistent storage for known peers

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -77,7 +77,7 @@ class CliBuilder:
         from hathor.event.storage import EventMemoryStorage, EventRocksDBStorage, EventStorage
         from hathor.event.websocket.factory import EventWebsocketFactory
         from hathor.p2p.netfilter.utils import add_peer_id_blacklist
-        from hathor.p2p.peer_discovery import BootstrapPeerDiscovery, DNSPeerDiscovery
+        from hathor.p2p.peer_discovery import BootstrapPeerDiscovery, DNSPeerDiscovery, StoragePeerDiscovery
         from hathor.storage import RocksDBStorage
         from hathor.transaction.storage import (
             TransactionCacheStorage,
@@ -298,6 +298,10 @@ class CliBuilder:
             rng=Random(),
         )
         SyncSupportLevel.add_factories(p2p_manager, sync_v1_support, sync_v2_support)
+
+        if not self._args.memory_storage:
+            assert self.rocksdb_storage is not None
+            p2p_manager.set_persistent_peer_storage(StoragePeerDiscovery(self.rocksdb_storage))
 
         vertex_handler = VertexHandler(
             reactor=reactor,

--- a/hathor/p2p/peer_discovery/__init__.py
+++ b/hathor/p2p/peer_discovery/__init__.py
@@ -15,9 +15,11 @@
 from .bootstrap import BootstrapPeerDiscovery
 from .dns import DNSPeerDiscovery
 from .peer_discovery import PeerDiscovery
+from .storage import StoragePeerDiscovery
 
 __all__ = [
     'PeerDiscovery',
     'BootstrapPeerDiscovery',
     'DNSPeerDiscovery',
+    'StoragePeerDiscovery',
 ]

--- a/hathor/p2p/peer_discovery/storage.py
+++ b/hathor/p2p/peer_discovery/storage.py
@@ -1,0 +1,169 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import asdict, dataclass, field
+from typing import Callable, Iterator
+
+from structlog import get_logger
+from typing_extensions import override
+
+from hathor.p2p.peer_id import PeerId
+from hathor.storage.rocksdb_storage import RocksDBStorage
+from hathor.util import json_dumpb, json_loadb
+
+from .peer_discovery import PeerDiscovery
+
+logger = get_logger()
+
+_CF_NAME: bytes = b'known-peers'
+PEER_FORGET_TIMEOUT = 3 * 24 * 3600  # forget a peer after 3 days
+
+
+@dataclass
+class _Record:
+    """Python object to load each entry of the database into, to be used only within this module."""
+    peer_id: str
+    entrypoints: list[str] = field(default_factory=list)
+    last_connection: int | None = None
+    last_connection_attempt: int | None = None
+    to_remove: bool = False
+
+
+def record_to_bytes(record: _Record) -> bytes:
+    """Serialize _Records into bytes using JSON."""
+    return json_dumpb(asdict(record))
+
+
+def bytes_to_record(raw_record: bytes) -> _Record:
+    """Parse bytes into _Record entry."""
+    return _Record(**json_loadb(raw_record))
+
+
+def peerid_to_bytes(peerid: str) -> bytes:
+    """Serialize peer-id into bytes by simply using byte equivalent of its hexadecimal representation."""
+    return bytes.fromhex(peerid)
+
+
+def bytes_to_peerid(raw_peerid: bytes) -> str:
+    """Parse bytes into peer-id."""
+    return raw_peerid.hex()
+
+
+class StoragePeerDiscovery(PeerDiscovery):
+    """ It implements a peer discovery strategy by simply trying to connect to known peers from previous starts.
+
+    Entries use the following pattern:
+
+        key   = [peer_id | 32 bytes]
+        value = [JSON encoded record | variable size]
+
+    Only peers which have had a sucessful handshake will be added to the storage because that's the only way to confirm
+    their peer-id so they can have a unique key. All of their entrypoints will be tried as part of the "discover and
+    connect" phase.
+
+    After a failed connection attempt if it has passed more than PEER_FORGET_TIMEOUT, the entry will be marked for
+    removal (which it means we won't try to connect to it on discovery), and then after another PEER_FORGET_TIMEOUT it
+    will be removed (to give a chance for any peer that was just connected in the mean time).
+    """
+
+    def __init__(self, storage: RocksDBStorage):
+        """ We need an RocksDBStorage to store entries into."""
+        super().__init__()
+        self.log = logger.new()
+        self._db = storage.get_db()
+        self._cf = storage.get_or_create_column_family(_CF_NAME)
+        self.peer_forget_timeout = PEER_FORGET_TIMEOUT
+
+    def _iter_records(self) -> Iterator[_Record]:
+        """ Iterate over all records in the database."""
+        it = self._db.itervalues(self._cf)
+        it.seek_to_first()
+        for raw_record in it:
+            yield bytes_to_record(raw_record)
+
+    def _iter_descriptors(self) -> Iterator[str]:
+        """ Iterate over known peer descriptors that are stored in the database and are not marked for removal."""
+        for record in self._iter_records():
+            if record.to_remove:
+                continue
+            yield from iter(record.entrypoints)
+
+    @override
+    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
+        for description in self._iter_descriptors():
+            connect_to(description)
+
+    def _remove(self, peer_id: str) -> None:
+        """ Remove entry from database."""
+        raw_peerid = peerid_to_bytes(peer_id)
+        self._db.delete((self._cf, raw_peerid))
+
+    def _get(self, peer_id: str) -> _Record | None:
+        """ Get record with given peer_id, returns None if there's no record with the given peer_id."""
+        raw_record = self._db.get((self._cf, peerid_to_bytes(peer_id)))
+        if raw_record is None:
+            return None
+        record = bytes_to_record(raw_record)
+        assert record.peer_id == peer_id
+        return record
+
+    def _put(self, record: _Record) -> None:
+        """ Add or update record into the database, previous entry is replaced."""
+        raw_peerid = peerid_to_bytes(record.peer_id)
+        raw_record = record_to_bytes(record)
+        self._db.put((self._cf, raw_peerid), raw_record)
+
+    def _get_or_create(self, peer_id: str) -> _Record:
+        """ Get a record with given peer_id, or create one if it doesn't exist."""
+        if (record := self._get(peer_id)) is not None:
+            return record
+        else:
+            return _Record(peer_id)
+
+    def add_connected(self, peer: PeerId, now_timestamp: int) -> None:
+        """ Add a peer that just connected, will update the last connection with the given timestamp."""
+        assert peer.id is not None
+        record = self._get_or_create(peer.id)
+        record.to_remove = False  # if this node was marked for removal
+        record.entrypoints = peer.entrypoints
+        record.last_connection = now_timestamp
+        self._put(record)
+
+    def mark_try_to_connect(self, peer: PeerId, now_timestamp: int) -> None:
+        """ Update the timestamp when we last tried to connect to a peer."""
+        assert peer.id is not None
+        record = self._get_or_create(peer.id)
+        record.last_connection_attempt = now_timestamp
+        self._put(record)
+
+    def run_cleanup(self, now_timestamp: int) -> None:
+        """ This should be called periodically so the database can be cleaned up."""
+        for record in self._iter_records():
+            # immediately remove record previously marked for removal
+            if record.to_remove:
+                self._remove(record.peer_id)
+                continue
+
+            # if for any reason there isn't a last_connection, we mark it for removal
+            if record.last_connection is None:
+                record.to_remove = True
+                self._put(record)
+                continue
+
+            # if it passed too long, we mark for removal
+            last_connection_delta = now_timestamp - record.last_connection
+            if last_connection_delta > self.peer_forget_timeout:
+                record.to_remove = True
+                self._put(record)
+                continue

--- a/tests/p2p/test_persistent_peer_storage.py
+++ b/tests/p2p/test_persistent_peer_storage.py
@@ -1,0 +1,158 @@
+import shutil
+import tempfile
+
+import pytest
+
+from hathor.p2p.peer_discovery.storage import StoragePeerDiscovery, _Record
+from hathor.storage.rocksdb_storage import RocksDBStorage
+from hathor.util import not_none
+from tests.unittest import PEER_ID_POOL, TestCase
+from tests.utils import HAS_ROCKSDB
+
+
+def _gen_entrypoints(k: int) -> list[str]:
+    """A helper function to deterministically generate a fake entrypoint list that varies in size.
+
+    The integer k is used to decide how many entrypoints will be generated and the ports. All entrypoints will the
+    hostname `local.test` which can't resolve to anything, so it will never really connect in case any test ends up
+    trying to, however tests using this should not try to test actuall connections.
+    """
+    entrypoints_len = (k % 3) + 1
+    return [f'tcp://local.test:{(1 + k // 100) % 10:01}{k % 100:02}{i:02}' for i in range(entrypoints_len)]
+
+
+def test_gen_entrypoints() -> None:
+    assert _gen_entrypoints(0) == ['tcp://local.test:10000']
+    assert _gen_entrypoints(1) == ['tcp://local.test:10100', 'tcp://local.test:10101']
+    assert _gen_entrypoints(99) == ['tcp://local.test:19900']
+    assert _gen_entrypoints(100) == ['tcp://local.test:20000', 'tcp://local.test:20001']
+
+
+RECORDS = [
+    _Record(
+        peer_id=not_none(peer_id.id),
+        entrypoints=_gen_entrypoints(i),
+    )
+    for i, peer_id in enumerate(PEER_ID_POOL)
+]
+
+
+def test_serialize_and_parse() -> None:
+    from hathor.p2p.peer_discovery.storage import bytes_to_record, record_to_bytes
+    for record in RECORDS:
+        raw_record = record_to_bytes(record)
+        record2 = bytes_to_record(raw_record)
+        assert record2 == record
+
+
+@pytest.mark.skipif(not HAS_ROCKSDB, reason='requires python-rocksdb')
+class PeerStorageTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._directory = tempfile.mkdtemp()
+        self.storage = StoragePeerDiscovery(RocksDBStorage(path=self._directory))
+
+    def _load_records(self, records: list[_Record]) -> None:
+        for record in records:
+            self.storage._put(record)
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        shutil.rmtree(self._directory)
+
+    def test_add_or_update(self) -> None:
+        peer = PEER_ID_POOL[0]
+        assert peer.id is not None
+        connection_time = 10
+        self.storage.add_connected(peer, connection_time)
+        record = self.storage._get(peer.id)
+        assert record is not None
+        assert record.peer_id == peer.id
+        assert record.entrypoints == peer.entrypoints
+        assert record.last_connection == connection_time
+        assert record.last_connection_attempt is None
+        assert record.to_remove is False
+
+    def test_mark_try_to_connect(self) -> None:
+        peer = PEER_ID_POOL[0]
+        assert peer.id is not None
+        connection_time = 10
+        self.storage.mark_try_to_connect(peer, connection_time)
+        record = self.storage._get(peer.id)
+        assert record is not None
+        assert record.peer_id == peer.id
+        assert record.entrypoints == []
+        assert record.last_connection is None
+        assert record.last_connection_attempt == connection_time
+        assert record.to_remove is False
+
+    async def test_discover_and_connect(self) -> None:
+        self._load_records(RECORDS)
+
+        entrypoints = set()
+
+        def add_to_list(entrypoint: str) -> None:
+            entrypoints.add(entrypoint)
+
+        await self.storage.discover_and_connect(add_to_list)
+
+        expected_entrypoints = set()
+        for record in RECORDS:
+            for entrypoint in record.entrypoints:
+                expected_entrypoints.add(entrypoint)
+
+        assert entrypoints == expected_entrypoints
+
+    def test_run_cleanup_none(self) -> None:
+        self._load_records(RECORDS)
+
+        # sanity check, we don't have to do this in every cleanup test
+        def key(r: _Record) -> str:
+            return r.peer_id
+        assert sorted(self.storage._iter_records(), key=key) == sorted(RECORDS, key=key)
+
+        # they way the records were just loaded make it so the last_connection and last_connection_attempt are both
+        # None, which mean that the first round of cleanup should mark them all as to_remove, and the second round
+        # should remove them all, and the now_timestamp doesn't matter for this, so we use 0
+        for record in self.storage._iter_records():
+            assert not record.to_remove
+        self.storage.run_cleanup(0)
+        for record in self.storage._iter_records():
+            assert record.to_remove
+        self.storage.run_cleanup(0)
+        assert list(self.storage._iter_records()) == []
+
+    def test_run_cleanup_simple(self) -> None:
+        self._load_records(RECORDS)
+
+        # mark every record with progressively increasing last_connection
+        for i, peer in enumerate(PEER_ID_POOL):
+            assert peer.id is not None
+            # XXX: a side effect is that the old entrypoints will be lost because the PeerId objects in PEER_ID_POOL
+            # have no entrypoints, but that's not a problem because entrypoints do not affect cleanup
+            self.storage.add_connected(peer, i)
+
+        # let's make it so we forget peers that haven't connected in the last 15 seconds
+        self.storage.peer_forget_timeout = 15
+
+        # supposed the timestamp is len(RECORDS), which mean we would try to remove all but the last 15 peers
+        now_timestamp = len(RECORDS)
+        self.storage.run_cleanup(now_timestamp)
+        assert len([r for r in self.storage._iter_records() if not r.to_remove]) == 15
+
+        # let's now suppose that we do end up connecting to one of the peers that we marked for removal, it should not
+        # be removed anymore
+        peer = PEER_ID_POOL[1]
+        assert peer.id is not None
+        self.storage.add_connected(peer, now_timestamp)
+        record = self.storage._get(peer.id)
+        assert record is not None
+        assert not record.to_remove
+
+        # now, we push another cleanup, we should have 16 peers, but since we advanced the timestamp, one of those
+        # should be marked for removal
+        now_timestamp += 1
+        self.storage.run_cleanup(now_timestamp)
+        records = list(self.storage._iter_records())
+        assert len(records) == 16
+        assert len([r for r in records if r.to_remove]) == 1


### PR DESCRIPTION
### Motivation

Fixes #1036

### Acceptance Criteria

- Add a peer discovery strategy that stores peer entrypoints from peers we've previously connected to on previous starts
- Use a rocksdb column family to store the entrypoints
- Enable this strategy when using a data dir, and do not enable when not using one
- Make peer manager aware of this object so it can call the appropriate methods to mark when a connection was attempted, when it successfully connected, and periodically clean up
- Add tests that covers the new module

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 