### PR TITLE
feat(side-dag): update APIs

### DIFF
--- a/hathor/cli/side_dag.py
+++ b/hathor/cli/side_dag.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import argparse
 import os
 import signal
 import sys
@@ -136,14 +135,14 @@ def main(capture_stdout: bool) -> None:
 
 def _process_logging_output(argv: list[str]) -> tuple[LoggingOutput, LoggingOutput]:
     """Extract logging output before argv parsing."""
-    from hathor.cli.util import LoggingOutput
+    from hathor.cli.util import LoggingOutput, create_parser
 
     class LogOutputConfig(str, Enum):
         HATHOR = 'hathor'
         SIDE_DAG = 'side-dag'
         BOTH = 'both'
 
-    parser = argparse.ArgumentParser(add_help=False)
+    parser = create_parser(add_help=False)
     log_args = parser.add_mutually_exclusive_group()
     log_args.add_argument('--json-logs', nargs='?', const='both', type=LogOutputConfig)
     log_args.add_argument('--disable-logs', nargs='?', const='both', type=LogOutputConfig)

--- a/hathor/cli/util.py
+++ b/hathor/cli/util.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import json
 import sys
 import traceback
@@ -28,8 +27,8 @@ from structlog.typing import EventDict
 from typing_extensions import assert_never
 
 
-def create_parser(*, prefix: str | None = None) -> ArgumentParser:
-    return configargparse.ArgumentParser(auto_env_var_prefix=prefix or 'hathor_')
+def create_parser(*, prefix: str | None = None, add_help: bool = True) -> ArgumentParser:
+    return configargparse.ArgumentParser(auto_env_var_prefix=prefix or 'hathor_', add_help=add_help)
 
 
 # docs at http://www.structlog.org/en/stable/api.html#structlog.dev.ConsoleRenderer
@@ -138,7 +137,7 @@ class LoggingOptions(NamedTuple):
 
 def process_logging_output(argv: list[str]) -> LoggingOutput:
     """Extract logging output before argv parsing."""
-    parser = argparse.ArgumentParser(add_help=False)
+    parser = create_parser(add_help=False)
 
     log_args = parser.add_mutually_exclusive_group()
     log_args.add_argument('--json-logs', action='store_true')
@@ -159,7 +158,7 @@ def process_logging_output(argv: list[str]) -> LoggingOutput:
 
 def process_logging_options(argv: list[str]) -> LoggingOptions:
     """Extract logging-specific options that are processed before argv parsing."""
-    parser = argparse.ArgumentParser(add_help=False)
+    parser = create_parser(add_help=False)
     parser.add_argument('--debug', action='store_true')
 
     args, remaining_argv = parser.parse_known_args(argv)

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -440,6 +440,10 @@ class HathorSettings(NamedTuple):
     # The consensus algorithm protocol settings.
     CONSENSUS_ALGORITHM: ConsensusSettings = PowSettings()
 
+    # The name and symbol of the native token. This is only used in APIs to serve clients.
+    NATIVE_TOKEN_NAME: str = 'Hathor'
+    NATIVE_TOKEN_SYMBOL: str = 'HTR'
+
     @classmethod
     def from_yaml(cls, *, filepath: str) -> 'HathorSettings':
         """Takes a filepath to a yaml file and returns a validated HathorSettings instance."""

--- a/hathor/consensus/poa/__init__.py
+++ b/hathor/consensus/poa/__init__.py
@@ -2,9 +2,12 @@ from .poa import (
     BLOCK_WEIGHT_IN_TURN,
     BLOCK_WEIGHT_OUT_OF_TURN,
     SIGNER_ID_LEN,
+    InvalidSignature,
+    ValidSignature,
     calculate_weight,
     get_hashed_poa_data,
     is_in_turn,
+    verify_poa_signature,
 )
 from .poa_block_producer import PoaBlockProducer
 from .poa_signer import PoaSigner, PoaSignerFile
@@ -19,4 +22,7 @@ __all__ = [
     'PoaBlockProducer',
     'PoaSigner',
     'PoaSignerFile',
+    'verify_poa_signature',
+    'InvalidSignature',
+    'ValidSignature'
 ]

--- a/hathor/transaction/poa/poa_block.py
+++ b/hathor/transaction/poa/poa_block.py
@@ -12,8 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import Any
+
+from typing_extensions import override
+
 from hathor.conf.settings import HathorSettings
 from hathor.consensus import poa
+from hathor.consensus.consensus_settings import PoaSettings
 from hathor.transaction import Block, TxOutput, TxVersion
 from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
@@ -56,6 +61,7 @@ class PoaBlock(Block):
         self.signer_id = signer_id
         self.signature = signature
 
+    @override
     def get_graph_fields_from_struct(self, buf: bytes, *, verbose: VerboseCallback = None) -> bytes:
         buf = super().get_graph_fields_from_struct(buf, verbose=verbose)
 
@@ -76,8 +82,22 @@ class PoaBlock(Block):
 
         return buf
 
+    @override
     def get_graph_struct(self) -> bytes:
         assert len(self.signer_id) == poa.SIGNER_ID_LEN
         struct_bytes_without_poa = super().get_graph_struct()
         signature_len = int_to_bytes(len(self.signature), 1)
         return struct_bytes_without_poa + self.signer_id + signature_len + self.signature
+
+    @override
+    def to_json(self, decode_script: bool = False, include_metadata: bool = False) -> dict[str, Any]:
+        poa_settings = self._settings.CONSENSUS_ALGORITHM
+        assert isinstance(poa_settings, PoaSettings)
+        json = super().to_json(decode_script=decode_script, include_metadata=include_metadata)
+        signature_validation = poa.verify_poa_signature(poa_settings, self)
+
+        if isinstance(signature_validation, poa.ValidSignature):
+            json['signer'] = signature_validation.public_key.hex()
+
+        json['signer_id'] = self.signer_id.hex()
+        return json

--- a/hathor/verification/poa_block_verifier.py
+++ b/hathor/verification/poa_block_verifier.py
@@ -12,15 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
-
 from hathor.conf.settings import HathorSettings
 from hathor.consensus import poa
 from hathor.consensus.consensus_settings import PoaSettings
-from hathor.consensus.poa.poa_signer import PoaSigner
-from hathor.crypto.util import get_public_key_from_bytes_compressed
 from hathor.transaction.exceptions import PoaValidationError
 from hathor.transaction.poa import PoaBlock
 
@@ -36,38 +30,22 @@ class PoaBlockVerifier:
         poa_settings = self._settings.CONSENSUS_ALGORITHM
         assert isinstance(poa_settings, PoaSettings)
 
+        parent_block = block.get_block_parent()
+        if block.timestamp < parent_block.timestamp + self._settings.AVG_TIME_BETWEEN_BLOCKS:
+            raise PoaValidationError(
+                f'blocks must have at least {self._settings.AVG_TIME_BETWEEN_BLOCKS} seconds between them'
+            )
+
         # validate block rewards
         if block.outputs:
             raise PoaValidationError('blocks must not have rewards in a PoA network')
 
         # validate that the signature is valid
-        sorted_signers = sorted(poa_settings.signers)
-        signer_index: int | None = None
-
-        for i, public_key_bytes in enumerate(sorted_signers):
-            if self._verify_poa_signature(block, public_key_bytes):
-                signer_index = i
-                break
-
-        if signer_index is None:
+        signature_validation = poa.verify_poa_signature(poa_settings, block)
+        if not isinstance(signature_validation, poa.ValidSignature):
             raise PoaValidationError('invalid PoA signature')
 
         # validate block weight is in turn
-        expected_weight = poa.calculate_weight(poa_settings, block, signer_index)
+        expected_weight = poa.calculate_weight(poa_settings, block, signature_validation.signer_index)
         if block.weight != expected_weight:
             raise PoaValidationError(f'block weight is {block.weight}, expected {expected_weight}')
-
-    @staticmethod
-    def _verify_poa_signature(block: PoaBlock, public_key_bytes: bytes) -> bool:
-        """Return whether the provided public key was used to sign the block Proof-of-Authority."""
-        signer_id = PoaSigner.get_poa_signer_id(public_key_bytes)
-        if block.signer_id != signer_id:
-            return False
-
-        public_key = get_public_key_from_bytes_compressed(public_key_bytes)
-        hashed_poa_data = poa.get_hashed_poa_data(block)
-        try:
-            public_key.verify(block.signature, hashed_poa_data, ec.ECDSA(hashes.SHA256()))
-        except InvalidSignature:
-            return False
-        return True

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -51,6 +51,14 @@ class VersionResource(Resource):
             'reward_spend_min_blocks': self._settings.REWARD_SPEND_MIN_BLOCKS,
             'max_number_inputs': self._settings.MAX_NUM_INPUTS,
             'max_number_outputs': self._settings.MAX_NUM_OUTPUTS,
+            'decimal_places': self._settings.DECIMAL_PLACES,
+            'genesis_block_hash': self._settings.GENESIS_BLOCK_HASH.hex(),
+            'genesis_tx1_hash': self._settings.GENESIS_TX1_HASH.hex(),
+            'genesis_tx2_hash': self._settings.GENESIS_TX2_HASH.hex(),
+            'native_token': dict(
+                name=self._settings.NATIVE_TOKEN_NAME,
+                symbol=self._settings.NATIVE_TOKEN_SYMBOL,
+            ),
         }
         return json_dumpb(data)
 


### PR DESCRIPTION
### Motivation

Update API response models to include side-dag and Proof-of-Authority related data.

### Acceptance Criteria

- Add `NATIVE_TOKEN_NAME` and `NATIVE_TOKEN_SYMBOL` to `HathorSettings` and to the `/v1a/version` API.
- Add `DECIMAL_PLACES` and genesis hashes to the `/v1a/version` API.
- Update `PoaBlock.to_json()` to include PoA fields.
- Implement `poa.get_signer_index_and_public_key()` and update `PoaBlockVerifier` to use it.
- Add missing `PoaBlock` timestamp verification.
- Change pre-argument parsers to use `create_parser()`, adding support for environment variables.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 