### PR TITLE
fix: healthcheck content-type

### DIFF
--- a/hathor/healthcheck/resources/healthcheck.py
+++ b/hathor/healthcheck/resources/healthcheck.py
@@ -53,6 +53,7 @@ class HealthcheckResource(Resource):
             status_code = result.get_http_status_code()
             request.setResponseCode(status_code)
 
+        request.setHeader(b'content-type', b'application/json; charset=utf-8')
         request.write(json_dumpb(result.to_json()))
         request.finish()
 

--- a/tests/resources/healthcheck/test_healthcheck.py
+++ b/tests/resources/healthcheck/test_healthcheck.py
@@ -191,6 +191,7 @@ class BaseHealthcheckReadinessTest(_BaseResourceTest._ResourceTest):
         response = yield self.web.get('/health')
         data = response.json_value()
 
+        self.assertTrue('application/json; charset=utf-8' in response.responseHeaders.getRawHeaders('content-type'))
         self.assertEqual(response.responseCode, 200)
         self.assertEqual(data, {
             'status': 'pass',


### PR DESCRIPTION
### Motivation

We are getting an error from aiohttp in explorer-service when trying to get `/health` from hathor-core and parse it as json.

### Acceptance Criteria

- The `/health` endpoint should use the correct Content-Type which should be `application/json`, instead of `text/html`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 