### PR TITLE
fix(p2p): status regression after entrypoint refactor

### DIFF
--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -91,11 +91,14 @@ class PeerId:
             self.generate_keys()
 
     def __str__(self):
-        entrypoints = [str(entrypoint) for entrypoint in self.entrypoints]
         return (
-            f'PeerId(id={self.id}, entrypoints={entrypoints}, retry_timestamp={self.retry_timestamp}, '
+            f'PeerId(id={self.id}, entrypoints={self.entrypoints_as_str()}, retry_timestamp={self.retry_timestamp}, '
             f'retry_interval={self.retry_interval})'
         )
+
+    def entrypoints_as_str(self) -> list[str]:
+        """Return a list of entrypoints serialized as str"""
+        return list(map(str, self.entrypoints))
 
     def merge(self, other: 'PeerId') -> None:
         """ Merge two PeerId objects, checking that they have the same
@@ -251,7 +254,7 @@ class PeerId:
         result = {
             'id': self.id,
             'pubKey': base64.b64encode(public_der).decode('utf-8'),
-            'entrypoints': [str(ep) for ep in self.entrypoints],
+            'entrypoints': self.entrypoints_as_str(),
         }
         if include_private_key:
             assert self.private_key is not None

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -83,7 +83,7 @@ class StatusResource(Resource):
         for peer in self.manager.connections.peer_storage.values():
             known_peers.append({
                 'id': peer.id,
-                'entrypoints': peer.entrypoints,
+                'entrypoints': peer.entrypoints_as_str(),
                 'last_seen': now - peer.last_seen,
                 'flags': [flag.value for flag in peer.flags],
             })
@@ -107,7 +107,7 @@ class StatusResource(Resource):
                 'state': self.manager.state.value,
                 'network': self.manager.network,
                 'uptime': now - self.manager.start_time,
-                'entrypoints': self.manager.connections.my_peer.entrypoints,
+                'entrypoints': self.manager.connections.my_peer.entrypoints_as_str(),
             },
             'peers_whitelist': self.manager.peers_whitelist,
             'known_peers': known_peers,

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -70,7 +70,7 @@ class PeerIdState(BaseState):
         hello = {
             'id': my_peer.id,
             'pubKey': my_peer.get_public_key(),
-            'entrypoints': my_peer.entrypoints,
+            'entrypoints': my_peer.entrypoints_as_str(),
         }
         self.send_message(ProtocolMessages.PEER_ID, json_dumps(hello))
 

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -166,7 +166,7 @@ class ReadyState(BaseState):
             if peer.entrypoints:
                 data.append({
                     'id': peer.id,
-                    'entrypoints': [str(entrypoint) for entrypoint in peer.entrypoints],
+                    'entrypoints': peer.entrypoints_as_str(),
                 })
         self.send_message(ProtocolMessages.PEERS, json_dumps(data))
         self.log.debug('send peers', peers=data)

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -3,6 +3,7 @@ from twisted.internet.defer import inlineCallbacks
 
 import hathor
 from hathor.conf.unittests import SETTINGS
+from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.resources import StatusResource
 from hathor.simulator import FakeConnection
 from tests import unittest
@@ -15,8 +16,11 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
     def setUp(self):
         super().setUp()
         self.web = StubSite(StatusResource(self.manager))
+        self.entrypoint = Entrypoint.parse('tcp://192.168.1.1:54321')
+        self.manager.connections.my_peer.entrypoints.append(self.entrypoint)
 
         self.manager2 = self.create_peer('testnet')
+        self.manager2.connections.my_peer.entrypoints.append(self.entrypoint)
         self.conn1 = FakeConnection(self.manager, self.manager2)
 
     @inlineCallbacks


### PR DESCRIPTION
### Motivation

After #1086 there were some other parts that broke that weren't covered by any test.

### Acceptance Criteria

- Add `.entrypoints_str()` helper method that returns a list of `str` serialized entrypoints
- Use `.entrypoints_str()` where previously `.entrypoints` was used with the expectation of being a list of `str`
- Add tests that cover the main 2 breakages: the `status` API and the `PEER-ID` message (when entrypoint is present)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 