### PR TITLE
feat(side-dag): add ability to update signers list

### DIFF
--- a/hathor/consensus/poa/__init__.py
+++ b/hathor/consensus/poa/__init__.py
@@ -5,6 +5,7 @@ from .poa import (
     InvalidSignature,
     ValidSignature,
     calculate_weight,
+    get_active_signers,
     get_hashed_poa_data,
     in_turn_signer_index,
     verify_poa_signature,
@@ -24,5 +25,6 @@ __all__ = [
     'PoaSignerFile',
     'verify_poa_signature',
     'InvalidSignature',
-    'ValidSignature'
+    'ValidSignature',
+    'get_active_signers',
 ]

--- a/tests/others/test_hathor_settings.py
+++ b/tests/others/test_hathor_settings.py
@@ -173,7 +173,12 @@ def test_consensus_algorithm() -> None:
         HathorSettings.from_yaml(filepath='some_path')
 
         # Test fails when PoA is enabled with default settings
-        mock_settings(dict(CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',))))
+        mock_settings(dict(
+            CONSENSUS_ALGORITHM=dict(
+                type='PROOF_OF_AUTHORITY',
+                signers=(dict(public_key=b'some_signer'),)
+            )
+        ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')
         assert 'PoA networks do not support block rewards' in str(e.value)
@@ -183,7 +188,7 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
-            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         HathorSettings.from_yaml(filepath='some_path')
 
@@ -203,7 +208,7 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=123,
             INITIAL_TOKEN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
-            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')
@@ -214,7 +219,7 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_UNITS_PER_BLOCK=123,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
-            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')
@@ -225,7 +230,7 @@ def test_consensus_algorithm() -> None:
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_UNITS_PER_BLOCK=123,
-            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(b'some_signer',)),
+            CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         with pytest.raises(ValidationError) as e:
             HathorSettings.from_yaml(filepath='some_path')

--- a/tests/poa/test_poa_verification.py
+++ b/tests/poa/test_poa_verification.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock, patch
 
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from hathor.consensus.consensus_settings import ConsensusType, PoaSettings
+from hathor.consensus.consensus_settings import ConsensusType, PoaSettings, PoaSignerSettings
 from hathor.consensus.poa import PoaSigner
 from hathor.crypto.util import get_public_key_bytes_compressed
 from hathor.transaction.poa import PoaBlock
@@ -43,7 +43,7 @@ class BasePoaVerificationTest(unittest.TestCase):
             MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
             CONSENSUS_ALGORITHM=PoaSettings(
                 type=ConsensusType.PROOF_OF_AUTHORITY,
-                signers=(public_key_bytes,),
+                signers=(PoaSignerSettings(public_key=public_key_bytes),),
             ),
         )
 


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1074

### Motivation

Implement ability to update the signers list on PoA networks by configuring start and end block heights where each signer is active. By the default, a signer is active from height 0 to infinity. By setting the start height on a new signer, the network can coordinate to add it without disrupting existing blocks.

### Acceptance Criteria

- Update PoA settings to be able to configure `start_height` and `end_height` for signers.
- Implement `poa.get_active_signers()` and update all usages of `poa_settings.signers` to use it instead.
- Update `PoaBlockProducer` to calculate the signer index depending on active signers.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 