### PR TITLE
feat(vertex_handler): Improve new vertex log

### DIFF
--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -237,10 +237,16 @@ class VertexHandler:
         if self._log_vertex_bytes:
             kwargs['bytes'] = bytes(tx).hex()
         if isinstance(tx, Block):
-            message = message_fmt.format('block')
+            if not metadata.voided_by:
+                message = message_fmt.format('block')
+            else:
+                message = message_fmt.format('voided block')
             kwargs['_height'] = tx.get_height()
         else:
-            message = message_fmt.format('tx')
+            if not metadata.voided_by:
+                message = message_fmt.format('tx')
+            else:
+                message = message_fmt.format('voided tx')
         if not quiet:
             log_func = self._log.info
         else:


### PR DESCRIPTION
### Motivation

As a node operator, having access to detailed log information is crucial for understanding the behavior of the system. Currently, log entries for block and tx events do not specify whether those blocks or transactions are valid or have been voided. This lack of clarity can create confusion—one might see multiple block log entries and incorrectly assume that mining is proceeding normally, when in fact those blocks could be voided.

### Acceptance Criteria

1. Update the log messages so they explicitly differentiate between voided and non-voided vertices.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 