### PR TITLE
refactor(p2p): move received peers storage to protocol

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -288,6 +288,9 @@ class HathorSettings(NamedTuple):
     # Maximum period without receiving any messages from ther peer (in seconds).
     PEER_IDLE_TIMEOUT: int = 60
 
+    # Maximum number of entrypoints that we accept that a peer broadcasts
+    PEER_MAX_ENTRYPOINTS: int = 30
+
     # Filepath of ca certificate file to generate connection certificates
     CA_FILEPATH: str = os.path.join(os.path.dirname(__file__), '../p2p/ca.crt')
 
@@ -430,6 +433,12 @@ class HathorSettings(NamedTuple):
     # Maximum number of tx tips to accept in the initial phase of the mempool sync 1000 is arbitrary, but it should be
     # more than enough for the forseeable future
     MAX_MEMPOOL_RECEIVING_TIPS: int = 1000
+
+    # Max number of peers simultanously stored in the node
+    MAX_VERIFIED_PEERS: int = 10_000
+
+    # Max number of peers simultanously stored per-connection
+    MAX_UNVERIFIED_PEERS_PER_CONN: int = 100
 
     # Used to enable nano contracts.
     #

--- a/hathor/p2p/peer.py
+++ b/hathor/p2p/peer.py
@@ -106,11 +106,11 @@ class PeerInfo:
     """ Stores entrypoint and connection attempts information.
     """
 
-    entrypoints: list[PeerAddress] = field(default_factory=list)
-    retry_timestamp: int = 0   # should only try connecting to this peer after this timestamp
-    retry_interval: int = 5     # how long to wait for next connection retry. It will double for each failure
-    retry_attempts: int = 0     # how many retries were made
-    last_seen: float = inf        # last time this peer was seen
+    entrypoints: set[PeerAddress] = field(default_factory=set)
+    retry_timestamp: int = 0  # should only try connecting to this peer after this timestamp
+    retry_interval: int = 5  # how long to wait for next connection retry. It will double for each failure
+    retry_attempts: int = 0  # how many retries were made
+    last_seen: float = inf  # last time this peer was seen
     flags: set[str] = field(default_factory=set)
     _settings: HathorSettings = field(default_factory=get_global_settings, repr=False)
 
@@ -121,21 +121,18 @@ class PeerInfo:
         return list(filter(lambda e: e.is_ipv6(), self.entrypoints))
 
     def ipv4_entrypoints_as_str(self) -> list[str]:
-        return list(map(str, self.get_ipv4_only_entrypoints()))
+        return sorted(map(str, self.get_ipv4_only_entrypoints()))
 
     def ipv6_entrypoints_as_str(self) -> list[str]:
-        return list(map(str, self.get_ipv6_only_entrypoints()))
+        return sorted(map(str, self.get_ipv6_only_entrypoints()))
 
     def entrypoints_as_str(self) -> list[str]:
         """Return a list of entrypoints serialized as str"""
-        return list(map(str, self.entrypoints))
+        return sorted(map(str, self.entrypoints))
 
     def _merge(self, other: PeerInfo) -> None:
         """Actual merge execution, must only be made after verifications."""
-        # Merge entrypoints.
-        for ep in other.entrypoints:
-            if ep not in self.entrypoints:
-                self.entrypoints.append(ep)
+        self.entrypoints.update(other.entrypoints)
 
     async def validate_entrypoint(self, protocol: HathorProtocol) -> bool:
         """ Validates if connection entrypoint is one of the peer entrypoints
@@ -237,7 +234,7 @@ class UnverifiedPeer:
         It is to create an UnverifiedPeer from a peer connection.
         """
         peer_id = PeerId(data['id'])
-        endpoints = []
+        endpoints = set()
 
         for endpoint_str in data.get('entrypoints', []):
             # We have to parse using PeerEndpoint to be able to support older peers that still
@@ -245,12 +242,14 @@ class UnverifiedPeer:
             endpoint = PeerEndpoint.parse(endpoint_str)
             if endpoint.peer_id is not None and endpoint.peer_id != peer_id:
                 raise ValueError(f'conflicting peer_id: {endpoint.peer_id} != {peer_id}')
-            endpoints.append(endpoint.addr)
+            endpoints.add(endpoint.addr)
 
-        return cls(
+        obj = cls(
             id=peer_id,
             info=PeerInfo(entrypoints=endpoints),
         )
+        obj.validate()
+        return obj
 
     def merge(self, other: UnverifiedPeer) -> None:
         """ Merge two UnverifiedPeer objects, checking that they have the same
@@ -259,6 +258,12 @@ class UnverifiedPeer:
         """
         assert self.id == other.id
         self.info._merge(other.info)
+        self.validate()
+
+    def validate(self) -> None:
+        """Check if there are too many entrypoints."""
+        if len(self.info.entrypoints) > self.info._settings.PEER_MAX_ENTRYPOINTS:
+            raise InvalidPeerIdException('too many entrypoints')
 
 
 @dataclass(slots=True)

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -37,6 +37,6 @@ class BootstrapPeerDiscovery(PeerDiscovery):
         self.entrypoints = entrypoints
 
     @override
-    async def discover_and_connect(self, connect_to: Callable[[PeerEndpoint], None]) -> None:
+    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
         for entrypoint in self.entrypoints:
-            connect_to(entrypoint)
+            connect_to_endpoint(entrypoint)

--- a/hathor/p2p/peer_discovery/dns.py
+++ b/hathor/p2p/peer_discovery/dns.py
@@ -53,13 +53,13 @@ class DNSPeerDiscovery(PeerDiscovery):
         return lookupText(host)
 
     @override
-    async def discover_and_connect(self, connect_to: Callable[[PeerEndpoint], None]) -> None:
+    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
         """ Run DNS lookup for host and connect to it
             This is executed when starting the DNS Peer Discovery and first connecting to the network
         """
         for host in self.hosts:
             for entrypoint in (await self.dns_seed_lookup(host)):
-                connect_to(entrypoint)
+                connect_to_endpoint(entrypoint)
 
     async def dns_seed_lookup(self, host: str) -> set[PeerEndpoint]:
         """ Run a DNS lookup for TXT, A, and AAAA records and return a list of connection strings.

--- a/hathor/p2p/peer_discovery/peer_discovery.py
+++ b/hathor/p2p/peer_discovery/peer_discovery.py
@@ -23,10 +23,10 @@ class PeerDiscovery(ABC):
     """
 
     @abstractmethod
-    async def discover_and_connect(self, connect_to: Callable[[PeerEndpoint], None]) -> None:
-        """ This method must discover the peers and call `connect_to` for each of them.
+    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
+        """ This method must discover the peers and call `connect_to_endpoint` for each of them.
 
-        :param connect_to: Function which will be called for each discovered peer.
-        :type connect_to: function
+        :param connect_to_endpoint: Function which will be called for each discovered peer.
+        :type connect_to_endpoint: function
         """
         raise NotImplementedError

--- a/hathor/p2p/resources/add_peers.py
+++ b/hathor/p2p/resources/add_peers.py
@@ -86,7 +86,7 @@ class AddPeersResource(Resource):
 
         pd = BootstrapPeerDiscovery(filtered_peers)
         # this fires and forget the coroutine, which is compatible with the original behavior
-        coro = pd.discover_and_connect(self.manager.connections.connect_to)
+        coro = pd.discover_and_connect(self.manager.connections.connect_to_endpoint)
         Deferred.fromCoroutine(coro)
 
         ret = {'success': True, 'peers': [str(p) for p in filtered_peers]}

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -187,7 +187,7 @@ class ReadyState(BaseState):
         for data in received_peers:
             peer = UnverifiedPeer.create_from_json(data)
             if self.protocol.connections:
-                self.protocol.connections.on_receive_peer(peer, origin=self)
+                self.protocol.on_receive_peer(peer)
         self.log.debug('received peers', payload=payload)
 
     def send_ping_if_necessary(self) -> None:

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -275,9 +275,10 @@ class FakeConnection:
         self._proto1 = self.manager1.connections.server_factory.buildProtocol(self.addr2)
         self._proto2 = self.manager2.connections.client_factory.buildProtocol(self.addr1)
 
-        # When _fake_bootstrap_id is set we don't pass the peer because that's how bootstrap calls connect_to()
+        # When _fake_bootstrap_id is set we don't pass the peer because that's how bootstrap calls
+        # connect_to_endpoint()
         peer = self._proto1.my_peer.to_unverified_peer() if self._fake_bootstrap_id is False else None
-        self.manager2.connections.connect_to(self.entrypoint, peer)
+        self.manager2.connections.connect_to_endpoint(self.entrypoint, peer)
 
         connecting_peers = list(self.manager2.connections.connecting_peers.values())
         for connecting_peer in connecting_peers:

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -72,7 +72,7 @@ class BaseMetricsTest(unittest.TestCase):
         # Execution
         endpoint = PeerEndpoint.parse('tcp://127.0.0.1:8005')
         # This will trigger sending to the pubsub one of the network events
-        manager.connections.connect_to(endpoint, use_ssl=True)
+        manager.connections.connect_to_endpoint(endpoint, use_ssl=True)
 
         self.run_to_completion()
 

--- a/tests/p2p/test_bootstrap.py
+++ b/tests/p2p/test_bootstrap.py
@@ -19,10 +19,10 @@ class MockPeerDiscovery(PeerDiscovery):
         self.mocked_host_ports = mocked_host_ports
 
     @override
-    async def discover_and_connect(self, connect_to: Callable[[PeerEndpoint], None]) -> None:
+    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
         for host, port in self.mocked_host_ports:
             addr = PeerAddress(Protocol.TCP, host, port)
-            connect_to(addr.with_id())
+            connect_to_endpoint(addr.with_id())
 
 
 class MockDNSPeerDiscovery(DNSPeerDiscovery):

--- a/tests/p2p/test_connections.py
+++ b/tests/p2p/test_connections.py
@@ -18,7 +18,7 @@ class ConnectionsTest(unittest.TestCase):
         manager: HathorManager = self.create_peer('testnet', enable_sync_v1=True, enable_sync_v2=False)
 
         endpoint = PeerEndpoint.parse('tcp://127.0.0.1:8005')
-        manager.connections.connect_to(endpoint, use_ssl=True)
+        manager.connections.connect_to_endpoint(endpoint, use_ssl=True)
 
         self.assertIn(endpoint, manager.connections.iter_not_ready_endpoints())
         self.assertNotIn(endpoint, manager.connections.iter_ready_connections())
@@ -36,7 +36,7 @@ class ConnectionsTest(unittest.TestCase):
         )
 
         endpoint = PeerEndpoint.parse('tcp://[::1]:8005')
-        manager.connections.connect_to(endpoint, use_ssl=True)
+        manager.connections.connect_to_endpoint(endpoint, use_ssl=True)
 
         self.assertNotIn(endpoint, manager.connections.iter_not_ready_endpoints())
         self.assertNotIn(endpoint, manager.connections.iter_ready_connections())
@@ -54,10 +54,10 @@ class ConnectionsTest(unittest.TestCase):
         )
 
         endpoint_ipv6 = PeerEndpoint.parse('tcp://[::3:2:1]:8005')
-        manager.connections.connect_to(endpoint_ipv6, use_ssl=True)
+        manager.connections.connect_to_endpoint(endpoint_ipv6, use_ssl=True)
 
         endpoint_ipv4 = PeerEndpoint.parse('tcp://1.2.3.4:8005')
-        manager.connections.connect_to(endpoint_ipv4, use_ssl=True)
+        manager.connections.connect_to_endpoint(endpoint_ipv4, use_ssl=True)
 
         self.assertIn(
             endpoint_ipv4.addr.host,
@@ -84,7 +84,7 @@ class ConnectionsTest(unittest.TestCase):
         )
 
         endpoint = PeerEndpoint.parse('tcp://127.0.0.1:8005')
-        manager.connections.connect_to(endpoint, use_ssl=True)
+        manager.connections.connect_to_endpoint(endpoint, use_ssl=True)
 
         self.assertEqual(0, len(list(manager.connections.iter_not_ready_endpoints())))
         self.assertEqual(0, len(list(manager.connections.iter_ready_connections())))

--- a/tests/p2p/test_connectivity.py
+++ b/tests/p2p/test_connectivity.py
@@ -1,0 +1,56 @@
+import time
+import urllib
+from contextlib import contextmanager
+from typing import Generator
+
+import requests
+
+from tests.utils import run_server
+
+
+@contextmanager
+def _run_servers_context(count: int) -> Generator[list[tuple[str, str]], None, None]:
+    """ Runs `count` number of `test.utils.run_server` that bootstrap in chain, yields a (endpoint, status_url) list.
+    """
+    if count > 80:
+        raise ValueError('cannot start more than 80 processes at once')
+    start_port = 8005
+    endpoint_and_status_urls = []
+    processes = []
+    try:
+        previous_endpoint: None | str = None
+        for listen_port in range(start_port, start_port + count):
+            status_port = listen_port + 80
+            endpoint = f'tcp://127.0.0.1:{listen_port}'
+            status_url = f'http://127.0.0.1:{status_port}'
+            # XXX: it's important for run_server to be inside the try because if it fails it will still terminate the
+            # ones that were previously started because they would have made it into the processes list
+            processes.append(run_server(listen=listen_port, status=status_port, bootstrap=previous_endpoint))
+            endpoint_and_status_urls.append((endpoint, status_url))
+            previous_endpoint = endpoint
+        yield endpoint_and_status_urls
+    finally:
+        for process in processes:
+            # XXX: this assumes process.terminate() will not fail
+            process.terminate()
+
+
+def test_manager_connection_transitivity() -> None:
+    """ Creates a chain of 4 peers that bootstrap to the previous one, they should all connect to each other.
+    """
+    with _run_servers_context(4) as endpoint_status_pairs:
+        assert len(endpoint_status_pairs) == 4
+        time.sleep(1)  # 1 sec should be more than enough for the peers to connect to themselves
+
+        statuses = [
+            requests.get(urllib.parse.urljoin(status_url, '/v1a/status/')).json()
+            for _, status_url in endpoint_status_pairs
+        ]
+
+        all_peer_ids = set(status['server']['id'] for status in statuses)
+
+        for status in statuses:
+            peer_id = status['server']['id']
+            all_other_peer_ids = all_peer_ids - {peer_id}
+            connected_peer_ids = {i['id'] for i in status['connections']['connected_peers']}
+            assert all_other_peer_ids == connected_peer_ids

--- a/tests/p2p/test_peer_id.py
+++ b/tests/p2p/test_peer_id.py
@@ -72,7 +72,7 @@ class PeerIdTest(unittest.TestCase):
 
     def test_merge_peer(self) -> None:
         # Testing peer storage with merge of peers
-        peer_storage = VerifiedPeerStorage()
+        peer_storage = VerifiedPeerStorage(rng=self.rng, max_size=100)
 
         p1 = PrivatePeer.auto_generated()
         p2 = PrivatePeer.auto_generated()
@@ -86,19 +86,19 @@ class PeerIdTest(unittest.TestCase):
         peer = peer_storage[p1.id]
         self.assertEqual(peer.id, p1.id)
         self.assertEqual(peer.public_key, p1.public_key)
-        self.assertEqual(peer.info.entrypoints, [])
+        self.assertEqual(peer.info.entrypoints, set())
 
         ep1 = PeerAddress.parse('tcp://127.0.0.1:1001')
         ep2 = PeerAddress.parse('tcp://127.0.0.1:1002')
         ep3 = PeerAddress.parse('tcp://127.0.0.1:1003')
 
         p3 = PrivatePeer.auto_generated().to_public_peer()
-        p3.info.entrypoints.append(ep1)
-        p3.info.entrypoints.append(ep2)
+        p3.info.entrypoints.add(ep1)
+        p3.info.entrypoints.add(ep2)
 
         p4 = PublicPeer(UnverifiedPeer(id=p3.id), public_key=p3.public_key)
-        p4.info.entrypoints.append(ep2)
-        p4.info.entrypoints.append(ep3)
+        p4.info.entrypoints.add(ep2)
+        p4.info.entrypoints.add(ep3)
         peer_storage.add_or_merge(p4)
 
         self.assertEqual(len(peer_storage), 2)
@@ -213,16 +213,16 @@ class PeerIdTest(unittest.TestCase):
 
         peer_json_simple = dict(
             id=str(peer_id),
-            entrypoints=[addr1, addr2, addr3]
+            entrypoints=sorted({addr1, addr2, addr3})
         )
         result = UnverifiedPeer.create_from_json(peer_json_simple)
 
         assert result.id == peer_id
-        assert result.info.entrypoints == [
+        assert result.info.entrypoints == {
             PeerAddress.parse(addr1),
             PeerAddress.parse(addr2),
             PeerAddress.parse(addr3),
-        ]
+        }
         assert result.to_json() == peer_json_simple
 
         # We support this for compatibility with old peers that may send ids in the URLs
@@ -237,11 +237,11 @@ class PeerIdTest(unittest.TestCase):
         result = UnverifiedPeer.create_from_json(peer_json_with_ids)
 
         assert result.id == peer_id
-        assert result.info.entrypoints == [
+        assert result.info.entrypoints == {
             PeerAddress.parse(addr1),
             PeerAddress.parse(addr2),
             PeerAddress.parse(addr3),
-        ]
+        }
         assert result.to_json() == peer_json_simple  # the roundtrip erases the ids from the URLs
 
         other_peer_id = PrivatePeer.auto_generated().id

--- a/tests/p2p/test_peer_storage.py
+++ b/tests/p2p/test_peer_storage.py
@@ -1,0 +1,30 @@
+import pytest
+
+from hathor.p2p.peer_storage import UnverifiedPeerStorage, VerifiedPeerStorage
+from hathor.util import Random
+from tests.unittest import PEER_ID_POOL
+
+
+@pytest.fixture
+def rng() -> Random:
+    import secrets
+    seed = secrets.randbits(64)
+    return Random(seed)
+
+
+def test_unverified_peer_storage_max_size(rng: Random) -> None:
+    max_size = 5
+    peer_storage = UnverifiedPeerStorage(rng=rng, max_size=max_size)
+    for i in range(2 * max_size):
+        peer = PEER_ID_POOL[i].to_unverified_peer()
+        peer_storage.add(peer)
+    assert len(peer_storage) == max_size
+
+
+def test_verified_peer_storage_max_size(rng: Random) -> None:
+    max_size = 5
+    peer_storage = VerifiedPeerStorage(rng=rng, max_size=max_size)
+    for i in range(2 * max_size):
+        peer = PEER_ID_POOL[i].to_public_peer()
+        peer_storage.add(peer)
+    assert len(peer_storage) == max_size

--- a/tests/p2p/test_protocol.py
+++ b/tests/p2p/test_protocol.py
@@ -78,8 +78,8 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
     def test_peer_with_entrypoint(self) -> None:
         entrypoint_str = 'tcp://192.168.1.1:54321'
         entrypoint = PeerAddress.parse(entrypoint_str)
-        self.peer1.info.entrypoints.append(entrypoint)
-        self.peer2.info.entrypoints.append(entrypoint)
+        self.peer1.info.entrypoints.add(entrypoint)
+        self.peer2.info.entrypoints.add(entrypoint)
         self.conn.run_one_step()  # HELLO
 
         msg1 = self.conn.peek_tr1_value()
@@ -228,9 +228,9 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         entrypoint_1_ipv4 = PeerEndpoint.parse(f'tcp://192.168.1.1:{port1}')
         entrypoint_2_ipv4 = PeerEndpoint.parse(f'tcp://192.168.1.1:{port2}')
 
-        self.peer1.info.entrypoints.append(entrypoint_1_ipv6.addr)
-        self.peer1.info.entrypoints.append(entrypoint_1_ipv4.addr)
-        self.peer2.info.entrypoints.append(entrypoint_2_ipv4.addr)
+        self.peer1.info.entrypoints.add(entrypoint_1_ipv6.addr)
+        self.peer1.info.entrypoints.add(entrypoint_1_ipv4.addr)
+        self.peer2.info.entrypoints.add(entrypoint_2_ipv4.addr)
 
         conn = FakeConnection(manager1, manager2, addr1=addr1, addr2=addr2)
 
@@ -239,8 +239,8 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
 
         self.assertEqual(len(conn.proto1.peer.info.entrypoints), 1)
         self.assertEqual(len(conn.proto2.peer.info.entrypoints), 1)
-        self.assertEqual(conn.proto1.peer.info.entrypoints[0].host, '192.168.1.1')
-        self.assertEqual(conn.proto2.peer.info.entrypoints[0].host, '192.168.1.1')
+        self.assertEqual(next(iter(conn.proto1.peer.info.entrypoints)).host, '192.168.1.1')
+        self.assertEqual(next(iter(conn.proto2.peer.info.entrypoints)).host, '192.168.1.1')
 
     def test_hello_with_ipv6_capability(self) -> None:
         """Tests the connection between peers with the IPV6 capability.
@@ -268,9 +268,9 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         entrypoint_1_ipv4 = PeerEndpoint.parse(f'tcp://192.168.1.1:{port1}')
         entrypoint_2_ipv4 = PeerEndpoint.parse(f'tcp://192.168.1.1:{port2}')
 
-        self.peer1.info.entrypoints.append(entrypoint_1_ipv6.addr)
-        self.peer1.info.entrypoints.append(entrypoint_1_ipv4.addr)
-        self.peer2.info.entrypoints.append(entrypoint_2_ipv4.addr)
+        self.peer1.info.entrypoints.add(entrypoint_1_ipv6.addr)
+        self.peer1.info.entrypoints.add(entrypoint_1_ipv4.addr)
+        self.peer2.info.entrypoints.add(entrypoint_2_ipv4.addr)
 
         conn = FakeConnection(manager1, manager2, addr1=addr1, addr2=addr2)
 
@@ -281,7 +281,7 @@ class BaseHathorProtocolTestCase(unittest.TestCase):
         self.assertEqual(len(conn.proto2.peer.info.entrypoints), 2)
         self.assertTrue('::1' in map(lambda x: x.host, conn.proto2.peer.info.entrypoints))
         self.assertTrue('192.168.1.1' in map(lambda x: x.host, conn.proto2.peer.info.entrypoints))
-        self.assertEqual(conn.proto1.peer.info.entrypoints[0].host, '192.168.1.1')
+        self.assertEqual(next(iter(conn.proto1.peer.info.entrypoints)).host, '192.168.1.1')
 
     def test_invalid_same_peer_id(self) -> None:
         manager3 = self.create_peer(self.network, peer=self.peer1)

--- a/tests/poa/test_poa_simulation.py
+++ b/tests/poa/test_poa_simulation.py
@@ -30,6 +30,7 @@ from hathor.consensus.poa.poa_signer import PoaSignerId
 from hathor.crypto.util import get_address_b58_from_public_key_bytes, get_public_key_bytes_compressed
 from hathor.manager import HathorManager
 from hathor.simulator import FakeConnection
+from hathor.simulator.trigger import StopWhenTrue
 from hathor.transaction import BaseTransaction, Block, TxInput, TxOutput
 from hathor.transaction.genesis import generate_new_genesis
 from hathor.transaction.poa import PoaBlock
@@ -156,8 +157,8 @@ class BasePoaSimulationTest(SimulatorTestCase):
         connection = FakeConnection(manager1, manager2)
         self.simulator.add_connection(connection)
 
-        # both managers are producing blocks
-        self.simulator.run(100)
+        trigger = StopWhenTrue(lambda: manager2.tx_storage.get_block_count() == 12)
+        assert self.simulator.run(200, trigger=trigger)
         assert manager1.tx_storage.get_block_count() == 12
         assert manager2.tx_storage.get_block_count() == 12
         assert manager1.tx_storage.get_best_block_tips() == manager2.tx_storage.get_best_block_tips()

--- a/tests/resources/p2p/test_status.py
+++ b/tests/resources/p2p/test_status.py
@@ -18,13 +18,13 @@ class BaseStatusTest(_BaseResourceTest._ResourceTest):
         super().setUp()
         self.web = StubSite(StatusResource(self.manager))
         address1 = IPv4Address('TCP', '192.168.1.1', 54321)
-        self.manager.connections.my_peer.info.entrypoints.append(PeerAddress.from_address(address1))
+        self.manager.connections.my_peer.info.entrypoints.add(PeerAddress.from_address(address1))
         self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
         self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
 
         self.manager2 = self.create_peer('testnet')
         address2 = IPv4Address('TCP', '192.168.1.1', 54322)
-        self.manager2.connections.my_peer.info.entrypoints.append(PeerAddress.from_address(address2))
+        self.manager2.connections.my_peer.info.entrypoints.add(PeerAddress.from_address(address2))
         self.conn1 = FakeConnection(self.manager, self.manager2, addr1=address1, addr2=address2)
 
     @inlineCallbacks


### PR DESCRIPTION
### Motivation

Names of methods `connect_to` and `connect_to_if_not_connected` don't clearly reflect what they do, and also storing received peers in connections manager is not ideal.

### Acceptance Criteria

- Rename `connect_to` to `connect_to_endpoint`
- Rename `connect_to_if_not_connected` to `connect_to_peer`
- Move `ConnectionsManager.unverified_peer_storage` to `HathorProtocol.unverified_peer_storage`
- Add `ConnectionsManager.new_connection_from_queue` to choose which protocol to get a new peer from
- Add `lc_connect: LoopingCall` to call `connect_to_peer_from_connection_queue` and start new connections

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 