### PR TITLE
chore(events): remove event queue from unsafe mode

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -242,6 +242,9 @@ class CliBuilder:
         pubsub = PubSubManager(reactor)
 
         if self._args.x_enable_event_queue:
+            self.log.warn('--x-enable-event-queue is deprecated and will be removed, use --enable-event-queue instead')
+
+        if self._args.x_enable_event_queue or self._args.enable_event_queue:
             self.event_ws_factory = EventWebsocketFactory(
                 peer_id=str(peer.id),
                 settings=settings,
@@ -270,8 +273,8 @@ class CliBuilder:
         full_verification = False
         if self._args.x_full_verification:
             self.check_or_raise(
-                not self._args.x_enable_event_queue,
-                '--x-full-verification cannot be used with --x-enable-event-queue'
+                not self._args.x_enable_event_queue and not self._args.enable_event_queue,
+                '--x-full-verification cannot be used with --enable-event-queue'
             )
             full_verification = True
 
@@ -282,8 +285,8 @@ class CliBuilder:
             execution_manager=execution_manager
         )
 
-        if self._args.x_enable_event_queue:
-            self.log.info('--x-enable-event-queue flag provided. '
+        if self._args.x_enable_event_queue or self._args.enable_event_queue:
+            self.log.info('--enable-event-queue flag provided. '
                           'The events detected by the full node will be stored and can be retrieved by clients')
 
         self.feature_service = FeatureService(settings=settings, tx_storage=tx_storage)
@@ -378,7 +381,7 @@ class CliBuilder:
             checkpoints=settings.CHECKPOINTS,
             environment_info=get_environment_info(args=str(self._args), peer_id=str(peer.id)),
             full_verification=full_verification,
-            enable_event_queue=self._args.x_enable_event_queue,
+            enable_event_queue=self._args.x_enable_event_queue or self._args.enable_event_queue,
             bit_signaling_service=bit_signaling_service,
             verification_service=verification_service,
             cpu_mining_service=cpu_mining_service,

--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -307,7 +307,7 @@ class ResourcesBuilder:
         ws_factory.subscribe(self.manager.pubsub)
 
         # Event websocket resource
-        if self._args.x_enable_event_queue:
+        if self._args.x_enable_event_queue or self._args.enable_event_queue:
             root.putChild(b'event_ws', WebSocketResource(self.event_ws_factory))
             root.putChild(b'event', EventResource(self.manager._event_manager))
 

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -55,7 +55,6 @@ class RunNode:
         ('--x-sync-bridge', lambda args: bool(args.x_sync_bridge)),
         ('--x-sync-v1-only', lambda args: bool(args.x_sync_v1_only)),
         ('--x-sync-v2-only', lambda args: bool(args.x_sync_v2_only)),
-        ('--x-enable-event-queue', lambda args: bool(args.x_enable_event_queue)),
         ('--x-asyncio-reactor', lambda args: bool(args.x_asyncio_reactor)),
         ('--x-ipython-kernel', lambda args: bool(args.x_ipython_kernel)),
     ]
@@ -146,7 +145,9 @@ class RunNode:
         sync_args.add_argument('--x-sync-bridge', action='store_true', help='Enable running both sync protocols.')
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
-        parser.add_argument('--x-enable-event-queue', action='store_true', help='Enable event queue mechanism')
+        parser.add_argument('--x-enable-event-queue', action='store_true',
+                            help='Deprecated: use --enable-event-queue instead.')
+        parser.add_argument('--enable-event-queue', action='store_true', help='Enable event queue mechanism')
         parser.add_argument('--peer-id-blacklist', action='extend', default=[], nargs='+', type=str,
                             help='Peer IDs to forbid connection')
         parser.add_argument('--config-yaml', type=str, help='Configuration yaml filepath')

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -76,6 +76,7 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     x_localhost_only: bool
     x_rocksdb_indexes: bool
     x_enable_event_queue: bool
+    enable_event_queue: bool
     peer_id_blacklist: list[str]
     config_yaml: Optional[str]
     signal_support: set[Feature]

--- a/tests/others/test_cli_builder.py
+++ b/tests/others/test_cli_builder.py
@@ -192,4 +192,4 @@ class BuilderTestCase(unittest.TestCase):
 
     def test_event_queue_with_full_verification(self):
         args = ['--x-enable-event-queue', '--memory-storage', '--x-full-verification']
-        self._build_with_error(args, '--x-full-verification cannot be used with --x-enable-event-queue')
+        self._build_with_error(args, '--x-full-verification cannot be used with --enable-event-queue')


### PR DESCRIPTION
### Motivation

The Event Queue feature has been used for a while now by the Wallet Service, so we can remove it from unsafe/experimental mode.

### Acceptance Criteria

- Remove `--x-enable-event-queue` from unsafe mode.
- Add `--enable-event-queue` and warning to deprecate `--x-enable-event-queue`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 