### PR TITLE
feat(side-dag): implement signer round-robin

### DIFF
--- a/hathor/consensus/poa/__init__.py
+++ b/hathor/consensus/poa/__init__.py
@@ -6,7 +6,7 @@ from .poa import (
     ValidSignature,
     calculate_weight,
     get_hashed_poa_data,
-    is_in_turn,
+    in_turn_signer_index,
     verify_poa_signature,
 )
 from .poa_block_producer import PoaBlockProducer
@@ -17,7 +17,7 @@ __all__ = [
     'BLOCK_WEIGHT_OUT_OF_TURN',
     'SIGNER_ID_LEN',
     'get_hashed_poa_data',
-    'is_in_turn',
+    'in_turn_signer_index',
     'calculate_weight',
     'PoaBlockProducer',
     'PoaSigner',

--- a/hathor/consensus/poa/poa.py
+++ b/hathor/consensus/poa/poa.py
@@ -43,15 +43,15 @@ def get_hashed_poa_data(block: PoaBlock) -> bytes:
     return hashed_poa_data
 
 
-def is_in_turn(*, settings: PoaSettings, height: int, signer_index: int) -> bool:
-    """Return whether the given signer is in turn for the given height."""
-    return height % len(settings.signers) == signer_index
+def in_turn_signer_index(settings: PoaSettings, height: int) -> int:
+    """Return the signer index that is in turn for the given height."""
+    return height % len(settings.signers)
 
 
 def calculate_weight(settings: PoaSettings, block: PoaBlock, signer_index: int) -> float:
     """Return the weight for the given block and signer."""
-    is_in_turn_flag = is_in_turn(settings=settings, height=block.get_height(), signer_index=signer_index)
-    return BLOCK_WEIGHT_IN_TURN if is_in_turn_flag else BLOCK_WEIGHT_OUT_OF_TURN
+    expected_index = in_turn_signer_index(settings, block.get_height())
+    return BLOCK_WEIGHT_IN_TURN if expected_index == signer_index else BLOCK_WEIGHT_OUT_OF_TURN
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/poa/test_poa.py
+++ b/tests/poa/test_poa.py
@@ -229,10 +229,10 @@ def test_verify_poa() -> None:
         (2, 3, 1, True),
     ]
 )
-def test_is_in_turn(n_signers: int, height: int, signer_index: int, expected: bool) -> None:
+def test_in_turn_signer_index(n_signers: int, height: int, signer_index: int, expected: bool) -> None:
     settings = PoaSettings.construct(signers=tuple(b'' for _ in range(n_signers)))
 
-    result = poa.is_in_turn(settings=settings, height=height, signer_index=signer_index)
+    result = poa.in_turn_signer_index(settings=settings, height=height) == signer_index
     assert result == expected
 
 


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1071

### Motivation

Improve the mechanism used in `PoaBlockProducer` to generate new block timestamps, as requested in https://github.com/HathorNetwork/hathor-core/pull/1061#discussion_r1635167050.

### Acceptance Criteria

- Change `poa.is_in_turn()` to `poa.in_turn_signer_index()`.
- Change `PoaBlockProducer` timestamp generation to use a signer round-robin approach instead of random delay.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 