### PR TITLE
tests: re-enable tests

### DIFF
--- a/tests/event/test_event_simulation_responses.py
+++ b/tests/event/test_event_simulation_responses.py
@@ -23,6 +23,8 @@ from tests.event.event_simulation_tester import (
 
 
 class BaseEventSimulationResponsesTest(BaseEventSimulationTester):
+    __test__ = False
+
     def test_no_start_no_blocks(self) -> None:
         self.simulator.run(36000)
 

--- a/tests/event/test_event_simulation_scenarios.py
+++ b/tests/event/test_event_simulation_scenarios.py
@@ -41,6 +41,8 @@ class BaseEventSimulationScenariosTest(BaseEventSimulationTester):
     console and then copying the output and manipulating it to create instances.
     """
 
+    __test__ = False
+
     seed_config = 6946502462188444706
 
     def assert_response_equal(self, responses: list[EventResponse], expected: list[EventResponse]) -> None:

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -27,7 +27,7 @@ from tests.simulation.base import SimulatorTestCase
 from tests.utils import HAS_ROCKSDB
 
 
-class BaseRandomSimulatorTestCase(SimulatorTestCase):
+class RandomSimulatorTestCase(SimulatorTestCase):
     __test__ = True
 
     seed_config = 2

--- a/tests/simulation/base.py
+++ b/tests/simulation/base.py
@@ -7,8 +7,6 @@ from tests import unittest
 
 
 class SimulatorTestCase(unittest.TestCase):
-    __test__ = False
-
     seed_config: Optional[int] = None
 
     def setUp(self) -> None:


### PR DESCRIPTION
### Motivation

We recently removed Sync-v1 from our tests suite, and I just found out that multiple tests are not running because they don't set `__test__ = True` anymore.

### Acceptance Criteria

- Remove `__test__ = False` from the `SimulatorTestCase`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 