### PR TITLE
chore(feature_activation): update start_height before release

### DIFF
--- a/hathor/conf/testnet.py
+++ b/hathor/conf/testnet.py
@@ -100,11 +100,11 @@ SETTINGS = HathorSettings(
             # NOP feature to test Feature Activation for Transactions
             Feature.NOP_FEATURE_1: Criteria(
                 bit=0,
-                # N = 4_394_880
-                # start_height expected to be reached around Sunday, 2024-12-01.
-                # Right now the best block is 4_377_375 on testnet (2024-11-25).
-                start_height=4_394_880,  # N
-                timeout_height=4_475_520,  # N + 4 * 20160 (4 weeks after the start)
+                # N = 4_495_680
+                # Expected to be reached around Tuesday, 2025-01-06.
+                # Right now the best block is 4_489_259 on testnet (2025-01-03).
+                start_height=4_495_680,  # N
+                timeout_height=4_576_320,  # N + 4 * 20160 (4 weeks after the start)
                 minimum_activation_height=0,
                 lock_in_on_timeout=False,
                 version='0.63.0',

--- a/hathor/conf/testnet.yml
+++ b/hathor/conf/testnet.yml
@@ -81,11 +81,11 @@ FEATURE_ACTIVATION:
     # NOP feature to test Feature Activation for Transactions
     NOP_FEATURE_1:
       bit: 0
-      # N = 4_394_880
-      # start_height expected to be reached around Sunday, 2024-12-01.
-      # Right now the best block is 4_377_375 on testnet (2024-11-25).
-      start_height: 4_394_880  # N
-      timeout_height: 4_475_520  # N + 4 * 20160 (4 weeks after the start)
+      # N = 4_495_680
+      # Expected to be reached around Tuesday, 2025-01-06.
+      # Right now the best block is 4_489_259 on testnet (2025-01-03).
+      start_height: 4_495_680  # N
+      timeout_height: 4_576_320  # N + 4 * 20160 (4 weeks after the start)
       minimum_activation_height: 0
       lock_in_on_timeout: false
       version: 0.63.0


### PR DESCRIPTION
### Motivation

The original test window for the transaction feature activation on testnet has passed.

### Acceptance Criteria

- Move the time window to the present.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 