### PR TITLE
refactor(vertex-handler): remove p2p_manager dependency [part 1/8]

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -614,7 +614,6 @@ class Builder:
                 tx_storage=self._get_or_create_tx_storage(),
                 verification_service=self._get_or_create_verification_service(),
                 consensus=self._get_or_create_consensus(),
-                p2p_manager=self._get_or_create_p2p_manager(),
                 feature_service=self._get_or_create_feature_service(),
                 pubsub=self._get_or_create_pubsub(),
                 wallet=self._get_or_create_wallet(),

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -334,7 +334,6 @@ class CliBuilder:
             tx_storage=tx_storage,
             verification_service=verification_service,
             consensus=consensus_algorithm,
-            p2p_manager=p2p_manager,
             feature_service=self.feature_service,
             pubsub=pubsub,
             wallet=self.wallet,

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -488,7 +488,9 @@ class NodeBlockSync(SyncAgent):
         data = [bytes.fromhex(x) for x in data]
         # filter-out txs we already have
         try:
-            self._receiving_tips.extend(VertexId(tx_id) for tx_id in data if not self.partial_vertex_exists(tx_id))
+            self._receiving_tips.extend(
+                VertexId(tx_id) for tx_id in data if not self.tx_storage.partial_vertex_exists(tx_id)
+            )
         except ValueError:
             self.protocol.send_error_and_close_connection('Invalid trasaction ID received')
         # XXX: it's OK to do this *after* the extend because the payload is limited by the line protocol
@@ -553,12 +555,6 @@ class NodeBlockSync(SyncAgent):
         assert self.protocol.state is not None
         self.protocol.state.send_message(cmd, payload)
 
-    def partial_vertex_exists(self, vertex_id: VertexId) -> bool:
-        """ Return true if the vertex exists no matter its validation state.
-        """
-        with self.tx_storage.allow_partially_validated_context():
-            return self.tx_storage.transaction_exists(vertex_id)
-
     @inlineCallbacks
     def find_best_common_block(self,
                                my_best_block: _HeightInfo,
@@ -621,11 +617,11 @@ class NodeBlockSync(SyncAgent):
         try:
             for tx in vertex_list:
                 if not self.tx_storage.transaction_exists(tx.hash):
-                    self.vertex_handler.on_new_vertex(tx, propagate_to_peers=False, fails_silently=False)
+                    self.vertex_handler.on_new_vertex(tx, fails_silently=False)
                 yield deferLater(self.reactor, 0, lambda: None)
 
             if not self.tx_storage.transaction_exists(blk.hash):
-                self.vertex_handler.on_new_vertex(blk, propagate_to_peers=False, fails_silently=False)
+                self.vertex_handler.on_new_vertex(blk, fails_silently=False)
         except InvalidNewTransaction:
             self.protocol.send_error_and_close_connection('invalid vertex received')
 
@@ -1163,7 +1159,7 @@ class NodeBlockSync(SyncAgent):
 
         tx.storage = self.protocol.node.tx_storage
 
-        if self.partial_vertex_exists(tx.hash):
+        if self.tx_storage.partial_vertex_exists(tx.hash):
             # transaction already added to the storage, ignore it
             # XXX: maybe we could add a hash blacklist and punish peers propagating known bad txs
             self.tx_storage.compare_bytes_with_local_tx(tx)
@@ -1174,7 +1170,9 @@ class NodeBlockSync(SyncAgent):
             if self.tx_storage.can_validate_full(tx):
                 self.log.debug('tx received in real time from peer', tx=tx.hash_hex, peer=self.protocol.get_peer_id())
                 try:
-                    self.vertex_handler.on_new_vertex(tx, propagate_to_peers=True, fails_silently=False)
+                    success = self.vertex_handler.on_new_vertex(tx, fails_silently=False)
+                    if success:
+                        self.protocol.connections.send_tx_to_peers(tx)
                 except InvalidNewTransaction:
                     self.protocol.send_error_and_close_connection('invalid vertex received')
             else:

--- a/hathor/p2p/sync_v2/mempool.py
+++ b/hathor/p2p/sync_v2/mempool.py
@@ -140,7 +140,9 @@ class SyncMempoolManager:
         if self.tx_storage.transaction_exists(tx.hash):
             return
         try:
-            self.vertex_handler.on_new_vertex(tx, fails_silently=False)
+            success = self.vertex_handler.on_new_vertex(tx, fails_silently=False)
+            if success:
+                self.sync_agent.protocol.connections.send_tx_to_peers(tx)
         except InvalidNewTransaction:
             self.sync_agent.protocol.send_error_and_close_connection('invalid vertex received')
             raise

--- a/hathor/profiler/cpu.py
+++ b/hathor/profiler/cpu.py
@@ -15,11 +15,14 @@
 import time
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Callable, Union
+from typing import Callable, ParamSpec, TypeVar, Union
 
 from twisted.internet.task import LoopingCall
 
 Key = tuple[str, ...]
+
+T = TypeVar('T')
+P = ParamSpec('P')
 
 
 class ProcItem:
@@ -184,7 +187,7 @@ class SimpleCPUProfiler:
         t1 = time.process_time()
         self.measures[('profiler',)].add_time(t1 - t0)
 
-    def profiler(self, key: Union[str, Callable[..., str]]) -> Callable[[Callable[..., Any]], Any]:
+    def profiler(self, key: Union[str, Callable[..., str]]) -> Callable[[Callable[P, T]], Callable[P, T]]:
         """Decorator to collect data. The `key` must be the key itself
         or a method that returns the key.
 

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -1132,6 +1132,11 @@ class TransactionStorage(ABC):
                 return True
         return all_exist and all_valid
 
+    def partial_vertex_exists(self, vertex_id: VertexId) -> bool:
+        """Return true if the vertex exists no matter its validation state."""
+        with self.allow_partially_validated_context():
+            return self.transaction_exists(vertex_id)
+
 
 class BaseTransactionStorage(TransactionStorage):
     indexes: Optional[IndexesManager]


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1153

### Motivation

As part of the P2P Multiprocess project, this PR refactors the `VertexHandler` so it does not depend on the `p2p_manager` anymore.

### Acceptance Criteria

- Remove the `p2p_manager` dependency from `VertexHandler`. This means it does not propagate vertices anymore, and it's the caller's responsibility to do it.
- Remove duplicate `partial_vertex_exists` methods from sync classes and move it to the storage.
- Update all calls to `VertexHandler.on_new_vertex` to propagate vertices accordingly:
  - If the call explicitly set `propagate_to_peers=False`, no change was necessary.
  - If the call didn't provide the `propagate_to_peers` argument or set it as `True`, add a follow-up call to `p2p_manager.send_tx_to_peers`.
- Move CPU profiler from `HathorManager.on_new_tx` to `VertexHandler.on_new_vertex`.
- Fix CPU profiler typing.
- No changes in behavior. 

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 