### PR TITLE
refactor: cleanup full verification

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -182,8 +182,6 @@ class Builder:
 
         self._enable_stratum_server: Optional[bool] = None
 
-        self._full_verification: Optional[bool] = None
-
         self._soft_voided_tx_ids: Optional[set[bytes]] = None
 
         self._execution_manager: ExecutionManager | None = None
@@ -238,9 +236,6 @@ class Builder:
             indexes.enable_utxo_index()
 
         kwargs: dict[str, Any] = {}
-
-        if self._full_verification is not None:
-            kwargs['full_verification'] = self._full_verification
 
         if self._enable_event_queue is not None:
             kwargs['enable_event_queue'] = self._enable_event_queue
@@ -776,21 +771,6 @@ class Builder:
     def disable_sync_v2(self) -> 'Builder':
         self.check_if_can_modify()
         self._sync_v2_support = SyncSupportLevel.DISABLED
-        return self
-
-    def set_full_verification(self, full_verification: bool) -> 'Builder':
-        self.check_if_can_modify()
-        self._full_verification = full_verification
-        return self
-
-    def enable_full_verification(self) -> 'Builder':
-        self.check_if_can_modify()
-        self._full_verification = True
-        return self
-
-    def disable_full_verification(self) -> 'Builder':
-        self.check_if_can_modify()
-        self._full_verification = False
         return self
 
     def enable_ipv6(self) -> 'Builder':

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -234,8 +234,6 @@ class CliBuilder:
             self.log.debug('enable utxo index')
             tx_storage.indexes.enable_utxo_index()
 
-        self.check_or_raise(not self._args.x_full_verification, '--x-full-verification is deprecated')
-
         soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
         consensus_algorithm = ConsensusAlgorithm(
             soft_voided_tx_ids,
@@ -331,7 +329,6 @@ class CliBuilder:
             wallet=self.wallet,
             checkpoints=settings.CHECKPOINTS,
             environment_info=get_environment_info(args=str(self._args), peer_id=str(peer.id)),
-            full_verification=False,
             enable_event_queue=self._args.x_enable_event_queue or self._args.enable_event_queue,
             bit_signaling_service=bit_signaling_service,
             verification_service=verification_service,

--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -61,7 +61,6 @@ def execute(args: Namespace, reactor: 'ReactorProtocol') -> None:
     simulator = Simulator(args.seed)
     simulator.start()
     builder = simulator.get_default_builder() \
-        .disable_full_verification() \
         .enable_event_queue()
 
     manager = simulator.create_peer(builder)

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -124,7 +124,6 @@ class RunNode:
         parser.add_argument('--cache-interval', type=int, help='Cache flush interval')
         parser.add_argument('--recursion-limit', type=int, help='Set python recursion limit')
         parser.add_argument('--allow-mining-without-peers', action='store_true', help='Allow mining without peers')
-        parser.add_argument('--x-full-verification', action='store_true', help=SUPPRESS)  # deprecated
         parser.add_argument('--procname-prefix', help='Add a prefix to the process name', default='')
         parser.add_argument('--allow-non-standard-script', action='store_true', help='Accept non-standard scripts on '
                             '/push-tx API')

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -59,7 +59,6 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     cache_interval: Optional[int]
     recursion_limit: Optional[int]
     allow_mining_without_peers: bool
-    x_full_verification: bool
     procname_prefix: str
     allow_non_standard_script: bool
     max_output_script_size: Optional[int]

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -359,10 +359,6 @@ class HathorSettings(NamedTuple):
     # Amount in which tx min weight reaches the middle point between the minimum and maximum weight
     MIN_TX_WEIGHT_K: int = 100
 
-    # When the node is being initialized (with a full verification) we don't verify
-    # the difficulty of all blocks, we execute the validation every N blocks only
-    VERIFY_WEIGHT_EVERY_N_BLOCKS: int = 1000
-
     # Capabilities
     CAPABILITY_WHITELIST: str = 'whitelist'
     CAPABILITY_SYNC_VERSION: str = 'sync-version'

--- a/hathor/simulator/simulator.py
+++ b/hathor/simulator/simulator.py
@@ -81,7 +81,6 @@ class Simulator:
         return Builder() \
             .set_peer(PrivatePeer.auto_generated()) \
             .set_soft_voided_tx_ids(set()) \
-            .enable_full_verification() \
             .enable_sync_v2() \
             .use_memory() \
             .set_settings(self.settings)

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -83,9 +83,6 @@ class TransactionStorage(ABC):
     # Key storage attribute to save if the network stored is the expected network
     _network_attribute: str = 'network'
 
-    # Key storage attribute to save if the full node is running a full verification
-    _running_full_verification_attribute: str = 'running_full_verification'
-
     # Key storage attribute to save if the manager is running
     _manager_running_attribute: str = 'manager_running'
 
@@ -908,22 +905,6 @@ class TransactionStorage(ABC):
         """ Save the network name
         """
         return self.add_value(self._network_attribute, network)
-
-    def start_full_verification(self) -> None:
-        """ Save full verification on storage
-        """
-        self.add_value(self._running_full_verification_attribute, '1')
-
-    def finish_full_verification(self) -> None:
-        """ Remove from storage that the full node is initializing with a full verification
-        """
-        self.remove_value(self._running_full_verification_attribute)
-
-    def is_running_full_verification(self) -> bool:
-        """ Return if the full node is initializing with a full verification
-            or was running a full verification and was stopped in the middle
-        """
-        return self.get_value(self._running_full_verification_attribute) == '1'
 
     def start_running_manager(self, execution_manager: ExecutionManager) -> None:
         """ Save on storage that manager is running

--- a/tests/event/event_simulation_tester.py
+++ b/tests/event/event_simulation_tester.py
@@ -34,7 +34,6 @@ class BaseEventSimulationTester(SimulatorTestCase):
     def _create_artifacts(self) -> None:
         peer = PrivatePeer.auto_generated()
         builder = self.builder.set_peer(peer) \
-            .disable_full_verification() \
             .enable_event_queue()
         artifacts = self.simulator.create_artifacts(builder)
 

--- a/tests/event/test_event_manager.py
+++ b/tests/event/test_event_manager.py
@@ -13,7 +13,6 @@ class EventManagerTest(unittest.TestCase):
         self.manager = self.create_peer(
             self.network,
             enable_event_queue=True,
-            full_verification=False,
             event_storage=self.event_storage
         )
 

--- a/tests/event/test_event_reorg.py
+++ b/tests/event/test_event_reorg.py
@@ -13,7 +13,6 @@ class EventReorgTest(unittest.TestCase):
         self.manager = self.create_peer(
             self.network,
             enable_event_queue=True,
-            full_verification=False,
             event_storage=self.event_storage
         )
 

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -681,8 +681,7 @@ class RocksDBStorageFeatureSimulationTest(BaseFeatureSimulationTest):
 
     def get_simulator_builder_from_dir(self, rocksdb_directory: str) -> Builder:
         return self.simulator.get_default_builder() \
-            .use_rocksdb(path=rocksdb_directory) \
-            .disable_full_verification()
+            .use_rocksdb(path=rocksdb_directory)
 
     def get_simulator_builder(self) -> Builder:
         rocksdb_directory = self.get_rocksdb_directory()

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -1,4 +1,3 @@
-import tempfile
 from typing import Iterator
 
 from hathor.conf.settings import HathorSettings
@@ -38,8 +37,8 @@ class ModifiedTransactionRocksDBStorage(TransactionRocksDBStorage):
 class SimpleManagerInitializationTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.tx_storage = ModifiedTransactionRocksDBStorage(path=self.temp_dir.name, settings=self._settings)
+        self.path = self.mkdtemp()
+        self.tx_storage = ModifiedTransactionRocksDBStorage(path=self.path, settings=self._settings)
         self.pubsub = PubSubManager(self.clock)
 
     def test_invalid_arguments(self):
@@ -98,8 +97,8 @@ class SimpleManagerInitializationTestCase(unittest.TestCase):
 class ManagerInitializationTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.tx_storage = ModifiedTransactionRocksDBStorage(path=self.temp_dir.name, settings=self._settings)
+        self.path = self.mkdtemp()
+        self.tx_storage = ModifiedTransactionRocksDBStorage(path=self.path, settings=self._settings)
         self.network = 'testnet'
         self.manager = self.create_peer(self.network, tx_storage=self.tx_storage)
 
@@ -140,7 +139,7 @@ class ManagerInitializationTestCase(unittest.TestCase):
         # a new manager must be successfully initialized
         self.manager.stop()
         self.tx_storage._rocksdb_storage.close()
-        new_storage = ModifiedTransactionRocksDBStorage(path=self.temp_dir.name, settings=self._settings)
+        new_storage = ModifiedTransactionRocksDBStorage(path=self.path, settings=self._settings)
         artifacts = self.get_builder().set_tx_storage(new_storage).build()
         artifacts.manager.start()
         self.clock.run()
@@ -165,7 +164,7 @@ class ManagerInitializationTestCase(unittest.TestCase):
         # a new manager must be successfully initialized
         self.manager.stop()
         self.tx_storage._rocksdb_storage.close()
-        new_storage = ModifiedTransactionRocksDBStorage(path=self.temp_dir.name, settings=self._settings)
+        new_storage = ModifiedTransactionRocksDBStorage(path=self.path, settings=self._settings)
         artifacts = self.get_builder().set_tx_storage(new_storage).build()
         artifacts.manager.start()
         self.clock.run()
@@ -201,7 +200,7 @@ class ManagerInitializationTestCase(unittest.TestCase):
         # create a new manager (which will initialize in the self.create_peer call)
         self.manager.stop()
         self.tx_storage._rocksdb_storage.close()
-        new_storage = ModifiedTransactionRocksDBStorage(path=self.temp_dir.name, settings=self._settings)
+        new_storage = ModifiedTransactionRocksDBStorage(path=self.path, settings=self._settings)
         artifacts = self.get_builder().set_tx_storage(new_storage).build()
         manager = artifacts.manager
         manager.start()

--- a/tests/p2p/test_sync_v2.py
+++ b/tests/p2p/test_sync_v2.py
@@ -41,7 +41,7 @@ class RandomSimulatorTestCase(SimulatorTestCase):
                     partial_blocks.add(tx.hash)
         return partial_blocks
 
-    def _run_restart_test(self, *, full_verification: bool, use_tx_storage_cache: bool) -> None:
+    def _run_restart_test(self, *, use_tx_storage_cache: bool) -> None:
         manager1 = self.create_peer()
         manager1.allow_mining_without_peers()
 
@@ -106,11 +106,6 @@ class RandomSimulatorTestCase(SimulatorTestCase):
             .set_peer(peer) \
             .use_rocksdb(path)
 
-        if full_verification:
-            builder3.enable_full_verification()
-        else:
-            builder3.disable_full_verification()
-
         if use_tx_storage_cache:
             builder3.use_tx_storage_cache()
 
@@ -146,17 +141,11 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         self.assertEqual(manager1.tx_storage.get_vertices_count(), manager3.tx_storage.get_vertices_count())
         self.assertConsensusEqualSyncV2(manager1, manager3)
 
-    def test_restart_fullnode_full_verification(self) -> None:
-        self._run_restart_test(full_verification=True, use_tx_storage_cache=False)
-
     def test_restart_fullnode_quick(self) -> None:
-        self._run_restart_test(full_verification=False, use_tx_storage_cache=False)
+        self._run_restart_test(use_tx_storage_cache=False)
 
     def test_restart_fullnode_quick_with_cache(self) -> None:
-        self._run_restart_test(full_verification=False, use_tx_storage_cache=True)
-
-    def test_restart_fullnode_full_verification_with_cache(self) -> None:
-        self._run_restart_test(full_verification=True, use_tx_storage_cache=True)
+        self._run_restart_test(use_tx_storage_cache=True)
 
     def test_exceeds_streaming_and_mempool_limits(self) -> None:
         manager1 = self.create_peer()

--- a/tests/poa/test_poa_simulation.py
+++ b/tests/poa/test_poa_simulation.py
@@ -75,7 +75,7 @@ def _assert_height_weight_signer_id(
 
 class PoaSimulationTest(SimulatorTestCase):
     def _get_manager(self, signer: PoaSigner | None = None) -> HathorManager:
-        builder = self.simulator.get_default_builder().disable_full_verification()
+        builder = self.simulator.get_default_builder()
         if signer:
             builder.set_poa_signer(signer)
         artifacts = self.simulator.create_artifacts(builder)
@@ -419,8 +419,7 @@ class PoaSimulationTest(SimulatorTestCase):
 
         builder_1b = self.simulator.get_default_builder() \
             .set_tx_storage(storage_1a) \
-            .set_poa_signer(signer1) \
-            .disable_full_verification()
+            .set_poa_signer(signer1)
         artifacts_1b = self.simulator.create_artifacts(builder_1b)
         manager_1b = artifacts_1b.manager
         manager_1b.allow_mining_without_peers()

--- a/tests/tx/test_tx_storage.py
+++ b/tests/tx/test_tx_storage.py
@@ -568,13 +568,6 @@ class BaseTransactionStorageTest(unittest.TestCase):
         yield gatherResults(deferreds)
         self.tx_storage._disable_weakref()
 
-    def test_full_verification_attribute(self):
-        self.assertFalse(self.tx_storage.is_running_full_verification())
-        self.tx_storage.start_full_verification()
-        self.assertTrue(self.tx_storage.is_running_full_verification())
-        self.tx_storage.finish_full_verification()
-        self.assertFalse(self.tx_storage.is_running_full_verification())
-
     def test_key_value_attribute(self):
         attr = 'test'
         val = 'a'

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -194,7 +194,6 @@ class TestCase(unittest.TestCase):
         unlock_wallet: bool = True,
         wallet_index: bool = False,
         capabilities: list[str] | None = None,
-        full_verification: bool = True,
         checkpoints: list[Checkpoint] | None = None,
         utxo_index: bool = False,
         event_manager: EventManager | None = None,
@@ -210,7 +209,6 @@ class TestCase(unittest.TestCase):
 
         settings = self._settings._replace(NETWORK_NAME=network)
         builder = self.get_builder() \
-            .set_full_verification(full_verification) \
             .set_settings(settings)
 
         if checkpoints is not None:


### PR DESCRIPTION
### Motivation

Recent PR https://github.com/HathorNetwork/hathor-core/pull/1206 deprecated `--x-full-verification`, but its code was not cleaned up. This PR does this.

### Acceptance Criteria

- Remove all mentions to full verification.
- Rename `HathorManager._initialize_components_new()` to `_initialize_components()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 