### PR TITLE
fix: make sure Nginx images will include Nano endpoints

### DIFF
--- a/hathor/cli/openapi_files/register.py
+++ b/hathor/cli/openapi_files/register.py
@@ -45,5 +45,6 @@ def get_registered_resources() -> list[type[Resource]]:
     import hathor.wallet.resources.nano_contracts  # noqa: 401
     import hathor.wallet.resources.thin_wallet  # noqa: 401
     import hathor.websocket  # noqa: 401
+    import hathor.nanocontracts.resources  # noqa: 401
     global _registered_resources
     return _registered_resources


### PR DESCRIPTION
### Motivation

We need to include the Nano Contracts endpoints in our Nginx images

### Acceptance Criteria

- Nginx images generated with the Makefile in `extras/nginx_docker` should include the Nano Contracts endpoints

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 