### PR TITLE
chore(cli): mark sync-v1 and bridge as unsafe

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -182,8 +182,10 @@ class CliBuilder:
 
         sync_choice: SyncChoice
         if self._args.sync_bridge:
+            self.log.warn('--sync-bridge is deprecated and will be removed')
             sync_choice = SyncChoice.BRIDGE_DEFAULT
         elif self._args.sync_v1_only:
+            self.log.warn('--sync-v1-only is deprecated and will be removed')
             sync_choice = SyncChoice.V1_DEFAULT
         elif self._args.sync_v2_only:
             self.log.warn('--sync-v2-only is the default, this parameter has no effect')
@@ -191,10 +193,13 @@ class CliBuilder:
         elif self._args.x_remove_sync_v1:
             sync_choice = SyncChoice.V2_ONLY
         elif self._args.x_sync_bridge:
-            self.log.warn('--x-sync-bridge is deprecated and will be removed, use --sync-bridge instead')
+            self.log.warn('--x-sync-bridge is deprecated and will be removed')
             sync_choice = SyncChoice.BRIDGE_DEFAULT
+        elif self._args.x_sync_v1_only:
+            self.log.warn('--x-sync-v1-only is deprecated and will be removed')
+            sync_choice = SyncChoice.V1_DEFAULT
         elif self._args.x_sync_v2_only:
-            self.log.warn('--x-sync-v2-only is deprecated and will be removed, use --sync-v2-only instead')
+            self.log.warn('--x-sync-v2-only is deprecated and will be removed')
             sync_choice = SyncChoice.V2_DEFAULT
         else:
             # XXX: this is the default behavior when no parameter is given

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -50,7 +50,10 @@ class RunNode:
     UNSAFE_ARGUMENTS: list[tuple[str, Callable[['RunNodeArgs'], bool]]] = [
         ('--test-mode-tx-weight', lambda args: bool(args.test_mode_tx_weight)),
         ('--enable-crash-api', lambda args: bool(args.enable_crash_api)),
+        ('--sync-bridge', lambda args: bool(args.sync_bridge)),
+        ('--sync-v1-only', lambda args: bool(args.sync_v1_only)),
         ('--x-sync-bridge', lambda args: bool(args.x_sync_bridge)),
+        ('--x-sync-v1-only', lambda args: bool(args.x_sync_v1_only)),
         ('--x-sync-v2-only', lambda args: bool(args.x_sync_v2_only)),
         ('--x-enable-event-queue', lambda args: bool(args.x_enable_event_queue)),
         ('--x-asyncio-reactor', lambda args: bool(args.x_asyncio_reactor)),
@@ -129,14 +132,14 @@ class RunNode:
         parser.add_argument('--enable-debug-api', action='store_true', help='Enable _debug/* endpoints')
         parser.add_argument('--enable-crash-api', action='store_true', help='Enable _crash/* endpoints')
         sync_args = parser.add_mutually_exclusive_group()
-        sync_args.add_argument('--sync-bridge', action='store_true',
-                               help='Enable running both sync protocols.')
-        sync_args.add_argument('--sync-v1-only', action='store_true', help='Disable support for running sync-v2.')
-        sync_args.add_argument('--sync-v2-only', action='store_true', help='Disable support for running sync-v1.')
+        sync_args.add_argument('--sync-bridge', action='store_true', help=SUPPRESS)  # moved to --x-sync-bridge
+        sync_args.add_argument('--sync-v1-only', action='store_true', help=SUPPRESS)  # moved to --x-sync-v1-only
+        sync_args.add_argument('--sync-v2-only', action='store_true', help=SUPPRESS)  # already default
         sync_args.add_argument('--x-remove-sync-v1', action='store_true', help='Make sync-v1 unavailable, thus '
-                               'impossible to be enable in runtime.')
+                               'impossible to be enabled in runtime.')
+        sync_args.add_argument('--x-sync-v1-only', action='store_true', help='Disable support for running sync-v2.')
         sync_args.add_argument('--x-sync-v2-only', action='store_true', help=SUPPRESS)  # old argument
-        sync_args.add_argument('--x-sync-bridge', action='store_true', help=SUPPRESS)  # old argument
+        sync_args.add_argument('--x-sync-bridge', action='store_true', help='Enable running both sync protocols.')
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
         parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -64,6 +64,7 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     enable_debug_api: bool
     enable_crash_api: bool
     x_sync_bridge: bool
+    x_sync_v1_only: bool
     x_sync_v2_only: bool
     x_remove_sync_v1: bool
     sync_bridge: bool


### PR DESCRIPTION
### Motivation

We're at a point where every node is running only `sync-v2`, except for a few nodes that we maintain in bridge mode that run `sync-v1 + sync-v2`. So for the next release we can safely disincentivize `sync-v1` from being used either through `--sync-v1-only` or `--sync-bridge`.

### Acceptance Criteria

- hide `--sync-bridge`, mark it as unsafe and unhide `--x-sync-bridge` (also unsafe) to be used instead
- hide `--sync-v1-only`, mark it as unsafe and add `--x-sync-v1-only` (also unsafe) to be used instead
- hide `--sync-v2-only`, since it's the default, using it will only show a warning
- after the above, every cli option that enables `sync-v1` should require `--unsafe=...` to be used

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 