### PR TITLE
fix(logging): make different version logging less obtrusive

### DIFF
--- a/hathor/p2p/states/hello.py
+++ b/hathor/p2p/states/hello.py
@@ -130,7 +130,10 @@ class HelloState(BaseState):
         protocol.sync_version = max(common_sync_versions)
 
         if data['app'] != self._app():
-            self.log.warn('different versions', theirs=data['app'], ours=self._app())
+            remote_app = data['app'].encode().hex()
+            our_app = self._app().encode().hex()
+            # XXX: this used to be a warning, but it shouldn't be since it's perfectly normal
+            self.log.debug('different versions', theirs=remote_app, ours=our_app)
 
         if data['network'] != protocol.network:
             protocol.send_error_and_close_connection('Wrong network.')


### PR DESCRIPTION
### Motivation

Different version log is unnecessarily a warning.

### Acceptance Criteria

- Change from `log.warn` to `log.debug`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 