### PR TITLE
refactor(settings): change wallets and reward lock to use injected settings

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -676,7 +676,7 @@ class Builder:
 
         if self._wallet_directory is None:
             return None
-        self._wallet = Wallet(directory=self._wallet_directory)
+        self._wallet = Wallet(directory=self._wallet_directory, settings=self._get_or_create_settings())
         if self._wallet_unlock is not None:
             self._wallet.unlock(self._wallet_unlock)
         return self._wallet

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -30,6 +30,8 @@ DECIMAL_PLACES = 2
 GENESIS_TOKEN_UNITS = 1 * (10**9)  # 1B
 GENESIS_TOKENS = GENESIS_TOKEN_UNITS * (10**DECIMAL_PLACES)  # 100B
 
+HATHOR_TOKEN_UID = b'\x00'
+
 
 class HathorSettings(NamedTuple):
     # Version byte of the address in P2PKH
@@ -125,7 +127,7 @@ class HathorSettings(NamedTuple):
     MIN_TX_WEIGHT: int = 14
     MIN_SHARE_WEIGHT: int = 21
 
-    HATHOR_TOKEN_UID: bytes = b'\x00'
+    HATHOR_TOKEN_UID: bytes = HATHOR_TOKEN_UID
 
     # Maximum distance between two consecutive blocks (in seconds), except for genesis.
     # This prevent some DoS attacks exploiting the calculation of the score of a side chain.

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -934,7 +934,7 @@ class HathorManager:
         if is_spending_voided_tx:
             raise SpendingVoidedError('Invalid transaction. At least one input is voided.')
 
-        if is_spent_reward_locked(tx):
+        if is_spent_reward_locked(self._settings, tx):
             raise RewardLockedError('Spent reward is locked.')
 
         # We are using here the method from lib because the property

--- a/hathor/reward_lock/reward_lock.py
+++ b/hathor/reward_lock/reward_lock.py
@@ -14,7 +14,7 @@
 
 from typing import TYPE_CHECKING, Iterator, Optional
 
-from hathor.conf.get_settings import get_global_settings
+from hathor.conf.settings import HathorSettings
 from hathor.transaction import Block
 from hathor.util import not_none
 
@@ -32,19 +32,23 @@ def iter_spent_rewards(tx: 'Transaction', storage: 'VertexStorageProtocol') -> I
             yield spent_tx
 
 
-def is_spent_reward_locked(tx: 'Transaction') -> bool:
+def is_spent_reward_locked(settings: HathorSettings, tx: 'Transaction') -> bool:
     """ Check whether any spent reward is currently locked, considering only the block rewards spent by this tx
     itself, and not the inherited `min_height`"""
-    return get_spent_reward_locked_info(tx, not_none(tx.storage)) is not None
+    return get_spent_reward_locked_info(settings, tx, not_none(tx.storage)) is not None
 
 
-def get_spent_reward_locked_info(tx: 'Transaction', storage: 'VertexStorageProtocol') -> Optional['RewardLockedInfo']:
+def get_spent_reward_locked_info(
+    settings: HathorSettings,
+    tx: 'Transaction',
+    storage: 'VertexStorageProtocol',
+) -> Optional['RewardLockedInfo']:
     """Check if any input block reward is locked, returning the locked information if any, or None if they are all
     unlocked."""
     from hathor.transaction.transaction import RewardLockedInfo
     best_height = get_minimum_best_height(storage)
     for blk in iter_spent_rewards(tx, storage):
-        needed_height = _spent_reward_needed_height(blk, best_height)
+        needed_height = _spent_reward_needed_height(settings, blk, best_height)
         if needed_height > 0:
             return RewardLockedInfo(blk.hash, needed_height)
     return None
@@ -65,10 +69,9 @@ def get_minimum_best_height(storage: 'VertexStorageProtocol') -> int:
     return best_height
 
 
-def _spent_reward_needed_height(block: Block, best_height: int) -> int:
+def _spent_reward_needed_height(settings: HathorSettings, block: Block, best_height: int) -> int:
     """ Returns height still needed to unlock this `block` reward: 0 means it's unlocked."""
     spent_height = block.get_height()
     spend_blocks = best_height - spent_height
-    settings = get_global_settings()
     needed_height = settings.REWARD_SPEND_MIN_BLOCKS - spend_blocks
     return max(needed_height, 0)

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -103,7 +103,7 @@ class Simulator:
         assert self._started, 'Simulator is not started.'
         builder = builder or self.get_default_builder()
 
-        wallet = HDWallet(gap_limit=2)
+        wallet = HDWallet(gap_limit=2, settings=self.settings)
         wallet._manually_initialize()
 
         cpu_mining_service = SimulatorCpuMiningService()

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -1063,7 +1063,7 @@ class TransactionStorage(ABC):
         for tx in self.iter_mempool_from_best_index():
             try:
                 TransactionVerifier.verify_reward_locked_for_height(
-                    tx, new_best_height, assert_min_height_verification=False
+                    self._settings, tx, new_best_height, assert_min_height_verification=False
                 )
             except RewardLocked:
                 tx.set_validation(ValidationState.INVALID)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -147,10 +147,11 @@ class TransactionVerifier:
         the block rewards spent by this tx itself, and the inherited `min_height`."""
         assert tx.storage is not None
         best_height = get_minimum_best_height(tx.storage)
-        self.verify_reward_locked_for_height(tx, best_height)
+        self.verify_reward_locked_for_height(self._settings, tx, best_height)
 
     @staticmethod
     def verify_reward_locked_for_height(
+        settings: HathorSettings,
         tx: Transaction,
         best_height: int,
         *,
@@ -174,7 +175,7 @@ class TransactionVerifier:
         and a normal `RewardLocked` exception is raised instead.
         """
         assert tx.storage is not None
-        info = get_spent_reward_locked_info(tx, tx.storage)
+        info = get_spent_reward_locked_info(settings, tx, tx.storage)
         if info is not None:
             raise RewardLocked(f'Reward {info.block_hash.hex()} still needs {info.blocks_needed} to be unlocked.')
 

--- a/hathor/wallet/hd_wallet.py
+++ b/hathor/wallet/hd_wallet.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from mnemonic import Mnemonic
 
+from hathor.conf.settings import HathorSettings
 from hathor.pubsub import HathorEvents
 from hathor.wallet import BaseWallet
 from hathor.wallet.exceptions import InvalidWords
@@ -58,7 +59,8 @@ class HDWallet(BaseWallet):
 
     def __init__(self, *, words: Optional[Any] = None, language: str = 'english', passphrase: bytes = b'',
                  gap_limit: int = 20, word_count: int = 24, directory: str = './', pubsub: Optional[Any] = None,
-                 reactor: Optional[Any] = None, initial_key_generation: Optional[Any] = None) -> None:
+                 reactor: Optional[Any] = None, initial_key_generation: Optional[Any] = None,
+                 settings: HathorSettings | None = None) -> None:
         """
         :param words: words to generate the seed. It's a string with the words separated by a single space.
         If None we generate new words when starting the wallet
@@ -84,7 +86,7 @@ class HDWallet(BaseWallet):
 
         :raises ValueError: Raised on invalid word_count
         """
-        super().__init__(directory=directory, pubsub=pubsub, reactor=reactor)
+        super().__init__(directory=directory, pubsub=pubsub, reactor=reactor, settings=settings)
 
         # dict[string(base58), BIP32Key]
         self.keys: dict[str, Any] = {}

--- a/hathor/wallet/wallet.py
+++ b/hathor/wallet/wallet.py
@@ -21,6 +21,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from twisted.internet.interfaces import IDelayedCall
 
+from hathor.conf.settings import HathorSettings
 from hathor.crypto.util import get_public_key_bytes_compressed
 from hathor.pubsub import HathorEvents
 from hathor.wallet import BaseWallet
@@ -30,7 +31,8 @@ from hathor.wallet.keypair import KeyPair
 
 class Wallet(BaseWallet):
     def __init__(self, keys: Optional[Any] = None, directory: str = './', filename: str = 'keys.json',
-                 pubsub: Optional[Any] = None, reactor: Optional[Any] = None) -> None:
+                 pubsub: Optional[Any] = None, reactor: Optional[Any] = None, settings: HathorSettings | None = None
+                 ) -> None:
         """ A wallet will hold key pair objects and the unspent and
         spent transactions associated with the keys.
 
@@ -49,7 +51,7 @@ class Wallet(BaseWallet):
         :param pubsub: If not given, a new one is created.
         :type pubsub: :py:class:`hathor.pubsub.PubSubManager`
         """
-        super().__init__(directory=directory, pubsub=pubsub, reactor=reactor)
+        super().__init__(directory=directory, pubsub=pubsub, reactor=reactor, settings=settings)
 
         self.filepath = os.path.join(directory, filename)
         self.keys: dict[str, Any] = keys or {}  # dict[string(b58_address), KeyPair]


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1146

### Motivation

Remove global settings from reward lock and test wallets. This will be useful for Feature Activation for Transaction tests.

### Acceptance Criteria

- Move `HathorSettings.HATHOR_TOKEN_UID` to a constant.
- Change reward lock functions to use injected settings.
- Change test wallets to use injected settings.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 