### PR TITLE
refactor(p2p): use Entrypoint type instead of str

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -34,6 +34,7 @@ from hathor.feature_activation.storage.feature_activation_storage import Feature
 from hathor.indexes import IndexesManager, MemoryIndexesManager, RocksDBIndexesManager
 from hathor.manager import HathorManager
 from hathor.mining.cpu_mining_service import CpuMiningService
+from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.utils import discover_hostname, get_genesis_short_hash
@@ -389,7 +390,8 @@ class CliBuilder:
             p2p_manager.add_peer_discovery(DNSPeerDiscovery(dns_hosts))
 
         if self._args.bootstrap:
-            p2p_manager.add_peer_discovery(BootstrapPeerDiscovery(self._args.bootstrap))
+            entrypoints = [Entrypoint.parse(desc) for desc in self._args.bootstrap]
+            p2p_manager.add_peer_discovery(BootstrapPeerDiscovery(entrypoints))
 
         if self._args.x_rocksdb_indexes:
             self.log.warn('--x-rocksdb-indexes is now the default, no need to specify it')

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -252,7 +252,7 @@ class Metrics:
                 continue
 
             metric = PeerConnectionMetrics(
-                connection_string=connection.connection_string if connection.connection_string else "",
+                connection_string=str(connection.entrypoint) if connection.entrypoint else "",
                 peer_id=connection.peer.id,
                 network=connection.network,
                 received_messages=connection.metrics.received_messages,

--- a/hathor/p2p/entrypoint.py
+++ b/hathor/p2p/entrypoint.py
@@ -1,0 +1,219 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from enum import Enum
+from urllib.parse import parse_qs, urlparse
+
+from twisted.internet.address import IPv4Address, IPv6Address
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.interfaces import IStreamClientEndpoint
+from typing_extensions import Self
+
+from hathor.reactor import ReactorProtocol as Reactor
+from hathor.types import Hash
+
+
+class Protocol(Enum):
+    TCP = 'tcp'
+
+
+class PeerId(Hash):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class Entrypoint:
+    """Endpoint description (returned from DNS query, or received from the p2p network) may contain a peer-id."""
+
+    protocol: Protocol
+    host: str
+    port: int
+    peer_id: PeerId | None
+
+    def __str__(self):
+        if self.peer_id is None:
+            return f'{self.protocol.value}://{self.host}:{self.port}'
+        else:
+            return f'{self.protocol.value}://{self.host}:{self.port}/?id={self.peer_id}'
+
+    @classmethod
+    def parse(cls, description: str) -> Self:
+        """Parse endpoint description into an Entrypoint object.
+
+        Examples:
+
+        >>> str(Entrypoint.parse('tcp://127.0.0.1:40403/'))
+        'tcp://127.0.0.1:40403'
+
+        >>> id1 = 'c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'
+        >>> Entrypoint.parse(f'tcp://127.0.0.1:40403/?id={id1}')
+        Entrypoint(protocol=<Protocol.TCP: 'tcp'>, host='127.0.0.1', port=40403, \
+peer_id=PeerId('c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'))
+
+        >>> str(Entrypoint.parse(f'tcp://127.0.0.1:40403/?id={id1}'))
+        'tcp://127.0.0.1:40403/?id=c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'
+
+        >>> Entrypoint.parse('tcp://127.0.0.1:40403')
+        Entrypoint(protocol=<Protocol.TCP: 'tcp'>, host='127.0.0.1', port=40403, peer_id=None)
+
+        >>> Entrypoint.parse('tcp://127.0.0.1:40403/')
+        Entrypoint(protocol=<Protocol.TCP: 'tcp'>, host='127.0.0.1', port=40403, peer_id=None)
+
+        >>> Entrypoint.parse('tcp://foo.bar.baz:40403/')
+        Entrypoint(protocol=<Protocol.TCP: 'tcp'>, host='foo.bar.baz', port=40403, peer_id=None)
+
+        >>> str(Entrypoint.parse('tcp://foo.bar.baz:40403/'))
+        'tcp://foo.bar.baz:40403'
+
+        >>> Entrypoint.parse('tcp://127.0.0.1:40403/?id=123')
+        Traceback (most recent call last):
+        ...
+        ValueError: non-hexadecimal number found in fromhex() arg at position 3
+
+        >>> Entrypoint.parse('tcp://127.0.0.1:4040f')
+        Traceback (most recent call last):
+        ...
+        ValueError: Port could not be cast to integer value as '4040f'
+
+        >>> Entrypoint.parse('udp://127.0.0.1:40403/')
+        Traceback (most recent call last):
+        ...
+        ValueError: 'udp' is not a valid Protocol
+
+        >>> Entrypoint.parse('tcp://127.0.0.1/')
+        Traceback (most recent call last):
+        ...
+        ValueError: expected a port
+
+        >>> Entrypoint.parse('tcp://:40403/')
+        Traceback (most recent call last):
+        ...
+        ValueError: expected a host
+
+        >>> Entrypoint.parse('tcp://127.0.0.1:40403/foo')
+        Traceback (most recent call last):
+        ...
+        ValueError: unexpected path: /foo
+
+        >>> id2 = 'bc5119d47bb4ea7c19100bd97fb11f36970482108bd3d45ff101ee4f6bbec872'
+        >>> Entrypoint.parse(f'tcp://127.0.0.1:40403/?id={id1}&id={id2}')
+        Traceback (most recent call last):
+        ...
+        ValueError: unexpected id count: 2
+        """
+        url = urlparse(description)
+        protocol = Protocol(url.scheme)
+        host = url.hostname
+        if host is None:
+            raise ValueError('expected a host')
+        port = url.port
+        if port is None:
+            raise ValueError('expected a port')
+        if url.path not in {'', '/'}:
+            raise ValueError(f'unexpected path: {url.path}')
+        peer_id: PeerId | None = None
+
+        if url.query:
+            query = parse_qs(url.query)
+            if 'id' in query:
+                ids = query['id']
+                if len(ids) != 1:
+                    raise ValueError(f'unexpected id count: {len(ids)}')
+                peer_id = PeerId(ids[0])
+
+        return cls(protocol, host, port, peer_id)
+
+    @classmethod
+    def from_hostname_address(cls, hostname: str, address: IPv4Address | IPv6Address) -> Self:
+        return cls.parse(f'{address.type}://{hostname}:{address.port}')
+
+    def to_client_endpoint(self, reactor: Reactor) -> IStreamClientEndpoint:
+        """This method generates a twisted client endpoint that has a .connect() method."""
+        # XXX: currently we don't support IPv6, but when we do we have to decide between TCP4ClientEndpoint and
+        # TCP6ClientEndpoint, when the host is an IP address that is easy, but when it is a DNS hostname, we will not
+        # know which to use until we know which resource records it holds (A or AAAA)
+        return TCP4ClientEndpoint(reactor, self.host, self.port)
+
+    def equals_ignore_peer_id(self, other: Self) -> bool:
+        """Compares `self` and `other` ignoring the `peer_id` fields of either.
+
+        Examples:
+
+        >>> ep1 = 'tcp://foo:111'
+        >>> ep2 = 'tcp://foo:111/?id=c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'
+        >>> ep3 = 'tcp://foo:111/?id=bc5119d47bb4ea7c19100bd97fb11f36970482108bd3d45ff101ee4f6bbec872'
+        >>> ep4 = 'tcp://bar:111/?id=c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'
+        >>> ep5 = 'tcp://foo:112/?id=c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'
+        >>> Entrypoint.parse(ep1).equals_ignore_peer_id(Entrypoint.parse(ep2))
+        True
+        >>> Entrypoint.parse(ep2).equals_ignore_peer_id(Entrypoint.parse(ep3))
+        True
+        >>> Entrypoint.parse(ep1).equals_ignore_peer_id(Entrypoint.parse(ep4))
+        False
+        >>> Entrypoint.parse(ep2).equals_ignore_peer_id(Entrypoint.parse(ep4))
+        False
+        >>> Entrypoint.parse(ep2).equals_ignore_peer_id(Entrypoint.parse(ep5))
+        False
+        """
+        return (self.protocol, self.host, self.port) == (other.protocol, other.host, other.port)
+
+    def peer_id_conflicts_with(self, other: Self) -> bool:
+        """Returns True if both self and other have a peer_id and they are different, returns False otherwise.
+
+        This method ignores the host. Which is useful for catching the cases where both `self` and `other` have a
+        declared `peer_id` and they are not equal.
+
+        >>> desc_no_pid = 'tcp://127.0.0.1:40403/'
+        >>> ep_no_pid = Entrypoint.parse(desc_no_pid)
+        >>> desc_pid1 = 'tcp://127.0.0.1:40403/?id=c0f19299c2a4dcbb6613a14011ff07b63d6cb809e4cee25e9c1ccccdd6628696'
+        >>> ep_pid1 = Entrypoint.parse(desc_pid1)
+        >>> desc_pid2 = 'tcp://127.0.0.1:40403/?id=bc5119d47bb4ea7c19100bd97fb11f36970482108bd3d45ff101ee4f6bbec872'
+        >>> ep_pid2 = Entrypoint.parse(desc_pid2)
+        >>> desc2_pid2 = 'tcp://foo.bar:40403/?id=bc5119d47bb4ea7c19100bd97fb11f36970482108bd3d45ff101ee4f6bbec872'
+        >>> ep2_pid2 = Entrypoint.parse(desc2_pid2)
+        >>> ep_no_pid.peer_id_conflicts_with(ep_no_pid)
+        False
+        >>> ep_no_pid.peer_id_conflicts_with(ep_pid1)
+        False
+        >>> ep_pid1.peer_id_conflicts_with(ep_no_pid)
+        False
+        >>> ep_pid1.peer_id_conflicts_with(ep_pid2)
+        True
+        >>> ep_pid1.peer_id_conflicts_with(ep2_pid2)
+        True
+        >>> ep_pid2.peer_id_conflicts_with(ep2_pid2)
+        False
+        """
+        return self.peer_id is not None and other.peer_id is not None and self.peer_id != other.peer_id
+
+    def is_localhost(self) -> bool:
+        """Used to determine if the entrypoint host is a localhost address.
+
+        Examples:
+
+        >>> Entrypoint.parse('tcp://127.0.0.1:444').is_localhost()
+        True
+        >>> Entrypoint.parse('tcp://localhost:444').is_localhost()
+        True
+        >>> Entrypoint.parse('tcp://8.8.8.8:444').is_localhost()
+        False
+        >>> Entrypoint.parse('tcp://foo.bar:444').is_localhost()
+        False
+        """
+        if self.host == '127.0.0.1':
+            return True
+        if self.host == 'localhost':
+            return True
+        return False

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -17,6 +17,8 @@ from typing import Callable
 from structlog import get_logger
 from typing_extensions import override
 
+from hathor.p2p.entrypoint import Entrypoint
+
 from .peer_discovery import PeerDiscovery
 
 logger = get_logger()
@@ -26,15 +28,15 @@ class BootstrapPeerDiscovery(PeerDiscovery):
     """ It implements a bootstrap peer discovery, which receives a static list of peers.
     """
 
-    def __init__(self, descriptions: list[str]):
+    def __init__(self, entrypoints: list[Entrypoint]):
         """
         :param descriptions: Descriptions of peers to connect to.
         """
         super().__init__()
         self.log = logger.new()
-        self.descriptions = descriptions
+        self.entrypoints = entrypoints
 
     @override
-    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
-        for description in self.descriptions:
-            connect_to(description)
+    async def discover_and_connect(self, connect_to: Callable[[Entrypoint], None]) -> None:
+        for entrypoint in self.entrypoints:
+            connect_to(entrypoint)

--- a/hathor/p2p/peer_discovery/peer_discovery.py
+++ b/hathor/p2p/peer_discovery/peer_discovery.py
@@ -15,13 +15,15 @@
 from abc import ABC, abstractmethod
 from typing import Callable
 
+from hathor.p2p.entrypoint import Entrypoint
+
 
 class PeerDiscovery(ABC):
     """ Base class to implement peer discovery strategies.
     """
 
     @abstractmethod
-    async def discover_and_connect(self, connect_to: Callable[[str], None]) -> None:
+    async def discover_and_connect(self, connect_to: Callable[[Entrypoint], None]) -> None:
         """ This method must discover the peers and call `connect_to` for each of them.
 
         :param connect_to: Function which will be called for each discovered peer.

--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -31,7 +31,8 @@ from twisted.internet.ssl import Certificate, CertificateOptions, TLSVersion, tr
 
 from hathor.conf.get_settings import get_global_settings
 from hathor.daa import DifficultyAdjustmentAlgorithm
-from hathor.p2p.utils import connection_string_to_host, discover_dns, generate_certificate
+from hathor.p2p.entrypoint import Entrypoint
+from hathor.p2p.utils import discover_dns, generate_certificate
 from hathor.util import not_none
 
 if TYPE_CHECKING:
@@ -59,7 +60,7 @@ class PeerId:
     """
 
     id: Optional[str]
-    entrypoints: list[str]
+    entrypoints: list[Entrypoint]
     private_key: Optional[rsa.RSAPrivateKeyWithSerialization]
     public_key: Optional[rsa.RSAPublicKey]
     certificate: Optional[x509.Certificate]
@@ -200,7 +201,11 @@ class PeerId:
             obj.private_key = private_key
 
         if 'entrypoints' in data:
-            obj.entrypoints = data['entrypoints']
+            for entrypoint_string in data['entrypoints']:
+                entrypoint = Entrypoint.parse(entrypoint_string)
+                if entrypoint.peer_id is not None:
+                    raise ValueError('do not add id= to peer.json entrypoints')
+                obj.entrypoints.append(entrypoint)
 
         # TODO(epnichols): call obj.validate()?
         return obj
@@ -243,7 +248,7 @@ class PeerId:
         result = {
             'id': self.id,
             'pubKey': base64.b64encode(public_der).decode('utf-8'),
-            'entrypoints': self.entrypoints,
+            'entrypoints': [str(ep) for ep in self.entrypoints],
         }
         if include_private_key:
             assert self.private_key is not None
@@ -352,23 +357,24 @@ class PeerId:
         # Entrypoint validation with connection string and connection host
         # Entrypoints have the format tcp://IP|name:port
         for entrypoint in self.entrypoints:
-            if protocol.connection_string:
+            if protocol.entrypoint is not None:
                 # Connection string has the format tcp://IP:port
                 # So we must consider that the entrypoint could be in name format
-                if protocol.connection_string == entrypoint:
+                if protocol.entrypoint.equals_ignore_peer_id(entrypoint):
+                    # XXX: wrong peer-id should not make it into self.entrypoints
+                    assert not protocol.entrypoint.peer_id_conflicts_with(entrypoint), 'wrong peer-id was added before'
                     # Found the entrypoint
                     found_entrypoint = True
                     break
-                host = connection_string_to_host(entrypoint)
                 # TODO: don't use `daa.TEST_MODE` for this
                 test_mode = not_none(DifficultyAdjustmentAlgorithm.singleton).TEST_MODE
-                result = await discover_dns(host, test_mode)
-                if protocol.connection_string in result:
+                result = await discover_dns(entrypoint.host, test_mode)
+                if protocol.entrypoint in result:
                     # Found the entrypoint
                     found_entrypoint = True
                     break
             else:
-                # When the peer is the server part of the connection we don't have the full connection_string
+                # When the peer is the server part of the connection we don't have the full entrypoint description
                 # So we can only validate the host from the protocol
                 assert protocol.transport is not None
                 connection_remote = protocol.transport.getPeer()
@@ -377,13 +383,12 @@ class PeerId:
                     continue
                 # Connection host has only the IP
                 # So we must consider that the entrypoint could be in name format and we just validate the host
-                host = connection_string_to_host(entrypoint)
-                if connection_host == host:
+                if connection_host == entrypoint.host:
                     found_entrypoint = True
                     break
                 test_mode = not_none(DifficultyAdjustmentAlgorithm.singleton).TEST_MODE
-                result = await discover_dns(host, test_mode)
-                if connection_host in [connection_string_to_host(x) for x in result]:
+                result = await discover_dns(entrypoint.host, test_mode)
+                if connection_host in [entrypoint.host for entrypoint in result]:
                     # Found the entrypoint
                     found_entrypoint = True
                     break

--- a/hathor/types.py
+++ b/hathor/types.py
@@ -24,3 +24,87 @@ TxOutputScript: TypeAlias = bytes  # NewType('TxOutputScript', bytes)
 Timestamp: TypeAlias = int         # NewType('Timestamp', int)
 TokenUid: TypeAlias = VertexId     # NewType('TokenUid', VertexId)
 Amount: TypeAlias = int            # NewType('Amount', int)
+
+
+class Hash:
+    r""" A type for easily representing a 32-byte hash, it is not meant to be used directly.
+
+    Instead it is meant to be used to make new-types that also happen to be a hash. This class will provide convenient
+    methods for parsing and representing it.
+
+    Examples:
+
+    >>> x = Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc')
+    >>> bytes(x)
+    b'\x00\x00\x06\xcb\x938[\x8b\x87\xa5E\xa1\xcb\xb6\x19~l\xaf\xf6\x00\xc1,\xc1/\xc5BP\xd3\x9c\x80\x88\xfc'
+
+    >>> Hash(b'\x00\x00\x06\xcb\x938[\x8b\x87\xa5E\xa1\xcb\xb6\x19~l\xaf\xf6\x00\xc1,\xc1/\xc5BP\xd3\x9c\x80\x88\xfc')
+    Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc')
+
+    >>> str(x)
+    '000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc'
+
+    >>> repr(x)
+    "Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc')"
+
+    >>> {x}
+    {Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc')}
+
+    >>> class Foo(Hash):
+    ...     pass
+    >>> y = Foo('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc')
+    >>> repr(y)
+    "Foo('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc')"
+
+    >>> x == y
+    True
+
+    >>> {x: 123}[y]
+    123
+
+    >>> Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc34')
+    Traceback (most recent call last):
+    ...
+    ValueError: expected 32 bytes, got 33 bytes
+
+    >>> Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088')
+    Traceback (most recent call last):
+    ...
+    ValueError: expected 32 bytes, got 31 bytes
+
+    >>> Hash('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088f')
+    Traceback (most recent call last):
+    ...
+    ValueError: non-hexadecimal number found in fromhex() arg at position 63
+
+    >>> Hash(123)
+    Traceback (most recent call last):
+    ...
+    TypeError: expected a bytes or str instance, got a <class 'int'> instead
+    """
+    __slots__ = ('_inner',)
+    _inner: bytes
+
+    def __init__(self, inner: bytes | str) -> None:
+        if isinstance(inner, str):
+            inner = bytes.fromhex(inner)
+        if not isinstance(inner, bytes):
+            raise TypeError(f'expected a bytes or str instance, got a {repr(type(inner))} instead')
+        if len(inner) != 32:
+            raise ValueError(f'expected 32 bytes, got {len(inner)} bytes')
+        self._inner = inner
+
+    def __bytes__(self):
+        return self._inner
+
+    def __str__(self):
+        return self._inner.hex()
+
+    def __repr__(self):
+        return f"{type(self).__name__}('{self}')"
+
+    def __hash__(self):
+        return hash(self._inner)
+
+    def __eq__(self, other):
+        return self._inner.__eq__(other._inner)

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.manager import PeerConnectionsMetrics
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.protocol import HathorProtocol
@@ -65,7 +66,7 @@ class BaseMetricsTest(unittest.TestCase):
         manager.connections.handshaking_peers.update({Mock()})
 
         # Execution
-        endpoint = 'tcp://127.0.0.1:8005'
+        endpoint = Entrypoint.parse('tcp://127.0.0.1:8005')
         # This will trigger sending to the pubsub one of the network events
         manager.connections.connect_to(endpoint, use_ssl=True)
 

--- a/tests/p2p/test_connections.py
+++ b/tests/p2p/test_connections.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+from hathor.p2p.entrypoint import Entrypoint
 from tests import unittest
 from tests.utils import run_server
 
@@ -20,7 +21,7 @@ class ConnectionsTest(unittest.TestCase):
     def test_manager_connections(self) -> None:
         manager = self.create_peer('testnet', enable_sync_v1=True, enable_sync_v2=False)
 
-        endpoint = 'tcp://127.0.0.1:8005'
+        endpoint = Entrypoint.parse('tcp://127.0.0.1:8005')
         manager.connections.connect_to(endpoint, use_ssl=True)
 
         self.assertIn(endpoint, manager.connections.iter_not_ready_endpoints())

--- a/tests/resources/p2p/test_add_peer.py
+++ b/tests/resources/p2p/test_add_peer.py
@@ -1,5 +1,6 @@
 from twisted.internet.defer import inlineCallbacks
 
+from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.peer_id import PeerId
 from hathor.p2p.resources import AddPeersResource
 from tests import unittest
@@ -21,7 +22,7 @@ class BaseAddPeerTest(_BaseResourceTest._ResourceTest):
 
         # test when we send a peer we're already connected to
         peer = PeerId()
-        peer.entrypoints = ['tcp://localhost:8006']
+        peer.entrypoints = [Entrypoint.parse('tcp://localhost:8006')]
         self.manager.connections.peer_storage.add(peer)
         response = yield self.web.post('p2p/peers', ['tcp://localhost:8006', 'tcp://localhost:8007'])
         data = response.json_value()


### PR DESCRIPTION
### Motivation

Using a `str` is not ideal.

### Acceptance Criteria

- introduce new `Entrypoint` class that can be parsed from and converted back to the `tcp://hostname:port` format, optionally allowing a peer-id (this was already supported): `tcp://hostname:port/?id=peer-id`
- introduce `Hash` class that works as a `bytes` with fixed length of 32, to be used as base for `PeerId` class that `Entrypoint` uses for storing peer-ids (this `Hash` class can be slowly used in more places in the future)
- replace every instance of `str` used as an endpoint description with `Entrypoint`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 