### PR TITLE
refactor(side-dag): general improvements

### DIFF
--- a/hathor/consensus/poa/__init__.py
+++ b/hathor/consensus/poa/__init__.py
@@ -7,7 +7,7 @@ from .poa import (
     calculate_weight,
     get_active_signers,
     get_hashed_poa_data,
-    in_turn_signer_index,
+    get_signer_index_distance,
     verify_poa_signature,
 )
 from .poa_block_producer import PoaBlockProducer
@@ -18,7 +18,6 @@ __all__ = [
     'BLOCK_WEIGHT_OUT_OF_TURN',
     'SIGNER_ID_LEN',
     'get_hashed_poa_data',
-    'in_turn_signer_index',
     'calculate_weight',
     'PoaBlockProducer',
     'PoaSigner',
@@ -27,4 +26,5 @@ __all__ = [
     'InvalidSignature',
     'ValidSignature',
     'get_active_signers',
+    'get_signer_index_distance',
 ]

--- a/tests/poa/test_poa.py
+++ b/tests/poa/test_poa.py
@@ -218,40 +218,55 @@ def test_verify_poa() -> None:
 @pytest.mark.parametrize(
     ['n_signers', 'height', 'signer_index', 'expected'],
     [
-        (1, 1, 0, True),
-        (1, 2, 0, True),
-        (1, 3, 0, True),
+        (1, 1, 0, 0),
+        (1, 2, 0, 0),
+        (1, 3, 0, 0),
 
-        (2, 1, 0, False),
-        (2, 2, 0, True),
-        (2, 3, 0, False),
+        (2, 1, 0, 1),
+        (2, 2, 0, 0),
+        (2, 3, 0, 1),
 
-        (2, 1, 1, True),
-        (2, 2, 1, False),
-        (2, 3, 1, True),
+        (2, 1, 1, 0),
+        (2, 2, 1, 1),
+        (2, 3, 1, 0),
+
+        (5, 1, 0, 4),
+        (5, 2, 0, 3),
+        (5, 3, 0, 2),
+        (5, 4, 0, 1),
+        (5, 5, 0, 0),
     ]
 )
-def test_in_turn_signer_index(n_signers: int, height: int, signer_index: int, expected: bool) -> None:
+def test_get_signer_index_distance(n_signers: int, height: int, signer_index: int, expected: int) -> None:
     settings = PoaSettings.construct(signers=tuple(PoaSignerSettings(public_key=b'') for _ in range(n_signers)))
 
-    result = poa.in_turn_signer_index(settings=settings, height=height) == signer_index
+    result = poa.get_signer_index_distance(settings=settings, signer_index=signer_index, height=height)
     assert result == expected
 
 
 @pytest.mark.parametrize(
     ['n_signers', 'height', 'signer_index', 'expected'],
     [
+        (1, 0, 0, poa.BLOCK_WEIGHT_IN_TURN),
         (1, 1, 0, poa.BLOCK_WEIGHT_IN_TURN),
         (1, 2, 0, poa.BLOCK_WEIGHT_IN_TURN),
         (1, 3, 0, poa.BLOCK_WEIGHT_IN_TURN),
 
+        (2, 0, 0, poa.BLOCK_WEIGHT_IN_TURN),
         (2, 1, 0, poa.BLOCK_WEIGHT_OUT_OF_TURN),
         (2, 2, 0, poa.BLOCK_WEIGHT_IN_TURN),
         (2, 3, 0, poa.BLOCK_WEIGHT_OUT_OF_TURN),
 
+        (2, 0, 1, poa.BLOCK_WEIGHT_OUT_OF_TURN),
         (2, 1, 1, poa.BLOCK_WEIGHT_IN_TURN),
         (2, 2, 1, poa.BLOCK_WEIGHT_OUT_OF_TURN),
         (2, 3, 1, poa.BLOCK_WEIGHT_IN_TURN),
+
+        (5, 0, 0, poa.BLOCK_WEIGHT_IN_TURN),
+        (5, 1, 0, poa.BLOCK_WEIGHT_OUT_OF_TURN / 4),
+        (5, 2, 0, poa.BLOCK_WEIGHT_OUT_OF_TURN / 3),
+        (5, 3, 0, poa.BLOCK_WEIGHT_OUT_OF_TURN / 2),
+        (5, 4, 0, poa.BLOCK_WEIGHT_OUT_OF_TURN / 1),
     ]
 )
 def test_calculate_weight(n_signers: int, height: int, signer_index: int, expected: float) -> None:

--- a/tests/poa/test_poa_block_producer.py
+++ b/tests/poa/test_poa_block_producer.py
@@ -57,7 +57,6 @@ def test_poa_block_producer_one_signer() -> None:
 
     # when we can start mining, we start producing blocks
     manager.can_start_mining = Mock(return_value=True)
-    reactor.advance(20)
 
     # we produce our first block
     reactor.advance(10)
@@ -116,7 +115,6 @@ def test_poa_block_producer_two_signers() -> None:
 
     # when we can start mining, we start producing blocks
     manager.can_start_mining = Mock(return_value=True)
-    reactor.advance(20)
 
     # we produce our first block
     reactor.advance(10)
@@ -144,14 +142,14 @@ def test_poa_block_producer_two_signers() -> None:
     manager.on_new_tx.reset_mock()
 
     # haven't produced the third block yet
-    reactor.advance(9)
+    reactor.advance(29)
 
     # we produce our third block
-    reactor.advance(2)
+    reactor.advance(1)
     manager.on_new_tx.assert_called_once()
     block3 = manager.on_new_tx.call_args.args[0]
     assert isinstance(block3, PoaBlock)
-    assert block3.timestamp == block2.timestamp + 11
+    assert block3.timestamp == block2.timestamp + 30
     assert block3.weight == poa.BLOCK_WEIGHT_OUT_OF_TURN
     assert block3.outputs == []
     assert block3.get_block_parent_hash() == block2.hash
@@ -161,15 +159,15 @@ def test_poa_block_producer_two_signers() -> None:
 @pytest.mark.parametrize(
     ['previous_height', 'signer_index', 'expected_delay'],
     [
-        (0, 0, 33),
+        (0, 0, 90),
         (0, 1, 30),
-        (0, 2, 31),
-        (0, 3, 32),
+        (0, 2, 70),
+        (0, 3, 80),
 
-        (1, 0, 32),
-        (1, 1, 33),
+        (1, 0, 80),
+        (1, 1, 90),
         (1, 2, 30),
-        (1, 3, 31),
+        (1, 3, 70),
     ]
 )
 def test_expected_block_timestamp(previous_height: int, signer_index: int, expected_delay: int) -> None:


### PR DESCRIPTION
### Motivation

Implement some of the requested changes in previous PRs.

### Acceptance Criteria

- Remove `poa.in_turn_signer_index()` and add `poa.get_signer_index_distance()`.
- Update `poa.calculate_weight()` to decrease the block weight inversely proportional to the index distance.
- Changes in `PoaBlockProducer`:
  - Merge both looping calls into one.
  - Add delayed block production cancellation.
  - Update logs.
  - Change block delay function to include a constant offset for out of turn blocks, and increase the interval between each signer.
- Update tests accordingly.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 