### PR TITLE
fix: profiler reactor initialization

### DIFF
--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional, cast
 from structlog import get_logger
 
 from hathor.conf.get_settings import get_global_settings
-from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block, Transaction, sum_weights
 from hathor.util import classproperty
 
@@ -26,7 +25,6 @@ if TYPE_CHECKING:
     from hathor.consensus.context import ConsensusAlgorithmContext
 
 logger = get_logger()
-cpu = get_cpu_profiler()
 
 _base_transaction_log = logger.new()
 

--- a/hathor/consensus/context.py
+++ b/hathor/consensus/context.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Optional
 
 from structlog import get_logger
 
-from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import PubSubManager
 from hathor.transaction import BaseTransaction, Block
 
@@ -26,7 +25,6 @@ if TYPE_CHECKING:
     from hathor.consensus.transaction_consensus import TransactionConsensusAlgorithm
 
 logger = get_logger()
-cpu = get_cpu_profiler()
 
 _base_transaction_log = logger.new()
 

--- a/hathor/consensus/transaction_consensus.py
+++ b/hathor/consensus/transaction_consensus.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, Iterable, cast
 from structlog import get_logger
 
 from hathor.conf.get_settings import get_global_settings
-from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block, Transaction, TxInput, sum_weights
 from hathor.util import classproperty
 
@@ -25,7 +24,6 @@ if TYPE_CHECKING:
     from hathor.consensus.context import ConsensusAlgorithmContext
 
 logger = get_logger()
-cpu = get_cpu_profiler()
 
 _base_transaction_log = logger.new()
 

--- a/hathor/profiler/cpu.py
+++ b/hathor/profiler/cpu.py
@@ -73,7 +73,7 @@ class SimpleCPUProfiler:
         self.proc_list: list[tuple[Key, ProcItem]] = []
 
         # Timer to call `self.update()` periodically.
-        self.lc_update = LoopingCall(self.update)
+        self.lc_update: LoopingCall | None = None
 
         # Interval to update the list of processes.
         self.update_interval = update_interval
@@ -102,6 +102,7 @@ class SimpleCPUProfiler:
             return
         self.reset()
         self.enabled = True
+        self.lc_update = LoopingCall(self.update)
         self.lc_update.start(self.update_interval)
 
     def stop(self) -> None:
@@ -109,6 +110,7 @@ class SimpleCPUProfiler:
         if not self.enabled:
             return
         self.enabled = False
+        assert self.lc_update is not None
         self.lc_update.stop()
 
     def get_proc_list(self) -> list[tuple[Key, ProcItem]]:

--- a/hathor/reactor/reactor.py
+++ b/hathor/reactor/reactor.py
@@ -70,7 +70,9 @@ def initialize_global_reactor(*, use_asyncio_reactor: bool = False) -> ReactorPr
             msg = (
                 "There's a Twisted reactor installed already. It's probably the default one, installed indirectly by "
                 "one of our imports. This can happen, for example, if we import from the hathor module in "
-                "entrypoint-level, like in CLI tools other than `RunNode`."
+                "entrypoint-level, like in CLI tools other than `RunNode`. Debug it by setting a breakpoint in "
+                "`installReactor()` in the `twisted/internet/main.py` file."
+
             )
             raise Exception(msg) from e
 

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Iterator, Optional
 from hathor.checkpoint import Checkpoint
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.feature_state import FeatureState
-from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, TxOutput, TxVersion
 from hathor.transaction.exceptions import CheckpointError
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
@@ -30,8 +29,6 @@ from hathor.utils.int import get_bit_list
 
 if TYPE_CHECKING:
     from hathor.transaction.storage import TransactionStorage  # noqa: F401
-
-cpu = get_cpu_profiler()
 
 # Signal bits (B), version (B), outputs len (B)
 _FUNDS_FORMAT_STRING = '!BBB'

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from hathor.checkpoint import Checkpoint
 from hathor.exception import InvalidNewTransaction
-from hathor.profiler import get_cpu_profiler
 from hathor.reward_lock import iter_spent_rewards
 from hathor.transaction import BaseTransaction, TxInput, TxOutput, TxVersion
 from hathor.transaction.base_transaction import TX_HASH_SIZE
@@ -30,8 +29,6 @@ from hathor.util import not_none
 
 if TYPE_CHECKING:
     from hathor.transaction.storage import TransactionStorage  # noqa: F401
-
-cpu = get_cpu_profiler()
 
 # Signal bits (B), version (B), token uids len (B) and inputs len (B), outputs len (B).
 _FUNDS_FORMAT_STRING = '!BBBBB'


### PR DESCRIPTION
### Motivation

The `get_cpu_profiler()` function which is called at the module-level in multiple places indirectly installed the Twisted reactor by calling `LoopingCall()`. This meant that when a module with a profiler was imported before reactor initialization (in `initialize_global_reactor`), a `ReactorAlreadyInstalledError` could be thrown.

This PR prevents the profiler from indirectly installing a reactor before it has been initialized.

### Acceptance Criteria

- Change `SimpleCPUProfiler` so it does not create a `LoopingCall` in its `__init__`.
- Remove some unused calls to `get_cpu_profiler()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 