### PR TITLE
fix(performance): using RocksDBMempoolTipsIndex made the sync too slow

### DIFF
--- a/hathor/indexes/manager.py
+++ b/hathor/indexes/manager.py
@@ -348,6 +348,7 @@ class RocksDBIndexesManager(IndexesManager):
             self.utxo = RocksDBUtxoIndex(self._db)
 
     def enable_mempool_index(self) -> None:
-        from hathor.indexes.rocksdb_mempool_tips_index import RocksDBMempoolTipsIndex
+        from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
         if self.mempool_tips is None:
-            self.mempool_tips = RocksDBMempoolTipsIndex(self._db)
+            # XXX: use of RocksDBMempoolTipsIndex is very slow and was suspended
+            self.mempool_tips = MemoryMempoolTipsIndex()


### PR DESCRIPTION
### Motivation

With the deploy of `v0.62.0-rc.1` the sync from scratch took significantly longer than expected. The cause was confirmed to be the use of `RocksDBMempoolTipsIndex` that was introduced. The simplest solution to quickly advance with the release is to revert to `MemoryMempoolTipsIndex`.

### Acceptance Criteria

- Revert back to `MemoryMempoolTipsIndex` for `RocksDBIndexesManager.mempool_tips`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 