### PR TITLE
ci: use macos-13 on Github Actions as macos-12 will be dropped

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           full_matrix = {
             'python': ['3.10', '3.11', '3.12'],
             # available OS's: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
-            'os': ['ubuntu-22.04', 'macos-12'],
+            'os': ['ubuntu-22.04', 'macos-13'],
           }
           # this is the fastest one:
           reduced_matrix = {


### PR DESCRIPTION
### Motivation

The macos-12 runner will be dropped by Github Actions: https://github.com/actions/runner-images/issues/10721

### Acceptance Criteria

- We should use macos-13 instead. There are newer ones, but I preferred the safe path of just one version up.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 