### PR TITLE
refactor: move can_validate_full method [part 2/8]

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -483,7 +483,7 @@ class HathorManager:
                 # TODO: deal with invalid tx
                 tx._update_parents_children_metadata()
 
-                if tx.can_validate_full():
+                if self.tx_storage.can_validate_full(tx):
                     tx.update_initial_metadata()
                     if tx.is_genesis:
                         assert tx.validate_checkpoint(self.checkpoints)

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -1171,7 +1171,7 @@ class NodeBlockSync(SyncAgent):
         else:
             # If we have not requested the data, it is a new transaction being propagated
             # in the network, thus, we propagate it as well.
-            if tx.can_validate_full():
+            if self.tx_storage.can_validate_full(tx):
                 self.log.debug('tx received in real time from peer', tx=tx.hash_hex, peer=self.protocol.get_peer_id())
                 try:
                     self.vertex_handler.on_new_vertex(tx, propagate_to_peers=True, fails_silently=False)

--- a/hathor/p2p/sync_v2/blockchain_streaming_client.py
+++ b/hathor/p2p/sync_v2/blockchain_streaming_client.py
@@ -130,7 +130,7 @@ class BlockchainStreamingClient:
         else:
             self.log.debug('block received', blk_id=blk.hash.hex())
 
-        if blk.can_validate_full():
+        if self.tx_storage.can_validate_full(blk):
             try:
                 self.vertex_handler.on_new_vertex(blk, propagate_to_peers=False, fails_silently=False)
             except HathorError:

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -461,29 +461,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         return addresses
 
-    def can_validate_full(self) -> bool:
-        """ Check if this transaction is ready to be fully validated, either all deps are full-valid or one is invalid.
-        """
-        assert self.storage is not None
-        assert self._hash is not None
-        if self.is_genesis:
-            return True
-        deps = self.get_all_dependencies()
-        all_exist = True
-        all_valid = True
-        # either they all exist and are fully valid
-        for dep in deps:
-            meta = self.storage.get_metadata(dep)
-            if meta is None:
-                all_exist = False
-                continue
-            if not meta.validation.is_fully_connected():
-                all_valid = False
-            if meta.validation.is_invalid():
-                # or any of them is invalid (which would make this one invalid too)
-                return True
-        return all_exist and all_valid
-
     def set_validation(self, validation: ValidationState) -> None:
         """ This method will set the internal validation state AND the appropriate voided_by marker.
 
@@ -849,17 +826,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
     @abstractmethod
     def get_token_uid(self, index: int) -> TokenUid:
         raise NotImplementedError
-
-    def is_ready_for_validation(self) -> bool:
-        """Check whether the transaction is ready to be validated: all dependencies exist and are fully connected."""
-        assert self.storage is not None
-        for dep_hash in self.get_all_dependencies():
-            dep_meta = self.storage.get_metadata(dep_hash)
-            if dep_meta is None:
-                return False
-            if not dep_meta.validation.is_fully_connected():
-                return False
-        return True
 
     @property
     def static_metadata(self) -> StaticMetadataT:


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1151

### Motivation

As part of the P2P Multiprocess project, move a `BaseTransaction` method that is used by the sync to the storage.

### Acceptance Criteria

- Move `can_validate_full` method from `BaseTransaction` to `TransactionStorage`.
- Remove similar and unused `BaseTransaction.is_ready_for_validation` method.
- No changes in behavior.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 