### PR TITLE
chore(feature-activation): delay NOP feature

### DIFF
--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -88,6 +88,8 @@ def execute(args: Namespace, reactor: 'ReactorProtocol') -> None:
 
     forwarding_ws_factory.start(stream_id='simulator_stream_id')
     scenario.simulate(simulator, manager)
+    assert manager.wallet is not None
+    log.info('final result', balances=manager.wallet.get_balance_per_address(simulator.settings.HATHOR_TOKEN_UID))
     reactor.listenTCP(args.port, site)
     reactor.run()
 

--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -73,11 +73,11 @@ SETTINGS = HathorSettings(
             # NOP feature to test Feature Activation for Transactions
             Feature.NOP_FEATURE_1: Criteria(
                 bit=0,
-                # N = 4_354_560
-                # Expected to be reached around Sunday, 2024-11-17.
-                # Right now the best block is 4_326_600 on testnet (2024-11-07).
-                start_height=4_354_560,  # N
-                timeout_height=4_394_880,  # N + 2 * 20160 (2 weeks after the start)
+                # N = 4_394_880
+                # start_height expected to be reached around Sunday, 2024-12-01.
+                # Right now the best block is 4_377_375 on testnet (2024-11-25).
+                start_height=4_394_880,  # N
+                timeout_height=4_475_520,  # N + 4 * 20160 (4 weeks after the start)
                 minimum_activation_height=0,
                 lock_in_on_timeout=False,
                 version='0.63.0',

--- a/hathor/conf/testnet.yml
+++ b/hathor/conf/testnet.yml
@@ -54,11 +54,11 @@ FEATURE_ACTIVATION:
     # NOP feature to test Feature Activation for Transactions
     NOP_FEATURE_1:
       bit: 0
-      # N = 4_354_560
-      # Expected to be reached around Sunday, 2024-11-17.
-      # Right now the best block is 4_326_600 on testnet (2024-11-07).
-      start_height: 4_354_560  # N
-      timeout_height: 4_394_880  # N + 2 * 20160 (2 weeks after the start)
+      # N = 4_394_880
+      # start_height expected to be reached around Sunday, 2024-12-01.
+      # Right now the best block is 4_377_375 on testnet (2024-11-25).
+      start_height: 4_394_880  # N
+      timeout_height: 4_475_520  # N + 4 * 20160 (4 weeks after the start)
       minimum_activation_height: 0
       lock_in_on_timeout: false
       version: 0.63.0


### PR DESCRIPTION
### Motivation

Delay the configuration of the NOP feature configuration to test Feature Activation for Transactions, as the new hathor-core version has not been released yet.

### Acceptance Criteria

- Delay NOP feature config on testnet.
- I'm also using this PR to add an unrelated log line in the `events_simulator` CLI.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 