### PR TITLE
fix(ws): Fix tx history streamer wrong logging when pauseProducing() is called multiple times

### DIFF
--- a/hathor/websocket/streamer.py
+++ b/hathor/websocket/streamer.py
@@ -49,7 +49,7 @@ class StreamerState(Enum):
 VALID_TRANSITIONS = {
     StreamerState.NOT_STARTED: {StreamerState.ACTIVE},
     StreamerState.ACTIVE: {StreamerState.ACTIVE, StreamerState.PAUSED, StreamerState.CLOSING, StreamerState.CLOSED},
-    StreamerState.PAUSED: {StreamerState.ACTIVE, StreamerState.CLOSED},
+    StreamerState.PAUSED: {StreamerState.ACTIVE, StreamerState.PAUSED, StreamerState.CLOSED},
     StreamerState.CLOSING: {StreamerState.CLOSED},
     StreamerState.CLOSED: set()
 }


### PR DESCRIPTION
### Motivation

Twisted can call `pauseProducing()` multiple times before calling `resumeProducing()`. This transition from PAUSED to PAUSED was not expected and it was generating a wrong warning log message.

### Acceptance Criteria

1. Allow transition `PAUSED -> PAUSED` which actually does nothing.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 