### PR TITLE
fix(ws): Slow empty address verification on address subscription

### DIFF
--- a/hathor/websocket/protocol.py
+++ b/hathor/websocket/protocol.py
@@ -56,6 +56,7 @@ class HathorAdminWebsocketProtocol(WebSocketServerProtocol):
         super().__init__()
 
         self.subscribed_to: set[str] = set()
+        self.empty_addresses: set[str] = set()
 
         # Enable/disable history streaming for this connection.
         self.is_history_streaming_enabled = is_history_streaming_enabled


### PR DESCRIPTION
### Motivation

The current implementation of empty addresses was too slow. It was running in O(n) where n is the number of subscribed addresses. So, the time complexity to load a wallet was O(n^2) because the check was executed for each address.

This PR reduces the time complexity to O(m) where m is the number of empty addresses. So, the load time is reduced to O(nm). Notice that `m < n / gap_limit`.

### Acceptance Criteria

1. Add a separate list of empty addresses.
2. On address subscription, add empty addresses to the empty address set.
3. Only validate the list of empty addresses if the empty address set is greater than the limit.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 