### PR TITLE
refactor(p2p): add PublicPeer and PrivatePeer to simplify Peer

### DIFF
--- a/hathor/cli/peer_id.py
+++ b/hathor/cli/peer_id.py
@@ -20,9 +20,9 @@ import json
 
 
 def main() -> None:
-    from hathor.p2p.peer import Peer
+    from hathor.p2p.peer import PrivatePeer
 
-    peer = Peer()
-    data = peer.to_json(include_private_key=True)
+    peer = PrivatePeer.auto_generated()
+    data = peer.to_json_private()
     txt = json.dumps(data, indent=4)
     print(txt)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -46,7 +46,7 @@ from hathor.feature_activation.bit_signaling_service import BitSignalingService
 from hathor.mining import BlockTemplate, BlockTemplates
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_id import PeerId
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
@@ -60,7 +60,7 @@ from hathor.transaction.storage.transaction_storage import TransactionStorage
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope
 from hathor.transaction.vertex_parser import VertexParser
 from hathor.types import Address, VertexId
-from hathor.util import EnvironmentInfo, LogDuration, Random, calculate_min_significant_weight, not_none
+from hathor.util import EnvironmentInfo, LogDuration, Random, calculate_min_significant_weight
 from hathor.verification.verification_service import VerificationService
 from hathor.vertex_handler import VertexHandler
 from hathor.wallet import BaseWallet
@@ -97,7 +97,7 @@ class HathorManager:
         pubsub: PubSubManager,
         consensus_algorithm: ConsensusAlgorithm,
         daa: DifficultyAdjustmentAlgorithm,
-        peer: Peer,
+        peer: PrivatePeer,
         tx_storage: TransactionStorage,
         p2p_manager: ConnectionsManager,
         event_manager: EventManager,
@@ -298,7 +298,7 @@ class HathorManager:
                 sys.exit(-1)
 
         if self._enable_event_queue:
-            self._event_manager.start(str(not_none(self.my_peer.id)))
+            self._event_manager.start(str(self.my_peer.id))
 
         self.state = self.NodeState.INITIALIZING
         self.pubsub.publish(HathorEvents.MANAGER_ON_START)

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -246,7 +246,7 @@ class Metrics:
         self.peer_connection_metrics.clear()
 
         for connection in self.connections.connections:
-            if not connection.peer or not connection.peer.id:
+            if not connection._peer:
                 # A connection without peer will not be able to communicate
                 # So we can just discard it for the sake of the metrics
                 continue

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -19,7 +19,7 @@ from twisted.internet.interfaces import IAddress
 
 from hathor.conf.settings import HathorSettings
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.protocol import HathorLineReceiver
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ class HathorServerFactory(protocol.ServerFactory):
     def __init__(
         self,
         network: str,
-        my_peer: Peer,
+        my_peer: PrivatePeer,
         p2p_manager: ConnectionsManager,
         *,
         settings: HathorSettings,
@@ -75,7 +75,7 @@ class HathorClientFactory(protocol.ClientFactory):
     def __init__(
         self,
         network: str,
-        my_peer: Peer,
+        my_peer: PrivatePeer,
         p2p_manager: ConnectionsManager,
         *,
         settings: HathorSettings,

--- a/hathor/p2p/netfilter/matches.py
+++ b/hathor/p2p/netfilter/matches.py
@@ -127,7 +127,7 @@ class NetfilterMatchPeerId(NetfilterMatch):
         if context.protocol is None:
             return False
 
-        if context.protocol.peer is None:
+        if context.protocol._peer is None:
             return False
 
         if str(context.protocol.peer.id) != self.peer_id:

--- a/hathor/p2p/peer_storage.py
+++ b/hathor/p2p/peer_storage.py
@@ -12,16 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.p2p.peer import Peer
+from typing import Protocol, TypeVar
+
+from typing_extensions import Self
+
+from hathor.p2p.peer import PublicPeer, UnverifiedPeer
 from hathor.p2p.peer_id import PeerId
 
 
-class PeerStorage(dict[PeerId, Peer]):
-    """ PeerStorage is used to store all known peers in memory.
-    It is a dict of peer objects, and peers can be retrieved by their `peer.id`.
+class GenericPeer(Protocol):
+    @property
+    def id(self) -> PeerId:
+        pass
+
+    def merge(self, other: Self) -> None:
+        pass
+
+
+PeerType = TypeVar('PeerType', bound=GenericPeer)
+
+
+class _BasePeerStorage(dict[PeerId, PeerType]):
+    """ Base class for VerifiedPeerStorage and UnverifiedPeerStorage, do not use directly.
     """
 
-    def add(self, peer: Peer) -> None:
+    def add(self, peer: PeerType) -> None:
         """ Add a new peer to the storage.
 
         Raises a `ValueError` if the peer has already been added.
@@ -31,9 +46,8 @@ class PeerStorage(dict[PeerId, Peer]):
             raise ValueError('Peer has already been added')
         self[peer.id] = peer
 
-    def add_or_merge(self, peer: Peer) -> Peer:
-        """ Add a peer to the storage if it has not been added yet.
-        Otherwise, merge the current peer with the given one.
+    def add_or_merge(self, peer: PeerType) -> PeerType:
+        """ Add a peer to the storage if it has not been added yet. Otherwise, merge it with the existing peer.
         """
         assert peer.id is not None
         if peer.id not in self:
@@ -44,9 +58,32 @@ class PeerStorage(dict[PeerId, Peer]):
             current.merge(peer)
             return current
 
-    def remove(self, peer: Peer) -> None:
+    def add_or_replace(self, peer: PeerType) -> PeerType:
+        """ Add a peer to the storage if it has not been added yet. Otherwise, replace the existing peer.
+        """
+        assert peer.id is not None
+        if peer.id in self:
+            del self[peer.id]
+        self.add(peer)
+        return peer
+
+    def remove(self, peer: GenericPeer) -> None:
         """ Remove a peer from the storage
         """
         assert peer.id is not None
         if peer.id in self:
             del self[peer.id]
+
+
+class VerifiedPeerStorage(_BasePeerStorage[PublicPeer]):
+    """ VerifiedPeerStorage is used to store all peers that we have connected to and verified.
+
+    It is a dict of PublicPeer objects, and peers can be retrieved by their `peer.id`.
+    """
+
+
+class UnverifiedPeerStorage(_BasePeerStorage[UnverifiedPeer]):
+    """ UnverifiedPeerStorage is used to store all received peers, we haven't verified their ids/entrypoints yet.
+
+    It is a dict of Peer objects, and peers can be retrieved by their `peer.id`.
+    """

--- a/hathor/p2p/resources/add_peers.py
+++ b/hathor/p2p/resources/add_peers.py
@@ -67,7 +67,7 @@ class AddPeersResource(Resource):
                 'message': 'Malformed entrypoint found.'
             })
 
-        known_peers = self.manager.connections.peer_storage.values()
+        known_peers = self.manager.connections.verified_peer_storage.values()
 
         def already_connected(entrypoint: Entrypoint) -> bool:
             # ignore peers that we're already trying to connect

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -80,12 +80,12 @@ class StatusResource(Resource):
             })
 
         known_peers = []
-        for peer in self.manager.connections.peer_storage.values():
+        for peer in self.manager.connections.verified_peer_storage.values():
             known_peers.append({
                 'id': str(peer.id),
-                'entrypoints': peer.entrypoints_as_str(),
-                'last_seen': now - peer.last_seen,
-                'flags': [flag.value for flag in peer.flags],
+                'entrypoints': peer.info.entrypoints_as_str(),
+                'last_seen': now - peer.info.last_seen,
+                'flags': [flag.value for flag in peer.info.flags],
             })
 
         app = 'Hathor v{}'.format(hathor.__version__)
@@ -106,7 +106,7 @@ class StatusResource(Resource):
                 'state': self.manager.state.value,
                 'network': self.manager.network,
                 'uptime': now - self.manager.start_time,
-                'entrypoints': self.manager.connections.my_peer.entrypoints_as_str(),
+                'entrypoints': self.manager.connections.my_peer.info.entrypoints_as_str(),
             },
             'peers_whitelist': [str(peer_id) for peer_id in self.manager.peers_whitelist],
             'known_peers': known_peers,

--- a/hathor/p2p/sync_v2/blockchain_streaming_client.py
+++ b/hathor/p2p/sync_v2/blockchain_streaming_client.py
@@ -40,7 +40,7 @@ class BlockchainStreamingClient:
         self.sync_agent = sync_agent
         self.protocol = self.sync_agent.protocol
         self.tx_storage = self.sync_agent.tx_storage
-        self.manager = self.sync_agent.manager
+        self.vertex_handler = self.sync_agent.vertex_handler
 
         self.log = logger.new(peer=self.protocol.get_short_peer_id())
 
@@ -132,7 +132,7 @@ class BlockchainStreamingClient:
 
         if blk.can_validate_full():
             try:
-                self.manager.on_new_tx(blk, propagate_to_peers=False, fails_silently=False)
+                self.vertex_handler.on_new_vertex(blk, propagate_to_peers=False, fails_silently=False)
             except HathorError:
                 self.fails(InvalidVertexError(blk.hash.hex()))
                 return

--- a/hathor/p2p/sync_v2/factory.py
+++ b/hathor/p2p/sync_v2/factory.py
@@ -21,16 +21,31 @@ from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_v2.agent import NodeBlockSync
 from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction.vertex_parser import VertexParser
+from hathor.vertex_handler import VertexHandler
 
 if TYPE_CHECKING:
     from hathor.p2p.protocol import HathorProtocol
 
 
 class SyncV2Factory(SyncAgentFactory):
-    def __init__(self, settings: HathorSettings, connections: ConnectionsManager, *, vertex_parser: VertexParser):
+    def __init__(
+        self,
+        settings: HathorSettings,
+        connections: ConnectionsManager,
+        *,
+        vertex_parser: VertexParser,
+        vertex_handler: VertexHandler,
+    ):
         self._settings = settings
         self.connections = connections
         self.vertex_parser = vertex_parser
+        self.vertex_handler = vertex_handler
 
     def create_sync_agent(self, protocol: 'HathorProtocol', reactor: Reactor) -> SyncAgent:
-        return NodeBlockSync(self._settings, protocol, reactor=reactor, vertex_parser=self.vertex_parser)
+        return NodeBlockSync(
+            self._settings,
+            protocol,
+            reactor=reactor,
+            vertex_parser=self.vertex_parser,
+            vertex_handler=self.vertex_handler,
+        )

--- a/hathor/p2p/sync_v2/mempool.py
+++ b/hathor/p2p/sync_v2/mempool.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Generator, Optional
 from structlog import get_logger
 from twisted.internet.defer import Deferred, inlineCallbacks
 
+from hathor.exception import InvalidNewTransaction
 from hathor.transaction import BaseTransaction
 
 if TYPE_CHECKING:
@@ -35,8 +36,8 @@ class SyncMempoolManager:
 
         # Shortcuts.
         self.sync_agent = sync_agent
-        self.manager = self.sync_agent.manager
-        self.tx_storage = self.manager.tx_storage
+        self.vertex_handler = self.sync_agent.vertex_handler
+        self.tx_storage = self.sync_agent.tx_storage
         self.reactor = self.sync_agent.reactor
 
         self._deferred: Optional[Deferred[bool]] = None
@@ -74,6 +75,8 @@ class SyncMempoolManager:
         is_synced = False
         try:
             is_synced = yield self._unsafe_run()
+        except InvalidNewTransaction:
+            return
         finally:
             # sync_agent.run_sync will start it again when needed
             self._is_running = False
@@ -134,4 +137,10 @@ class SyncMempoolManager:
     def _add_tx(self, tx: BaseTransaction) -> None:
         """Add tx to the DAG."""
         self.missing_tips.discard(tx.hash)
-        self.manager.on_new_tx(tx)
+        if self.tx_storage.transaction_exists(tx.hash):
+            return
+        try:
+            self.vertex_handler.on_new_vertex(tx, fails_silently=False)
+        except InvalidNewTransaction:
+            self.sync_agent.protocol.send_error_and_close_connection('invalid vertex received')
+            raise

--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -45,8 +45,8 @@ class TransactionStreamingClient:
         self.sync_agent = sync_agent
         self.protocol = self.sync_agent.protocol
         self.tx_storage = self.sync_agent.tx_storage
-        self.manager = self.sync_agent.manager
-        self.reactor = self.manager.reactor
+        self.verification_service = self.protocol.node.verification_service
+        self.reactor = sync_agent.reactor
 
         self.log = logger.new(peer=self.protocol.get_short_peer_id())
 
@@ -153,7 +153,7 @@ class TransactionStreamingClient:
         # Run basic verification.
         if not tx.is_genesis:
             try:
-                self.manager.verification_service.verify_basic(tx)
+                self.verification_service.verify_basic(tx)
             except TxValidationError as e:
                 self.fails(InvalidVertexError(repr(e)))
                 return

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import deque
 from typing import TYPE_CHECKING, Optional
 
@@ -20,21 +22,27 @@ from structlog import get_logger
 from twisted.internet.address import HostnameAddress
 from twisted.internet.testing import StringTransport
 
+from hathor.p2p.peer import PrivatePeer
+
 if TYPE_CHECKING:
     from hathor.manager import HathorManager
-    from hathor.p2p.peer import Peer
+    from hathor.p2p.peer import PublicPeer
 
 logger = get_logger()
 
 
 class HathorStringTransport(StringTransport):
-    def __init__(self, peer: 'Peer'):
+    def __init__(self, peer: PrivatePeer):
         super().__init__()
-        self.peer = peer
+        self._peer = peer
+
+    @property
+    def peer(self) -> PublicPeer:
+        return self._peer.to_public_peer()
 
     def getPeerCertificate(self) -> X509:
-        certificate = self.peer.get_certificate()
-        return X509.from_cryptography(certificate)
+        assert isinstance(self._peer, PrivatePeer)
+        return X509.from_cryptography(self._peer.certificate)
 
 
 class FakeConnection:

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -26,7 +26,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.manager import HathorManager
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.simulator.clock import HeapClock, MemoryReactorHeapClock
 from hathor.simulator.miner.geometric_miner import GeometricMiner
 from hathor.simulator.patches import SimulatorCpuMiningService, SimulatorVertexVerifier
@@ -81,7 +81,7 @@ class Simulator:
         """
         return Builder() \
             .set_network(self._network) \
-            .set_peer(Peer()) \
+            .set_peer(PrivatePeer.auto_generated()) \
             .set_soft_voided_tx_ids(set()) \
             .enable_full_verification() \
             .enable_sync_v1() \

--- a/tests/event/event_simulation_tester.py
+++ b/tests/event/event_simulation_tester.py
@@ -23,7 +23,7 @@ from hathor.builder import Builder
 from hathor.event.websocket import EventWebsocketProtocol
 from hathor.event.websocket.request import Request
 from hathor.event.websocket.response import EventResponse, InvalidRequestResponse
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.transaction.util import unpack, unpack_len
 from hathor.util import json_loadb
 from tests.simulation.base import SimulatorTestCase
@@ -34,7 +34,7 @@ class BaseEventSimulationTester(SimulatorTestCase):
     builder: Builder
 
     def _create_artifacts(self) -> None:
-        peer = Peer()
+        peer = PrivatePeer.auto_generated()
         builder = self.builder.set_peer(peer) \
             .disable_full_verification() \
             .enable_event_queue()

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -5,7 +5,7 @@ import pytest
 
 from hathor.p2p.entrypoint import Entrypoint
 from hathor.p2p.manager import PeerConnectionsMetrics
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.protocol import HathorProtocol
 from hathor.pubsub import HathorEvents
 from hathor.simulator.utils import add_new_blocks
@@ -61,7 +61,11 @@ class BaseMetricsTest(unittest.TestCase):
         wallet.unlock(b'teste')
         manager = self.create_peer('testnet', tx_storage=tx_storage, wallet=wallet)
 
-        manager.connections.peer_storage.update({"1": Peer(), "2": Peer(), "3": Peer()})
+        manager.connections.verified_peer_storage.update({
+            "1": PrivatePeer.auto_generated(),
+            "2": PrivatePeer.auto_generated(),
+            "3": PrivatePeer.auto_generated(),
+        })
         manager.connections.connected_peers.update({"1": Mock(), "2": Mock()})
         manager.connections.handshaking_peers.update({Mock()})
 
@@ -223,7 +227,7 @@ class BaseMetricsTest(unittest.TestCase):
                 inbound=False,
                 settings=self._settings
             )
-            protocol.peer = Peer()
+            protocol._peer = PrivatePeer.auto_generated().to_public_peer()
 
             return protocol
 

--- a/tests/p2p/netfilter/test_match.py
+++ b/tests/p2p/netfilter/test_match.py
@@ -11,7 +11,7 @@ from hathor.p2p.netfilter.matches import (
     NetfilterMatchOr,
     NetfilterMatchPeerId,
 )
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.simulator import FakeConnection
 from tests import unittest
 
@@ -202,8 +202,8 @@ class BaseNetfilterMatchTest(unittest.TestCase):
 
     def test_match_peer_id(self) -> None:
         network = 'testnet'
-        peer1 = Peer()
-        peer2 = Peer()
+        peer1 = PrivatePeer.auto_generated()
+        peer2 = PrivatePeer.auto_generated()
         manager1 = self.create_peer(network, peer=peer1)
         manager2 = self.create_peer(network, peer=peer2)
 

--- a/tests/p2p/test_bootstrap.py
+++ b/tests/p2p/test_bootstrap.py
@@ -6,7 +6,7 @@ from typing_extensions import override
 
 from hathor.p2p.entrypoint import Entrypoint, Protocol
 from hathor.p2p.manager import ConnectionsManager
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_discovery import DNSPeerDiscovery, PeerDiscovery
 from hathor.p2p.peer_discovery.dns import LookupResult
 from hathor.pubsub import PubSubManager
@@ -48,7 +48,8 @@ class MockDNSPeerDiscovery(DNSPeerDiscovery):
 class BootstrapTestCase(unittest.TestCase):
     def test_mock_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
-        connections = ConnectionsManager(self._settings, self.clock, 'testnet', Peer(), pubsub, True, self.rng, True)
+        peer = PrivatePeer.auto_generated()
+        connections = ConnectionsManager(self._settings, self.clock, 'testnet', peer, pubsub, True, self.rng, True)
         host_ports1 = [
             ('foobar', 1234),
             ('127.0.0.99', 9999),
@@ -71,7 +72,8 @@ class BootstrapTestCase(unittest.TestCase):
 
     def test_dns_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
-        connections = ConnectionsManager(self._settings, self.clock, 'testnet', Peer(), pubsub, True, self.rng, True)
+        peer = PrivatePeer.auto_generated()
+        connections = ConnectionsManager(self._settings, self.clock, 'testnet', peer, pubsub, True, self.rng, True)
         bootstrap_a = [
             '127.0.0.99',
             '127.0.0.88',

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -7,51 +7,49 @@ from unittest.mock import Mock
 from twisted.internet.interfaces import ITransport
 
 from hathor.p2p.entrypoint import Entrypoint
-from hathor.p2p.peer import InvalidPeerIdException, Peer
+from hathor.p2p.peer import InvalidPeerIdException, PrivatePeer, PublicPeer, UnverifiedPeer
 from hathor.p2p.peer_id import PeerId
-from hathor.p2p.peer_storage import PeerStorage
-from hathor.util import not_none
+from hathor.p2p.peer_storage import VerifiedPeerStorage
 from tests import unittest
 from tests.unittest import TestBuilder
 
 
 class PeerIdTest(unittest.TestCase):
     def test_invalid_id(self) -> None:
-        p1 = Peer()
-        p1.id = PeerId(str(not_none(p1.id))[::-1])
+        p1 = PrivatePeer.auto_generated()
+        p1._public_peer._peer.id = PeerId(str(p1.id)[::-1])
         self.assertRaises(InvalidPeerIdException, p1.validate)
 
     def test_invalid_public_key(self) -> None:
-        p1 = Peer()
-        p2 = Peer()
-        p1.public_key = p2.public_key
+        p1 = PrivatePeer.auto_generated()
+        p2 = PrivatePeer.auto_generated()
+        p1._public_peer.public_key = p2.public_key
         self.assertRaises(InvalidPeerIdException, p1.validate)
 
     def test_invalid_private_key(self) -> None:
-        p1 = Peer()
-        p2 = Peer()
+        p1 = PrivatePeer.auto_generated()
+        p2 = PrivatePeer.auto_generated()
         p1.private_key = p2.private_key
         self.assertRaises(InvalidPeerIdException, p1.validate)
 
     def test_no_private_key(self) -> None:
-        p1 = Peer()
-        p1.private_key = None
+        p1 = PrivatePeer.auto_generated().to_public_peer()
         p1.validate()
 
     def test_create_from_json(self) -> None:
-        p1 = Peer()
-        data1 = p1.to_json(include_private_key=True)
-        p2 = Peer.create_from_json(data1)
-        data2 = p2.to_json(include_private_key=True)
+        p1 = PrivatePeer.auto_generated()
+        data1 = p1.to_json_private()
+        p2 = PrivatePeer.create_from_json(data1)
+        data2 = p2.to_json_private()
         self.assertEqual(data1, data2)
         p2.validate()
 
     def test_create_from_json_without_private_key(self) -> None:
-        p1 = Peer()
+        p1 = PrivatePeer.auto_generated()
         data1 = p1.to_json()
         # Just to test a part of the code
         del data1['entrypoints']
-        p2 = Peer.create_from_json(data1)
+        p2 = PublicPeer.create_from_json(data1)
         data2 = p2.to_json()
         self.assertEqual(data2['entrypoints'], [])
         data1['entrypoints'] = []
@@ -60,53 +58,46 @@ class PeerIdTest(unittest.TestCase):
 
     def test_sign_verify(self) -> None:
         data = b'abacate'
-        p1 = Peer()
+        p1 = PrivatePeer.auto_generated()
         signature = p1.sign(data)
-        self.assertTrue(p1.verify_signature(signature, data))
+        self.assertTrue(p1.to_public_peer().verify_signature(signature, data))
 
     def test_sign_verify_fail(self) -> None:
         data = b'abacate'
-        p1 = Peer()
+        p1 = PrivatePeer.auto_generated()
         signature = p1.sign(data)
         signature = signature[::-1]
-        self.assertFalse(p1.verify_signature(signature, data))
+        self.assertFalse(p1.to_public_peer().verify_signature(signature, data))
 
     def test_merge_peer(self) -> None:
         # Testing peer storage with merge of peers
-        peer_storage = PeerStorage()
+        peer_storage = VerifiedPeerStorage()
 
-        p1 = Peer()
-        p2 = Peer()
-        p2.id = p1.id
-        p2.public_key = p1.public_key
-        p1.public_key = None
+        p1 = PrivatePeer.auto_generated()
+        p2 = PrivatePeer.auto_generated()
+        p2._public_peer._peer.id = p1.id
+        p2._public_peer.public_key = p1.public_key
 
-        peer_storage.add_or_merge(p1)
+        peer_storage.add_or_merge(p1.to_public_peer())
         self.assertEqual(len(peer_storage), 1)
 
-        peer_storage.add_or_merge(p2)
-
-        peer = peer_storage[not_none(p1.id)]
+        peer_storage.add_or_merge(p2.to_public_peer())
+        peer = peer_storage[p1.id]
         self.assertEqual(peer.id, p1.id)
-        self.assertEqual(peer.private_key, p1.private_key)
         self.assertEqual(peer.public_key, p1.public_key)
-        self.assertEqual(peer.entrypoints, [])
+        self.assertEqual(peer.info.entrypoints, [])
 
         ep1 = Entrypoint.parse('tcp://127.0.0.1:1001')
         ep2 = Entrypoint.parse('tcp://127.0.0.1:1002')
         ep3 = Entrypoint.parse('tcp://127.0.0.1:1003')
 
-        p3 = Peer()
-        p3.entrypoints.append(ep1)
-        p3.entrypoints.append(ep2)
-        p3.public_key = None
+        p3 = PrivatePeer.auto_generated().to_public_peer()
+        p3.info.entrypoints.append(ep1)
+        p3.info.entrypoints.append(ep2)
 
-        p4 = Peer()
-        p4.public_key = None
-        p4.private_key = None
-        p4.id = p3.id
-        p4.entrypoints.append(ep2)
-        p4.entrypoints.append(ep3)
+        p4 = PublicPeer(UnverifiedPeer(id=p3.id), public_key=p3.public_key)
+        p4.info.entrypoints.append(ep2)
+        p4.info.entrypoints.append(ep3)
         peer_storage.add_or_merge(p4)
 
         self.assertEqual(len(peer_storage), 2)
@@ -114,18 +105,17 @@ class PeerIdTest(unittest.TestCase):
         peer_storage.add_or_merge(p3)
         self.assertEqual(len(peer_storage), 2)
 
-        peer = peer_storage[not_none(p3.id)]
+        peer = peer_storage[p3.id]
         self.assertEqual(peer.id, p3.id)
-        self.assertEqual(peer.private_key, p3.private_key)
-        self.assertEqual(set(peer.entrypoints), {ep1, ep2, ep3})
+        self.assertEqual(set(peer.info.entrypoints), {ep1, ep2, ep3})
 
         with self.assertRaises(ValueError):
-            peer_storage.add(p1)
+            peer_storage.add(p1.to_public_peer())
 
     def test_save_peer_file(self) -> None:
         import json
 
-        p = Peer()
+        p = PrivatePeer.auto_generated()
         tmpdir = tempfile.mkdtemp()
         path = os.path.join(tmpdir, 'peer.json')
         p.save_to_file(path)
@@ -133,87 +123,86 @@ class PeerIdTest(unittest.TestCase):
         with open(path, 'r') as f:
             peer_from_file = json.load(f)
 
-        self.assertEqual(p.to_json(include_private_key=True), peer_from_file)
+        self.assertEqual(p.to_json_private(), peer_from_file)
 
         # Removing tmpdir
         shutil.rmtree(tmpdir)
 
     def test_retry_connection(self) -> None:
-        p = Peer()
-        interval = p.retry_interval
-        p.increment_retry_attempt(0)
-        self.assertEqual(self._settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER*interval, p.retry_interval)
-        self.assertEqual(interval, p.retry_timestamp)
+        p = PrivatePeer.auto_generated()
+        interval = p.info.retry_interval
+        p.info.increment_retry_attempt(0)
+        self.assertEqual(self._settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER*interval, p.info.retry_interval)
+        self.assertEqual(interval, p.info.retry_timestamp)
 
         # when retry_interval is already 180
-        p.retry_interval = self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 10
-        p.increment_retry_attempt(0)
-        self.assertEqual(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL, p.retry_interval)
+        p.info.retry_interval = self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 10
+        p.info.increment_retry_attempt(0)
+        self.assertEqual(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL, p.info.retry_interval)
 
         # reset
-        p.reset_retry_timestamp()
-        self.assertEqual(p.retry_interval, 5)
-        self.assertEqual(p.retry_timestamp, 0)
+        p.info.reset_retry_timestamp()
+        self.assertEqual(p.info.retry_interval, 5)
+        self.assertEqual(p.info.retry_timestamp, 0)
 
     def test_validate_certificate(self) -> None:
         builder = TestBuilder()
         artifacts = builder.build()
         protocol = artifacts.p2p_manager.server_factory.buildProtocol(Mock())
 
-        peer = Peer()
+        peer = PrivatePeer.auto_generated()
 
         from OpenSSL import crypto
 
         class FakeTransport:
             def getPeerCertificate(self) -> crypto.X509:
-
                 # we use a new peer here just to save the trouble of manually creating a certificate
-                random_peer = Peer()
-                return crypto.X509.from_cryptography(random_peer.get_certificate())
+                random_peer = PrivatePeer.auto_generated()
+                return crypto.X509.from_cryptography(random_peer.certificate)
         protocol.transport = cast(ITransport, FakeTransport())
-        result = peer.validate_certificate(protocol)
+        result = peer.to_public_peer().validate_certificate(protocol)
         self.assertFalse(result)
 
     def test_retry_logic(self) -> None:
-        peer = Peer()
-        self.assertTrue(peer.can_retry(0))
+        peer = PrivatePeer.auto_generated()
+        self.assertTrue(peer.info.can_retry(0))
 
-        retry_interval = peer.retry_interval
+        retry_interval = peer.info.retry_interval
 
-        peer.increment_retry_attempt(0)
-        self.assertFalse(peer.can_retry(0))
-        self.assertFalse(peer.can_retry(retry_interval - 1))
-        self.assertTrue(peer.can_retry(retry_interval))
-        self.assertTrue(peer.can_retry(retry_interval + 1))
+        peer.info.increment_retry_attempt(0)
+        self.assertFalse(peer.info.can_retry(0))
+        self.assertFalse(peer.info.can_retry(retry_interval - 1))
+        self.assertTrue(peer.info.can_retry(retry_interval))
+        self.assertTrue(peer.info.can_retry(retry_interval + 1))
 
-        peer.increment_retry_attempt(0)
-        self.assertFalse(peer.can_retry(retry_interval))
+        peer.info.increment_retry_attempt(0)
+        self.assertFalse(peer.info.can_retry(retry_interval))
 
         retry_interval *= self._settings.PEER_CONNECTION_RETRY_INTERVAL_MULTIPLIER
-        self.assertFalse(peer.can_retry(retry_interval - 1))
-        self.assertTrue(peer.can_retry(retry_interval))
-        self.assertTrue(peer.can_retry(retry_interval))
+        self.assertFalse(peer.info.can_retry(retry_interval - 1))
+        self.assertTrue(peer.info.can_retry(retry_interval))
+        self.assertTrue(peer.info.can_retry(retry_interval))
 
         # Retry until we reach max retry interval.
-        while peer.retry_interval < self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL:
-            peer.increment_retry_attempt(0)
+        while peer.info.retry_interval < self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL:
+            peer.info.increment_retry_attempt(0)
         # We need to call it once more because peer.retry_interval is always one step behind.
-        peer.increment_retry_attempt(0)
+        peer.info.increment_retry_attempt(0)
 
         # Confirm we are at the max retry interval.
-        self.assertFalse(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
-        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
-        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
+        self.assertFalse(peer.info.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
+        self.assertTrue(peer.info.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
+        self.assertTrue(peer.info.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
 
         # It shouldn't change with another retry.
-        peer.increment_retry_attempt(0)
-        self.assertFalse(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
-        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
-        self.assertTrue(peer.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
+        peer.info.increment_retry_attempt(0)
+        self.assertFalse(peer.info.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL - 1))
+        self.assertTrue(peer.info.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL))
+        self.assertTrue(peer.info.can_retry(self._settings.PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL + 1))
 
         # Finally, reset it.
-        peer.reset_retry_timestamp()
-        self.assertTrue(peer.can_retry(0))
+        peer.info.reset_retry_timestamp()
+        self.assertTrue(peer.info.can_retry(0))
 
 
 class BasePeerIdTest(unittest.TestCase):
@@ -222,38 +211,38 @@ class BasePeerIdTest(unittest.TestCase):
     async def test_validate_entrypoint(self) -> None:
         manager = self.create_peer('testnet', unlock_wallet=False)
         peer = manager.my_peer
-        peer.entrypoints = [Entrypoint.parse('tcp://127.0.0.1:40403')]
+        peer.info.entrypoints = [Entrypoint.parse('tcp://127.0.0.1:40403')]
 
         # we consider that we are starting the connection to the peer
         protocol = manager.connections.client_factory.buildProtocol('127.0.0.1')
         protocol.entrypoint = Entrypoint.parse('tcp://127.0.0.1:40403')
-        result = await peer.validate_entrypoint(protocol)
+        result = await peer.info.validate_entrypoint(protocol)
         self.assertTrue(result)
         # if entrypoint is an URI
-        peer.entrypoints = [Entrypoint.parse('tcp://uri_name:40403')]
-        result = await peer.validate_entrypoint(protocol)
+        peer.info.entrypoints = [Entrypoint.parse('tcp://uri_name:40403')]
+        result = await peer.info.validate_entrypoint(protocol)
         self.assertTrue(result)
         # test invalid. DNS in test mode will resolve to '127.0.0.1:40403'
         protocol.entrypoint = Entrypoint.parse('tcp://45.45.45.45:40403')
-        result = await peer.validate_entrypoint(protocol)
+        result = await peer.info.validate_entrypoint(protocol)
         self.assertFalse(result)
 
         # now test when receiving the connection - i.e. the peer starts it
         protocol.entrypoint = None
-        peer.entrypoints = [Entrypoint.parse('tcp://127.0.0.1:40403')]
+        peer.info.entrypoints = [Entrypoint.parse('tcp://127.0.0.1:40403')]
 
         from collections import namedtuple
-        Peer = namedtuple('Peer', 'host')
+        DummyPeer = namedtuple('DummyPeer', 'host')
 
         class FakeTransport:
-            def getPeer(self) -> Peer:
-                return Peer(host='127.0.0.1')
+            def getPeer(self) -> DummyPeer:
+                return DummyPeer(host='127.0.0.1')
         protocol.transport = FakeTransport()
-        result = await peer.validate_entrypoint(protocol)
+        result = await peer.info.validate_entrypoint(protocol)
         self.assertTrue(result)
         # if entrypoint is an URI
-        peer.entrypoints = [Entrypoint.parse('tcp://uri_name:40403')]
-        result = await peer.validate_entrypoint(protocol)
+        peer.info.entrypoints = [Entrypoint.parse('tcp://uri_name:40403')]
+        result = await peer.info.validate_entrypoint(protocol)
         self.assertTrue(result)
 
 

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -7,7 +7,7 @@ from twisted.internet.defer import Deferred, succeed
 from twisted.python.failure import Failure
 
 from hathor.p2p.messages import ProtocolMessages
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.states import ReadyState
 from hathor.p2p.sync_v2.agent import NodeBlockSync, _HeightInfo
 from hathor.simulator import FakeConnection
@@ -66,7 +66,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
 
         # Create a new peer and run sync for a while (but stop before getting synced).
         path = self.mkdtemp()
-        peer = Peer()
+        peer = PrivatePeer.auto_generated()
         builder2 = self.simulator.get_default_builder() \
             .set_peer(peer) \
             .disable_sync_v1() \
@@ -220,7 +220,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
             print()
 
         # Create a new peer and run sync for a while (but stop before getting synced).
-        peer = Peer()
+        peer = PrivatePeer.auto_generated()
         builder2 = self.simulator.get_default_builder() \
             .set_peer(peer) \
             .disable_sync_v1() \
@@ -311,7 +311,7 @@ class BaseRandomSimulatorTestCase(SimulatorTestCase):
         self.assertGreater(mempool_tips_count, 30)
 
         # Create a new peer and run sync for a while (but stop before getting synced).
-        peer = Peer()
+        peer = PrivatePeer.auto_generated()
         builder2 = self.simulator.get_default_builder() \
             .set_peer(peer) \
             .disable_sync_v1() \

--- a/tests/resources/p2p/test_add_peer.py
+++ b/tests/resources/p2p/test_add_peer.py
@@ -1,7 +1,7 @@
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.p2p.entrypoint import Entrypoint
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.resources import AddPeersResource
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
@@ -21,9 +21,9 @@ class BaseAddPeerTest(_BaseResourceTest._ResourceTest):
         self.assertTrue(data['success'])
 
         # test when we send a peer we're already connected to
-        peer = Peer()
+        peer = PrivatePeer.auto_generated()
         peer.entrypoints = [Entrypoint.parse('tcp://localhost:8006')]
-        self.manager.connections.peer_storage.add(peer)
+        self.manager.connections.verified_peer_storage.add(peer)
         response = yield self.web.post('p2p/peers', ['tcp://localhost:8006', 'tcp://localhost:8007'])
         data = response.json_value()
         self.assertTrue(data['success'])

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -17,12 +17,12 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
         super().setUp()
         self.web = StubSite(StatusResource(self.manager))
         self.entrypoint = Entrypoint.parse('tcp://192.168.1.1:54321')
-        self.manager.connections.my_peer.entrypoints.append(self.entrypoint)
+        self.manager.connections.my_peer.info.entrypoints.append(self.entrypoint)
         self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
         self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
 
         self.manager2 = self.create_peer('testnet')
-        self.manager2.connections.my_peer.entrypoints.append(self.entrypoint)
+        self.manager2.connections.my_peer.info.entrypoints.append(self.entrypoint)
         self.conn1 = FakeConnection(self.manager, self.manager2)
 
     @inlineCallbacks

--- a/tests/simulation/test_simulator_itself.py
+++ b/tests/simulation/test_simulator_itself.py
@@ -2,7 +2,7 @@ import pytest
 
 from hathor.builder import SyncSupportLevel
 from hathor.manager import HathorManager
-from hathor.p2p.peer import Peer
+from hathor.p2p.peer import PrivatePeer
 from hathor.simulator import FakeConnection, Simulator
 from tests import unittest
 
@@ -42,7 +42,7 @@ class BaseSimulatorSelfTestCase(unittest.TestCase):
     def create_simulator_peer(
         self,
         simulator: Simulator,
-        peer_pool: list[Peer],
+        peer_pool: list[PrivatePeer],
         enable_sync_v1: bool | None = None,
         enable_sync_v2: bool | None = None
     ) -> HathorManager:


### PR DESCRIPTION
### Motivation

The `hathor.p2p.peer.Peer` type represents multiple types of peers, which makes it needed to check for `None` on its properties and also makes it more cumbersome to check for some invariants.

### Acceptance Criteria

- Split `hathor.p2p.peer.Peer` into `Peer`, `PublicPeer` and `PrivatePeer`
- `Peer` is just the base type with no public or private key, it implies that the peer-id cannot be verified because of the lack of a public key
- `Peer` is renamed to `UnverifiedPeer`
- `PublicPeer` (internally has an `UnverifiedPeer`) has a public-key, which can be used to verify its peer-id, it's implied that we've connected to this peer before and thus we verified its public-key
- `PrivatePeer` (internally has a `PublicPeer`) has a private-key, in practice it's only used for the node's own peer-id
- Split `PeerStorage` into a `VerifiedPeerStorage` that can only store `PublicPeer` and a `UnverifiedPeerStorage` that only stores `UnverifiedPeer`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 