### PR TITLE
feat(side-dag): implement PoaBlockProducer

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 from structlog import get_logger
 
 from hathor.cli.run_node_args import RunNodeArgs
+from hathor.cli.side_dag import SideDagArgs
 from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.event import EventManager
@@ -335,6 +336,18 @@ class CliBuilder:
             execution_manager=execution_manager,
             vertex_handler=vertex_handler,
         )
+
+        if settings.CONSENSUS_ALGORITHM.is_poa():
+            assert isinstance(self._args, SideDagArgs)
+            if self._args.poa_signer_file:
+                from hathor.consensus.poa import PoaBlockProducer, PoaSignerFile
+                poa_signer_file = PoaSignerFile.parse_file(self._args.poa_signer_file)
+                self.manager.poa_block_producer = PoaBlockProducer(
+                    settings=settings,
+                    reactor=reactor,
+                    manager=self.manager,
+                    poa_signer=poa_signer_file.get_signer(),
+                )
 
         if self._args.x_ipython_kernel:
             self.check_or_raise(self._args.x_asyncio_reactor,

--- a/hathor/cli/generate_genesis.py
+++ b/hathor/cli/generate_genesis.py
@@ -1,0 +1,79 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+import base58
+
+
+def main():
+    from hathor.cli.util import create_parser
+    from hathor.conf.get_settings import get_global_settings
+    from hathor.mining.cpu_mining_service import CpuMiningService
+    from hathor.transaction import Block, Transaction, TxOutput
+    from hathor.transaction.scripts import P2PKH
+
+    parser = create_parser()
+    parser.add_argument('--config-yaml', type=str, help='Configuration yaml filepath')
+    parser.add_argument('--genesis-address', type=str, help='Address for genesis tokens')
+    parser.add_argument('--genesis-block-timestamp', type=int, help='Timestamp for the genesis block')
+
+    args = parser.parse_args(sys.argv[1:])
+    if not args.config_yaml:
+        raise Exception('`--config-yaml` is required')
+    if not args.genesis_address:
+        raise Exception('`--genesis-address` is required')
+    if not args.genesis_block_timestamp:
+        raise Exception('`--genesis-block-timestamp` is required')
+
+    os.environ['HATHOR_CONFIG_YAML'] = args.config_yaml
+    settings = get_global_settings()
+    output_script = P2PKH.create_output_script(address=base58.b58decode(args.genesis_address))
+    block_timestamp = int(args.genesis_block_timestamp)
+    mining_service = CpuMiningService()
+
+    block = Block(
+        timestamp=block_timestamp,
+        weight=settings.MIN_BLOCK_WEIGHT,
+        outputs=[
+            TxOutput(settings.GENESIS_TOKENS, output_script),
+        ],
+    )
+    mining_service.start_mining(block)
+    block.update_hash()
+
+    tx1 = Transaction(
+        timestamp=settings.GENESIS_TX1_TIMESTAMP,
+        weight=settings.MIN_TX_WEIGHT,
+    )
+    mining_service.start_mining(tx1)
+    tx1.update_hash()
+
+    tx2 = Transaction(
+        timestamp=settings.GENESIS_TX2_TIMESTAMP,
+        weight=settings.MIN_TX_WEIGHT,
+    )
+    mining_service.start_mining(tx2)
+    tx2.update_hash()
+
+    # The output format is compatible with the yaml config file
+    print('GENESIS_OUTPUT_SCRIPT:', output_script.hex())
+    print('GENESIS_BLOCK_TIMESTAMP:', block.timestamp)
+    print('GENESIS_BLOCK_HASH:', block.hash_hex)
+    print('GENESIS_BLOCK_NONCE:', block.nonce)
+    print('GENESIS_TX1_HASH:', tx1.hash_hex)
+    print('GENESIS_TX1_NONCE:', tx1.nonce)
+    print('GENESIS_TX2_HASH:', tx2.hash_hex)
+    print('GENESIS_TX2_NONCE:', tx2.nonce)

--- a/hathor/cli/main.py
+++ b/hathor/cli/main.py
@@ -34,6 +34,7 @@ class CliManager:
         from . import (
             db_export,
             db_import,
+            generate_genesis,
             generate_poa_keys,
             generate_valid_words,
             load_from_logs,
@@ -74,6 +75,7 @@ class CliManager:
         self.add_cmd('side-dag', 'run_node_with_side_dag', side_dag, 'Run a side-dag')
         self.add_cmd('side-dag', 'gen_poa_keys', generate_poa_keys, 'Generate a private/public key pair and its '
                                                                     'address to be used in Proof-of-Authority')
+        self.add_cmd('side-dag', 'gen_genesis', generate_genesis, 'Generate a new genesis')
         self.add_cmd('docs', 'generate_openapi_json', openapi_json, 'Generate OpenAPI json for API docs')
         self.add_cmd('multisig', 'gen_multisig_address', multisig_address, 'Generate a new multisig address')
         self.add_cmd('multisig', 'spend_multisig_output', multisig_spend, 'Generate tx that spends a multisig output')

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -457,7 +457,6 @@ class RunNode:
             ]))
 
     def __init__(self, *, argv=None):
-        from hathor.cli.run_node_args import RunNodeArgs
         from hathor.conf import NANO_TESTNET_SETTINGS_FILEPATH, TESTNET_SETTINGS_FILEPATH
         from hathor.conf.get_settings import get_global_settings
         self.log = logger.new()
@@ -469,7 +468,7 @@ class RunNode:
         self.parser = self.create_parser()
         raw_args = self.parse_args(argv)
 
-        self._args = RunNodeArgs.parse_obj(vars(raw_args))
+        self._args = self._parse_args_obj(vars(raw_args))
 
         if self._args.config_yaml:
             os.environ['HATHOR_CONFIG_YAML'] = self._args.config_yaml
@@ -530,6 +529,10 @@ class RunNode:
 
     def parse_args(self, argv: list[str]) -> Namespace:
         return self.parser.parse_args(argv)
+
+    def _parse_args_obj(self, args: dict[str, Any]) -> 'RunNodeArgs':
+        from hathor.cli.run_node_args import RunNodeArgs
+        return RunNodeArgs.parse_obj(args)
 
     def run(self) -> None:
         self.reactor.run()

--- a/hathor/cli/side_dag.py
+++ b/hathor/cli/side_dag.py
@@ -19,12 +19,15 @@ import os
 import signal
 import sys
 import traceback
+from argparse import ArgumentParser
 from dataclasses import dataclass
 from enum import Enum
 from multiprocessing import Pipe, Process
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from typing_extensions import assert_never
+from typing_extensions import assert_never, override
+
+from hathor.cli.run_node_args import RunNodeArgs  # skip-cli-import-custom-check
 
 if TYPE_CHECKING:
     from hathor.cli.util import LoggingOutput
@@ -44,6 +47,10 @@ logger = get_logger()
 
 PRE_SETUP_LOGGING: bool = False
 HATHOR_NODE_INIT_WAIT_PERIOD: int = 10
+
+
+class SideDagArgs(RunNodeArgs):
+    poa_signer_file: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +75,17 @@ class SideDagProcessTerminated:
 
 class SideDagRunNode(RunNode):
     env_vars_prefix = 'hathor_side_dag_'
+
+    @override
+    def _parse_args_obj(self, args: dict[str, Any]) -> RunNodeArgs:
+        return SideDagArgs.parse_obj(args)
+
+    @classmethod
+    @override
+    def create_parser(cls) -> ArgumentParser:
+        parser = super().create_parser()
+        parser.add_argument('--poa-signer-file', help='File containing the Proof-of-Authority signer private key.')
+        return parser
 
 
 def main(capture_stdout: bool) -> None:
@@ -201,7 +219,7 @@ def _run_side_dag_node(argv: list[str], *, hathor_node_process: Process, conn: '
     try:
         side_dag = SideDagRunNode(argv=argv)
     except (BaseException, Exception):
-        logger.critical('terminating hathor node...')
+        logger.exception('terminating hathor node due to exception in side-dag node...')
         conn.send(SideDagProcessTerminated())
         hathor_node_process.terminate()
         return
@@ -252,6 +270,7 @@ def _run_hathor_node(
         setup_logging(logging_output=logging_output, logging_options=log_options, capture_stdout=capture_stdout)
         hathor_node = run_node_cmd(argv=argv)
     except (BaseException, Exception):
+        logger.exception('hathor process terminated due to exception in initialization')
         conn.send(HathorProcessInitFail(traceback.format_exc()))
         return
 

--- a/hathor/consensus/consensus_settings.py
+++ b/hathor/consensus/consensus_settings.py
@@ -67,12 +67,18 @@ class PoaSettings(_BaseConsensusSettings):
     type: Literal[ConsensusType.PROOF_OF_AUTHORITY] = ConsensusType.PROOF_OF_AUTHORITY
 
     # A list of Proof-of-Authority signer public keys that have permission to produce blocks.
-    signers: tuple[bytes, ...] = ()
+    signers: tuple[bytes, ...]
 
-    @validator('signers', each_item=True)
-    def parse_hex_str(cls, hex_str: str | bytes) -> bytes:
+    @validator('signers', each_item=True, pre=True)
+    def _parse_hex_str(cls, hex_str: str | bytes) -> bytes:
         from hathor.conf.settings import parse_hex_str
         return parse_hex_str(hex_str)
+
+    @validator('signers')
+    def _validate_signers(cls, signers: tuple[bytes, ...]) -> tuple[bytes, ...]:
+        if len(signers) == 0:
+            raise ValueError('At least one signer must be provided in PoA networks')
+        return signers
 
     @override
     def _get_valid_vertex_versions(self) -> set[TxVersion]:

--- a/hathor/consensus/poa/__init__.py
+++ b/hathor/consensus/poa/__init__.py
@@ -1,8 +1,22 @@
-from .poa import BLOCK_WEIGHT_IN_TURN, BLOCK_WEIGHT_OUT_OF_TURN, SIGNER_ID_LEN, get_hashed_poa_data
+from .poa import (
+    BLOCK_WEIGHT_IN_TURN,
+    BLOCK_WEIGHT_OUT_OF_TURN,
+    SIGNER_ID_LEN,
+    calculate_weight,
+    get_hashed_poa_data,
+    is_in_turn,
+)
+from .poa_block_producer import PoaBlockProducer
+from .poa_signer import PoaSigner, PoaSignerFile
 
 __all__ = [
     'BLOCK_WEIGHT_IN_TURN',
     'BLOCK_WEIGHT_OUT_OF_TURN',
     'SIGNER_ID_LEN',
     'get_hashed_poa_data',
+    'is_in_turn',
+    'calculate_weight',
+    'PoaBlockProducer',
+    'PoaSigner',
+    'PoaSignerFile',
 ]

--- a/hathor/consensus/poa/poa.py
+++ b/hathor/consensus/poa/poa.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 from typing import TYPE_CHECKING
 
+from hathor.consensus.consensus_settings import PoaSettings
 from hathor.transaction import Block
 
 if TYPE_CHECKING:
@@ -34,3 +35,14 @@ def get_hashed_poa_data(block: PoaBlock) -> bytes:
     poa_data += block.get_struct_nonce()
     hashed_poa_data = hashlib.sha256(poa_data).digest()
     return hashed_poa_data
+
+
+def is_in_turn(*, settings: PoaSettings, height: int, signer_index: int) -> bool:
+    """Return whether the given signer is in turn for the given height."""
+    return height % len(settings.signers) == signer_index
+
+
+def calculate_weight(settings: PoaSettings, block: PoaBlock, signer_index: int) -> float:
+    """Return the weight for the given block and signer."""
+    is_in_turn_flag = is_in_turn(settings=settings, height=block.get_height(), signer_index=signer_index)
+    return BLOCK_WEIGHT_IN_TURN if is_in_turn_flag else BLOCK_WEIGHT_OUT_OF_TURN

--- a/hathor/consensus/poa/poa_block_producer.py
+++ b/hathor/consensus/poa/poa_block_producer.py
@@ -1,0 +1,173 @@
+#  Copyright 2024 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+from twisted.internet.task import LoopingCall
+
+from hathor.conf.settings import HathorSettings
+from hathor.consensus import poa
+from hathor.consensus.consensus_settings import PoaSettings
+from hathor.crypto.util import get_public_key_bytes_compressed
+from hathor.reactor import ReactorProtocol
+
+if TYPE_CHECKING:
+    from hathor.consensus.poa import PoaSigner
+    from hathor.manager import HathorManager
+    from hathor.transaction import Block
+    from hathor.transaction.poa import PoaBlock
+
+logger = get_logger()
+
+# Number of seconds to wait for a sync to finish before trying to produce blocks
+_WAIT_SYNC_DELAY: int = 30
+
+# Number of seconds used in random delay calculation
+_RANDOM_DELAY_MULTIPLIER: int = 1
+
+
+class PoaBlockProducer:
+    """
+    This class is analogous to mining classes, but for Proof-of-Authority networks.
+    It waits for blocks to arrive, gets templates, and propagates new blocks accordingly.
+    """
+    __slots__ = (
+        '_log',
+        '_settings',
+        '_poa_settings',
+        '_reactor',
+        '_manager',
+        '_poa_signer',
+        '_signer_index',
+        '_started_producing',
+        '_start_producing_lc',
+        '_schedule_block_lc',
+        '_last_seen_best_block',
+    )
+
+    def __init__(
+        self,
+        *,
+        settings: HathorSettings,
+        reactor: ReactorProtocol,
+        manager: 'HathorManager',
+        poa_signer: PoaSigner,
+    ) -> None:
+        assert isinstance(settings.CONSENSUS_ALGORITHM, PoaSettings)
+        self._log = logger.new()
+        self._settings = settings
+        self._poa_settings = settings.CONSENSUS_ALGORITHM
+        self._reactor = reactor
+        self._manager = manager
+        self._poa_signer = poa_signer
+        self._signer_index = self._calculate_signer_index(self._poa_settings, self._poa_signer)
+        self._last_seen_best_block: Block | None = None
+
+        self._started_producing = False
+        self._start_producing_lc = LoopingCall(self._start_producing)
+        self._start_producing_lc.clock = self._reactor
+
+        self._schedule_block_lc = LoopingCall(self._schedule_block)
+        self._schedule_block_lc.clock = self._reactor
+
+    def start(self) -> None:
+        self._start_producing_lc.start(_WAIT_SYNC_DELAY)
+        self._schedule_block_lc.start(self._settings.AVG_TIME_BETWEEN_BLOCKS)
+
+    def stop(self) -> None:
+        if self._start_producing_lc.running:
+            self._start_producing_lc.stop()
+
+        if self._schedule_block_lc.running:
+            self._schedule_block_lc.stop()
+
+    @staticmethod
+    def _calculate_signer_index(settings: PoaSettings, poa_signer: PoaSigner) -> int:
+        """Return the signer index for the given private key."""
+        public_key = poa_signer.get_public_key()
+        public_key_bytes = get_public_key_bytes_compressed(public_key)
+        sorted_signers = sorted(settings.signers)
+        try:
+            return sorted_signers.index(public_key_bytes)
+        except ValueError:
+            raise ValueError(f'Public key "{public_key_bytes.hex()}" not in list of PoA signers')
+
+    def _start_producing(self) -> None:
+        """Start producing new blocks."""
+        if not self._manager.can_start_mining():
+            # We're syncing, so we'll try again later
+            self._log.warn('cannot start producing new blocks, node not synced')
+            return
+
+        self._log.info('started producing new blocks')
+        self._started_producing = True
+        self._start_producing_lc.stop()
+
+    def _schedule_block(self) -> None:
+        """Schedule propagation of a new block."""
+        previous_block = self._manager.tx_storage.get_best_block()
+        if not self._started_producing or previous_block == self._last_seen_best_block:
+            return
+
+        self._last_seen_best_block = previous_block
+        now = self._reactor.seconds()
+        expected_timestamp = self._expected_block_timestamp(previous_block)
+        propagation_delay = 0 if expected_timestamp < now else expected_timestamp - now
+
+        self._reactor.callLater(propagation_delay, self._produce_block, previous_block)
+        self._log.debug(
+            'scheduling block production',
+            previous_block=previous_block.hash_hex,
+            previous_block_height=previous_block.get_height(),
+            delay=propagation_delay,
+        )
+
+    def _produce_block(self, previous_block: PoaBlock) -> None:
+        """Create and propagate a new block."""
+        from hathor.transaction.poa import PoaBlock
+        block_templates = self._manager.get_block_templates(parent_block_hash=previous_block.hash)
+        block = block_templates.generate_mining_block(self._manager.rng, cls=PoaBlock)
+        assert isinstance(block, PoaBlock)
+        block.weight = poa.calculate_weight(self._poa_settings, block, self._signer_index)
+        self._poa_signer.sign_block(block)
+        block.update_hash()
+
+        self._manager.on_new_tx(block, propagate_to_peers=False, fails_silently=False)
+        if not block.get_metadata().voided_by:
+            self._manager.connections.send_tx_to_peers(block)
+
+        self._log.debug(
+            'produced new block',
+            block=block.hash_hex,
+            height=block.get_height(),
+            weight=block.weight,
+            parent=block.get_block_parent_hash().hex(),
+            voided=bool(block.get_metadata().voided_by),
+        )
+
+    def _expected_block_timestamp(self, previous_block: Block) -> int:
+        """Calculate the expected timestamp for a new block."""
+        height = previous_block.get_height() + 1
+        is_in_turn = poa.is_in_turn(settings=self._poa_settings, height=height, signer_index=self._signer_index)
+        timestamp = previous_block.timestamp + self._settings.AVG_TIME_BETWEEN_BLOCKS
+        if is_in_turn:
+            return timestamp
+
+        signer_count = len(self._poa_settings.signers)
+        assert signer_count >= 1
+        random_offset = self._manager.rng.choice(range(signer_count * _RANDOM_DELAY_MULTIPLIER)) + 1
+        return timestamp + random_offset

--- a/hathor/merged_mining/coordinator.py
+++ b/hathor/merged_mining/coordinator.py
@@ -45,7 +45,7 @@ from hathor.merged_mining.bitcoin import (
 )
 from hathor.merged_mining.bitcoin_rpc import IBitcoinRPC
 from hathor.merged_mining.util import Periodic
-from hathor.transaction import BitcoinAuxPow, MergeMinedBlock as HathorBlock
+from hathor.transaction import BitcoinAuxPow, MergeMinedBlock, MergeMinedBlock as HathorBlock
 from hathor.transaction.exceptions import ScriptError, TxValidationError
 from hathor.util import MaxSizeOrderedDict, Random, ichunks
 
@@ -1296,7 +1296,7 @@ class MergedMiningCoordinator:
             block_template = block_templates.choose_random_template(self.rng)
             address_str = self.payback_address_hathor
             address = decode_address(address_str) if address_str is not None else None
-            block = block_template.generate_mining_block(self.rng, merge_mined=True, address=address)
+            block = block_template.generate_mining_block(self.rng, address=address, cls=MergeMinedBlock)
             height = block_template.height
             assert isinstance(block, HathorBlock)
             self.last_hathor_block_received = time.time()

--- a/hathor/transaction/poa/poa_block.py
+++ b/hathor/transaction/poa/poa_block.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from hathor.consensus import poa
-from hathor.transaction import Block, TxVersion
+from hathor.transaction import Block, TxOutput, TxVersion
 from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
 
@@ -29,6 +29,7 @@ class PoaBlock(Block):
         timestamp: int | None = None,
         signal_bits: int = 0,
         weight: float = 0,
+        outputs: list[TxOutput] | None = None,
         parents: list[bytes] | None = None,
         hash: bytes | None = None,
         data: bytes = b'',
@@ -36,6 +37,7 @@ class PoaBlock(Block):
         signer_id: bytes = b'',
         signature: bytes = b'',
     ) -> None:
+        assert not outputs, 'PoaBlocks must not have outputs'
         super().__init__(
             nonce=0,
             timestamp=timestamp,

--- a/tests/others/test_hathor_settings.py
+++ b/tests/others/test_hathor_settings.py
@@ -31,7 +31,6 @@ from hathor.conf.nano_testnet import SETTINGS as NANO_TESTNET_SETTINGS
 from hathor.conf.settings import HathorSettings
 from hathor.conf.testnet import SETTINGS as TESTNET_SETTINGS
 from hathor.conf.unittests import SETTINGS as UNITTESTS_SETTINGS
-from hathor.consensus.consensus_settings import PoaSettings, PowSettings
 
 
 @pytest.mark.parametrize('filepath', ['fixtures/valid_hathor_settings_fixture.yml'])
@@ -119,11 +118,11 @@ def test_consensus_algorithm() -> None:
 
     with patch('hathor.conf.settings.yaml', yaml_mock):
         # Test passes when PoA is disabled with default settings
-        mock_settings(dict(CONSENSUS_ALGORITHM=PowSettings()))
+        mock_settings(dict())
         HathorSettings.from_yaml(filepath='some_path')
 
         # Test fails when PoA is enabled with default settings
-        mock_settings(dict(CONSENSUS_ALGORITHM=PoaSettings(signers=(b'some_signer',))))
+        mock_settings(dict(CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',))))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')
         assert 'PoA networks do not support block rewards' in str(e.value)
@@ -133,16 +132,27 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
-            CONSENSUS_ALGORITHM=PoaSettings(signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
         ))
         HathorSettings.from_yaml(filepath='some_path')
+
+        # Test fails when no signer is provided
+        mock_settings(dict(
+            BLOCKS_PER_HALVING=None,
+            INITIAL_TOKEN_UNITS_PER_BLOCK=0,
+            MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=()),
+        ))
+        with pytest.raises(ValidationError) as e:
+            HathorSettings.from_yaml(filepath='some_path')
+        assert 'At least one signer must be provided in PoA networks' in str(e.value)
 
         # Test fails when PoA is enabled with BLOCKS_PER_HALVING
         mock_settings(dict(
             BLOCKS_PER_HALVING=123,
             INITIAL_TOKEN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
-            CONSENSUS_ALGORITHM=PoaSettings(signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
         ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')
@@ -153,7 +163,7 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_UNITS_PER_BLOCK=123,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
-            CONSENSUS_ALGORITHM=PoaSettings(signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
         ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')
@@ -164,7 +174,7 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=123,
-            CONSENSUS_ALGORITHM=PoaSettings(signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
         ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')

--- a/tests/tx/test_block.py
+++ b/tests/tx/test_block.py
@@ -227,15 +227,15 @@ def test_verify_poa() -> None:
         public_key_bytes = get_public_key_bytes_compressed(public_key)
         address = get_address_b58_from_public_key(public_key)
         file = PoaSignerFile.parse_obj(dict(
-            private_key=private_key_bytes.hex(),
-            public_key=public_key_bytes.hex(),
+            private_key_hex=private_key_bytes.hex(),
+            public_key_hex=public_key_bytes.hex(),
             address=address
         ))
         return file.get_signer(), public_key_bytes
 
     poa_signer, public_key_bytes = get_signer()
     settings = Mock(spec_set=HathorSettings)
-    settings.CONSENSUS_ALGORITHM = PoaSettings()
+    settings.CONSENSUS_ALGORITHM = PoaSettings.construct(signers=())
     block_verifier = PoaBlockVerifier(settings=settings)
     block = PoaBlock(
         timestamp=123,
@@ -254,7 +254,7 @@ def test_verify_poa() -> None:
     block.outputs = []
 
     # Test no signers
-    settings.CONSENSUS_ALGORITHM = PoaSettings(signers=())
+    settings.CONSENSUS_ALGORITHM = PoaSettings.construct(signers=())
     with pytest.raises(PoaValidationError) as e:
         block_verifier.verify_poa(block)
     assert str(e.value) == 'invalid PoA signature'


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1060

### Motivation

Finish the Proof-of-Authority side-dag implementation by implementing the `PoaBlockProducer` which is analogous to a mining service, in the full node itself.

### Acceptance Criteria

- Implement `poa` module and `PoaBlockProducer`.
- Implement `gen_genesis` CLI command.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 