### PR TITLE
fix(side-dag): remove init timeout

### DIFF
--- a/hathor/cli/side_dag.py
+++ b/hathor/cli/side_dag.py
@@ -43,7 +43,7 @@ from hathor.cli.run_node import RunNode
 logger = get_logger()
 
 PRE_SETUP_LOGGING: bool = False
-HATHOR_NODE_INIT_TIMEOUT: int = 10
+HATHOR_NODE_INIT_WAIT_PERIOD: int = 10
 
 
 @dataclass(frozen=True, slots=True)
@@ -186,12 +186,8 @@ def _partition_argv(argv: list[str]) -> tuple[list[str], list[str]]:
 def _run_side_dag_node(argv: list[str], *, hathor_node_process: Process, conn: 'Connection') -> None:
     """Function to be called by the main process to run the side-dag full node."""
     logger.info('waiting for hathor node to initialize...')
-    if not conn.poll(HATHOR_NODE_INIT_TIMEOUT):
-        logger.critical(
-            f'side-dag node not started because hathor node failed to initialize before {HATHOR_NODE_INIT_TIMEOUT} '
-            f'seconds timeout'
-        )
-        return
+    while not conn.poll(HATHOR_NODE_INIT_WAIT_PERIOD):
+        logger.info('still waiting for hathor node to initialize...')
 
     message = conn.recv()
     if isinstance(message, HathorProcessInitFail):

--- a/tests/cli/test_side_dag.py
+++ b/tests/cli/test_side_dag.py
@@ -61,19 +61,6 @@ def test_process_argv(
     assert side_dag_argv == expected_side_dag_argv
 
 
-def test_run_side_dag_node_hathor_init_timed_out() -> None:
-    argv: list[str] = []
-    conn_mock = Mock()
-    conn_mock.poll = Mock(return_value=False)
-    hathor_node_process = Mock()
-
-    with patch.object(side_dag, 'SideDagRunNode') as side_dag_mock:
-        _run_side_dag_node(argv, conn=conn_mock, hathor_node_process=hathor_node_process)
-        side_dag_mock.assert_not_called()
-        hathor_node_process.terminate.assert_not_called()
-        conn_mock.send.assert_not_called()
-
-
 def test_run_side_dag_node_hathor_init_failed() -> None:
     argv: list[str] = []
     conn_mock = Mock()


### PR DESCRIPTION
### Motivation

The new `run_node_with_side_dag` command timed out in 10 seconds if the Hathor node did not start. This was incorrect because when loading from an existing storage, the Hathor node will always take more than 10 seconds to initialize.

This PR removes the timeout and simply waits indefinitely until the Hathor node is either ready or errored. This will be further improved when the monitor process is implemented (see https://github.com/HathorNetwork/hathor-core/issues/1051).

### Acceptance Criteria

- Remove Hathor node init timeout in favor of waiting.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 