### PR TITLE
fix(cli): regression of --help after side-dag cli

### DIFF
--- a/hathor/cli/side_dag.py
+++ b/hathor/cli/side_dag.py
@@ -120,7 +120,7 @@ def _process_logging_output(argv: list[str]) -> tuple[LoggingOutput, LoggingOutp
         SIDE_DAG = 'side-dag'
         BOTH = 'both'
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     log_args = parser.add_mutually_exclusive_group()
     log_args.add_argument('--json-logs', nargs='?', const='both', type=LogOutputConfig)
     log_args.add_argument('--disable-logs', nargs='?', const='both', type=LogOutputConfig)

--- a/hathor/cli/util.py
+++ b/hathor/cli/util.py
@@ -137,7 +137,7 @@ class LoggingOptions(NamedTuple):
 
 def process_logging_output(argv: list[str]) -> LoggingOutput:
     """Extract logging output before argv parsing."""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
 
     log_args = parser.add_mutually_exclusive_group()
     log_args.add_argument('--json-logs', action='store_true')
@@ -158,7 +158,7 @@ def process_logging_output(argv: list[str]) -> LoggingOutput:
 
 def process_logging_options(argv: list[str]) -> LoggingOptions:
     """Extract logging-specific options that are processed before argv parsing."""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--debug', action='store_true')
 
     args, remaining_argv = parser.parse_known_args(argv)


### PR DESCRIPTION
### Motivation

After #1039 using `python -m hathor run_node --help` shows an unrelated help display. This wasn't caught during review or by any tests. We should add tests for cli display in the future, although this PR only fixes the immediate problem.

### Acceptance Criteria

- Include `add_help=False` to all the 3 `argparse.ArgumentParser` introduced in #1039 for partial parsing

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 