### PR TITLE
refactor(p2p): simplify factory [part 1/5]

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -143,7 +143,6 @@ class Builder:
         self._capabilities: Optional[list[str]] = None
 
         self._peer: Optional[PrivatePeer] = None
-        self._network: Optional[str] = None
         self._cmdline: str = ''
 
         self._storage_type: StorageType = StorageType.MEMORY
@@ -207,9 +206,6 @@ class Builder:
         if self.artifacts is not None:
             raise ValueError('cannot call build twice')
 
-        if self._network is None:
-            raise TypeError('you must set a network')
-
         if SyncSupportLevel.ENABLED not in {self._sync_v1_support, self._sync_v2_support}:
             raise TypeError('you must enable at least one sync version')
 
@@ -257,7 +253,6 @@ class Builder:
         manager = HathorManager(
             reactor,
             settings=settings,
-            network=self._network,
             pubsub=pubsub,
             consensus_algorithm=consensus_algorithm,
             daa=daa,
@@ -423,12 +418,9 @@ class Builder:
         reactor = self._get_reactor()
         my_peer = self._get_peer()
 
-        assert self._network is not None
-
         self._p2p_manager = ConnectionsManager(
             settings=self._get_or_create_settings(),
             reactor=reactor,
-            network=self._network,
             my_peer=my_peer,
             pubsub=self._get_or_create_pubsub(),
             ssl=enable_ssl,
@@ -522,7 +514,7 @@ class Builder:
             storage = self._get_or_create_event_storage()
             factory = EventWebsocketFactory(
                 peer_id=str(peer.id),
-                network=settings.NETWORK_NAME,
+                settings=settings,
                 reactor=reactor,
                 event_storage=storage,
             )
@@ -774,11 +766,6 @@ class Builder:
     def set_pubsub(self, pubsub: PubSubManager) -> 'Builder':
         self.check_if_can_modify()
         self._pubsub = pubsub
-        return self
-
-    def set_network(self, network: str) -> 'Builder':
-        self.check_if_can_modify()
-        self._network = network
         return self
 
     def set_sync_v1_support(self, support_level: SyncSupportLevel) -> 'Builder':

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -197,7 +197,6 @@ class CliBuilder:
             self.log.info('with wallet', wallet=self.wallet, path=self._args.data)
 
         hostname = self.get_hostname()
-        network = settings.NETWORK_NAME
 
         sync_choice: SyncChoice
         if self._args.sync_bridge:
@@ -245,7 +244,7 @@ class CliBuilder:
         if self._args.x_enable_event_queue:
             self.event_ws_factory = EventWebsocketFactory(
                 peer_id=str(peer.id),
-                network=network,
+                settings=settings,
                 reactor=reactor,
                 event_storage=event_storage
             )
@@ -322,7 +321,6 @@ class CliBuilder:
         p2p_manager = ConnectionsManager(
             settings=settings,
             reactor=reactor,
-            network=network,
             my_peer=peer,
             pubsub=pubsub,
             ssl=True,
@@ -367,7 +365,6 @@ class CliBuilder:
         self.manager = HathorManager(
             reactor,
             settings=settings,
-            network=network,
             hostname=hostname,
             pubsub=pubsub,
             consensus_algorithm=consensus_algorithm,

--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -48,6 +48,7 @@ def execute(args: Namespace, reactor: 'ReactorProtocol') -> None:
     os.environ['HATHOR_CONFIG_YAML'] = UNITTESTS_SETTINGS_FILEPATH
     from hathor.cli.events_simulator.event_forwarding_websocket_factory import EventForwardingWebsocketFactory
     from hathor.cli.events_simulator.scenario import Scenario
+    from hathor.conf.get_settings import get_global_settings
     from hathor.simulator import Simulator
 
     try:
@@ -70,7 +71,7 @@ def execute(args: Namespace, reactor: 'ReactorProtocol') -> None:
     forwarding_ws_factory = EventForwardingWebsocketFactory(
         simulator=simulator,
         peer_id='simulator_peer_id',
-        network='simulator_network',
+        settings=get_global_settings(),
         reactor=reactor,
         event_storage=event_ws_factory._event_storage
     )

--- a/hathor/event/websocket/factory.py
+++ b/hathor/event/websocket/factory.py
@@ -17,6 +17,7 @@ from typing import Optional
 from autobahn.twisted.websocket import WebSocketServerFactory
 from structlog import get_logger
 
+from hathor.conf.settings import HathorSettings
 from hathor.event.model.base_event import BaseEvent
 from hathor.event.storage import EventStorage
 from hathor.event.websocket.protocol import EventWebsocketProtocol
@@ -45,14 +46,14 @@ class EventWebsocketFactory(WebSocketServerFactory):
         self,
         *,
         peer_id: str,
-        network: str,
+        settings: HathorSettings,
         reactor: Reactor,
         event_storage: EventStorage
     ) -> None:
         super().__init__()
         self.log = logger.new()
         self._peer_id = peer_id
-        self._network = network
+        self._network = settings.NETWORK_NAME
         self._reactor = reactor
         self._event_storage = event_storage
         self._connections: set[EventWebsocketProtocol] = set()

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -107,7 +107,6 @@ class HathorManager:
         bit_signaling_service: BitSignalingService,
         verification_service: VerificationService,
         cpu_mining_service: CpuMiningService,
-        network: str,
         execution_manager: ExecutionManager,
         vertex_handler: VertexHandler,
         vertex_parser: VertexParser,
@@ -126,8 +125,6 @@ class HathorManager:
         """
         :param reactor: Twisted reactor which handles the mainloop and the events.
         :param peer: Peer object, with peer-id of this node.
-        :param network: Name of the network this node participates. Usually it is either testnet or mainnet.
-        :type network: string
 
         :param tx_storage: Required storage backend.
         :type tx_storage: :py:class:`hathor.transaction.storage.transaction_storage.TransactionStorage`
@@ -170,7 +167,7 @@ class HathorManager:
         self.remote_address = None
 
         self.my_peer = peer
-        self.network = network
+        self.network = settings.NETWORK_NAME
 
         self.is_started: bool = False
 

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -256,7 +256,7 @@ class Metrics:
             metric = PeerConnectionMetrics(
                 connection_string=str(connection.entrypoint) if connection.entrypoint else "",
                 peer_id=str(connection.peer.id),
-                network=connection.network,
+                network=settings.NETWORK_NAME,
                 received_messages=connection.metrics.received_messages,
                 sent_messages=connection.metrics.sent_messages,
                 received_bytes=connection.metrics.received_bytes,

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional
+from abc import ABC
 
 from twisted.internet import protocol
 from twisted.internet.interfaces import IAddress
@@ -22,81 +22,43 @@ from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.protocol import HathorLineReceiver
 
-if TYPE_CHECKING:
-    from hathor.manager import HathorManager  # noqa: F401
 
-MyServerProtocol = HathorLineReceiver
-MyClientProtocol = HathorLineReceiver
+class _HathorLineReceiverFactory(ABC, protocol.Factory):
+    inbound: bool
+
+    def __init__(
+        self,
+        my_peer: PrivatePeer,
+        p2p_manager: ConnectionsManager,
+        *,
+        settings: HathorSettings,
+        use_ssl: bool,
+    ):
+        super().__init__()
+        self._settings = settings
+        self.my_peer = my_peer
+        self.p2p_manager = p2p_manager
+        self.use_ssl = use_ssl
+
+    def buildProtocol(self, addr: IAddress) -> HathorLineReceiver:
+        p = HathorLineReceiver(
+            my_peer=self.my_peer,
+            p2p_manager=self.p2p_manager,
+            use_ssl=self.use_ssl,
+            inbound=self.inbound,
+            settings=self._settings
+        )
+        p.factory = self
+        return p
 
 
-class HathorServerFactory(protocol.ServerFactory):
+class HathorServerFactory(_HathorLineReceiverFactory, protocol.ServerFactory):
     """ HathorServerFactory is used to generate HathorProtocol objects when a new connection arrives.
     """
-
-    manager: Optional[ConnectionsManager]
-    protocol: type[MyServerProtocol] = MyServerProtocol
-
-    def __init__(
-        self,
-        network: str,
-        my_peer: PrivatePeer,
-        p2p_manager: ConnectionsManager,
-        *,
-        settings: HathorSettings,
-        use_ssl: bool,
-    ):
-        super().__init__()
-        self._settings = settings
-        self.network = network
-        self.my_peer = my_peer
-        self.p2p_manager = p2p_manager
-        self.use_ssl = use_ssl
-
-    def buildProtocol(self, addr: IAddress) -> MyServerProtocol:
-        assert self.protocol is not None
-        p = self.protocol(
-            network=self.network,
-            my_peer=self.my_peer,
-            p2p_manager=self.p2p_manager,
-            use_ssl=self.use_ssl,
-            inbound=True,
-            settings=self._settings
-        )
-        p.factory = self
-        return p
+    inbound = True
 
 
-class HathorClientFactory(protocol.ClientFactory):
+class HathorClientFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
     """ HathorClientFactory is used to generate HathorProtocol objects when we connected to another peer.
     """
-
-    protocol: type[MyClientProtocol] = MyClientProtocol
-
-    def __init__(
-        self,
-        network: str,
-        my_peer: PrivatePeer,
-        p2p_manager: ConnectionsManager,
-        *,
-        settings: HathorSettings,
-        use_ssl: bool,
-    ):
-        super().__init__()
-        self._settings = settings
-        self.network = network
-        self.my_peer = my_peer
-        self.p2p_manager = p2p_manager
-        self.use_ssl = use_ssl
-
-    def buildProtocol(self, addr: IAddress) -> MyClientProtocol:
-        assert self.protocol is not None
-        p = self.protocol(
-            network=self.network,
-            my_peer=self.my_peer,
-            p2p_manager=self.p2p_manager,
-            use_ssl=self.use_ssl,
-            inbound=False,
-            settings=self._settings
-        )
-        p.factory = self
-        return p
+    inbound = False

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -95,7 +95,6 @@ class ConnectionsManager:
         self,
         settings: HathorSettings,
         reactor: Reactor,
-        network: str,
         my_peer: PrivatePeer,
         pubsub: PubSubManager,
         ssl: bool,
@@ -114,8 +113,6 @@ class ConnectionsManager:
         self.reactor = reactor
         self.my_peer = my_peer
 
-        self.network = network
-
         # List of address descriptions to listen for new connections (eg: [tcp:8000])
         self.listen_address_descriptions: list[str] = []
 
@@ -132,10 +129,10 @@ class ConnectionsManager:
         from hathor.p2p.factory import HathorClientFactory, HathorServerFactory
         self.use_ssl = ssl
         self.server_factory = HathorServerFactory(
-            self.network, self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
+            self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
         self.client_factory = HathorClientFactory(
-            self.network, self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
+            self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
 
         # Global maximum number of connections.
@@ -407,7 +404,7 @@ class ConnectionsManager:
         self.unverified_peer_storage.pop(protocol.peer.id, None)
 
         # we emit the event even if it's a duplicate peer as a matching
-        # NETWORK_PEER_DISCONNECTED will be emmited regardless
+        # NETWORK_PEER_DISCONNECTED will be emitted regardless
         self.pubsub.publish(
             HathorEvents.NETWORK_PEER_READY,
             protocol=protocol,

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -73,7 +73,6 @@ class HathorProtocol:
         NO_PEER_ID_URL = 'no_peer_id_url'
         NO_ENTRYPOINTS = 'no_entrypoints'
 
-    network: str
     my_peer: PrivatePeer
     connections: 'ConnectionsManager'
     node: 'HathorManager'
@@ -99,7 +98,6 @@ class HathorProtocol:
 
     def __init__(
         self,
-        network: str,
         my_peer: PrivatePeer,
         p2p_manager: 'ConnectionsManager',
         *,
@@ -108,7 +106,6 @@ class HathorProtocol:
         inbound: bool,
     ) -> None:
         self._settings = settings
-        self.network = network
         self.my_peer = my_peer
         self.connections = p2p_manager
 

--- a/hathor/p2p/states/hello.py
+++ b/hathor/p2p/states/hello.py
@@ -52,7 +52,7 @@ class HelloState(BaseState):
         remote = protocol.transport.getPeer()
         data = {
             'app': self._app(),
-            'network': protocol.network,
+            'network': self._settings.NETWORK_NAME,
             'remote_address': format_address(remote),
             'genesis_short_hash': get_genesis_short_hash(),
             'timestamp': protocol.node.reactor.seconds(),
@@ -135,7 +135,7 @@ class HelloState(BaseState):
             # XXX: this used to be a warning, but it shouldn't be since it's perfectly normal
             self.log.debug('different versions', theirs=remote_app, ours=our_app)
 
-        if data['network'] != protocol.network:
+        if data['network'] != self._settings.NETWORK_NAME:
             protocol.send_error_and_close_connection('Wrong network.')
             return
 

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -55,7 +55,6 @@ class Simulator:
         self.seed = seed
         self.rng = Random(self.seed)
         self.settings = get_global_settings()._replace(AVG_TIME_BETWEEN_BLOCKS=SIMULATOR_AVG_TIME_BETWEEN_BLOCKS)
-        self._network = 'testnet'
         self._clock = MemoryReactorHeapClock()
         self._peers: OrderedDict[str, HathorManager] = OrderedDict()
         self._connections: list['FakeConnection'] = []
@@ -80,7 +79,6 @@ class Simulator:
         Returns a builder with default configuration, for convenience when using create_peer() or create_artifacts()
         """
         return Builder() \
-            .set_network(self._network) \
             .set_peer(PrivatePeer.auto_generated()) \
             .set_soft_voided_tx_ids(set()) \
             .enable_full_verification() \

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -359,6 +359,7 @@ class Block(GenericVertex[BlockStaticMetadata]):
     def iter_transactions_in_this_block(self) -> Iterator[BaseTransaction]:
         """Return an iterator of the transactions that have this block as meta.first_block."""
         from hathor.transaction.storage.traversal import BFSOrderWalk
+        assert self.storage is not None
         bfs = BFSOrderWalk(self.storage, is_dag_verifications=True, is_dag_funds=True, is_left_to_right=False)
         for tx in bfs.run(self, skip_root=True):
             tx_meta = tx.get_metadata()

--- a/hathor/transaction/storage/__init__.py
+++ b/hathor/transaction/storage/__init__.py
@@ -15,6 +15,7 @@
 from hathor.transaction.storage.cache_storage import TransactionCacheStorage
 from hathor.transaction.storage.memory_storage import TransactionMemoryStorage
 from hathor.transaction.storage.transaction_storage import TransactionStorage
+from hathor.transaction.storage.vertex_storage_protocol import VertexStorageProtocol
 
 try:
     from hathor.transaction.storage.rocksdb_storage import TransactionRocksDBStorage
@@ -26,4 +27,5 @@ __all__ = [
     'TransactionMemoryStorage',
     'TransactionCacheStorage',
     'TransactionRocksDBStorage',
+    'VertexStorageProtocol'
 ]

--- a/hathor/transaction/storage/traversal.py
+++ b/hathor/transaction/storage/traversal.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import heapq
 from abc import ABC, abstractmethod
@@ -21,7 +22,7 @@ from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Union
 
 if TYPE_CHECKING:
     from hathor.transaction import BaseTransaction  # noqa: F401
-    from hathor.transaction.storage import TransactionStorage  # noqa: F401
+    from hathor.transaction.storage import VertexStorageProtocol
     from hathor.types import VertexId
 
 
@@ -47,8 +48,14 @@ class GenericWalk(ABC):
     """
     seen: set['VertexId']
 
-    def __init__(self, storage: 'TransactionStorage', *, is_dag_funds: bool = False,
-                 is_dag_verifications: bool = False, is_left_to_right: bool = True):
+    def __init__(
+        self,
+        storage: VertexStorageProtocol,
+        *,
+        is_dag_funds: bool = False,
+        is_dag_verifications: bool = False,
+        is_left_to_right: bool = True,
+    ) -> None:
         """
         If `is_left_to_right` is `True`, we walk in the direction of the unverified transactions.
         Otherwise, we walk in the direction of the genesis.
@@ -112,7 +119,7 @@ class GenericWalk(ABC):
         for _hash in it:
             if _hash not in self.seen:
                 self.seen.add(_hash)
-                neighbor = self.storage.get_transaction(_hash)
+                neighbor = self.storage.get_vertex(_hash)
                 self._push_visit(neighbor)
 
     def skip_neighbors(self, tx: 'BaseTransaction') -> None:
@@ -155,8 +162,20 @@ class BFSTimestampWalk(GenericWalk):
     """
     _to_visit: list[HeapItem]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        storage: VertexStorageProtocol,
+        *,
+        is_dag_funds: bool = False,
+        is_dag_verifications: bool = False,
+        is_left_to_right: bool = True,
+    ) -> None:
+        super().__init__(
+            storage,
+            is_dag_funds=is_dag_funds,
+            is_dag_verifications=is_dag_verifications,
+            is_left_to_right=is_left_to_right
+        )
         self._to_visit = []
 
     def _is_empty(self) -> bool:
@@ -179,8 +198,20 @@ class BFSOrderWalk(GenericWalk):
     """
     _to_visit: deque['BaseTransaction']
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        storage: VertexStorageProtocol,
+        *,
+        is_dag_funds: bool = False,
+        is_dag_verifications: bool = False,
+        is_left_to_right: bool = True,
+    ) -> None:
+        super().__init__(
+            storage,
+            is_dag_funds=is_dag_funds,
+            is_dag_verifications=is_dag_verifications,
+            is_left_to_right=is_left_to_right
+        )
         self._to_visit = deque()
 
     def _is_empty(self) -> bool:
@@ -198,8 +229,20 @@ class DFSWalk(GenericWalk):
     """
     _to_visit: list['BaseTransaction']
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        storage: VertexStorageProtocol,
+        *,
+        is_dag_funds: bool = False,
+        is_dag_verifications: bool = False,
+        is_left_to_right: bool = True,
+    ) -> None:
+        super().__init__(
+            storage,
+            is_dag_funds=is_dag_funds,
+            is_dag_verifications=is_dag_verifications,
+            is_left_to_right=is_left_to_right
+        )
         self._to_visit = []
 
     def _is_empty(self) -> bool:

--- a/tests/cli/test_events_simulator.py
+++ b/tests/cli/test_events_simulator.py
@@ -11,10 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 from unittest.mock import Mock
 
 from hathor.cli.events_simulator.event_forwarding_websocket_factory import EventForwardingWebsocketFactory
 from hathor.cli.events_simulator.events_simulator import create_parser, execute
+from hathor.conf.get_settings import get_global_settings
 from tests.test_memory_reactor_clock import TestMemoryReactorClock
 
 
@@ -29,7 +31,7 @@ def test_events_simulator() -> None:
     factory = EventForwardingWebsocketFactory(
         simulator=Mock(),
         peer_id='test_peer_id',
-        network='test_network',
+        settings=get_global_settings(),
         reactor=reactor,
         event_storage=Mock()
     )

--- a/tests/event/websocket/test_factory.py
+++ b/tests/event/websocket/test_factory.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
+from hathor.conf.get_settings import get_global_settings
 from hathor.event.storage import EventMemoryStorage
 from hathor.event.websocket.factory import EventWebsocketFactory
 from hathor.event.websocket.protocol import EventWebsocketProtocol
@@ -76,7 +77,7 @@ def test_broadcast_event(can_receive_event: bool) -> None:
 
     response = EventResponse(
         peer_id='my_peer_id',
-        network='my_network',
+        network='unittests',
         event=event,
         latest_event_id=n_starting_events - 1,
         stream_id=stream_id
@@ -141,7 +142,7 @@ def test_send_next_event_to_connection(next_expected_event_id: int, can_receive_
         event = EventMocker.create_event(_id)
         response = EventResponse(
             peer_id='my_peer_id',
-            network='my_network',
+            network='unittests',
             event=event,
             latest_event_id=n_starting_events - 1,
             stream_id=stream_id
@@ -164,7 +165,7 @@ def _get_factory(
 
     return EventWebsocketFactory(
         peer_id='my_peer_id',
-        network='my_network',
+        settings=get_global_settings(),
         reactor=clock,
         event_storage=event_storage
     )

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -96,7 +96,7 @@ class BaseMetricsTest(unittest.TestCase):
         self.tmpdirs.append(path)
 
         def _init_manager():
-            builder = self.get_builder('testnet') \
+            builder = self.get_builder() \
                 .use_rocksdb(path, cache_capacity=100) \
                 .force_memory_index() \
                 .set_wallet(self._create_test_wallet(unlocked=True))
@@ -148,7 +148,7 @@ class BaseMetricsTest(unittest.TestCase):
         self.tmpdirs.append(path)
 
         def _init_manager():
-            builder = self.get_builder('testnet') \
+            builder = self.get_builder() \
                 .use_rocksdb(path, cache_capacity=100) \
                 .force_memory_index() \
                 .set_wallet(self._create_test_wallet(unlocked=True)) \
@@ -220,7 +220,6 @@ class BaseMetricsTest(unittest.TestCase):
 
         def build_hathor_protocol():
             protocol = HathorProtocol(
-                network="testnet",
                 my_peer=my_peer,
                 p2p_manager=manager.connections,
                 use_ssl=False,

--- a/tests/p2p/test_bootstrap.py
+++ b/tests/p2p/test_bootstrap.py
@@ -49,7 +49,7 @@ class BootstrapTestCase(unittest.TestCase):
     def test_mock_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
         peer = PrivatePeer.auto_generated()
-        connections = ConnectionsManager(self._settings, self.clock, 'testnet', peer, pubsub, True, self.rng, True)
+        connections = ConnectionsManager(self._settings, self.clock, peer, pubsub, True, self.rng, True)
         host_ports1 = [
             ('foobar', 1234),
             ('127.0.0.99', 9999),
@@ -73,7 +73,7 @@ class BootstrapTestCase(unittest.TestCase):
     def test_dns_discovery(self) -> None:
         pubsub = PubSubManager(self.clock)
         peer = PrivatePeer.auto_generated()
-        connections = ConnectionsManager(self._settings, self.clock, 'testnet', peer, pubsub, True, self.rng, True)
+        connections = ConnectionsManager(self._settings, self.clock, peer, pubsub, True, self.rng, True)
         bootstrap_a = [
             '127.0.0.99',
             '127.0.0.88',

--- a/tests/poa/test_poa_verification.py
+++ b/tests/poa/test_poa_verification.py
@@ -47,7 +47,7 @@ class BasePoaVerificationTest(unittest.TestCase):
             ),
         )
 
-        builder = self.get_builder('network').set_settings(settings)
+        builder = self.get_builder().set_settings(settings)
         self.manager = self.create_peer_from_builder(builder)
         self.verifiers = self.manager.verification_service.verifiers
 

--- a/tests/tx/test_cache_storage.py
+++ b/tests/tx/test_cache_storage.py
@@ -14,7 +14,7 @@ class BaseCacheStorageTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        builder = self.get_builder('testnet') \
+        builder = self.get_builder() \
             .use_memory() \
             .use_tx_storage_cache(capacity=5) \
             .set_wallet(self._create_test_wallet(unlocked=True))

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -85,7 +85,6 @@ class TestBuilder(Builder):
 
     def __init__(self, settings: HathorSettings | None = None) -> None:
         super().__init__()
-        self.set_network('testnet')
         # default builder has sync-v2 enabled for tests
         self.enable_sync_v2()
         self.set_settings(settings or get_global_settings())
@@ -171,11 +170,10 @@ class TestCase(unittest.TestCase):
             wallet.lock()
         return wallet
 
-    def get_builder(self, network: str) -> TestBuilder:
+    def get_builder(self) -> TestBuilder:
         builder = TestBuilder()
         builder.set_rng(self.rng) \
-            .set_reactor(self.clock) \
-            .set_network(network)
+            .set_reactor(self.clock)
         return builder
 
     def create_peer_from_builder(self, builder: Builder, start_manager: bool = True) -> HathorManager:
@@ -218,9 +216,10 @@ class TestCase(unittest.TestCase):
     ):  # TODO: Add -> HathorManager here. It breaks the lint in a lot of places.
         enable_sync_v1, enable_sync_v2 = self._syncVersionFlags(enable_sync_v1, enable_sync_v2)
 
-        builder = self.get_builder(network) \
+        settings = self._settings._replace(NETWORK_NAME=network)
+        builder = self.get_builder() \
             .set_full_verification(full_verification) \
-            .set_settings(self._settings)
+            .set_settings(settings)
 
         if checkpoints is not None:
             builder.set_checkpoints(checkpoints)


### PR DESCRIPTION
### Motivation

This PR contains some useful pre-refactors for the P2P Multiprocess project.

### Acceptance Criteria

- Remove unnecessary `network` parameter from multiple classes. They use `settings.NETWORK_NAME` instead.
- Refactor `p2p/factory.py`, unifying client and server factories in a base class to simplify it.
- Update typings in the `traversal` module so it can receive the more flexible `VertexStorageProtocol` instead of a `TransactionStorage`.
- No changes in behavior.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 