### PR TITLE
fix(ws): Fix JSON decode error on invalid commands

### DIFF
--- a/hathor/websocket/messages.py
+++ b/hathor/websocket/messages.py
@@ -23,6 +23,12 @@ class WebSocketMessage(BaseModel):
     pass
 
 
+class WebSocketErrorMessage(WebSocketMessage):
+    type: str = Field('error', const=True)
+    success: bool = Field(False, const=True)
+    errmsg: str
+
+
 class CapabilitiesMessage(WebSocketMessage):
     type: str = Field('capabilities', const=True)
     capabilities: list[str]


### PR DESCRIPTION
### Motivation

Fix an unhandled exception when a websocket command was malformed.

### Acceptance Criteria

1. Send a `WebsocketErrorMessage` when a command is malformed.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 