### PR TITLE
Draft - Connection Pool Slots - Enum Refactor

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -24,6 +24,7 @@ from hathor.consensus.consensus_settings import ConsensusSettings, PowSettings
 from hathor.feature_activation.settings import Settings as FeatureActivationSettings
 from hathor.utils import yaml
 from hathor.utils.named_tuple import validated_named_tuple_from_dict
+from enum import Enum
 
 DECIMAL_PLACES = 2
 
@@ -307,6 +308,12 @@ class HathorSettings(NamedTuple):
     if PEER_MAX_DISCOVERED_PEERS_CONNECTIONS <= 0:
         raise Exception("PEER_MAX_DISCOVERED_PEERS_CONNECTIONS must be bigger than zero.")
 
+    class ConnectionType(Enum):
+        # Types of Connection as inputs for an instance of the Hathor Protocol
+        OUTGOING = 0
+        INCOMING = 1
+        DISCOVERED = 2
+        CHECK_ENTRYPOINTS = 3
 
     # Filepath of ca certificate file to generate connection certificates
     CA_FILEPATH: str = os.path.join(os.path.dirname(__file__), '../p2p/ca.crt')

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -291,6 +291,14 @@ class HathorSettings(NamedTuple):
     # Maximum number of entrypoints that we accept that a peer broadcasts
     PEER_MAX_ENTRYPOINTS: int = 30
 
+    # Maximum number of other peers's entrypoints a given node may connect to.
+    # It does not include the discovered peers connections nor the check trust slots.
+    PEER_MAX_OUTGOING_CONNECTIONS: int = 60
+
+    # Maximum number of other entrypoints a peer may connect to for checking other peers' trustworthiness.
+    # The discovered peers slot is left bound by PEER_MAX_CONNECTIONS.
+    PEER_MAX_CHECK_PEER_CONNECTIONS: int = 10
+
     # Filepath of ca certificate file to generate connection certificates
     CA_FILEPATH: str = os.path.join(os.path.dirname(__file__), '../p2p/ca.crt')
 

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -296,19 +296,19 @@ class HathorSettings(NamedTuple):
     PEER_IDLE_TIMEOUT: int = 60
 
     # Maximum number of entrypoints that we accept that a peer broadcasts
-    PEER_MAX_ENTRYPOINTS: int = PERCENTAGE_MAX_INCOMING_CONNECTIONS*PEER_MAX_CONNECTIONS
+    PEER_MAX_ENTRYPOINTS: int = PERCENTAGE_MAX_INCOMING_CONNECTIONS*PEER_MAX_CONNECTIONS/100
 
     # Maximum number of other peers's entrypoints a given node may connect to.
     # It does not include the discovered peers connections nor the check trust slots.
-    PEER_MAX_OUTGOING_CONNECTIONS: int = PERCENTAGE_MAX_OUTGOING_CONNECTIONS*PEER_MAX_CONNECTIONS
+    PEER_MAX_OUTGOING_CONNECTIONS: int = PERCENTAGE_MAX_OUTGOING_CONNECTIONS*PEER_MAX_CONNECTIONS/100
 
     # Maximum number of other entrypoints a peer may connect to for checking other peers' trustworthiness.
     # The discovered peers slot is left bound by PEER_MAX_CONNECTIONS.
-    PEER_MAX_CHECK_PEER_CONNECTIONS: int = PERCENTAGE_MAX_CHECK_ENTRYPOINTS_CONNECTIONS*PEER_MAX_CONNECTIONS
+    PEER_MAX_CHECK_PEER_CONNECTIONS: int = PERCENTAGE_MAX_CHECK_ENTRYPOINTS_CONNECTIONS*PEER_MAX_CONNECTIONS/100
 
     # Maximum number of connections for discovered peers after bootstrap.
     PEER_MAX_DISCOVERED_PEERS_CONNECTIONS: int = PEER_MAX_CONNECTIONS - PEER_MAX_ENTRYPOINTS 
-    - PEER_MAX_OUTGOING_CONNECTIONS - PEER_MAX_OUTGOING_CONNECTIONS 
+    - PEER_MAX_OUTGOING_CONNECTIONS - PEER_MAX_CHECK_PEER_CONNECTIONS 
     
     # Safeguard check
     if PEER_MAX_DISCOVERED_PEERS_CONNECTIONS <= 0:

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -286,19 +286,25 @@ class HathorSettings(NamedTuple):
     # Number max of connections in the p2p network
     PEER_MAX_CONNECTIONS: int = 125
 
+    # Percentages to each connection slot (int):
+    PERCENTAGE_MAX_INCOMING_CONNECTIONS: int = 30
+    PERCENTAGE_MAX_OUTGOING_CONNECTIONS: int = 30
+    PERCENTAGE_MAX_DISCOVERED_CONNECTIONS: int = 30
+    PERCENTAGE_MAX_CHECK_ENTRYPOINTS_CONNECTIONS: int = 10
+
     # Maximum period without receiving any messages from ther peer (in seconds).
     PEER_IDLE_TIMEOUT: int = 60
 
     # Maximum number of entrypoints that we accept that a peer broadcasts
-    PEER_MAX_ENTRYPOINTS: int = 30
+    PEER_MAX_ENTRYPOINTS: int = PERCENTAGE_MAX_INCOMING_CONNECTIONS*PEER_MAX_CONNECTIONS
 
     # Maximum number of other peers's entrypoints a given node may connect to.
     # It does not include the discovered peers connections nor the check trust slots.
-    PEER_MAX_OUTGOING_CONNECTIONS: int = 60
+    PEER_MAX_OUTGOING_CONNECTIONS: int = PERCENTAGE_MAX_OUTGOING_CONNECTIONS*PEER_MAX_CONNECTIONS
 
     # Maximum number of other entrypoints a peer may connect to for checking other peers' trustworthiness.
     # The discovered peers slot is left bound by PEER_MAX_CONNECTIONS.
-    PEER_MAX_CHECK_PEER_CONNECTIONS: int = 10
+    PEER_MAX_CHECK_PEER_CONNECTIONS: int = PERCENTAGE_MAX_CHECK_ENTRYPOINTS_CONNECTIONS*PEER_MAX_CONNECTIONS
 
     # Maximum number of connections for discovered peers after bootstrap.
     PEER_MAX_DISCOVERED_PEERS_CONNECTIONS: int = PEER_MAX_CONNECTIONS - PEER_MAX_ENTRYPOINTS 

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -299,6 +299,15 @@ class HathorSettings(NamedTuple):
     # The discovered peers slot is left bound by PEER_MAX_CONNECTIONS.
     PEER_MAX_CHECK_PEER_CONNECTIONS: int = 10
 
+    # Maximum number of connections for discovered peers after bootstrap.
+    PEER_MAX_DISCOVERED_PEERS_CONNECTIONS: int = PEER_MAX_CONNECTIONS - PEER_MAX_ENTRYPOINTS 
+    - PEER_MAX_OUTGOING_CONNECTIONS - PEER_MAX_OUTGOING_CONNECTIONS 
+    
+    # Safeguard check
+    if PEER_MAX_DISCOVERED_PEERS_CONNECTIONS <= 0:
+        raise Exception("PEER_MAX_DISCOVERED_PEERS_CONNECTIONS must be bigger than zero.")
+
+
     # Filepath of ca certificate file to generate connection certificates
     CA_FILEPATH: str = os.path.join(os.path.dirname(__file__), '../p2p/ca.crt')
 

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -24,7 +24,7 @@ from hathor.p2p.protocol import HathorLineReceiver
 
 
 class _HathorLineReceiverFactory(ABC, protocol.Factory):
-    inbound: bool
+    inbound: HathorSettings.ConnectionType
 
     def __init__(
         self,

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -55,10 +55,10 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
 class HathorServerFactory(_HathorLineReceiverFactory, protocol.ServerFactory):
     """ HathorServerFactory is used to generate HathorProtocol objects when a new connection arrives.
     """
-    inbound = True
+    inbound = HathorSettings.ConnectionType.INCOMING
 
 
 class HathorClientFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
     """ HathorClientFactory is used to generate HathorProtocol objects when we connected to another peer.
     """
-    inbound = False
+    inbound = HathorSettings.ConnectionType.OUTGOING

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -70,7 +70,11 @@ class PeerConnectionsMetrics(NamedTuple):
     handshaking_peers_count: int
     connected_peers_count: int
     known_peers_count: int
-
+    # Counters for the connection pool slots
+    incoming_connections_count: int
+    outgoing_connections_count: int
+    discovered_connections_count: int
+    check_entrypoint_connections_count: int
 
 class ConnectionsManager:
     """ It manages all peer-to-peer connections and events related to control messages.

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -388,8 +388,8 @@ class ConnectionsManager:
             len(self.verified_peer_storage),
             len(self.incoming_connections),
             len(self.outgoing_connections),
+            len(self.discovered_connections),
             len(self.check_entrypoint_connections),
-            len(self.discovered_connections)
         )
 
     def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -141,6 +141,18 @@ class ConnectionsManager:
         # Global maximum number of connections.
         self.max_connections: int = self._settings.PEER_MAX_CONNECTIONS
 
+        # Maximum number of incoming connections.
+        self.max_incoming_connections: int = self._settings.PEER_MAX_ENTRYPOINTS
+
+        # Maximum number of outgoing connections. 
+        self.max_outgoing_connections: int = self._settings.PEER_MAX_OUTGOING_CONNECTIONS
+
+        # Maximum number of connections for untrustworthy peers checking.
+        self.max_check_peers_connections: int = self._settings.PEER_MAX_CHECK_PEER_CONNECTIONS
+
+        # Maximum connections for discovered peers:
+        self.max_discovered_peers_connections: int = self._settings.PEER_MAX_DISCOVERED_PEERS_CONNECTIONS
+
         # Global rate limiter for all connections.
         self.rate_limiter = RateLimiter(self.reactor)
         self.enable_rate_limiter()

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -462,7 +462,7 @@ class ConnectionsManager:
                 self.log.warn('reached maximum number of CHECK_PEERS connections', max_connections=self.max_check_peers_connections )
                 protocol.disconnect(force=True)
                 return 
-            self.check_entrypoint_connectionss.add(protocol)
+            self.check_entrypoint_connections.add(protocol)
         elif protocol.discovered:
             if len(self.discovered_connections) >= self.max_discovered_peers_connections:
                 self.log.warn('reached maximum number of DISCOVERED connections', max_connections=self.max_discovered_peers_connections )

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -385,7 +385,11 @@ class ConnectionsManager:
             len(self.connecting_peers),
             len(self.handshaking_peers),
             len(self.connected_peers),
-            len(self.verified_peer_storage)
+            len(self.verified_peer_storage),
+            len(self.incoming_connections),
+            len(self.outgoing_connections),
+            len(self.check_entrypoint_connections),
+            len(self.discovered_connections)
         )
 
     def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -105,6 +105,8 @@ class HathorProtocol:
         settings: HathorSettings,
         use_ssl: bool,
         inbound: bool,
+        
+        check_entrypoint: bool,
     ) -> None:
         self._settings = settings
         self.my_peer = my_peer
@@ -118,6 +120,9 @@ class HathorProtocol:
 
         # Indicate whether it is an inbound connection (true) or an outbound connection (false).
         self.inbound = inbound
+
+        # Connection to check a specific entrypoint to be trustworthy or not.
+        self.check_entrypoint = check_entrypoint
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -125,7 +125,7 @@ class HathorProtocol:
         self.check_entrypoint = check_entrypoint
 
         # Flag of this connection belonging to a discovered peer.
-        self.discovered_connection = discovered
+        self.discovered = discovered
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -104,9 +104,7 @@ class HathorProtocol:
         *,
         settings: HathorSettings,
         use_ssl: bool,
-        inbound: bool,
-        discovered: bool,
-        check_entrypoint: bool,
+        inbound: HathorSettings.ConnectionType,
     ) -> None:
         self._settings = settings
         self.my_peer = my_peer
@@ -119,13 +117,15 @@ class HathorProtocol:
         self.reactor = self.connections.reactor
 
         # Indicate whether it is an inbound connection (true) or an outbound connection (false).
-        self.inbound = inbound
+        # Update: Now, inbound is an enum (0, 1, 2, or 3). 
+        # 0 == Outgoing Connection, 1 == Incoming, 2 == Discovered, 3 == For Checking Entrypoints.
+        self.connection_type = inbound
 
         # Connection to check a specific entrypoint to be trustworthy or not.
-        self.check_entrypoint = check_entrypoint
+        #self.check_entrypoint = check_entrypoint
 
         # Flag of this connection belonging to a discovered peer.
-        self.discovered = discovered
+        # self.discovered = discovered
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -105,7 +105,7 @@ class HathorProtocol:
         settings: HathorSettings,
         use_ssl: bool,
         inbound: bool,
-        
+        discovered: bool,
         check_entrypoint: bool,
     ) -> None:
         self._settings = settings
@@ -123,6 +123,9 @@ class HathorProtocol:
 
         # Connection to check a specific entrypoint to be trustworthy or not.
         self.check_entrypoint = check_entrypoint
+
+        # Flag of this connection belonging to a discovered peer.
+        self.discovered_connection = discovered
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/tests/others/test_metrics.py
+++ b/tests/others/test_metrics.py
@@ -9,6 +9,7 @@ from hathor.pubsub import HathorEvents
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.storage import TransactionCacheStorage, TransactionMemoryStorage
 from hathor.wallet import Wallet
+from hathor.conf.settings import HathorSettings
 from tests import unittest
 
 
@@ -216,7 +217,7 @@ class MetricsTest(unittest.TestCase):
                 my_peer=my_peer,
                 p2p_manager=manager.connections,
                 use_ssl=False,
-                inbound=False,
+                inbound = HathorSettings.ConnectionType.OUTGOING,
                 settings=self._settings
             )
             protocol._peer = PrivatePeer.auto_generated().to_public_peer()


### PR DESCRIPTION
### Motivation

Second Draft of the PR for Connection Pool Slots (to be read for meeting purposes) - to be DENIED.

### Acceptance Criteria

The full node must accept at most N incoming connections (FUNCTIONAL)
The full node must open at most M outgoing connections to verified entry points. ((FUNCTIONAL))
The full node must keep at most P connections to discovered peers.  - ONGOING
The full node must have slots available to check for untrusted entry points. - ONGOING
The full node must cycle through outgoing and incoming connections. - DEPRECATED


### Checklist

- NOT SUITABLE FOR PRODUCTION CODE - PR for review and to be denied eventually.