### PR TITLE
fix: add view decorator on dozer_pool and change types import

### DIFF
--- a/hathor/nanocontracts/blueprints/dozer_pool.py
+++ b/hathor/nanocontracts/blueprints/dozer_pool.py
@@ -3,8 +3,16 @@ from typing import NamedTuple
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCFail
-from hathor.nanocontracts.types import NCAction, NCActionType, public, view
-from hathor.types import Address, Amount, Timestamp, TokenUid
+from hathor.nanocontracts.types import (
+    Address,
+    Amount,
+    Timestamp,
+    TokenUid,
+    NCAction,
+    NCActionType,
+    public,
+    view,
+)
 
 PRECISION = 10**20
 
@@ -670,6 +678,7 @@ class Dozer_Pool(Blueprint):
             "fee": str(self.fee_numerator / 10),
         }
 
+    @view
     def user_info(
         self,
         address: Address,
@@ -688,6 +697,7 @@ class Dozer_Pool(Blueprint):
             "max_withdraw_b": max_withdraw_b,
         }
 
+    @view
     def pool_data(
         self,
     ) -> dict[str, float]:


### PR DESCRIPTION
- pool_data and user_info is used by Dozer dApp and they was without the `@view` decorator.
- We fixed the type imports as it was causing bug in the explorer