### PR TITLE
fix(cli): regression on `run_node --help`

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -66,6 +66,11 @@ class CliBuilder:
         if not condition:
             raise BuilderError(message)
 
+    def check_or_warn(self, condition: bool, message: str) -> None:
+        """Will log a warning `message` if `condition` is False."""
+        if not condition:
+            self.log.warn(message)
+
     def create_manager(self, reactor: Reactor) -> HathorManager:
         import hathor
         from hathor.builder import SyncSupportLevel
@@ -190,20 +195,13 @@ class CliBuilder:
 
         hostname = self.get_hostname()
 
-        if self._args.sync_bridge:
-            raise BuilderError('--sync-bridge was removed')
-        elif self._args.sync_v1_only:
-            raise BuilderError('--sync-v1-only was removed')
-        elif self._args.sync_v2_only:
-            self.log.warn('--sync-v2-only is the default, this parameter has no effect')
-        elif self._args.x_remove_sync_v1:
-            self.log.warn('--x-remove-sync-v1 is deprecated and has no effect')
-        elif self._args.x_sync_bridge:
-            raise BuilderError('--x-sync-bridge was removed')
-        elif self._args.x_sync_v1_only:
-            raise BuilderError('--x-sync-v1-only was removed')
-        elif self._args.x_sync_v2_only:
-            self.log.warn('--x-sync-v2-only is deprecated and will be removed')
+        self.check_or_raise(not self._args.sync_bridge, '--sync-bridge was removed')
+        self.check_or_raise(not self._args.sync_v1_only, '--sync-v1-only was removed')
+        self.check_or_raise(not self._args.x_sync_bridge, '--x-sync-bridge was removed')
+        self.check_or_raise(not self._args.x_sync_v1_only, '--x-sync-v1-only was removed')
+        self.check_or_warn(not self._args.sync_v2_only, '--sync-v2-only is the default, this parameter has no effect')
+        self.check_or_warn(not self._args.x_remove_sync_v1, '--x-remove-sync-v1 is deprecated and has no effect')
+        self.check_or_warn(not self._args.x_sync_v2_only, '--x-sync-v2-only is deprecated and will be removed')
 
         pubsub = PubSubManager(reactor)
 

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -124,8 +124,7 @@ class RunNode:
         parser.add_argument('--cache-interval', type=int, help='Cache flush interval')
         parser.add_argument('--recursion-limit', type=int, help='Set python recursion limit')
         parser.add_argument('--allow-mining-without-peers', action='store_true', help='Allow mining without peers')
-        fvargs = parser.add_mutually_exclusive_group()
-        fvargs.add_argument('--x-full-verification', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--x-full-verification', action='store_true', help=SUPPRESS)  # deprecated
         parser.add_argument('--procname-prefix', help='Add a prefix to the process name', default='')
         parser.add_argument('--allow-non-standard-script', action='store_true', help='Accept non-standard scripts on '
                             '/push-tx API')
@@ -134,14 +133,13 @@ class RunNode:
         parser.add_argument('--sentry-dsn', help='Sentry DSN')
         parser.add_argument('--enable-debug-api', action='store_true', help='Enable _debug/* endpoints')
         parser.add_argument('--enable-crash-api', action='store_true', help='Enable _crash/* endpoints')
-        sync_args = parser.add_mutually_exclusive_group()
-        sync_args.add_argument('--sync-bridge', action='store_true', help=SUPPRESS)  # deprecated
-        sync_args.add_argument('--sync-v1-only', action='store_true', help=SUPPRESS)  # deprecated
-        sync_args.add_argument('--sync-v2-only', action='store_true', help=SUPPRESS)  # deprecated
-        sync_args.add_argument('--x-remove-sync-v1', action='store_true', help=SUPPRESS)  # deprecated
-        sync_args.add_argument('--x-sync-v1-only', action='store_true', help=SUPPRESS)  # deprecated
-        sync_args.add_argument('--x-sync-v2-only', action='store_true', help=SUPPRESS)  # deprecated
-        sync_args.add_argument('--x-sync-bridge', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--sync-bridge', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--sync-v1-only', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--sync-v2-only', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--x-remove-sync-v1', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--x-sync-v1-only', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--x-sync-v2-only', action='store_true', help=SUPPRESS)  # deprecated
+        parser.add_argument('--x-sync-bridge', action='store_true', help=SUPPRESS)  # deprecated
         parser.add_argument('--x-localhost-only', action='store_true', help='Only connect to peers on localhost')
         parser.add_argument('--x-rocksdb-indexes', action='store_true', help=SUPPRESS)
         parser.add_argument('--x-enable-event-queue', action='store_true',

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -23,3 +23,27 @@ class CliMainTest(unittest.TestCase):
 
         # 3 is the number of prints we have without any command
         self.assertTrue(len(output) >= 3)
+
+    def test_help(self):
+        import sys
+
+        # basically making sure importing works
+        cli = main.CliManager()
+
+        # Help method only prints on the screen
+        # So just making sure it has no errors
+        f = StringIO()
+        with self.assertRaises(SystemExit) as cm:
+            with capture_logs():
+                with redirect_stdout(f):
+                    sys.argv = ['hathor-core', 'run_node', '--help']
+                    cli.execute_from_command_line()
+
+        # Must exit with code 0
+        self.assertEqual(cm.exception.args[0], 0)
+
+        # Transforming prints str in array
+        output = f.getvalue().strip().splitlines()
+
+        # The help output will normally contain at least 80 lines
+        self.assertGreaterEqual(len(output), 80)


### PR DESCRIPTION
### Motivation

Doing `python -m hathor run_node --help` broke in some cases due to a bug in some versions of argparse.

### Acceptance Criteria

- Remove all mutually exclusive groups where all arguments have `help=SUPRESS`, but keep the arguments in the base parser
- Add a test that runs the CLI's help and have a basic sanity check (exit code 0 and at least 80 lines)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 