### PR TITLE
fix(metrics): websocket metrics was not being updated

### DIFF
--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -323,6 +323,7 @@ class ResourcesBuilder:
 
         # Set websocket factory in metrics. It'll be started when the manager is started.
         self.manager.websocket_factory = ws_factory
+        self.manager.metrics.websocket_factory = ws_factory
 
         self._built_status = True
         return status_server


### PR DESCRIPTION
### Motivation

Fixes #1204

### Acceptance Criteria

- When setting the `websocket_factory` on the `CliBuilder` also update the `manager.metrics` otherwise it will remain `None` and not be able to observe the stats

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 