### PR TITLE
fix(dag_builder): Fix generating two or more vertices with the same hash

### DIFF
--- a/tests/dag_builder/test_dag_builter.py
+++ b/tests/dag_builder/test_dag_builter.py
@@ -203,3 +203,18 @@ class DAGCreatorTestCase(unittest.TestCase):
 
         for node, vertex in artifacts.list:
             self.manager.on_new_tx(vertex, fails_silently=False)
+
+    def test_no_hash_conflict(self) -> None:
+        artifacts = self.dag_builder.build_from_str("""
+            blockchain genesis b[1..33]
+
+            b30 < dummy
+
+            tx10.out[0] <<< tx20 tx30 tx40
+        """)
+
+        for node, vertex in artifacts.list:
+            print()
+            print(node.name)
+            print()
+            self.manager.on_new_tx(vertex, fails_silently=False)


### PR DESCRIPTION
### Motivation

If might happen that two different transactions have the same hash if their description is exactly the same. This PR fixes it by increasing the nonce.

### Acceptance Criteria

1. Assert that each transaction has a unique hash.
2. Fix conflicts by increasing the nonce.
3. Set a maximum of 100 attempts to fix conflicts. If it fails, an exception is raised.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 