### PR TITLE
refactor(p2p): rename peer_id.PeerId to peer.Peer

### DIFF
--- a/docs/legacy/ref/p2p.rst
+++ b/docs/legacy/ref/p2p.rst
@@ -27,7 +27,7 @@ The :py:mod:`hathor.p2p.states` has all states and messages of the p2p network. 
 to send new messages and handle the new incoming ones.
 
 
-The :py:class:`hathor.p2p.peer_id.PeerId` stores the peer's identity, entrypoint, reputation and history.
+The :py:class:`hathor.p2p.peer.Peer` stores the peer's identity, entrypoint, reputation and history.
 
 
 

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -36,7 +36,7 @@ from hathor.manager import HathorManager
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.utils import discover_hostname, get_genesis_short_hash
 from hathor.pubsub import PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
@@ -98,7 +98,7 @@ class CliBuilder:
         self.log = logger.new()
         self.reactor = reactor
 
-        peer_id = PeerId.create_from_json_path(self._args.peer) if self._args.peer else PeerId()
+        peer = Peer.create_from_json_path(self._args.peer) if self._args.peer else Peer()
         python = f'{platform.python_version()}-{platform.python_implementation()}'
 
         self.log.info(
@@ -106,7 +106,7 @@ class CliBuilder:
             hathor=hathor.__version__,
             pid=os.getpid(),
             genesis=get_genesis_short_hash(),
-            my_peer_id=str(peer_id.id),
+            my_peer_id=str(peer.id),
             python=python,
             platform=platform.platform(),
             settings=settings_source,
@@ -225,7 +225,7 @@ class CliBuilder:
 
         if self._args.x_enable_event_queue:
             self.event_ws_factory = EventWebsocketFactory(
-                peer_id=not_none(peer_id.id),
+                peer_id=not_none(peer.id),
                 network=network,
                 reactor=reactor,
                 event_storage=event_storage
@@ -307,7 +307,7 @@ class CliBuilder:
             settings=settings,
             reactor=reactor,
             network=network,
-            my_peer=peer_id,
+            my_peer=peer,
             pubsub=pubsub,
             ssl=True,
             whitelist_only=False,
@@ -348,13 +348,13 @@ class CliBuilder:
             pubsub=pubsub,
             consensus_algorithm=consensus_algorithm,
             daa=daa,
-            peer_id=peer_id,
+            peer=peer,
             tx_storage=tx_storage,
             p2p_manager=p2p_manager,
             event_manager=event_manager,
             wallet=self.wallet,
             checkpoints=settings.CHECKPOINTS,
-            environment_info=get_environment_info(args=str(self._args), peer_id=peer_id.id),
+            environment_info=get_environment_info(args=str(self._args), peer_id=peer.id),
             full_verification=full_verification,
             enable_event_queue=self._args.x_enable_event_queue,
             bit_signaling_service=bit_signaling_service,

--- a/hathor/cli/peer_id.py
+++ b/hathor/cli/peer_id.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Generates a random PeerId and print it to stdout.
+""" Generates a random Peer and print it to stdout.
 It may be used to testing purposes.
 """
 
@@ -20,9 +20,9 @@ import json
 
 
 def main() -> None:
-    from hathor.p2p.peer_id import PeerId
+    from hathor.p2p.peer import Peer
 
-    peer_id = PeerId()
-    data = peer_id.to_json(include_private_key=True)
+    peer = Peer()
+    data = peer.to_json(include_private_key=True)
     txt = json.dumps(data, indent=4)
     print(txt)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -219,7 +219,7 @@ class RunNode:
 
         from hathor.builder.builder import BuildArtifacts
         self.artifacts = BuildArtifacts(
-            peer_id=self.manager.my_peer,
+            peer=self.manager.my_peer,
             settings=settings,
             rng=self.manager.rng,
             reactor=self.manager.reactor,

--- a/hathor/daa.py
+++ b/hathor/daa.py
@@ -47,7 +47,7 @@ class TestMode(IntFlag):
 
 
 class DifficultyAdjustmentAlgorithm:
-    # TODO: This singleton is temporary, and only used in PeerId. It should be removed from there, and then from here.
+    # TODO: This singleton is temporary, and only used in Peer. It should be removed from there, and then from here.
     singleton: ClassVar[Optional['DifficultyAdjustmentAlgorithm']] = None
 
     def __init__(self, *, settings: HathorSettings, test_mode: TestMode = TestMode.DISABLED) -> None:

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -46,7 +46,7 @@ from hathor.feature_activation.bit_signaling_service import BitSignalingService
 from hathor.mining import BlockTemplate, BlockTemplates
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
@@ -96,7 +96,7 @@ class HathorManager:
         pubsub: PubSubManager,
         consensus_algorithm: ConsensusAlgorithm,
         daa: DifficultyAdjustmentAlgorithm,
-        peer_id: PeerId,
+        peer: Peer,
         tx_storage: TransactionStorage,
         p2p_manager: ConnectionsManager,
         event_manager: EventManager,
@@ -119,7 +119,7 @@ class HathorManager:
     ) -> None:
         """
         :param reactor: Twisted reactor which handles the mainloop and the events.
-        :param peer_id: Id of this node.
+        :param peer: Peer object, with peer-id of this node.
         :param network: Name of the network this node participates. Usually it is either testnet or mainnet.
         :type network: string
 
@@ -163,7 +163,7 @@ class HathorManager:
         # Remote address, which can be different from local address.
         self.remote_address = None
 
-        self.my_peer = peer_id
+        self.my_peer = peer
         self.network = network
 
         self.is_started: bool = False
@@ -976,7 +976,7 @@ class HathorManager:
     def has_sync_version_capability(self) -> bool:
         return self._settings.CAPABILITY_SYNC_VERSION in self.capabilities
 
-    def add_peer_to_whitelist(self, peer_id):
+    def add_peer_to_whitelist(self, peer_id: str) -> None:
         if not self._settings.ENABLE_PEER_WHITELIST:
             return
 

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -19,7 +19,7 @@ from twisted.internet.interfaces import IAddress
 
 from hathor.conf.settings import HathorSettings
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.protocol import HathorLineReceiver
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ class HathorServerFactory(protocol.ServerFactory):
     def __init__(
         self,
         network: str,
-        my_peer: PeerId,
+        my_peer: Peer,
         p2p_manager: ConnectionsManager,
         *,
         settings: HathorSettings,
@@ -75,7 +75,7 @@ class HathorClientFactory(protocol.ClientFactory):
     def __init__(
         self,
         network: str,
-        my_peer: PeerId,
+        my_peer: Peer,
         p2p_manager: ConnectionsManager,
         *,
         settings: HathorSettings,

--- a/hathor/p2p/peer.py
+++ b/hathor/p2p/peer.py
@@ -49,7 +49,7 @@ class PeerFlags(str, Enum):
     RETRIES_EXCEEDED = 'retries_exceeded'
 
 
-class PeerId:
+class Peer:
     """ Identify a peer, even when it is disconnected.
 
     The public_key and private_key are used to ensure that a new connection
@@ -92,7 +92,7 @@ class PeerId:
 
     def __str__(self):
         return (
-            f'PeerId(id={self.id}, entrypoints={self.entrypoints_as_str()}, retry_timestamp={self.retry_timestamp}, '
+            f'Peer(id={self.id}, entrypoints={self.entrypoints_as_str()}, retry_timestamp={self.retry_timestamp}, '
             f'retry_interval={self.retry_interval})'
         )
 
@@ -100,8 +100,8 @@ class PeerId:
         """Return a list of entrypoints serialized as str"""
         return list(map(str, self.entrypoints))
 
-    def merge(self, other: 'PeerId') -> None:
-        """ Merge two PeerId objects, checking that they have the same
+    def merge(self, other: 'Peer') -> None:
+        """ Merge two Peer objects, checking that they have the same
         id, public_key, and private_key. The entrypoints are merged without
         duplicating their entries.
         """
@@ -174,18 +174,18 @@ class PeerId:
             return True
 
     @classmethod
-    def create_from_json_path(cls, path: str) -> 'PeerId':
-        """Create a new PeerId from a JSON file."""
+    def create_from_json_path(cls, path: str) -> 'Peer':
+        """Create a new Peer from a JSON file."""
         data = json.load(open(path, 'r'))
-        peer = PeerId.create_from_json(data)
+        peer = Peer.create_from_json(data)
         peer.source_file = path
         return peer
 
     @classmethod
-    def create_from_json(cls, data: dict[str, Any]) -> 'PeerId':
-        """ Create a new PeerId from JSON data.
+    def create_from_json(cls, data: dict[str, Any]) -> 'Peer':
+        """ Create a new Peer from JSON data.
 
-        It is used both to load a PeerId from disk and to create a PeerId
+        It is used both to load a Peer from disk and to create a Peer
         from a peer connection.
         """
         obj = cls(auto_generate_keys=False)
@@ -436,18 +436,18 @@ class PeerId:
         return True
 
     def reload_entrypoints_from_source_file(self) -> None:
-        """Update this PeerId's entrypoints from the json file."""
+        """Update this Peer's entrypoints from the json file."""
         if not self.source_file:
             raise Exception('Trying to reload entrypoints but no peer config file was provided.')
 
-        new_peer_id = PeerId.create_from_json_path(self.source_file)
+        new_peer = Peer.create_from_json_path(self.source_file)
 
-        if new_peer_id.id != self.id:
+        if new_peer.id != self.id:
             self._log.error(
                 'Ignoring peer id file update because the peer_id does not match.',
                 current_peer_id=self.id,
-                new_peer_id=new_peer_id.id,
+                new_peer_id=new_peer.id,
             )
             return
 
-        self.entrypoints = new_peer_id.entrypoints
+        self.entrypoints = new_peer.entrypoints

--- a/hathor/p2p/peer_storage.py
+++ b/hathor/p2p/peer_storage.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 
 
-class PeerStorage(dict[str, PeerId]):
+class PeerStorage(dict[str, Peer]):
     """ PeerStorage is used to store all known peers in memory.
     It is a dict of peer objects, and peers can be retrieved by their `peer.id`.
     """
 
-    def add(self, peer: PeerId) -> None:
+    def add(self, peer: Peer) -> None:
         """ Add a new peer to the storage.
 
         Raises a `ValueError` if the peer has already been added.
@@ -30,7 +30,7 @@ class PeerStorage(dict[str, PeerId]):
             raise ValueError('Peer has already been added')
         self[peer.id] = peer
 
-    def add_or_merge(self, peer: PeerId) -> PeerId:
+    def add_or_merge(self, peer: Peer) -> Peer:
         """ Add a peer to the storage if it has not been added yet.
         Otherwise, merge the current peer with the given one.
         """
@@ -43,7 +43,7 @@ class PeerStorage(dict[str, PeerId]):
             current.merge(peer)
             return current
 
-    def remove(self, peer: PeerId) -> None:
+    def remove(self, peer: Peer) -> None:
         """ Remove a peer from the storage
         """
         assert peer.id is not None

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -26,7 +26,7 @@ from twisted.python.failure import Failure
 from hathor.conf.settings import HathorSettings
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.messages import ProtocolMessages
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.rate_limiter import RateLimiter
 from hathor.p2p.states import BaseState, HelloState, PeerIdState, ReadyState
 from hathor.p2p.sync_version import SyncVersion
@@ -73,12 +73,12 @@ class HathorProtocol:
         NO_ENTRYPOINTS = 'no_entrypoints'
 
     network: str
-    my_peer: PeerId
+    my_peer: Peer
     connections: 'ConnectionsManager'
     node: 'HathorManager'
     app_version: str
     last_message: float
-    peer: Optional[PeerId]
+    peer: Optional[Peer]
     transport: Optional[ITransport]
     state: Optional[BaseState]
     connection_time: float
@@ -94,7 +94,7 @@ class HathorProtocol:
     def __init__(
         self,
         network: str,
-        my_peer: PeerId,
+        my_peer: Peer,
         p2p_manager: 'ConnectionsManager',
         *,
         settings: HathorSettings,

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -18,7 +18,7 @@ from structlog import get_logger
 
 from hathor.conf.settings import HathorSettings
 from hathor.p2p.messages import ProtocolMessages
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.states.base import BaseState
 from hathor.util import json_dumps, json_loads
 
@@ -87,7 +87,7 @@ class PeerIdState(BaseState):
 
         data = json_loads(payload)
 
-        peer = PeerId.create_from_json(data)
+        peer = Peer.create_from_json(data)
         peer.validate()
         assert peer.id is not None
 

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -21,7 +21,7 @@ from twisted.internet.task import LoopingCall
 from hathor.conf.settings import HathorSettings
 from hathor.indexes.height_index import HeightInfo
 from hathor.p2p.messages import ProtocolMessages
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.states.base import BaseState
 from hathor.p2p.sync_agent import SyncAgent
 from hathor.p2p.utils import to_height_info, to_serializable_best_blockchain
@@ -158,7 +158,7 @@ class ReadyState(BaseState):
         for peer in self.protocol.connections.peer_storage.values():
             self.send_peers([peer])
 
-    def send_peers(self, peer_list: Iterable['PeerId']) -> None:
+    def send_peers(self, peer_list: Iterable['Peer']) -> None:
         """ Send a PEERS command with a list of peers.
         """
         data = []
@@ -177,7 +177,7 @@ class ReadyState(BaseState):
         """
         received_peers = json_loads(payload)
         for data in received_peers:
-            peer = PeerId.create_from_json(data)
+            peer = Peer.create_from_json(data)
             peer.validate()
             if self.protocol.connections:
                 self.protocol.connections.on_receive_peer(peer, origin=self)

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -22,13 +22,13 @@ from twisted.internet.testing import StringTransport
 
 if TYPE_CHECKING:
     from hathor.manager import HathorManager
-    from hathor.p2p.peer_id import PeerId
+    from hathor.p2p.peer import Peer
 
 logger = get_logger()
 
 
 class HathorStringTransport(StringTransport):
-    def __init__(self, peer: 'PeerId'):
+    def __init__(self, peer: 'Peer'):
         super().__init__()
         self.peer = peer
 

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -26,7 +26,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.manager import HathorManager
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.simulator.clock import HeapClock, MemoryReactorHeapClock
 from hathor.simulator.miner.geometric_miner import GeometricMiner
 from hathor.simulator.patches import SimulatorCpuMiningService, SimulatorVertexVerifier
@@ -81,7 +81,7 @@ class Simulator:
         """
         return Builder() \
             .set_network(self._network) \
-            .set_peer_id(PeerId()) \
+            .set_peer(Peer()) \
             .set_soft_voided_tx_ids(set()) \
             .enable_full_verification() \
             .enable_sync_v1() \

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -156,13 +156,15 @@ class SysctlInitTest(unittest.TestCase):
                 expected_sysctl_dict['p2p.sync_update_interval'])
 
         # assert always_enabled_sync when it is set with a file
+        peer_1 = '0e2bd0d8cd1fb6d040801c32ec27e8986ce85eb8810b6c878dcad15bce3b5b1e'
+        peer_2 = '2ff0d2c80c50f724de79f132a2f8cae576c64b57ea531d400577adf7db3e7c15'
         expected_sysctl_dict = {
-            'p2p.always_enable_sync': ['peer-3', 'peer-4'],
+            'p2p.always_enable_sync': [peer_1, peer_2],
         }
 
         file_content = [
-            'peer-3',
-            'peer-4',
+            peer_1,
+            peer_2,
         ]
 
         # set the always_enabled_sync peers file
@@ -195,6 +197,6 @@ class SysctlInitTest(unittest.TestCase):
         self.assertTrue(run_node is not None)
         conn = run_node.manager.connections
 
-        curr_always_enabled_sync = list(conn.always_enable_sync)
+        curr_always_enabled_sync = list(map(str, conn.always_enable_sync))
         self.assertTrue(
                 set(curr_always_enabled_sync).issuperset(set(expected_sysctl_dict['p2p.always_enable_sync'])))

--- a/tests/event/event_simulation_tester.py
+++ b/tests/event/event_simulation_tester.py
@@ -23,7 +23,7 @@ from hathor.builder import Builder
 from hathor.event.websocket import EventWebsocketProtocol
 from hathor.event.websocket.request import Request
 from hathor.event.websocket.response import EventResponse, InvalidRequestResponse
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.transaction.util import unpack, unpack_len
 from hathor.util import json_loadb
 from tests.simulation.base import SimulatorTestCase
@@ -34,14 +34,14 @@ class BaseEventSimulationTester(SimulatorTestCase):
     builder: Builder
 
     def _create_artifacts(self) -> None:
-        peer_id = PeerId()
-        builder = self.builder.set_peer_id(peer_id) \
+        peer = Peer()
+        builder = self.builder.set_peer(peer) \
             .disable_full_verification() \
             .enable_event_queue()
         artifacts = self.simulator.create_artifacts(builder)
 
-        assert peer_id.id is not None
-        self.peer_id: str = peer_id.id
+        assert peer.id is not None
+        self.peer_id: str = peer.id
         self.manager = artifacts.manager
         self.manager.allow_mining_without_peers()
         self.settings = artifacts.settings

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -5,7 +5,7 @@ import pytest
 
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.manager import PeerConnectionsMetrics
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.protocol import HathorProtocol
 from hathor.pubsub import HathorEvents
 from hathor.simulator.utils import add_new_blocks
@@ -61,7 +61,7 @@ class BaseMetricsTest(unittest.TestCase):
         wallet.unlock(b'teste')
         manager = self.create_peer('testnet', tx_storage=tx_storage, wallet=wallet)
 
-        manager.connections.peer_storage.update({"1": PeerId(), "2": PeerId(), "3": PeerId()})
+        manager.connections.peer_storage.update({"1": Peer(), "2": Peer(), "3": Peer()})
         manager.connections.connected_peers.update({"1": Mock(), "2": Mock()})
         manager.connections.handshaking_peers.update({Mock()})
 
@@ -223,7 +223,7 @@ class BaseMetricsTest(unittest.TestCase):
                 inbound=False,
                 settings=self._settings
             )
-            protocol.peer = PeerId()
+            protocol.peer = Peer()
 
             return protocol
 

--- a/tests/p2p/netfilter/test_match.py
+++ b/tests/p2p/netfilter/test_match.py
@@ -11,7 +11,7 @@ from hathor.p2p.netfilter.matches import (
     NetfilterMatchOr,
     NetfilterMatchPeerId,
 )
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.simulator import FakeConnection
 from tests import unittest
 
@@ -202,15 +202,15 @@ class BaseNetfilterMatchTest(unittest.TestCase):
 
     def test_match_peer_id(self) -> None:
         network = 'testnet'
-        peer_id1 = PeerId()
-        peer_id2 = PeerId()
-        manager1 = self.create_peer(network, peer_id=peer_id1)
-        manager2 = self.create_peer(network, peer_id=peer_id2)
+        peer1 = Peer()
+        peer2 = Peer()
+        manager1 = self.create_peer(network, peer=peer1)
+        manager2 = self.create_peer(network, peer=peer2)
 
         conn = FakeConnection(manager1, manager2)
         self.assertTrue(conn.proto2.is_state(conn.proto2.PeerState.HELLO))
 
-        matcher = NetfilterMatchPeerId(str(peer_id1.id))
+        matcher = NetfilterMatchPeerId(str(peer1.id))
         context = NetfilterContext(protocol=conn.proto2)
         self.assertFalse(matcher.match(context))
 
@@ -231,7 +231,7 @@ class BaseNetfilterMatchTest(unittest.TestCase):
         # Guarantee the to_json is working fine
         json = matcher.to_json()
         self.assertEqual(json['type'], 'NetfilterMatchPeerId')
-        self.assertEqual(json['match_params']['peer_id'], str(peer_id1.id))
+        self.assertEqual(json['match_params']['peer_id'], str(peer1.id))
 
 
 class SyncV1NetfilterMatchTest(unittest.SyncV1Params, BaseNetfilterMatchTest):

--- a/tests/p2p/test_bootstrap.py
+++ b/tests/p2p/test_bootstrap.py
@@ -6,9 +6,9 @@ from typing_extensions import override
 
 from hathor.p2p.entrypoint import Entrypoint, Protocol
 from hathor.p2p.manager import ConnectionsManager
+from hathor.p2p.peer import Peer
 from hathor.p2p.peer_discovery import DNSPeerDiscovery, PeerDiscovery
 from hathor.p2p.peer_discovery.dns import LookupResult
-from hathor.p2p.peer_id import PeerId
 from hathor.pubsub import PubSubManager
 from tests import unittest
 from tests.test_memory_reactor_clock import TestMemoryReactorClock
@@ -48,7 +48,7 @@ class MockDNSPeerDiscovery(DNSPeerDiscovery):
 class BootstrapTestCase(unittest.TestCase):
     def test_mock_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
-        connections = ConnectionsManager(self._settings, self.clock, 'testnet', PeerId(), pubsub, True, self.rng, True)
+        connections = ConnectionsManager(self._settings, self.clock, 'testnet', Peer(), pubsub, True, self.rng, True)
         host_ports1 = [
             ('foobar', 1234),
             ('127.0.0.99', 9999),
@@ -71,7 +71,7 @@ class BootstrapTestCase(unittest.TestCase):
 
     def test_dns_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
-        connections = ConnectionsManager(self._settings, self.clock, 'testnet', PeerId(), pubsub, True, self.rng, True)
+        connections = ConnectionsManager(self._settings, self.clock, 'testnet', Peer(), pubsub, True, self.rng, True)
         bootstrap_a = [
             '127.0.0.99',
             '127.0.0.88',

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -7,7 +7,7 @@ from twisted.internet.defer import Deferred, succeed
 from twisted.python.failure import Failure
 
 from hathor.p2p.messages import ProtocolMessages
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.states import ReadyState
 from hathor.p2p.sync_v2.agent import NodeBlockSync, _HeightInfo
 from hathor.simulator import FakeConnection
@@ -66,9 +66,9 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
 
         # Create a new peer and run sync for a while (but stop before getting synced).
         path = self.mkdtemp()
-        peer_id = PeerId()
+        peer = Peer()
         builder2 = self.simulator.get_default_builder() \
-            .set_peer_id(peer_id) \
+            .set_peer(peer) \
             .disable_sync_v1() \
             .enable_sync_v2() \
             .use_rocksdb(path)
@@ -107,7 +107,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
 
         # Restart full node using the same db.
         builder3 = self.simulator.get_default_builder() \
-            .set_peer_id(peer_id) \
+            .set_peer(peer) \
             .disable_sync_v1() \
             .enable_sync_v2() \
             .use_rocksdb(path)
@@ -220,9 +220,9 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
             print()
 
         # Create a new peer and run sync for a while (but stop before getting synced).
-        peer_id = PeerId()
+        peer = Peer()
         builder2 = self.simulator.get_default_builder() \
-            .set_peer_id(peer_id) \
+            .set_peer(peer) \
             .disable_sync_v1() \
             .enable_sync_v2() \
 
@@ -311,9 +311,9 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         self.assertGreater(mempool_tips_count, 30)
 
         # Create a new peer and run sync for a while (but stop before getting synced).
-        peer_id = PeerId()
+        peer = Peer()
         builder2 = self.simulator.get_default_builder() \
-            .set_peer_id(peer_id) \
+            .set_peer(peer) \
             .disable_sync_v1() \
             .enable_sync_v2() \
 

--- a/tests/resources/p2p/test_add_peer.py
+++ b/tests/resources/p2p/test_add_peer.py
@@ -1,7 +1,7 @@
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.p2p.entrypoint import Entrypoint
-from hathor.p2p.peer_id import PeerId
+from hathor.p2p.peer import Peer
 from hathor.p2p.resources import AddPeersResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
@@ -21,7 +21,7 @@ class BaseAddPeerTest(_BaseResourceTest._ResourceTest):
         self.assertTrue(data['success'])
 
         # test when we send a peer we're already connected to
-        peer = PeerId()
+        peer = Peer()
         peer.entrypoints = [Entrypoint.parse('tcp://localhost:8006')]
         self.manager.connections.peer_storage.add(peer)
         response = yield self.web.post('p2p/peers', ['tcp://localhost:8006', 'tcp://localhost:8007'])

--- a/tests/simulation/base.py
+++ b/tests/simulation/base.py
@@ -48,7 +48,7 @@ class SimulatorTestCase(unittest.TestCase):
             simulator = self.simulator
 
         builder = simulator.get_default_builder() \
-            .set_peer_id(self.get_random_peer_id_from_pool(rng=simulator.rng)) \
+            .set_peer(self.get_random_peer_from_pool(rng=simulator.rng)) \
             .set_soft_voided_tx_ids(soft_voided_tx_ids) \
             .set_sync_v1_support(sync_v1_support) \
             .set_sync_v2_support(sync_v2_support)


### PR DESCRIPTION
### Motivation

This is the first part of a series of refactors. This first refactor is a step to make using `PeerId` for only the `id` part of `Peer`.

### Acceptance Criteria

- rename `hathor.p2p.peer_id.PeerId` to `hathor.p2p.peer.Peer`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 