### PR TITLE
refactor(p2p): use PeerId type instead of str

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -47,7 +47,7 @@ from hathor.transaction.storage import (
     TransactionStorage,
 )
 from hathor.transaction.vertex_parser import VertexParser
-from hathor.util import Random, get_environment_info, not_none
+from hathor.util import Random, get_environment_info
 from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor.vertex_handler import VertexHandler
@@ -264,7 +264,7 @@ class Builder:
             rng=self._rng,
             checkpoints=self._checkpoints,
             capabilities=self._capabilities,
-            environment_info=get_environment_info(self._cmdline, peer.id),
+            environment_info=get_environment_info(self._cmdline, str(peer.id)),
             bit_signaling_service=bit_signaling_service,
             verification_service=verification_service,
             cpu_mining_service=cpu_mining_service,
@@ -515,7 +515,7 @@ class Builder:
             reactor = self._get_reactor()
             storage = self._get_or_create_event_storage()
             factory = EventWebsocketFactory(
-                peer_id=not_none(peer.id),
+                peer_id=str(peer.id),
                 network=settings.NETWORK_NAME,
                 reactor=reactor,
                 event_storage=storage,

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -42,7 +42,7 @@ from hathor.pubsub import PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
 from hathor.stratum import StratumFactory
 from hathor.transaction.vertex_parser import VertexParser
-from hathor.util import Random, not_none
+from hathor.util import Random
 from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor.vertex_handler import VertexHandler
@@ -225,7 +225,7 @@ class CliBuilder:
 
         if self._args.x_enable_event_queue:
             self.event_ws_factory = EventWebsocketFactory(
-                peer_id=not_none(peer.id),
+                peer_id=str(peer.id),
                 network=network,
                 reactor=reactor,
                 event_storage=event_storage
@@ -354,7 +354,7 @@ class CliBuilder:
             event_manager=event_manager,
             wallet=self.wallet,
             checkpoints=settings.CHECKPOINTS,
-            environment_info=get_environment_info(args=str(self._args), peer_id=peer.id),
+            environment_info=get_environment_info(args=str(self._args), peer_id=str(peer.id)),
             full_verification=full_verification,
             enable_event_queue=self._args.x_enable_event_queue,
             bit_signaling_service=bit_signaling_service,

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -47,6 +47,7 @@ from hathor.mining import BlockTemplate, BlockTemplates
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import Peer
+from hathor.p2p.peer_id import PeerId
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
@@ -225,7 +226,7 @@ class HathorManager:
         self._full_verification = full_verification
 
         # List of whitelisted peers
-        self.peers_whitelist: list[str] = []
+        self.peers_whitelist: list[PeerId] = []
 
         # List of capabilities of the peer
         if capabilities is not None:
@@ -297,7 +298,7 @@ class HathorManager:
                 sys.exit(-1)
 
         if self._enable_event_queue:
-            self._event_manager.start(not_none(self.my_peer.id))
+            self._event_manager.start(str(not_none(self.my_peer.id)))
 
         self.state = self.NodeState.INITIALIZING
         self.pubsub.publish(HathorEvents.MANAGER_ON_START)
@@ -976,7 +977,7 @@ class HathorManager:
     def has_sync_version_capability(self) -> bool:
         return self._settings.CAPABILITY_SYNC_VERSION in self.capabilities
 
-    def add_peer_to_whitelist(self, peer_id: str) -> None:
+    def add_peer_to_whitelist(self, peer_id: PeerId) -> None:
         if not self._settings.ENABLE_PEER_WHITELIST:
             return
 
@@ -985,7 +986,7 @@ class HathorManager:
         else:
             self.peers_whitelist.append(peer_id)
 
-    def remove_peer_from_whitelist_and_disconnect(self, peer_id: str) -> None:
+    def remove_peer_from_whitelist_and_disconnect(self, peer_id: PeerId) -> None:
         if not self._settings.ENABLE_PEER_WHITELIST:
             return
 

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -253,7 +253,7 @@ class Metrics:
 
             metric = PeerConnectionMetrics(
                 connection_string=str(connection.entrypoint) if connection.entrypoint else "",
-                peer_id=connection.peer.id,
+                peer_id=str(connection.peer.id),
                 network=connection.network,
                 received_messages=connection.metrics.received_messages,
                 sent_messages=connection.metrics.sent_messages,

--- a/hathor/p2p/entrypoint.py
+++ b/hathor/p2p/entrypoint.py
@@ -21,16 +21,12 @@ from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.internet.interfaces import IStreamClientEndpoint
 from typing_extensions import Self
 
+from hathor.p2p.peer_id import PeerId
 from hathor.reactor import ReactorProtocol as Reactor
-from hathor.types import Hash
 
 
 class Protocol(Enum):
     TCP = 'tcp'
-
-
-class PeerId(Hash):
-    pass
 
 
 @dataclass(frozen=True, slots=True)

--- a/hathor/p2p/netfilter/matches.py
+++ b/hathor/p2p/netfilter/matches.py
@@ -130,7 +130,7 @@ class NetfilterMatchPeerId(NetfilterMatch):
         if context.protocol.peer is None:
             return False
 
-        if context.protocol.peer.id != self.peer_id:
+        if str(context.protocol.peer.id) != self.peer_id:
             return False
 
         return True

--- a/hathor/p2p/peer_id.py
+++ b/hathor/p2p/peer_id.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathor.types import Hash
+
+
+class PeerId(Hash):
+    pass

--- a/hathor/p2p/peer_storage.py
+++ b/hathor/p2p/peer_storage.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from hathor.p2p.peer import Peer
+from hathor.p2p.peer_id import PeerId
 
 
-class PeerStorage(dict[str, Peer]):
+class PeerStorage(dict[PeerId, Peer]):
     """ PeerStorage is used to store all known peers in memory.
     It is a dict of peer objects, and peers can be retrieved by their `peer.id`.
     """

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -27,6 +27,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer import Peer
+from hathor.p2p.peer_id import PeerId
 from hathor.p2p.rate_limiter import RateLimiter
 from hathor.p2p.states import BaseState, HelloState, PeerIdState, ReadyState
 from hathor.p2p.sync_version import SyncVersion
@@ -192,7 +193,7 @@ class HathorProtocol:
         assert self.transport is not None
         return format_address(self.transport.getPeer())
 
-    def get_peer_id(self) -> Optional[str]:
+    def get_peer_id(self) -> Optional[PeerId]:
         """Get peer id for logging."""
         if self.peer and self.peer.id:
             return self.peer.id
@@ -201,7 +202,7 @@ class HathorProtocol:
     def get_short_peer_id(self) -> Optional[str]:
         """Get short peer id for logging."""
         if self.peer and self.peer.id:
-            return self.peer.id[:7]
+            return str(self.peer.id)[:7]
         return None
 
     def get_logger_context(self) -> dict[str, Optional[str]]:

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -64,7 +64,7 @@ class StatusResource(Resource):
             status = {}
             status[conn.state.sync_agent.name] = conn.state.sync_agent.get_status()
             connected_peers.append({
-                'id': conn.peer.id,
+                'id': str(conn.peer.id),
                 'app_version': conn.app_version,
                 'current_time': now,
                 'uptime': now - conn.connection_time,
@@ -82,7 +82,7 @@ class StatusResource(Resource):
         known_peers = []
         for peer in self.manager.connections.peer_storage.values():
             known_peers.append({
-                'id': peer.id,
+                'id': str(peer.id),
                 'entrypoints': peer.entrypoints_as_str(),
                 'last_seen': now - peer.last_seen,
                 'flags': [flag.value for flag in peer.flags],
@@ -102,7 +102,7 @@ class StatusResource(Resource):
 
         data = {
             'server': {
-                'id': self.manager.connections.my_peer.id,
+                'id': str(self.manager.connections.my_peer.id),
                 'app_version': app,
                 'state': self.manager.state.value,
                 'network': self.manager.network,

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -19,6 +19,7 @@ from structlog import get_logger
 from hathor.conf.settings import HathorSettings
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer import Peer
+from hathor.p2p.peer_id import PeerId
 from hathor.p2p.states.base import BaseState
 from hathor.util import json_dumps, json_loads
 
@@ -68,7 +69,7 @@ class PeerIdState(BaseState):
         protocol = self.protocol
         my_peer = protocol.my_peer
         hello = {
-            'id': my_peer.id,
+            'id': str(my_peer.id),
             'pubKey': my_peer.get_public_key(),
             'entrypoints': my_peer.entrypoints_as_str(),
         }
@@ -139,7 +140,7 @@ class PeerIdState(BaseState):
 
         self.send_ready()
 
-    def _should_block_peer(self, peer_id: str) -> bool:
+    def _should_block_peer(self, peer_id: PeerId) -> bool:
         """ Determine if peer should not be allowed to connect.
 
         Currently this is only because the peer is not in a whitelist and whitelist blocking is active.

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -165,7 +165,7 @@ class ReadyState(BaseState):
         for peer in peer_list:
             if peer.entrypoints:
                 data.append({
-                    'id': peer.id,
+                    'id': str(peer.id),
                     'entrypoints': peer.entrypoints_as_str(),
                 })
         self.send_message(ProtocolMessages.PEERS, json_dumps(data))

--- a/hathor/p2p/utils.py
+++ b/hathor/p2p/utils.py
@@ -31,6 +31,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.indexes.height_index import HeightInfo
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.peer_discovery import DNSPeerDiscovery
+from hathor.p2p.peer_id import PeerId
 from hathor.transaction.genesis import get_representation_for_all_genesis
 
 
@@ -142,7 +143,7 @@ def parse_file(text: str, *, header: Optional[str] = None) -> list[str]:
     return list(nonblank_lines)
 
 
-def parse_whitelist(text: str, *, header: Optional[str] = None) -> set[str]:
+def parse_whitelist(text: str, *, header: Optional[str] = None) -> set[PeerId]:
     """ Parses the list of whitelist peer ids
 
     Example:
@@ -161,12 +162,7 @@ G2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367
 
     """
     lines = parse_file(text, header=header)
-    peerids = {line.split()[0] for line in lines}
-    for peerid in peerids:
-        bpeerid = bytes.fromhex(peerid)
-        if len(bpeerid) != 32:
-            raise ValueError('invalid peerid size')
-    return peerids
+    return {PeerId(line.split()[0]) for line in lines}
 
 
 def format_address(addr: IAddress) -> str:

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -670,7 +670,7 @@ class StratumProtocol(JSONRPC):
         assert self.miner_id is not None
 
         # Only get first 32 bytes of peer_id because block data is limited to 100 bytes
-        data = '{}-{}-{}'.format(peer_id[:32], self.miner_id.hex, jobid.hex).encode()
+        data = '{}-{}-{}'.format(str(peer_id)[:32], self.miner_id.hex, jobid.hex).encode()
         data = data[:self._settings.BLOCK_DATA_MAX_SIZE]
         block = self.manager.generate_mining_block(data=data, address=self.miner_address,
                                                    merge_mined=self.merged_mining)

--- a/tests/event/event_simulation_tester.py
+++ b/tests/event/event_simulation_tester.py
@@ -40,8 +40,7 @@ class BaseEventSimulationTester(SimulatorTestCase):
             .enable_event_queue()
         artifacts = self.simulator.create_artifacts(builder)
 
-        assert peer.id is not None
-        self.peer_id: str = peer.id
+        self.peer_id: str = str(peer.id)
         self.manager = artifacts.manager
         self.manager.allow_mining_without_peers()
         self.settings = artifacts.settings

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -8,6 +8,7 @@ from twisted.internet.interfaces import ITransport
 
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.peer import InvalidPeerIdException, Peer
+from hathor.p2p.peer_id import PeerId
 from hathor.p2p.peer_storage import PeerStorage
 from hathor.util import not_none
 from tests import unittest
@@ -17,7 +18,7 @@ from tests.unittest import TestBuilder
 class PeerIdTest(unittest.TestCase):
     def test_invalid_id(self) -> None:
         p1 = Peer()
-        p1.id = not_none(p1.id)[::-1]
+        p1.id = PeerId(str(not_none(p1.id))[::-1])
         self.assertRaises(InvalidPeerIdException, p1.validate)
 
     def test_invalid_public_key(self) -> None:

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -89,10 +89,10 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
         self.assertGreater(server_data['uptime'], 0)
 
         self.assertEqual(len(known_peers), 1)
-        self.assertEqual(known_peers[0]['id'], self.manager2.my_peer.id)
+        self.assertEqual(known_peers[0]['id'], str(self.manager2.my_peer.id))
 
         self.assertEqual(len(connections['connected_peers']), 1)
-        self.assertEqual(connections['connected_peers'][0]['id'], self.manager2.my_peer.id)
+        self.assertEqual(connections['connected_peers'][0]['id'], str(self.manager2.my_peer.id))
 
     @inlineCallbacks
     def test_connecting_peers(self):


### PR DESCRIPTION
### Motivation

This is the second refactor in this series. It makes it so `Peer.id` is a `PeerId` instead of a `str`, that way it is already checked to be a valid hash.

### Acceptance Criteria

- Change the type of `hathor.p2p.peer.Peer.id` from `str` to `hathor.p2p.peer_id.PeerId`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 