### PR TITLE
chore: flake.nix creating a devshell with all fullnode dependencies needed to run the fullnode

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if [[ $(type -t use_flake) != function ]]; then
+  echo "ERROR: use_flake function missing."
+  echo "Please update direnv to v2.30.0 or later."
+  exit 1
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ extras/docker/envvars
 /dist/
 /requirements.txt
 *.egg-info
+
+# Nix
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1717408969,
+        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1722013011,
+        "narHash": "sha256-to6bktzSzfcC7KfwA6+UwGqzh1lSgYGVuGrookW+PrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "58e9d6e92dcc6c80c01a3fcfb51a9bd230025e9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "virtual environments";
+
+  inputs.devshell.url = "github:numtide/devshell";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+
+  outputs = { self, flake-utils, devshell, nixpkgs }:
+
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShells.default =
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ devshell.overlays.default ];
+          };
+        in
+          pkgs.mkShell {
+            buildInputs = [
+              pkgs.python310
+              pkgs.poetry
+              pkgs.rocksdb
+              pkgs.snappy
+              pkgs.openssl
+              pkgs.readline
+              pkgs.zlib
+              pkgs.xz
+              pkgs.bzip2
+              pkgs.lz4
+              pkgs.cmake
+            ];
+
+            shellHook = ''
+              export CFLAGS="-I${pkgs.rocksdb}/include"
+              export LDFLAGS="-L${pkgs.rocksdb}/lib"
+              poetry env use python3.10
+            '';
+          };
+    });
+}


### PR DESCRIPTION
### Motivation

Improve developer experience running the fullnode when using nix (with nix-flakes and direnv) by having a reproducible dev environment with fixed versions

### Acceptance Criteria

- We should have a `direnv` with all dependencies needed by the fullnode to run
- We should use flake-utils to make the dev env available to all default systems supported by nixpkgs  (e.g., x86_64-linux, aarch64-linux, x86_64-darwin, etc.)
- We should use python 3.10
- The dev env should set the poetry env python to v3.10

### Future possibilities

This flake uses a hybrid approach (nix + poetry), which is fine as poetry has a rich lock file which results in deterministic installs and builds, but we could use [poetry2nix](https://github.com/nix-community/poetry2nix) to have nix also managing python dependencies. More on this [here](https://www.tweag.io/blog/2020-08-12-poetry2nix/)

### Checklist

- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 