### PR TITLE
fix: fix timestamps on gen-genesis CLI

### DIFF
--- a/hathor/transaction/genesis.py
+++ b/hathor/transaction/genesis.py
@@ -68,21 +68,21 @@ def generate_new_genesis(
         weight=min_block_weight,
         outputs=[TxOutput(tokens, output_script)],
     )
-    mining_service.start_mining(block)
+    mining_service.start_mining(block, update_time=False)
     block.update_hash()
 
     tx1 = Transaction(
         timestamp=block_timestamp + 1,
         weight=min_tx_weight,
     )
-    mining_service.start_mining(tx1)
+    mining_service.start_mining(tx1, update_time=False)
     tx1.update_hash()
 
     tx2 = Transaction(
         timestamp=block_timestamp + 2,
         weight=min_tx_weight,
     )
-    mining_service.start_mining(tx2)
+    mining_service.start_mining(tx2, update_time=False)
     tx2.update_hash()
 
     return block, tx1, tx2


### PR DESCRIPTION
### Motivation

There's a bug in the `gen-genesis` CLI tool where the timestamps are changed when the genesis weights are greater than zero.

### Acceptance Criteria

- Set `update_time=False` on genesis generation.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 