### PR TITLE
fix: update python-rocksdb

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1813,7 +1813,7 @@ test = ["pytest"]
 type = "git"
 url = "https://github.com/hathornetwork/python-rocksdb.git"
 reference = "HEAD"
-resolved_reference = "72edcfbd22f4a3ca816f94096d3ec181da41031e"
+resolved_reference = "1f0ce6a35472ad2e631335f159db9906ed2ebc86"
 
 [[package]]
 name = "sentry-sdk"


### PR DESCRIPTION
### Motivation

macOS CI is currently failing on `master` because rocksdb bindings are outdated. This PR fixes this.

### Acceptance Criteria

- Update `python-rocksdb` to the latest commit.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 