### PR TITLE
chore(p2p): decrease p2p.max_enabled_sync's default value: 16 -> 8

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -403,7 +403,7 @@ class HathorSettings(NamedTuple):
     PARTIALLY_VALIDATED_ID: bytes = b'pending-validation'
 
     # Maximum number of sync running simultaneously.
-    MAX_ENABLED_SYNC: int = 16
+    MAX_ENABLED_SYNC: int = 8
 
     # Time to update the peers that are running sync.
     SYNC_UPDATE_INTERVAL: int = 10 * 60  # seconds


### PR DESCRIPTION
### Motivation

The default value of 16 can be slower than expected in certain cases.

### Acceptance Criteria

- Reduce the default value to 8, it can still be adjusted through the settings and even in runtime through sysctl.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 