### PR TITLE
feat(p2p): support IPv6

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -202,6 +202,9 @@ class Builder:
         self._poa_signer: PoaSigner | None = None
         self._poa_block_producer: PoaBlockProducer | None = None
 
+        self._enable_ipv6: bool = False
+        self._disable_ipv4: bool = False
+
     def build(self) -> BuildArtifacts:
         if self.artifacts is not None:
             raise ValueError('cannot call build twice')
@@ -426,6 +429,8 @@ class Builder:
             ssl=enable_ssl,
             whitelist_only=False,
             rng=self._rng,
+            enable_ipv6=self._enable_ipv6,
+            disable_ipv4=self._disable_ipv4,
         )
         SyncSupportLevel.add_factories(
             self._get_or_create_settings(),
@@ -810,6 +815,16 @@ class Builder:
     def disable_full_verification(self) -> 'Builder':
         self.check_if_can_modify()
         self._full_verification = False
+        return self
+
+    def enable_ipv6(self) -> 'Builder':
+        self.check_if_can_modify()
+        self._enable_ipv6 = True
+        return self
+
+    def disable_ipv4(self) -> 'Builder':
+        self.check_if_can_modify()
+        self._disable_ipv4 = True
         return self
 
     def set_soft_voided_tx_ids(self, soft_voided_tx_ids: set[bytes]) -> 'Builder':

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -326,6 +326,8 @@ class CliBuilder:
             ssl=True,
             whitelist_only=False,
             rng=Random(),
+            enable_ipv6=self._args.x_enable_ipv6,
+            disable_ipv4=self._args.x_disable_ipv4,
         )
 
         vertex_handler = VertexHandler(

--- a/hathor/cli/nginx_config.py
+++ b/hathor/cli/nginx_config.py
@@ -240,11 +240,12 @@ limit_conn_zone $per_ip_key zone=per_ip__event_ws:10m;
 
     server_open = f'''
 upstream backend {{
-    server fullnode:8080;
+    server 127.0.0.1:8080;
 }}
 
 server {{
     listen 80;
+    listen [::]:80;
     server_name localhost;
 
     # Look for client IP in the X-Forwarded-For header

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -36,7 +36,9 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     listen: list[str]
     bootstrap: Optional[list[str]]
     status: Optional[int]
+    x_status_ipv6_interface: Optional[str]
     stratum: Optional[int]
+    x_stratum_ipv6_interface: Optional[str]
     data: Optional[str]
     rocksdb_storage: bool
     memory_storage: bool
@@ -83,3 +85,5 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     nano_testnet: bool
     log_vertex_bytes: bool
     disable_ws_history_streaming: bool
+    x_enable_ipv6: bool
+    x_disable_ipv4: bool

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -364,6 +364,7 @@ class HathorSettings(NamedTuple):
     CAPABILITY_WHITELIST: str = 'whitelist'
     CAPABILITY_SYNC_VERSION: str = 'sync-version'
     CAPABILITY_GET_BEST_BLOCKCHAIN: str = 'get-best-blockchain'
+    CAPABILITY_IPV6: str = 'ipv6'  # peers announcing this capability will be relayed ipv6 entrypoints from other peers
 
     # Where to download whitelist from
     WHITELIST_URL: Optional[str] = None

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -251,7 +251,8 @@ class HathorManager:
         return [
             self._settings.CAPABILITY_WHITELIST,
             self._settings.CAPABILITY_SYNC_VERSION,
-            self._settings.CAPABILITY_GET_BEST_BLOCKCHAIN
+            self._settings.CAPABILITY_GET_BEST_BLOCKCHAIN,
+            self._settings.CAPABILITY_IPV6,
         ]
 
     def start(self) -> None:

--- a/hathor/p2p/peer.py
+++ b/hathor/p2p/peer.py
@@ -114,6 +114,18 @@ class PeerInfo:
     flags: set[str] = field(default_factory=set)
     _settings: HathorSettings = field(default_factory=get_global_settings, repr=False)
 
+    def get_ipv4_only_entrypoints(self) -> list[PeerAddress]:
+        return list(filter(lambda e: not e.is_ipv6(), self.entrypoints))
+
+    def get_ipv6_only_entrypoints(self) -> list[PeerAddress]:
+        return list(filter(lambda e: e.is_ipv6(), self.entrypoints))
+
+    def ipv4_entrypoints_as_str(self) -> list[str]:
+        return list(map(str, self.get_ipv4_only_entrypoints()))
+
+    def ipv6_entrypoints_as_str(self) -> list[str]:
+        return list(map(str, self.get_ipv6_only_entrypoints()))
+
     def entrypoints_as_str(self) -> list[str]:
         """Return a list of entrypoints serialized as str"""
         return list(map(str, self.entrypoints))
@@ -203,14 +215,19 @@ class UnverifiedPeer:
     id: PeerId
     info: PeerInfo = field(default_factory=PeerInfo)
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self, only_ipv4_entrypoints: bool = True) -> dict[str, Any]:
         """ Return a JSON serialization of the object.
 
         This format is compatible with libp2p.
         """
+        if only_ipv4_entrypoints:
+            entrypoints_as_str = self.info.ipv4_entrypoints_as_str()
+        else:
+            entrypoints_as_str = self.info.entrypoints_as_str()
+
         return {
             'id': str(self.id),
-            'entrypoints': self.info.entrypoints_as_str(),
+            'entrypoints': entrypoints_as_str,
         }
 
     @classmethod

--- a/hathor/p2p/peer_endpoint.py
+++ b/hathor/p2p/peer_endpoint.py
@@ -14,13 +14,14 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from twisted.internet.address import IPv4Address, IPv6Address
-from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.endpoints import TCP4ClientEndpoint, TCP6ClientEndpoint
 from twisted.internet.interfaces import IAddress, IStreamClientEndpoint
 from typing_extensions import Self
 
@@ -31,6 +32,37 @@ COMPARISON_ERROR_MESSAGE = (
     'never compare PeerAddress with PeerEndpoint or two PeerEndpoint instances directly! '
     'instead, compare the addr attribute explicitly, and if relevant, the peer_id too.'
 )
+
+"""
+This Regex will match any valid IPv6 address.
+
+Some examples that will match:
+    '::'
+    '::1'
+    '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    '2001:db8:85a3:0:0:8a2e:370:7334'
+    '2001:db8::8a2e:370:7334'
+    '2001:db8:0:0:0:0:2:1'
+    '1234::5678'
+    'fe80::'
+    '::abcd:abcd:abcd:abcd:abcd:abcd'
+    '0:0:0:0:0:0:0:1'
+    '0:0:0:0:0:0:0:0'
+
+Some examples that won't match:
+    '127.0.0.1' -->  # IPv4
+    '1200::AB00:1234::2552:7777:1313' -->  # double '::'
+    '2001:db8::g123' -->  # invalid character
+    '2001:db8::85a3::7334' -->  # double '::'
+    '2001:db8:85a3:0000:0000:8a2e:0370:7334:1234' -->  # too many groups
+    '12345::abcd' -->  # too many characters in a group
+    '2001:db8:85a3:8a2e:0370' -->  # too few groups
+    '2001:db8:85a3::8a2e:3707334' -->  # too many characters in a group
+    '1234:56789::abcd' -->  # too many characters in a group
+    ':2001:db8::1' -->  # invalid start
+    '2001:db8::1:' -->  # invalid end
+"""
+IPV6_REGEX = re.compile(r'''^(([0-9a-fA-F]{1,4}:){7}([0-9a-fA-F]{1,4}|:)|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$''')  # noqa: E501
 
 
 class Protocol(Enum):
@@ -46,7 +78,11 @@ class PeerAddress:
     port: int
 
     def __str__(self) -> str:
-        return f'{self.protocol.value}://{self.host}:{self.port}'
+        host = self.host
+        if self.is_ipv6():
+            host = f'[{self.host}]'
+
+        return f'{self.protocol.value}://{host}:{self.port}'
 
     def __eq__(self, other: Any) -> bool:
         """
@@ -138,9 +174,11 @@ instead, compare the addr attribute explicitly, and if relevant, the peer_id too
 
     def to_client_endpoint(self, reactor: Reactor) -> IStreamClientEndpoint:
         """This method generates a twisted client endpoint that has a .connect() method."""
-        # XXX: currently we don't support IPv6, but when we do we have to decide between TCP4ClientEndpoint and
-        # TCP6ClientEndpoint, when the host is an IP address that is easy, but when it is a DNS hostname, we will not
-        # know which to use until we know which resource records it holds (A or AAAA)
+        # XXX: currently we only support IPv6 IPs, not hosts resolving to AAAA records.
+        # To support them we would have to perform DNS queries to resolve
+        # the host and check which record it holds (A or AAAA).
+        if self.is_ipv6():
+            return TCP6ClientEndpoint(reactor, self.host, self.port)
         return TCP4ClientEndpoint(reactor, self.host, self.port)
 
     def is_localhost(self) -> bool:
@@ -157,7 +195,18 @@ instead, compare the addr attribute explicitly, and if relevant, the peer_id too
         >>> PeerAddress.parse('tcp://foo.bar:444').is_localhost()
         False
         """
-        return self.host in ('127.0.0.1', 'localhost')
+        return self.host in ('127.0.0.1', 'localhost', '::1')
+
+    def is_ipv6(self) -> bool:
+        """Used to determine if the entrypoint host is an IPv6 address.
+        """
+        # XXX: This means we don't currently consider DNS names that resolve to IPv6 addresses as IPv6.
+        return IPV6_REGEX.fullmatch(self.host) is not None
+
+    def is_ipv4(self) -> bool:
+        """Used to determine if the entrypoint host is an IPv4 address.
+        """
+        return not self.is_ipv6()
 
     def with_id(self, peer_id: PeerId | None = None) -> PeerEndpoint:
         """Create a PeerEndpoint instance with self as the address and with the provided peer_id, or None."""

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Literal, Optional
 
 from OpenSSL.crypto import X509
 from structlog import get_logger
-from twisted.internet.address import IPv4Address
+from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.testing import StringTransport
 
 from hathor.p2p.peer import PrivatePeer
@@ -34,7 +34,7 @@ logger = get_logger()
 
 
 class HathorStringTransport(StringTransport):
-    def __init__(self, peer: PrivatePeer, *, peer_address: IPv4Address):
+    def __init__(self, peer: PrivatePeer, *, peer_address: IPv4Address | IPv6Address):
         super().__init__(peerAddress=peer_address)
         self._peer = peer
 
@@ -58,8 +58,8 @@ class FakeConnection:
         *,
         latency: float = 0,
         autoreconnect: bool = False,
-        addr1: IPv4Address | None = None,
-        addr2: IPv4Address | None = None,
+        addr1: IPv4Address | IPv6Address | None = None,
+        addr2: IPv4Address | IPv6Address | None = None,
         fake_bootstrap_id: PeerId | None | Literal[False] = False,
     ):
         """

--- a/tests/cli/test_run_node.py
+++ b/tests/cli/test_run_node.py
@@ -20,6 +20,7 @@ class RunNodeTest(unittest.TestCase):
 
     @patch('twisted.internet.reactor.listenTCP')
     def test_listen_tcp_ipv4(self, mock_listenTCP):
+        """Should call listenTCP with no interface defined when using only IPv4"""
         class CustomRunNode(RunNode):
             def start_manager(self) -> None:
                 pass
@@ -31,3 +32,31 @@ class RunNodeTest(unittest.TestCase):
         self.assertTrue(run_node is not None)
 
         mock_listenTCP.assert_called_with(1234, ANY)
+
+    @patch('twisted.internet.reactor.listenTCP')
+    def test_listen_tcp_ipv6(self, mock_listenTCP):
+        """Should call listenTCP with interface='::0' when enabling IPv6"""
+        class CustomRunNode(RunNode):
+            def start_manager(self) -> None:
+                pass
+
+            def register_signal_handlers(self) -> None:
+                pass
+
+        run_node = CustomRunNode(argv=['--memory-storage', '--x-enable-ipv6', '--status', '1234'])
+        self.assertTrue(run_node is not None)
+
+        mock_listenTCP.assert_called_with(1234, ANY, interface='::0')
+
+    def test_validate_ipv4_or_ipv6(self):
+        """The program should exit if no IP version is enabled"""
+        class CustomRunNode(RunNode):
+            def start_manager(self) -> None:
+                pass
+
+            def register_signal_handlers(self) -> None:
+                pass
+
+        # Should call system exit
+        with self.assertRaises(SystemExit):
+            CustomRunNode(argv=['--memory-storage', '--x-disable-ipv4', '--status', '1234'])

--- a/tests/p2p/test_bootstrap.py
+++ b/tests/p2p/test_bootstrap.py
@@ -50,7 +50,18 @@ class BootstrapTestCase(unittest.TestCase):
     def test_mock_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
         peer = PrivatePeer.auto_generated()
-        connections = ConnectionsManager(self._settings, self.clock, peer, pubsub, True, self.rng, True)
+        connections = ConnectionsManager(
+            self._settings,
+            self.clock,
+            peer,
+            pubsub,
+            True,
+            self.rng,
+            True,
+            enable_ipv6=False,
+            disable_ipv4=False
+        )
+
         host_ports1 = [
             ('foobar', 1234),
             ('127.0.0.99', 9999),
@@ -74,7 +85,18 @@ class BootstrapTestCase(unittest.TestCase):
     def test_dns_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
         peer = PrivatePeer.auto_generated()
-        connections = ConnectionsManager(self._settings, self.clock, peer, pubsub, True, self.rng, True)
+        connections = ConnectionsManager(
+            self._settings,
+            self.clock,
+            peer,
+            pubsub,
+            True,
+            self.rng,
+            True,
+            enable_ipv6=False,
+            disable_ipv4=False
+        )
+
         bootstrap_a = [
             '127.0.0.99',
             '127.0.0.88',

--- a/tests/p2p/test_entrypoint.py
+++ b/tests/p2p/test_entrypoint.py
@@ -1,0 +1,42 @@
+from hathor.p2p.peer_endpoint import PeerAddress, PeerEndpoint, Protocol
+from tests import unittest
+
+
+class EntrypointTestCase(unittest.TestCase):
+    def test_is_ipv6(self) -> None:
+        valid_addresses = [
+            '::',
+            '::1',
+            '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            '2001:db8:85a3:0:0:8a2e:370:7334',
+            '2001:db8::8a2e:370:7334',
+            '2001:db8:0:0:0:0:2:1',
+            '1234::5678',
+            'fe80::',
+            '::abcd:abcd:abcd:abcd:abcd:abcd',
+            '0:0:0:0:0:0:0:1',
+            '0:0:0:0:0:0:0:0'
+        ]
+
+        invalid_addresses = [
+            '127.0.0.1',
+            '1200::AB00:1234::2552:7777:1313',
+            '2001:db8::g123',
+            '2001:db8::85a3::7334',
+            '2001:db8:85a3:0000:0000:8a2e:0370:7334:1234',
+            '12345::abcd',
+            '2001:db8:85a3:8a2e:0370',
+            '2001:db8:85a3::8a2e:3707334',
+            '1234:56789::abcd',
+            ':2001:db8::1',
+            '2001:db8::1:',
+            '2001::85a3::8a2e:370:7334'
+        ]
+
+        for address in valid_addresses:
+            peer_address = PeerAddress(Protocol.TCP, address, 40403)
+            self.assertTrue(PeerEndpoint(peer_address).addr.is_ipv6())
+
+        for address in invalid_addresses:
+            peer_address = PeerAddress(Protocol.TCP, address, 40403)
+            self.assertFalse(PeerEndpoint(peer_address).addr.is_ipv6())

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -276,6 +276,10 @@ class BasePeerIdTest(unittest.TestCase):
         peer.info.entrypoints = [PeerAddress.parse('tcp://uri_name:40403')]
         result = await peer.info.validate_entrypoint(protocol)
         self.assertTrue(result)
+        # if entrypoint is an IPv6
+        peer.entrypoints = [PeerEndpoint.parse('tcp://[::1]:40403')]
+        result = await peer.info.validate_entrypoint(protocol)
+        self.assertTrue(result)
         # test invalid. DNS in test mode will resolve to '127.0.0.1:40403'
         protocol.entrypoint = PeerEndpoint.parse('tcp://45.45.45.45:40403')
         result = await peer.info.validate_entrypoint(protocol)
@@ -296,6 +300,10 @@ class BasePeerIdTest(unittest.TestCase):
         self.assertTrue(result)
         # if entrypoint is an URI
         peer.info.entrypoints = [PeerAddress.parse('tcp://uri_name:40403')]
+        result = await peer.info.validate_entrypoint(protocol)
+        self.assertTrue(result)
+        # if entrypoint is an IPv6
+        peer.entrypoints = [PeerEndpoint.parse('tcp://[2001:db8::ff00:42:8329]:40403')]
         result = await peer.info.validate_entrypoint(protocol)
         self.assertTrue(result)
 

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -226,7 +226,9 @@ class TestCase(unittest.TestCase):
         pubsub: PubSubManager | None = None,
         event_storage: EventStorage | None = None,
         enable_event_queue: bool | None = None,
-        use_memory_storage: bool | None = None
+        use_memory_storage: bool | None = None,
+        enable_ipv6: bool = False,
+        disable_ipv4: bool = False,
     ):  # TODO: Add -> HathorManager here. It breaks the lint in a lot of places.
         enable_sync_v1, enable_sync_v2 = self._syncVersionFlags(enable_sync_v1, enable_sync_v2)
 
@@ -289,6 +291,15 @@ class TestCase(unittest.TestCase):
 
         if utxo_index:
             builder.enable_utxo_index()
+
+        if capabilities is not None:
+            builder.set_capabilities(capabilities)
+
+        if enable_ipv6:
+            builder.enable_ipv6()
+
+        if disable_ipv4:
+            builder.disable_ipv4()
 
         daa = DifficultyAdjustmentAlgorithm(settings=self._settings, test_mode=TestMode.TEST_ALL_WEIGHT)
         builder.set_daa(daa)


### PR DESCRIPTION
### Motivation

We want to support IPv6 connections between fullnodes and support exposing their API through IPv6

### Acceptance Criteria

- We should be able to listen the API, the Stratum and the P2P port in IPv6 interfaces. This will be activated by a new CLI argument deemed initially as experimental: `--x-enable-ipv6`
- We will also have a `--x-disable-ipv4`, to make nodes stop connecting to IPv4 endpoints. For now this will be used mostly for tests though, to force a fullnode to behave as IPv6-only.
- The peers should relay IPv6 endpoints only to other peers that also have the IPv6 capability. Relaying them to old fullnodes would cause errors when they try to parse IPv6.
- For simplicity, this PR only implements support for IPv6 addresses in endpoints, not domains that contain AAAA records

### TODO

- [ ] After merging, we should think about how to have permanent nodes that are dualstack and ipv6-only so we always test this is working

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 