### PR TITLE
chore: upgrade actions to a version that use node20 (LTS)

### DIFF
--- a/.github/actions/setup-hathor-env/action.yml
+++ b/.github/actions/setup-hathor-env/action.yml
@@ -13,7 +13,7 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python ${{ inputs.python }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python }}
         cache: 'poetry'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
           - '3.12'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Prepare base version
         id: prep
         run: |
@@ -49,28 +49,28 @@ jobs:
           VERSION: ${{ steps.prep.outputs.check-version }}
         run: make check-custom
       - name: Set up QEMU  # arm64 is not available natively
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           version: latest
           install: true
           driver-opts: network=host
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: steps.prep.outputs.login-dockerhub == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: steps.prep.outputs.login-ghcr == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: steps.prep_base_version.outputs.is-nightly == 'false'
         with:
           path: /tmp/.buildx-cache
@@ -79,7 +79,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-refs/heads/master-
       - name: Build and export to Docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ steps.prep.outputs.dockerfile }}
@@ -92,7 +92,7 @@ jobs:
       - name: Test image
         run: docker run --rm ${{ env.TEST_TAG }} quick_test --data / --testnet
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         if: ${{ !env.ACT }}  # Skip this step when testing locally with https://github.com/nektos/act
         with:
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,14 +62,14 @@ jobs:
       matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/setup-hathor-env
         name: Setup Hathor node environment
         with:
           python: ${{ matrix.python }}
           os: ${{ matrix.os }}
       - name: Cache mypy
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .mypy_cache
           # this key is setup such that every branch has its cache and new branches can reuse dev's cache, but not the other way around


### PR DESCRIPTION
### Motivation

Some workflows were giving warnings that they were using actions running on node16 and node16 has reached EOL for almost a year.
For now all node16 runners are forced to run on node20 and this behavior will be set to fail the action in a few months.

[Github announcement](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)

![image](https://github.com/user-attachments/assets/f75482b0-6867-44f6-9667-6f1af25bd67f)


### Acceptance Criteria

- upgrade actions to a version that use node20 (LTS)

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 