### PR TITLE
fix(api): status regression after p2p refactor

### DIFF
--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -108,7 +108,7 @@ class StatusResource(Resource):
                 'uptime': now - self.manager.start_time,
                 'entrypoints': self.manager.connections.my_peer.entrypoints_as_str(),
             },
-            'peers_whitelist': self.manager.peers_whitelist,
+            'peers_whitelist': [str(peer_id) for peer_id in self.manager.peers_whitelist],
             'known_peers': known_peers,
             'connections': {
                 'connected_peers': connected_peers,

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -18,6 +18,8 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
         self.web = StubSite(StatusResource(self.manager))
         self.entrypoint = Entrypoint.parse('tcp://192.168.1.1:54321')
         self.manager.connections.my_peer.entrypoints.append(self.entrypoint)
+        self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
+        self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
 
         self.manager2 = self.create_peer('testnet')
         self.manager2.connections.my_peer.entrypoints.append(self.entrypoint)


### PR DESCRIPTION
### Motivation

The `/v1a/status` had a regression after merging #1114 

### Acceptance Criteria

- Convert PeerId to str for the status response
- Tweak test to not have an empty whitelist so that this is covered

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 