### PR TITLE
fix: acc weight regression

### DIFF
--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -22,7 +22,7 @@ import weakref
 from abc import ABC, abstractmethod
 from enum import IntEnum
 from itertools import chain
-from math import inf, isfinite, log
+from math import isfinite, log
 from struct import error as StructError, pack
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Iterator, Optional, TypeAlias, TypeVar
 
@@ -638,7 +638,12 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         self.storage.save_transaction(self, only_metadata=True)
 
-    def update_accumulated_weight(self, *, stop_value: float = inf, save_file: bool = True) -> TransactionMetadata:
+    def update_accumulated_weight(
+        self,
+        *,
+        stop_value: int | None = None,
+        save_file: bool = True,
+    ) -> TransactionMetadata:
         """Calculates the tx's accumulated weight and update its metadata.
 
         It starts at the current transaction and does a BFS to the tips. In the
@@ -656,10 +661,10 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         assert self.storage is not None
 
         metadata = self.get_metadata()
-        if metadata.accumulated_weight > stop_value:
+        if stop_value is not None and metadata.accumulated_weight > stop_value:
             return metadata
 
-        accumulated_weight = weight_to_work(self.weight)
+        work = weight_to_work(self.weight)
 
         # TODO Another optimization is that, when we calculate the acc weight of a transaction, we
         # also partially calculate the acc weight of its descendants. If it were a DFS, when returning
@@ -674,11 +679,11 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         from hathor.transaction.storage.traversal import BFSTimestampWalk
         bfs_walk = BFSTimestampWalk(self.storage, is_dag_funds=True, is_dag_verifications=True, is_left_to_right=True)
         for tx in bfs_walk.run(self, skip_root=True):
-            accumulated_weight += weight_to_work(tx.weight)
-            if accumulated_weight > stop_value:
+            work += weight_to_work(tx.weight)
+            if stop_value is not None and work > stop_value:
                 break
 
-        metadata.accumulated_weight = accumulated_weight
+        metadata.accumulated_weight = work
         if save_file:
             self.storage.save_transaction(self, only_metadata=True)
 

--- a/hathor/transaction/resources/transaction_confirmation.py
+++ b/hathor/transaction/resources/transaction_confirmation.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from math import log
+from math import log2
 from typing import Any
 
 from hathor.api_util import Resource, get_args, get_missing_params_msg, set_cors, validate_tx_hash
 from hathor.cli.openapi_files.register import register_resource
+from hathor.manager import HathorManager
 from hathor.util import json_dumpb
+from hathor.utils.weight import weight_to_work, work_to_weight
+
+N_CONFIRMATION_BLOCKS: int = 6
 
 
 @register_resource
@@ -28,7 +32,7 @@ class TransactionAccWeightResource(Resource):
     """
     isLeaf = True
 
-    def __init__(self, manager):
+    def __init__(self, manager: HathorManager) -> None:
         # Important to have the manager so we can know the tx_storage
         self.manager = manager
 
@@ -48,15 +52,21 @@ class TransactionAccWeightResource(Resource):
 
         if meta.first_block:
             block = self.manager.tx_storage.get_transaction(meta.first_block)
-            stop_value = block.weight + log(6, 2)
-            meta = tx.update_accumulated_weight(stop_value=stop_value)
-            data['accumulated_weight'] = meta.accumulated_weight
-            data['accumulated_bigger'] = meta.accumulated_weight > stop_value
+            stop_value = block.weight + log2(N_CONFIRMATION_BLOCKS)
+            meta = tx.update_accumulated_weight(stop_value=weight_to_work(stop_value))
+            acc_weight = work_to_weight(meta.accumulated_weight)
+            acc_weight_raw = str(meta.accumulated_weight)
+            data['accumulated_weight'] = acc_weight
+            data['accumulated_weight_raw'] = acc_weight_raw
+            data['accumulated_bigger'] = acc_weight > stop_value
             data['stop_value'] = stop_value
-            data['confirmation_level'] = min(meta.accumulated_weight / stop_value, 1)
+            data['confirmation_level'] = min(acc_weight / stop_value, 1)
         else:
             meta = tx.update_accumulated_weight()
-            data['accumulated_weight'] = meta.accumulated_weight
+            acc_weight = work_to_weight(meta.accumulated_weight)
+            acc_weight_raw = str(meta.accumulated_weight)
+            data['accumulated_weight'] = acc_weight
+            data['accumulated_weight_raw'] = acc_weight_raw
             data['accumulated_bigger'] = False
             data['confirmation_level'] = 0
         return data
@@ -125,7 +135,8 @@ TransactionAccWeightResource.openapi = {
                                 'success': {
                                     'summary': 'Success',
                                     'value': {
-                                        'accumulated_weight': 43237,
+                                        'accumulated_weight': 15.4,
+                                        'accumulated_weight_raw': '43238',
                                         'confirmation_level': 0.88,
                                         'stop_value': 14.5,
                                         'accumulated_bigger': True,

--- a/tests/resources/transaction/test_transaction_confirmation.py
+++ b/tests/resources/transaction/test_transaction_confirmation.py
@@ -2,7 +2,6 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.resources import TransactionAccWeightResource
-from hathor.utils.weight import weight_to_work
 from tests import unittest
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward, add_new_transactions
@@ -25,7 +24,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
         )
         data_success = response_success.json_value()
         self.assertTrue(data_success['success'])
-        self.assertEqual(data_success['accumulated_weight'], weight_to_work(genesis_tx.weight))
+        self.assertEqual(data_success['accumulated_weight'], genesis_tx.weight)
         self.assertEqual(data_success['confirmation_level'], 0)
 
         # Adding blocks to have funds
@@ -39,7 +38,7 @@ class BaseTransactionTest(_BaseResourceTest._ResourceTest):
             {b'id': bytes(tx.hash.hex(), 'utf-8')}
         )
         data_success2 = response_success2.json_value()
-        self.assertGreater(data_success2['accumulated_weight'], weight_to_work(tx.weight))
+        self.assertGreater(data_success2['accumulated_weight'], tx.weight)
         self.assertEqual(data_success2['confirmation_level'], 1)
 
         # Test sending hash that does not exist


### PR DESCRIPTION
### Motivation

The recent typing change in the `meta.accumulated_weight` introduced a regression in the `BaseTransaction.update_accumulated_weight()` method. Its implementation was not updated to consider the change. Also, the `/transaction_acc_weight` API was changed to incorrectly return work instead of weight, making it a breaking change for clients.

### Acceptance Criteria

- Fix `BaseTransaction.update_accumulated_weight()` so it correctly compares work to the provided `stop_value`.
- Fix `update_accumulated_weight()` call in the consensus which was passing the incorrect `stop_value`.
- Fix `/transaction_acc_weight` API so it returns the correct values (weight instead of work).

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 