### PR TITLE
chore: improve p2p protocol error logging

### DIFF
--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -327,7 +327,7 @@ class HathorProtocol:
             .addErrback(self._on_cmd_handler_error, cmd)
 
     def _on_cmd_handler_error(self, failure: Failure, cmd: ProtocolMessages) -> None:
-        self.log.warn('recv_message processing error', reason=failure.getErrorMessage(), exc_info=True)
+        self.log.error(f'recv_message processing error:\n{failure.getTraceback()}', reason=failure.getErrorMessage())
         self.send_error_and_close_connection(f'Error processing "{cmd.value}" command')
 
     def send_error(self, msg: str) -> None:


### PR DESCRIPTION
### Motivation

In a recent PR we changed the error handling when processing P2P protocol messages. It was changed from a `try-except` to an errback on a Deferred. Because of that, logging with `exc_info` is not useful, since we're not in an exception context anymore, it's empty. Instead, we should log the traceback from the `twisted.Failure`.

Also, I changed it from `warn` to `error` as any error should be handled before reaching this code, and if it does, it's an unhandled error that we should know about. 

### Acceptance Criteria

- When logging errors during processing of a P2P protocol message, include the traceback and change it to `error` instead of `warn`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 