### PR TITLE
chore: add make fix-rocksdb command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,3 +147,16 @@ docker-push: docker
 docker-push-aws: docker
 	docker tag $(docker_tag) 769498303037.dkr.ecr.us-east-1.amazonaws.com/fullnode:$(docker_subtag)
 	docker push 769498303037.dkr.ecr.us-east-1.amazonaws.com/fullnode:$(docker_subtag)
+
+# If you get errors similar to the one below, running `make fix-rocksdb` may fix the problem.
+#
+# Traceback (most recent call last):
+#   File "<string>", line 1, in <module>
+#   File "/<redacted>/pypoetry/virtualenvs/hathor-29FNXj3I-py3.11/lib/python3.11/site-packages/rocksdb/__init__.py", line 1, in <module>
+#     from ._rocksdb import *
+# ImportError: dlopen(/<redacted>/pypoetry/virtualenvs/hathor-29FNXj3I-py3.11/lib/python3.11/site-packages/rocksdb/_rocksdb.cpython-311-darwin.so, 0x0002): Library not loaded: /opt/homebrew/opt/rocksdb/lib/librocksdb.9.dylib
+#   Referenced from: /<redacted>/pypoetry/virtualenvs/hathor-29FNXj3I-py3.11/lib/python3.11/site-packages/rocksdb/_rocksdb.cpython-311-darwin.so
+#   Reason: tried: '/opt/homebrew/opt/rocksdb/lib/librocksdb.9.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/rocksdb/lib/librocksdb.9.dylib' (no such file), '/opt/homebrew/opt/rocksdb/lib/librocksdb.9.dylib' (no such file), '/opt/homebrew/Cellar/rocksdb/10.0.1/lib/librocksdb.9.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/rocksdb/10.0.1/lib/librocksdb.9.dylib' (no such file), '/opt/homebrew/Cellar/rocksdb/10.0.1/lib/librocksdb.9.dylib' (no such file)
+.PHONY: fix-rocksdb
+fix-rocksdb:
+	poetry run pip uninstall -y rocksdb && poetry run pip install --no-binary :all: git+https://github.com/hathornetwork/python-rocksdb.git


### PR DESCRIPTION
### Motivation

Sometimes when rocksdb is upgraded, the `python-rocksdb` bindings installation stops working, and a simple reinstall with `--no-binary` fixes it. This PR adds this command to the Makefile so it's easier for new devs to deal with this.

PS: Poetry does support [the no-binary option](https://python-poetry.org/docs/configuration/#installerno-binary) as a local config, but I couldn't get it to work. It seems it doesn't work with dependencies from git.

### Acceptance Criteria

- Add `make fix-rocksdb` command.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 