### PR TITLE
fix(p2p): regression after entrypoint refactor

### DIFF
--- a/hathor/p2p/entrypoint.py
+++ b/hathor/p2p/entrypoint.py
@@ -40,7 +40,7 @@ class Entrypoint:
     protocol: Protocol
     host: str
     port: int
-    peer_id: PeerId | None
+    peer_id: PeerId | None = None
 
     def __str__(self):
         if self.peer_id is None:

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -645,7 +645,7 @@ class ConnectionsManager:
 
         deferred.addCallback(self._connect_to_callback, peer, endpoint, entrypoint)
         deferred.addErrback(self.on_connection_failure, peer, endpoint)
-        self.log.info('connect to', entrypoint=entrypoint, peer=str(peer))
+        self.log.info('connect to', entrypoint=str(entrypoint), peer=str(peer))
         self.pubsub.publish(
             HathorEvents.NETWORK_PEER_CONNECTING,
             peer=peer,

--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -91,8 +91,11 @@ class PeerId:
             self.generate_keys()
 
     def __str__(self):
-        return ('PeerId(id=%s, entrypoints=%s, retry_timestamp=%d, retry_interval=%d)' % (self.id, self.entrypoints,
-                self.retry_timestamp, self.retry_interval))
+        entrypoints = [str(entrypoint) for entrypoint in self.entrypoints]
+        return (
+            f'PeerId(id={self.id}, entrypoints={entrypoints}, retry_timestamp={self.retry_timestamp}, '
+            f'retry_interval={self.retry_interval})'
+        )
 
     def merge(self, other: 'PeerId') -> None:
         """ Merge two PeerId objects, checking that they have the same

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -167,7 +167,7 @@ class ReadyState(BaseState):
             if peer.entrypoints:
                 data.append({
                     'id': peer.id,
-                    'entrypoints': peer.entrypoints,
+                    'entrypoints': [str(entrypoint) for entrypoint in peer.entrypoints],
                 })
         self.send_message(ProtocolMessages.PEERS, json_dumps(data))
         self.log.debug('send peers', peers=data)

--- a/tests/p2p/test_bootstrap.py
+++ b/tests/p2p/test_bootstrap.py
@@ -1,0 +1,92 @@
+from typing import Callable
+
+from twisted.internet.defer import Deferred
+from twisted.names.dns import TXT, A, Record_A, Record_TXT, RRHeader
+from typing_extensions import override
+
+from hathor.p2p.entrypoint import Entrypoint, Protocol
+from hathor.p2p.manager import ConnectionsManager
+from hathor.p2p.peer_discovery import DNSPeerDiscovery, PeerDiscovery
+from hathor.p2p.peer_discovery.dns import LookupResult
+from hathor.p2p.peer_id import PeerId
+from hathor.pubsub import PubSubManager
+from tests import unittest
+from tests.test_memory_reactor_clock import TestMemoryReactorClock
+
+
+class MockPeerDiscovery(PeerDiscovery):
+    def __init__(self, mocked_host_ports: list[tuple[str, int]]):
+        self.mocked_host_ports = mocked_host_ports
+
+    @override
+    async def discover_and_connect(self, connect_to: Callable[[Entrypoint], None]) -> None:
+        for host, port in self.mocked_host_ports:
+            connect_to(Entrypoint(Protocol.TCP, host, port))
+
+
+class MockDNSPeerDiscovery(DNSPeerDiscovery):
+    def __init__(self, reactor: TestMemoryReactorClock, bootstrap_txt: list[tuple[str, int]], bootstrap_a: list[str]):
+        super().__init__(['test.example'])
+        self.reactor = reactor
+        self.mocked_lookup_a = [RRHeader(type=A, payload=Record_A(address)) for address in bootstrap_a]
+        txt_entries = [f'tcp://{h}:{p}'.encode() for h, p in bootstrap_txt]
+        self.mocked_lookup_txt = [RRHeader(type=TXT, payload=Record_TXT(*txt_entries))]
+
+    def do_lookup_address(self, host: str) -> Deferred[LookupResult]:
+        deferred: Deferred[LookupResult] = Deferred()
+        lookup_result = [self.mocked_lookup_a, [], []]
+        self.reactor.callLater(0, deferred.callback, lookup_result)
+        return deferred
+
+    def do_lookup_text(self, host: str) -> Deferred[LookupResult]:
+        deferred: Deferred[LookupResult] = Deferred()
+        lookup_result = [self.mocked_lookup_txt, [], []]
+        self.reactor.callLater(0, deferred.callback, lookup_result)
+        return deferred
+
+
+class BootstrapTestCase(unittest.TestCase):
+    def test_mock_discovery(self) -> None:
+        pubsub = PubSubManager(self.clock)
+        connections = ConnectionsManager(self.clock, 'testnet', PeerId(), pubsub, True, self.rng, True)
+        host_ports1 = [
+            ('foobar', 1234),
+            ('127.0.0.99', 9999),
+        ]
+        host_ports2 = [
+            ('baz', 456),
+            ('127.0.0.88', 8888),
+        ]
+        connections.add_peer_discovery(MockPeerDiscovery(host_ports1))
+        connections.add_peer_discovery(MockPeerDiscovery(host_ports2))
+        connections.do_discovery()
+        self.clock.advance(1)
+        connecting_entrypoints = {str(entrypoint) for entrypoint, _ in connections.connecting_peers.values()}
+        self.assertEqual(connecting_entrypoints, {
+            'tcp://foobar:1234',
+            'tcp://127.0.0.99:9999',
+            'tcp://baz:456',
+            'tcp://127.0.0.88:8888',
+        })
+
+    def test_dns_discovery(self) -> None:
+        pubsub = PubSubManager(self.clock)
+        connections = ConnectionsManager(self.clock, 'testnet', PeerId(), pubsub, True, self.rng, True)
+        bootstrap_a = [
+            '127.0.0.99',
+            '127.0.0.88',
+        ]
+        bootstrap_txt = [
+            ('foobar', 1234),
+            ('baz', 456),
+        ]
+        connections.add_peer_discovery(MockDNSPeerDiscovery(self.clock, bootstrap_txt, bootstrap_a))
+        connections.do_discovery()
+        self.clock.advance(1)
+        connecting_entrypoints = {str(entrypoint) for entrypoint, _ in connections.connecting_peers.values()}
+        self.assertEqual(connecting_entrypoints, {
+            'tcp://127.0.0.99:40403',
+            'tcp://127.0.0.88:40403',
+            'tcp://foobar:1234',
+            'tcp://baz:456',
+        })


### PR DESCRIPTION
### Motivation

#1086 introduced a regression as can be seen [in the failed docker build, during the image test](https://github.com/HathorNetwork/hathor-core/actions/runs/9997668572/job/27634764715)

### Acceptance Criteria

- `Entrypoint.peer_id` should default to `None` (mypy didn't catch this)
- `defer.gatherResults` had to be chained before passing it to `set`
- `ProtocolMessages.PEERS` data was being constructed with `Entrypoint` objects, which can't be used in `json.dumps`, it needed to be converted to `str`
- Adjust `PeerId.__str__` so it uses `str(entrypoint)` instead of `repr(entrypoint)` to keep it less verbose
- Add tests that cover all the lines that have errors

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 