### PR TITLE
Feat/poc connection pool slots

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -291,6 +291,14 @@ class HathorSettings(NamedTuple):
     # Maximum number of entrypoints that we accept that a peer broadcasts
     PEER_MAX_ENTRYPOINTS: int = 30
 
+    # Maximum number of other peers's entrypoints a given node may connect to.
+    # It does not include the discovered peers connections nor the check trust slots.
+    PEER_MAX_OUTGOING_CONNECTIONS: int = 60
+
+    # Maximum number of other entrypoints a peer may connect to for checking other peers' trustworthiness.
+    # The discovered peers slot is left bound by PEER_MAX_CONNECTIONS.
+    PEER_MAX_CHECK_PEER_CONNECTIONS: int = 10
+
     # Filepath of ca certificate file to generate connection certificates
     CA_FILEPATH: str = os.path.join(os.path.dirname(__file__), '../p2p/ca.crt')
 

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -299,6 +299,15 @@ class HathorSettings(NamedTuple):
     # The discovered peers slot is left bound by PEER_MAX_CONNECTIONS.
     PEER_MAX_CHECK_PEER_CONNECTIONS: int = 10
 
+    # Maximum number of connections for discovered peers after bootstrap.
+    PEER_MAX_DISCOVERED_PEERS_CONNECTIONS: int = PEER_MAX_CONNECTIONS - PEER_MAX_ENTRYPOINTS 
+    - PEER_MAX_OUTGOING_CONNECTIONS - PEER_MAX_OUTGOING_CONNECTIONS 
+    
+    # Safeguard check
+    if PEER_MAX_DISCOVERED_PEERS_CONNECTIONS <= 0:
+        raise Exception("PEER_MAX_DISCOVERED_PEERS_CONNECTIONS must be bigger than zero.")
+
+
     # Filepath of ca certificate file to generate connection certificates
     CA_FILEPATH: str = os.path.join(os.path.dirname(__file__), '../p2p/ca.crt')
 

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -141,6 +141,18 @@ class ConnectionsManager:
         # Global maximum number of connections.
         self.max_connections: int = self._settings.PEER_MAX_CONNECTIONS
 
+        # Maximum number of incoming connections.
+        self.max_incoming_connections: int = self._settings.PEER_MAX_ENTRYPOINTS
+
+        # Maximum number of outgoing connections. 
+        self.max_outgoing_connections: int = self._settings.PEER_MAX_OUTGOING_CONNECTIONS
+
+        # Maximum number of connections for untrustworthy peers checking.
+        self.max_check_peers_connections: int = self._settings.PEER_MAX_CHECK_PEER_CONNECTIONS
+
+        # Maximum connections for discovered peers:
+        self.max_discovered_peers_connections: int = self._settings.PEER_MAX_DISCOVERED_PEERS_CONNECTIONS
+
         # Global rate limiter for all connections.
         self.rate_limiter = RateLimiter(self.reactor)
         self.enable_rate_limiter()

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -462,7 +462,7 @@ class ConnectionsManager:
                 self.log.warn('reached maximum number of CHECK_PEERS connections', max_connections=self.max_check_peers_connections )
                 protocol.disconnect(force=True)
                 return 
-            self.check_entrypoint_connectionss.add(protocol)
+            self.check_entrypoint_connections.add(protocol)
         elif protocol.discovered:
             if len(self.discovered_connections) >= self.max_discovered_peers_connections:
                 self.log.warn('reached maximum number of DISCOVERED connections', max_connections=self.max_discovered_peers_connections )

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -385,7 +385,11 @@ class ConnectionsManager:
             len(self.connecting_peers),
             len(self.handshaking_peers),
             len(self.connected_peers),
-            len(self.verified_peer_storage)
+            len(self.verified_peer_storage),
+            len(self.incoming_connections),
+            len(self.outgoing_connections),
+            len(self.check_entrypoint_connections),
+            len(self.discovered_connections)
         )
 
     def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -105,6 +105,8 @@ class HathorProtocol:
         settings: HathorSettings,
         use_ssl: bool,
         inbound: bool,
+        
+        check_entrypoint: bool,
     ) -> None:
         self._settings = settings
         self.my_peer = my_peer
@@ -118,6 +120,9 @@ class HathorProtocol:
 
         # Indicate whether it is an inbound connection (true) or an outbound connection (false).
         self.inbound = inbound
+
+        # Connection to check a specific entrypoint to be trustworthy or not.
+        self.check_entrypoint = check_entrypoint
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -125,7 +125,7 @@ class HathorProtocol:
         self.check_entrypoint = check_entrypoint
 
         # Flag of this connection belonging to a discovered peer.
-        self.discovered_connection = discovered
+        self.discovered = discovered
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -105,7 +105,7 @@ class HathorProtocol:
         settings: HathorSettings,
         use_ssl: bool,
         inbound: bool,
-        
+        discovered: bool,
         check_entrypoint: bool,
     ) -> None:
         self._settings = settings
@@ -123,6 +123,9 @@ class HathorProtocol:
 
         # Connection to check a specific entrypoint to be trustworthy or not.
         self.check_entrypoint = check_entrypoint
+
+        # Flag of this connection belonging to a discovered peer.
+        self.discovered_connection = discovered
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT


### PR DESCRIPTION
### Motivation

Slotting the connections of the p2p network into types ( incoming, outgoing, discovered and check_peers) and set a limit for each, in order to avoid cross-flooding of features by malicious attackers, which may jam all types of connections by flooding one type.

### Acceptance Criteria

The full node must accept at most N incoming connections.
The full node must open at most M outgoing connections to verified entry points.
The full node must keep at most P connections to discovered peers.
The full node must have slots available to check for untrusted entry points.
The full node must cycle through outgoing and incoming connections. (this one was demoted in a meeting, to be its own pr/rfc).


### Checklist
- Note: Solely a DRAFT, as there are still implementations to be done, mainly some refactorings. This is being pulled EXCLUSIVELY for draft revision, not yet to be merged for production. 