### PR TITLE
feat: add sync-v2 benchmark to CI

### DIFF
--- a/.github/actions/setup-hathor-env/action.yml
+++ b/.github/actions/setup-hathor-env/action.yml
@@ -1,0 +1,38 @@
+name: setup-hathor-env
+description: Setup Hathor node environment
+inputs:
+  python:
+    description: The python version
+  os:
+    description: The OS name
+runs:
+  using: composite
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry
+
+    - name: Set up Python ${{ inputs.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python }}
+        cache: 'poetry'
+
+    - name: Install Ubuntu dependencies
+      if: startsWith(inputs.os, 'ubuntu')
+      run: |
+        sudo apt-get -qy update
+        sudo apt-get -qy install graphviz librocksdb-dev libsnappy-dev liblz4-dev
+      shell: bash
+
+    - name: Install macOS dependencies
+      if: startsWith(inputs.os, 'macos')
+      run: |
+        brew cleanup -q
+        # brew update -q
+        brew install -q graphviz rocksdb pkg-config
+      shell: bash
+
+    - name: Install Poetry dependencies
+      run: poetry install -n --no-root
+      shell: bash

--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -1,0 +1,34 @@
+# yamllint disable rule:line-length
+name: benchmarking
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+
+jobs:
+  benchmark_base_branch:
+    name: Continuous Benchmarking base branch
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bencherdev/bencher@main
+      - name: Install hyperfine
+        run: |
+          wget https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine_1.12.0_amd64.deb
+          sudo dpkg -i hyperfine_1.12.0_amd64.deb
+      - uses: ./.github/actions/setup-hathor-env
+        name: Setup Hathor node environment
+        with:
+          python: 3.11
+          os: ubuntu-22.04
+      - name: Track base branch benchmarks with Bencher
+        run: |
+          bencher run \
+          --project hathor-core \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch master \
+          --testbed ubuntu-22.04 \
+          --adapter shell_hyperfine \
+          --err \
+          --file bench_results.json \
+          './extras/benchmarking/benchmark_sync_v2.sh'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,26 +63,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Poetry
-        run: pipx install poetry
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+      - uses: ./.github/actions/setup-hathor-env
+        name: Setup Hathor node environment
         with:
-          python-version: ${{ matrix.python }}
-          cache: 'poetry'
-      - name: Install Ubuntu dependencies
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get -qy update
-          sudo apt-get -qy install graphviz librocksdb-dev libsnappy-dev liblz4-dev
-      - name: Install macOS dependencies
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          brew cleanup -q
-          # brew update -q
-          brew install -q graphviz rocksdb pkg-config
-      - name: Install Poetry dependencies
-        run: poetry install -n --no-root
+          python: ${{ matrix.python }}
+          os: ${{ matrix.os }}
       - name: Cache mypy
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -1,0 +1,41 @@
+# yamllint disable rule:line-length
+name: benchmarking
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  benchmark_pr_branch:
+    name: Continuous Benchmarking PRs
+    # DO NOT REMOVE: For handling Fork PRs see Pull Requests from Forks
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bencherdev/bencher@main
+      - name: Install hyperfine
+        run: |
+          wget https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine_1.12.0_amd64.deb
+          sudo dpkg -i hyperfine_1.12.0_amd64.deb
+      - uses: ./.github/actions/setup-hathor-env
+        name: Setup Hathor node environment
+        with:
+          python: 3.11
+          os: ubuntu-22.04
+      - name: Track PR Benchmarks with Bencher
+        run: |
+          bencher run \
+          --project hathor-core \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch '${{ github.head_ref }}' \
+          --branch-start-point '${{ github.base_ref }}' \
+          --branch-start-point-hash '${{ github.event.pull_request.base.sha }}' \
+          --testbed ubuntu-22.04 \
+          --adapter shell_hyperfine \
+          --err \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --file bench_results.json \
+          './extras/benchmarking/benchmark_sync_v2.sh'

--- a/extras/benchmarking/benchmark_sync_v2.sh
+++ b/extras/benchmarking/benchmark_sync_v2.sh
@@ -1,0 +1,45 @@
+N_BLOCKS=20000
+CACHE_SIZE=100000
+TESTNET_DATA_DIR=server-data
+TCP_PORT=40403
+AWAIT_INIT_DELAY=10
+N_RUNS=2
+BENCH_FILE=bench_results.json
+BENCH_DATA_DIR=bench-data
+
+BLUE='\033[0;34m'
+NO_COLOR='\033[0m'
+
+echo "${BLUE}Downloading testnet data...${NO_COLOR}"
+mkdir $TESTNET_DATA_DIR
+poetry run hathor-cli quick_test --testnet --data $TESTNET_DATA_DIR --quit-after-n-blocks $N_BLOCKS > /dev/null 2>&1
+
+echo "${BLUE}Running server node in the background...${NO_COLOR}"
+poetry run hathor-cli run_node \
+  --testnet \
+  --data $TESTNET_DATA_DIR \
+  --cache \
+  --cache-size $CACHE_SIZE \
+  --x-localhost-only \
+  --listen tcp:$TCP_PORT \
+  > /dev/null 2>&1 &
+
+# Await initialization
+sleep $AWAIT_INIT_DELAY
+
+echo "${BLUE}Running benchmark...${NO_COLOR}"
+hyperfine \
+  --runs $N_RUNS \
+  --export-json $BENCH_FILE \
+  --command-name "sync-v2 (up to $N_BLOCKS blocks)" \
+  --prepare "rm -rf $BENCH_DATA_DIR && mkdir $BENCH_DATA_DIR" \
+  "
+    poetry run hathor-cli quick_test \
+      --testnet \
+      --data $BENCH_DATA_DIR \
+      --cache \
+      --cache-size $CACHE_SIZE \
+      --x-localhost-only \
+      --bootstrap tcp://localhost:$TCP_PORT \
+      --quit-after-n-blocks $N_BLOCKS
+  "


### PR DESCRIPTION
### Motivation

This PR implements the basic infrastructure for running benchmarks in our CI through GitHub Actions and the [Bencher](https://bencher.dev) tool, which automatically tracks changes in performance across PRs (though it is more flexible than that). Bencher is [open source](https://github.com/bencherdev/bencher) and provides their cloud to run the Bencher service, which we're using through a free tier plan. We can consider upgrading our plan or running our own self-hosted service if necessary, but I don't see any reasons for now. This means our benchmarking results are public on the [Bencher Console](https://bencher.dev/console/projects/hathor-core/).

We setup a benchmark for tracking sync-v2 performance. It works by:

1. Setting up a temporary node connected to testnet that exits after downloading 20k blocks.
2. Running a server node in the background, connected only on localhost, and using the database with the previously downloaded blocks.
3. Running a [Hyperfine](https://github.com/sharkdp/hyperfine) benchmark integrated with Bencher, which starts a new full node that syncs 20k blocks with the server node, and exits.

By doing this we isolate the network and test only the node performance itself. Of course there may be unpredictable variations in GitHub machines, but we'll only understand this impact by observing the metrics over time.

The job described above runs in two workflows, one for every push on `master`, which sets the baseline for our metrics, and one for each PR to `master`, which compares the metric value to the baseline and triggers a CI error if it's above a certain threshold. This is configured though the Bencher console directly. I configured both upper and lower thresholds of 10% (it's useful to set a lower threshold to track performance improvements, as an unpredicted drop in time may indicate new bugs).

There are improvements to be made in the future:

- [ ] Instead of using a node connected to testnet and syncing 20k blocks every time, we could have a pre-downloaded database and save it in S3, for example. Currently, this downloading step is way slower than the benchmark itself (to be clear: it does not affect the benchmark time, but it does affect the CI job duration).
- [ ] We currently only sync 20k blocks from testnet, and that doesn't include any transactions. We could test the improvement above with different database sizes and find a tradeoff to include transactions. We could even create a fake database with specific blocks/transactions ratios and benchmark them.
- [ ] We can add other benchmarks such as node initialization time, vertex (de)serialization time, API response times, etc.
- [ ] We could add this to other projects, not only hathor-core.

### Acceptance Criteria

- Create a new reusable action `setup-hathor-env`, used by our main CI and the new benchmarking workflows.
- Add new `Continuous Benchmarking base branch` and `Continuous Benchmarking PRs` jobs.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 