### PR TITLE
refactor[websocket]: improve websocket factory start

### DIFF
--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -297,7 +297,6 @@ class ResourcesBuilder:
                                                  address_index=self.manager.tx_storage.indexes.addresses)
         if self._args.disable_ws_history_streaming:
             ws_factory.disable_history_streaming()
-        ws_factory.start()
         root.putChild(b'ws', WebSocketResource(ws_factory))
 
         if settings.CONSENSUS_ALGORITHM.is_pow():
@@ -322,8 +321,8 @@ class ResourcesBuilder:
         status_server = SiteProfiler(real_root)
         self.log.info('with status', listen=self._args.status, with_wallet_api=with_wallet_api)
 
-        # Set websocket factory in metrics
-        self.manager.metrics.websocket_factory = ws_factory
+        # Set websocket factory in metrics. It'll be started when the manager is started.
+        self.manager.websocket_factory = ws_factory
 
         self._built_status = True
         return status_server

--- a/hathor/builder/sysctl_builder.py
+++ b/hathor/builder/sysctl_builder.py
@@ -38,7 +38,7 @@ class SysctlBuilder:
         root.put_child('core', core)
         root.put_child('p2p', ConnectionsManagerSysctl(self.artifacts.p2p_manager))
 
-        ws_factory = self.artifacts.manager.metrics.websocket_factory
+        ws_factory = self.artifacts.manager.websocket_factory
         if ws_factory is not None:
             root.put_child('ws', WebsocketManagerSysctl(ws_factory))
 

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -198,7 +198,6 @@ class RunNode:
 
         self.tx_storage = self.manager.tx_storage
         self.wallet = self.manager.wallet
-        self.start_manager()
 
         if self._args.stratum:
             assert self.manager.stratum_factory is not None
@@ -218,6 +217,8 @@ class RunNode:
             if self._args.status:
                 assert status_server is not None
                 self.reactor.listenTCP(self._args.status, status_server)
+
+        self.start_manager()
 
         from hathor.builder.builder import BuildArtifacts
         self.artifacts = BuildArtifacts(

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -217,6 +217,8 @@ class Metrics:
         """ Set websocket metrics data. Connections and addresses subscribed.
         """
         if self.websocket_factory:
+            assert self.websocket_factory.is_running, 'Websocket factory has not been started'
+
             self.websocket_connections = len(self.websocket_factory.connections)
             self.subscribed_addresses = len(self.websocket_factory.address_connections)
 

--- a/tests/cli/test_run_node.py
+++ b/tests/cli/test_run_node.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY, patch
+
 from hathor.cli.run_node import RunNode
 from tests import unittest
 
@@ -15,3 +17,17 @@ class RunNodeTest(unittest.TestCase):
 
         run_node = CustomRunNode(argv=['--memory-storage'])
         self.assertTrue(run_node is not None)
+
+    @patch('twisted.internet.reactor.listenTCP')
+    def test_listen_tcp_ipv4(self, mock_listenTCP):
+        class CustomRunNode(RunNode):
+            def start_manager(self) -> None:
+                pass
+
+            def register_signal_handlers(self) -> None:
+                pass
+
+        run_node = CustomRunNode(argv=['--memory-storage', '--status', '1234'])
+        self.assertTrue(run_node is not None)
+
+        mock_listenTCP.assert_called_with(1234, ANY)

--- a/tests/cli/test_sysctl_init.py
+++ b/tests/cli/test_sysctl_init.py
@@ -39,7 +39,7 @@ class SysctlInitTest(unittest.TestCase):
         # prepare to register only p2p commands
         artifacts = Mock(**{
             'p2p_manager': Mock(),
-            'manager.metrics.websocket_factory.return_value': None
+            'manager.websocket_factory.return_value': None
         })
 
         with self.assertRaises(SysctlEntryNotFound) as context:
@@ -68,7 +68,7 @@ class SysctlInitTest(unittest.TestCase):
         # prepare to register only p2p commands
         artifacts = Mock(**{
             'p2p_manager': Mock(),
-            'manager.metrics.websocket_factory.return_value': None
+            'manager.websocket_factory.return_value': None
         })
 
         with self.assertRaises(SysctlRunnerException) as context:
@@ -85,7 +85,7 @@ class SysctlInitTest(unittest.TestCase):
         # prepare to register only p2p commands
         artifacts = Mock(**{
             'p2p_manager': Mock(),
-            'manager.metrics.websocket_factory.return_value': None
+            'manager.websocket_factory.return_value': None
         })
 
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
### Motivation

I had a problem while trying to write a test for `run_node.py` in another PR. The reason was that the `HathorAdminWebsocketFactory` was started and never stopped.

I noticed that its stop method was never called, and its start was called inside `ResourcesBuilder.create_resources`, which was unlike any other resource we start.

I've included a test similar to the one I had problems with to make my difficulties clearer.

### Acceptance Criteria

- The `HathorAdminWebsocketFactory` should be started as a consequence of starting the Manager, and should be stopped when the Manager is stopped
- There should be no impact in the overall logic of hathor-core. Everything should work like before.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 