### PR TITLE
Connection Pool Slots

### DIFF
--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -1,0 +1,148 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import deque
+from typing import Optional
+
+from hathor.conf.settings import HathorSettings
+from hathor.p2p.protocol import HathorProtocol
+from hathor.p2p.peer_endpoint import PeerAddress, PeerEndpoint
+
+
+class Slot:
+    """
+        Class of a connection pool slot - outgoing, incoming, discovered or check_entrypoints connections.
+    """
+    connection_slot: set[HathorProtocol]
+    entrypoint_queue_slot: deque[PeerAddress]
+    type: HathorProtocol.ConnectionType
+    max_slot_connections: int
+    queue_size_entrypoints: int
+    entrypoint_set: set[PeerAddress | None]
+
+    def __init__(self, type: HathorProtocol.ConnectionType, _settings: HathorSettings, max_connections: int):
+        self.type = type
+        self.connection_slot = set()
+        self.entrypoint_queue_slot = deque()
+        self.entrypoint_set = set()
+
+        if max_connections <= 0:
+            raise ValueError("Slot max number must allow at least one connection")
+        
+        max_outgoing: int = _settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_incoming: int = _settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
+        max_discovered: int = _settings.P2P_PEER_MAX_DISCOVERED_PEERS_CONNECTIONS
+        max_check_ep: int = _settings.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
+
+        type = self.type
+
+        # For each type of slot, there is a maximum of connections allowed.
+        if type == HathorProtocol.ConnectionType.OUTGOING:
+            assert max_connections <= max_outgoing
+
+        if type == HathorProtocol.ConnectionType.INCOMING:
+            assert max_connections <= max_incoming
+
+        if type == HathorProtocol.ConnectionType.DISCOVERED:
+            assert max_connections <= max_discovered
+
+        if type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS:
+            assert max_connections <= max_check_ep
+
+        self.max_slot_connections = max_connections
+        # All slots have the same maximum size.
+        # Only valid for check_entrypoin
+        self.queue_size_entrypoints = _settings.QUEUE_SIZE
+
+    def add_connection(self, protocol: HathorProtocol) -> bool:
+        """
+            Adds connection protocol to the slot. Checks whether the slot is full or not. If full,
+            disconnects the protocol. If the type is 'check_entrypoints', the returns peers of it
+            may go to a queue.
+
+        """
+        # Make sure connection types match
+        assert self.type == protocol.connection_type
+
+        if protocol in self.connection_slot:
+            return False
+
+        # If check_entrypoints, there is a set.
+        # If set minus queue >= 1, a dequeued entrypoint in remove_connection is being connected
+        # We leave at least one space for it.
+        if len(self.entrypoint_set) > len(self.entrypoint_queue_slot):
+            if len(self.connection_slot) == self.max_slot_connections - 1:
+                protocol.disconnect(reason="Dequeued connection being added. Leaving space for it.")
+                return False
+
+        # Check if slot is full. If type is check_entrypoints, there is a queue.
+        if len(self.connection_slot) >= self.max_slot_connections:
+            if self.type == HathorProtocol.ConnectionType.OUTGOING:
+
+                # The connection must be turned into CHECK_ENTRYPOINTS.
+                # Will return to on_peer_connect and slot it into check_entrypoints.
+                protocol.connection_type = HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS
+                return False
+
+            # Check_EP is disconnected too, as we only queue endpoints of ready/valid peers.
+            protocol.disconnect(reason="Connect attempt to slot full, no queue.")
+            return False
+
+        # If not full, add to slot if types match.
+        assert protocol.connection_type == self.type
+        self.connection_slot.add(protocol)
+
+        return True
+
+    def remove_connection(self, protocol: HathorProtocol, revisit: bool = False,
+                          previous_entrypoint: PeerAddress | None = None) -> Optional[PeerAddress] | None:
+        """
+            Removes from given instance the protocol passed. Returns protocol from queue
+            when disconnection leads to free space in slot. Revisit flag for continuously popping verified entrypoints
+            from queue and deleting previous entrypoints from set.
+        """
+        if not revisit:
+            self.connection_slot.discard(protocol)
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS and not revisit:
+            dequeued_entrypoint = None
+            # If protocol READY, the peer was verified. We take its EP's to the queue.
+            # If protocol e.p. not in set, it is a new protocol with new e.p.'s to check.
+            # If in set, it is a connection from a previously dequeued entrypoint.
+            if protocol.connection_state == HathorProtocol.ConnectionState.READY:
+                if protocol.entrypoint and protocol.entrypoint.addr not in self.entrypoint_set:
+                    entrypoints = protocol.peer.info.entrypoints
+                    # Unpack the entrypoints and put them in the queue and the set.
+                    for each_entrypoint in entrypoints:
+                        if protocol.entrypoint and each_entrypoint != protocol.entrypoint.addr:
+                            if len(self.entrypoint_queue_slot) == self.queue_size_entrypoints:
+                                # Limit achieved for QUEUE
+                                break
+
+                            if each_entrypoint not in self.entrypoint_queue_slot:
+                                self.entrypoint_queue_slot.appendleft(each_entrypoint)
+
+                            if each_entrypoint not in self.entrypoint_set:
+                                self.entrypoint_set.add(each_entrypoint)
+
+        # If protocol not READY, it was a timeout.
+        # Take one from the queue and turn it into a connection.
+        if self.entrypoint_queue_slot:
+            if revisit:
+                self.entrypoint_set.discard(previous_entrypoint)
+
+            dequeued_entrypoint = self.entrypoint_queue_slot.pop()
+            return dequeued_entrypoint
+
+        return None

--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -16,8 +16,8 @@ from collections import deque
 from typing import Optional
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.peer_endpoint import PeerAddress
 from hathor.p2p.protocol import HathorProtocol
-from hathor.p2p.peer_endpoint import PeerAddress, PeerEndpoint
 
 
 class Slot:
@@ -96,7 +96,7 @@ class Slot:
                 return False
 
             # Check_EP is disconnected too, as we only queue endpoints of ready/valid peers.
-            protocol.disconnect(reason="Connect attempt to slot full, no queue.")
+            protocol.disconnect(reason="Connection Slot if full. Try again later.")
             return False
 
         # If not full, add to slot if types match.

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -25,6 +25,7 @@ from hathor.p2p.protocol import HathorLineReceiver
 
 class _HathorLineReceiverFactory(ABC, protocol.Factory):
     connection_type: HathorLineReceiver.ConnectionType
+
     def __init__(
         self,
         my_peer: PrivatePeer,

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -24,7 +24,7 @@ from hathor.p2p.protocol import HathorLineReceiver
 
 
 class _HathorLineReceiverFactory(ABC, protocol.Factory):
-    inbound: bool
+    connection_type: HathorLineReceiver.ConnectionType  # HLR inherits HathorProtocol, which has ConnectionType.
 
     def __init__(
         self,
@@ -45,7 +45,7 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
             my_peer=self.my_peer,
             p2p_manager=self.p2p_manager,
             use_ssl=self.use_ssl,
-            inbound=self.inbound,
+            connection_type=self.connection_type,
             settings=self._settings
         )
         p.factory = self
@@ -55,10 +55,18 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
 class HathorServerFactory(_HathorLineReceiverFactory, protocol.ServerFactory):
     """ HathorServerFactory is used to generate HathorProtocol objects when a new connection arrives.
     """
-    inbound = True
+    connection_type = HathorLineReceiver.ConnectionType.INCOMING
 
 
 class HathorClientFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
     """ HathorClientFactory is used to generate HathorProtocol objects when we connected to another peer.
     """
-    inbound = False
+    connection_type = HathorLineReceiver.ConnectionType.OUTGOING
+
+
+class HathorDiscoveredFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
+    """
+        HathorDiscoveredFactory is the same as a HathorClientFactory, but the type of connection is set to
+        discovered, for connection pool slotting.
+    """
+    connection_type = HathorLineReceiver.ConnectionType.DISCOVERED

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -24,8 +24,7 @@ from hathor.p2p.protocol import HathorLineReceiver
 
 
 class _HathorLineReceiverFactory(ABC, protocol.Factory):
-    connection_type: HathorLineReceiver.ConnectionType  # HLR inherits HathorProtocol, which has ConnectionType.
-
+    connection_type: HathorLineReceiver.ConnectionType
     def __init__(
         self,
         my_peer: PrivatePeer,

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -87,7 +87,7 @@ class Slot:
             self.max_slot_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
 
         if self.type == HathorProtocol.ConnectionType.INCOMING:
-            self.max_slot_connections = _settings.PEER_MAX_ENTRYPOINTS
+            self.max_slot_connections = _settings.PEER_MAX_INCOMING_CONNECTIONS
 
         if self.type == HathorProtocol.ConnectionType.DISCOVERED:
             self.max_slot_connections = _settings.PEER_MAX_DISCOVERED_PEERS_CONNECTIONS
@@ -1024,9 +1024,15 @@ class ConnectionsManager:
         assert protocol.peer.id is not None
         assert protocol.my_peer.id is not None
         other_connection = self.connected_peers[protocol.peer.id]
+        _outbound_types = (
+            HathorProtocol.ConnectionType.OUTGOING,
+            HathorProtocol.ConnectionType.DISCOVERED,
+            HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS,
+        )
+        is_outbound = protocol.connection_type in _outbound_types
         if bytes(protocol.my_peer.id) > bytes(protocol.peer.id):
             # connection started by me is kept
-            if not protocol.connection_type:
+            if is_outbound:
                 # other connection is dropped
                 return other_connection
             else:
@@ -1034,7 +1040,7 @@ class ConnectionsManager:
                 return protocol
         else:
             # connection started by peer is kept
-            if not protocol.connection_type:
+            if is_outbound:
                 return protocol
             else:
                 return other_connection

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -65,6 +65,122 @@ class _ConnectingPeer(NamedTuple):
     endpoint_deferred: Deferred
 
 
+class Slot:
+    """
+        Class of a connection pool slot - outgoing, incoming, discovered or check_entrypoints connections.
+    """
+    connection_slot: set[HathorProtocol]
+    entrypoint_queue_slot: deque[PeerAddress]
+    type: HathorProtocol.ConnectionType
+    max_slot_connections: int
+    queue_size_entrypoints: int
+    entrypoint_set: set[PeerAddress | None]
+
+    def __init__(self, type: HathorProtocol.ConnectionType, _settings: HathorSettings):
+        self.type = type
+        self.connection_slot = set()
+        self.entrypoint_queue_slot = deque()
+        self.entrypoint_set = set()
+
+        # For each type of slot, there is a maximum of connections allowed.
+        if self.type == HathorProtocol.ConnectionType.OUTGOING:
+            self.max_slot_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
+
+        if self.type == HathorProtocol.ConnectionType.INCOMING:
+            self.max_slot_connections = _settings.PEER_MAX_ENTRYPOINTS
+
+        if self.type == HathorProtocol.ConnectionType.DISCOVERED:
+            self.max_slot_connections = _settings.PEER_MAX_DISCOVERED_PEERS_CONNECTIONS
+
+        if self.type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS:
+            self.max_slot_connections = _settings.PEER_MAX_CHECK_PEER_CONNECTIONS
+
+        # All slots have the same maximum size.
+        # Only valid for check_entrypoin
+        self.queue_size_entrypoints = _settings.QUEUE_SIZE
+
+    def add_connection(self, protocol: HathorProtocol) -> bool:
+        """
+            Adds connection protocol to the slot. Checks whether the slot is full or not. If full,
+            disconnects the protocol. If the type is 'check_entrypoints', the returns peers of it
+            may go to a queue.
+
+        """
+        # Make sure connection types match
+        if self.type != protocol.connection_type:
+            raise Exception("Protocol type DOES NOT match Slot type.")
+
+        if protocol in self.connection_slot:
+            return False
+
+        # If check_entrypoints, there is a set.
+        # If set minus queue >= 1, a dequeued entrypoint in remove_connection is being connected
+        # We leave at least one space for it.
+        if len(self.entrypoint_set) > len(self.entrypoint_queue_slot):
+            if len(self.connection_slot) == self.max_slot_connections - 1:
+                protocol.disconnect(reason="Dequeued connection being added. Leaving space for it.")
+                return False
+
+        # Check if slot is full. If type is check_entrypoints, there is a queue.
+        if len(self.connection_slot) >= self.max_slot_connections:
+            if self.type == HathorProtocol.ConnectionType.OUTGOING:
+
+                # The connection must be turned into CHECK_ENTRYPOINTS.
+                # Will return to on_peer_connect and slot it into check_entrypoints.
+                protocol.connection_type = HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS
+                return False
+
+            # Check_EP is disconnected too, as we only queue endpoints of ready/valid peers.
+            protocol.disconnect(reason="Connect attempt to slot full, no queue.")
+            return False
+
+        # If not full, add to slot
+        self.connection_slot.add(protocol)
+        return True
+
+    def remove_connection(self, protocol: HathorProtocol, revisit: bool = False,
+                          previous_entrypoint: PeerAddress | None = None) -> Optional[PeerAddress] | None:
+        """
+            Removes from given instance the protocol passed. Returns protocol from queue
+            when disconnection leads to free space in slot. Revisit flag for continuously popping verified entrypoints
+            from queue and deleting previous entrypoints from set.
+        """
+        if not revisit:
+            self.connection_slot.discard(protocol)
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS and not revisit:
+            dequeued_entrypoint = None
+            # If protocol READY, the peer was verified. We take its EP's to the queue.
+            # If protocol e.p. not in set, it is a new protocol with new e.p.'s to check.
+            # If in set, it is a connection from a previously dequeued entrypoint.
+            if protocol.connection_state == HathorProtocol.ConnectionState.READY:
+                if protocol.entrypoint and protocol.entrypoint.addr not in self.entrypoint_set:
+                    entrypoints = protocol.peer.info.entrypoints
+                    # Unpack the entrypoints and put them in the queue and the set.
+                    for each_entrypoint in entrypoints:
+                        if protocol.entrypoint and each_entrypoint != protocol.entrypoint.addr:
+                            if len(self.entrypoint_queue_slot) == self.queue_size_entrypoints:
+                                # Limit achieved for QUEUE
+                                break
+
+                            if each_entrypoint not in self.entrypoint_queue_slot:
+                                self.entrypoint_queue_slot.appendleft(each_entrypoint)
+
+                            if each_entrypoint not in self.entrypoint_set:
+                                self.entrypoint_set.add(each_entrypoint)
+
+        # If protocol not READY, it was a timeout.
+        # Take one from the queue and turn it into a connection.
+        if self.entrypoint_queue_slot:
+            if revisit:
+                self.entrypoint_set.discard(previous_entrypoint)
+
+            dequeued_entrypoint = self.entrypoint_queue_slot.pop()
+            return dequeued_entrypoint
+
+        return None
+
+
 class PeerConnectionsMetrics(NamedTuple):
     connecting_peers_count: int
     handshaking_peers_count: int
@@ -92,6 +208,11 @@ class ConnectionsManager:
 
     rate_limiter: RateLimiter
 
+    outgoing_slot: Slot
+    incoming_slot: Slot
+    discovered_slot: Slot
+    check_entrypoints_slot: Slot
+
     def __init__(
         self,
         settings: HathorSettings,
@@ -115,7 +236,6 @@ class ConnectionsManager:
 
         self.reactor = reactor
         self.my_peer = my_peer
-
         # List of address descriptions to listen for new connections (eg: [tcp:8000])
         self.listen_address_descriptions: list[str] = []
 
@@ -129,12 +249,15 @@ class ConnectionsManager:
         self.localhost_only = False
 
         # Factories.
-        from hathor.p2p.factory import HathorClientFactory, HathorServerFactory
+        from hathor.p2p.factory import HathorClientFactory, HathorDiscoveredFactory, HathorServerFactory
         self.use_ssl = ssl
         self.server_factory = HathorServerFactory(
             self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
         self.client_factory = HathorClientFactory(
+            self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
+        )
+        self.discovered_factory = HathorDiscoveredFactory(
             self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
 
@@ -156,6 +279,12 @@ class ConnectionsManager:
 
         # List of peers connected and ready to communicate.
         self.connected_peers = {}
+
+        # List of connections by each slot
+        self.outgoing_slot = Slot(HathorProtocol.ConnectionType.OUTGOING, settings)
+        self.incoming_slot = Slot(HathorProtocol.ConnectionType.INCOMING, settings)
+        self.discovered_slot = Slot(HathorProtocol.ConnectionType.DISCOVERED, settings)
+        self.check_entrypoints_slot = Slot(HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS, settings)
 
         # Queue of ready peer-id's used by connect_to_peer_from_connection_queue to choose the next peer to pull a
         # random new connection from
@@ -356,7 +485,7 @@ class ConnectionsManager:
             len(self.connecting_peers),
             len(self.handshaking_peers),
             len(self.connected_peers),
-            len(self.verified_peer_storage)
+            len(self.verified_peer_storage),
         )
 
     def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:
@@ -412,27 +541,54 @@ class ConnectionsManager:
 
     def on_peer_connect(self, protocol: HathorProtocol) -> None:
         """Called when a new connection is established."""
+
+        # Checks whether connections in the network are at limit.
         if len(self.connections) >= self.max_connections:
             self.log.warn('reached maximum number of connections', max_connections=self.max_connections)
             protocol.disconnect(force=True)
             return
-        self.connections.add(protocol)
-        self.handshaking_peers.add(protocol)
 
-        self.pubsub.publish(
-            HathorEvents.NETWORK_PEER_CONNECTED,
-            protocol=protocol,
-            peers_count=self._get_peers_count()
-        )
+        protocol_connected = False  # If protocol is added to slot, True. If to Queue or disconnected, False.
+        # Next block sends the connection to the appropriate slot.
+        if protocol.connection_type == HathorProtocol.ConnectionType.OUTGOING:
+            # Here, it can happend that the protocol changes to Check Entrypoints.
+            protocol_connected = self.outgoing_slot.add_connection(protocol)
+            # The check is done so discovered connections are not added doubly.
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.INCOMING:
+            protocol_connected = self.incoming_slot.add_connection(protocol)
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.DISCOVERED:
+            protocol_connected = self.discovered_slot.add_connection(protocol)
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS:
+            protocol_connected = self.check_entrypoints_slot.add_connection(protocol)
+
+        # Regardless of the slot sent, the total connections increases.
+        # A connection waiting in queue is not added (yet) to the whole pool, only if another disconnects.
+        if protocol_connected:
+            self.connections.add(protocol)
+            self.handshaking_peers.add(protocol)
+
+            # If not queued, connection state is "CONNECTING", as it is not ready yet, added to handshaking.
+            protocol.connection_state = HathorProtocol.ConnectionState.CONNECTING
+
+            self.pubsub.publish(
+                HathorEvents.NETWORK_PEER_CONNECTED,
+                protocol=protocol,
+                peers_count=self._get_peers_count()
+            )
 
     def on_peer_ready(self, protocol: HathorProtocol) -> None:
         """Called when a peer is ready."""
         assert protocol.peer is not None
         self.verified_peer_storage.add_or_replace(protocol.peer)
-
         self.handshaking_peers.remove(protocol)
+
         for conn in self.iter_all_connections():
             conn.unverified_peer_storage.remove(protocol.peer)
+
+        protocol.connection_state = HathorProtocol.ConnectionState.READY
 
         # we emit the event even if it's a duplicate peer as a matching
         # NETWORK_PEER_DISCONNECTED will be emitted regardless
@@ -470,6 +626,10 @@ class ConnectionsManager:
         # Notify other peers about this new peer connection.
         self.relay_peer_to_ready_connections(protocol.peer)
 
+        # Connection Ready. If it is a check_entrypoint conn, we must discard it from slot.
+        if protocol.connection_type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS:
+            protocol.disconnect(reason="READY connection for check_entrypoint slot.")
+
     def relay_peer_to_ready_connections(self, peer: PublicPeer) -> None:
         """Relay peer to all ready connections."""
         for conn in self.iter_ready_connections():
@@ -480,9 +640,38 @@ class ConnectionsManager:
 
     def on_peer_disconnect(self, protocol: HathorProtocol) -> None:
         """Called when a peer disconnect."""
+
+        # Discard handles case when not in connections.
         self.connections.discard(protocol)
+
+        # If the protocol discarded is from check_entrypoints slot.
+        dequeued_ep = None
+
+        # Each conn is from a slot - discard from it as well.
+        if protocol.connection_type == HathorProtocol.ConnectionType.OUTGOING:
+            self.outgoing_slot.remove_connection(protocol)
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.INCOMING:
+            self.incoming_slot.remove_connection(protocol)
+
+        if protocol.connection_type == HathorProtocol.ConnectionType.DISCOVERED:
+            self.discovered_slot.remove_connection(protocol)
+
+        # The only connection type that may pop from a queue is CHECK_ENTRYPOINTS
+        if protocol.connection_type == HathorProtocol.ConnectionType.CHECK_ENTRYPOINTS:
+            dequeued_ep = self.check_entrypoints_slot.remove_connection(protocol)
+            # For a given ep, check if some verified peer has it. If so, pop it off and restart.
+            while dequeued_ep:
+                for peer in self.verified_peer_storage.values():
+                    if dequeued_ep in peer.info.entrypoints:
+                        dequeued_ep = self.check_entrypoints_slot.remove_connection(protocol, True, dequeued_ep)
+                        break
+                if dequeued_ep and dequeued_ep not in peer.info.entrypoints:
+                    self.connect_to_endpoint(entrypoint=dequeued_ep.with_id(None))
+
         if protocol in self.handshaking_peers:
             self.handshaking_peers.remove(protocol)
+
         if protocol._peer is not None:
             peer_id = protocol.peer.id
             existing_protocol = self.connected_peers.pop(peer_id, None)
@@ -499,21 +688,24 @@ class ConnectionsManager:
             elif peer_id in self.new_connection_from_queue:
                 # now we're sure it can be removed from new_connection_from_queue
                 self.new_connection_from_queue.remove(peer_id)
+
         self.pubsub.publish(
             HathorEvents.NETWORK_PEER_DISCONNECTED,
             protocol=protocol,
             peers_count=self._get_peers_count()
         )
 
+        # SUGGESTION: To make a NETWORK_PEER_DEQUEUED. It would be clearer, since in the case of a dequeue,
+        # the order of events would be "NETWORK_PEER_READY" and then "NETWORK_PEER_CONNECTED", which is
+        # the opposite.
+
     def iter_all_connections(self) -> Iterable[HathorProtocol]:
         """Iterate over all connections."""
-        for conn in self.connections:
-            yield conn
+        yield from self.connections
 
     def iter_ready_connections(self) -> Iterable[HathorProtocol]:
         """Iterate over ready connections."""
-        for conn in self.connected_peers.values():
-            yield conn
+        yield from self.connected_peers.values()
 
     def iter_not_ready_endpoints(self) -> Iterable[PeerEndpoint]:
         """Iterate over not-ready connections."""
@@ -675,13 +867,18 @@ class ConnectionsManager:
         peer: UnverifiedPeer | PublicPeer | None,
         endpoint: IStreamClientEndpoint,
         entrypoint: PeerEndpoint,
+        discovery_call: bool = False
     ) -> None:
         """Called when we successfully connect to a peer."""
         if isinstance(protocol, HathorProtocol):
+            if discovery_call:
+                protocol.connection_type = HathorProtocol.ConnectionType.DISCOVERED
             protocol.on_outbound_connect(entrypoint, peer)
         else:
             assert isinstance(protocol, TLSMemoryBIOProtocol)
             assert isinstance(protocol.wrappedProtocol, HathorProtocol)
+            if discovery_call:
+                protocol.wrappedProtocol.connection_type = HathorProtocol.ConnectionType.DISCOVERED
             protocol.wrappedProtocol.on_outbound_connect(entrypoint, peer)
         self.connecting_peers.pop(endpoint)
 
@@ -690,6 +887,7 @@ class ConnectionsManager:
         entrypoint: PeerEndpoint,
         peer: UnverifiedPeer | PublicPeer | None = None,
         use_ssl: bool | None = None,
+        discovery_call: bool = False
     ) -> None:
         """ Attempt to connect directly to an endpoint, prefer calling `connect_to_peer` when possible.
 
@@ -699,6 +897,7 @@ class ConnectionsManager:
 
         If `use_ssl` is True, then the connection will be wraped by a TLS.
         """
+
         if entrypoint.peer_id is not None and peer is not None and entrypoint.peer_id != peer.id:
             self.log.debug('skipping because the entrypoint peer_id does not match the actual peer_id',
                            entrypoint=str(entrypoint))
@@ -730,10 +929,16 @@ class ConnectionsManager:
         endpoint = entrypoint.addr.to_client_endpoint(self.reactor)
 
         factory: IProtocolFactory
-        if use_ssl:
-            factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, self.client_factory)
+        if discovery_call:
+            if use_ssl:
+                factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, self.discovered_factory)
+            else:
+                factory = self.discovered_factory
         else:
-            factory = self.client_factory
+            if use_ssl:
+                factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, self.client_factory)
+            else:
+                factory = self.client_factory
 
         if peer is not None:
             now = int(self.reactor.seconds())
@@ -742,7 +947,7 @@ class ConnectionsManager:
         deferred = endpoint.connect(factory)
         self.connecting_peers[endpoint] = _ConnectingPeer(entrypoint, deferred)
 
-        deferred.addCallback(self._connect_to_callback, peer, endpoint, entrypoint)
+        deferred.addCallback(self._connect_to_callback, peer, endpoint, entrypoint, discovery_call)
         deferred.addErrback(self.on_connection_failure, peer, endpoint)
         self.log.info('connecting to', entrypoint=str(entrypoint), peer=str(peer))
         self.pubsub.publish(
@@ -821,7 +1026,7 @@ class ConnectionsManager:
         other_connection = self.connected_peers[protocol.peer.id]
         if bytes(protocol.my_peer.id) > bytes(protocol.peer.id):
             # connection started by me is kept
-            if not protocol.inbound:
+            if not protocol.connection_type:
                 # other connection is dropped
                 return other_connection
             else:
@@ -829,7 +1034,7 @@ class ConnectionsManager:
                 return protocol
         else:
             # connection started by peer is kept
-            if not protocol.inbound:
+            if not protocol.connection_type:
                 return protocol
             else:
                 return other_connection

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -431,7 +431,7 @@ class ConnectionsManager:
             peers_count=self._get_peers_count()
         )
 
-    def on_peer_connect(self, protocol: HathorProtocol) -> ConnectionResult:
+    def on_peer_connect(self, protocol: HathorProtocol) -> None:
         """Called when a new connection is established."""
 
         # Checks whether connections in the network are at limit.
@@ -440,7 +440,8 @@ class ConnectionsManager:
             protocol.disconnect(force=True)
             return
 
-        connection_allowed = False  # If protocol is added to slot, True. If to Queue or disconnected, False.
+        connection_allowed: ConnectionResult
+        # If protocol is added to slot, True. If to Queue or disconnected, False.
         # Next block sends the connection to the appropriate slot.
         conn_type = protocol.connection_type
 
@@ -464,8 +465,8 @@ class ConnectionsManager:
 
         # Regardless of the slot sent, the total connections increases.
         # A connection waiting in queue is not added (yet) to the whole pool, only if another disconnects.
-        if connection_allowed.isinstance(ConnectionRejected):
-            return connection_allowed
+        if isinstance(connection_allowed, ConnectionRejected):
+            return
 
         self.connections.add(protocol)
         self.handshaking_peers.add(protocol)

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -40,4 +40,3 @@ class BootstrapPeerDiscovery(PeerDiscovery):
     async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
         for entrypoint in self.entrypoints:
             connect_to_endpoint(entrypoint, discovery_call=True)
-

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -39,4 +39,4 @@ class BootstrapPeerDiscovery(PeerDiscovery):
     @override
     async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
         for entrypoint in self.entrypoints:
-            connect_to_endpoint(entrypoint)
+            connect_to_endpoint(entrypoint, discovery_call=True)  # type: ignore[call-arg]

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -39,4 +39,5 @@ class BootstrapPeerDiscovery(PeerDiscovery):
     @override
     async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
         for entrypoint in self.entrypoints:
-            connect_to_endpoint(entrypoint, discovery_call=True)  # type: ignore[call-arg]
+            connect_to_endpoint(entrypoint, discovery_call=True)
+

--- a/hathor/p2p/peer_discovery/bootstrap.py
+++ b/hathor/p2p/peer_discovery/bootstrap.py
@@ -37,6 +37,6 @@ class BootstrapPeerDiscovery(PeerDiscovery):
         self.entrypoints = entrypoints
 
     @override
-    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
+    async def discover_and_connect(self, connect_to_endpoint: Callable[..., None]) -> None:
         for entrypoint in self.entrypoints:
             connect_to_endpoint(entrypoint, discovery_call=True)

--- a/hathor/p2p/peer_discovery/dns.py
+++ b/hathor/p2p/peer_discovery/dns.py
@@ -61,7 +61,6 @@ class DNSPeerDiscovery(PeerDiscovery):
             for entrypoint in (await self.dns_seed_lookup(host)):
                 connect_to_endpoint(entrypoint, discovery_call=True)
 
-
     async def dns_seed_lookup(self, host: str) -> set[PeerEndpoint]:
         """ Run a DNS lookup for TXT, A, and AAAA records and return a list of connection strings.
         """

--- a/hathor/p2p/peer_discovery/dns.py
+++ b/hathor/p2p/peer_discovery/dns.py
@@ -53,7 +53,7 @@ class DNSPeerDiscovery(PeerDiscovery):
         return lookupText(host)
 
     @override
-    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
+    async def discover_and_connect(self, connect_to_endpoint: Callable[..., None]) -> None:
         """ Run DNS lookup for host and connect to it
             This is executed when starting the DNS Peer Discovery and first connecting to the network
         """

--- a/hathor/p2p/peer_discovery/dns.py
+++ b/hathor/p2p/peer_discovery/dns.py
@@ -59,7 +59,7 @@ class DNSPeerDiscovery(PeerDiscovery):
         """
         for host in self.hosts:
             for entrypoint in (await self.dns_seed_lookup(host)):
-                connect_to_endpoint(entrypoint)
+                connect_to_endpoint(entrypoint, discovery_call=True)  # type: ignore[call-arg]
 
     async def dns_seed_lookup(self, host: str) -> set[PeerEndpoint]:
         """ Run a DNS lookup for TXT, A, and AAAA records and return a list of connection strings.

--- a/hathor/p2p/peer_discovery/dns.py
+++ b/hathor/p2p/peer_discovery/dns.py
@@ -59,7 +59,8 @@ class DNSPeerDiscovery(PeerDiscovery):
         """
         for host in self.hosts:
             for entrypoint in (await self.dns_seed_lookup(host)):
-                connect_to_endpoint(entrypoint, discovery_call=True)  # type: ignore[call-arg]
+                connect_to_endpoint(entrypoint, discovery_call=True)
+
 
     async def dns_seed_lookup(self, host: str) -> set[PeerEndpoint]:
         """ Run a DNS lookup for TXT, A, and AAAA records and return a list of connection strings.

--- a/hathor/p2p/peer_discovery/peer_discovery.py
+++ b/hathor/p2p/peer_discovery/peer_discovery.py
@@ -15,15 +15,13 @@
 from abc import ABC, abstractmethod
 from typing import Callable
 
-from hathor.p2p.peer_endpoint import PeerEndpoint
-
 
 class PeerDiscovery(ABC):
     """ Base class to implement peer discovery strategies.
     """
 
     @abstractmethod
-    async def discover_and_connect(self, connect_to_endpoint: Callable[[PeerEndpoint], None]) -> None:
+    async def discover_and_connect(self, connect_to_endpoint: Callable[..., None]) -> None:
         """ This method must discover the peers and call `connect_to_endpoint` for each of them.
 
         :param connect_to_endpoint: Function which will be called for each discovered peer.

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -73,17 +73,17 @@ class HathorProtocol:
         READY = ReadyState
 
     class ConnectionType(Enum):
-        # Types of Connection as inputs for an instance of the Hathor Protocol
+        """ Types of Connection as inputs for an instance of the Hathor Protocol. """
         OUTGOING = 0
         INCOMING = 1
         DISCOVERED = 2
         CHECK_ENTRYPOINTS = 3
 
     class ConnectionState(Enum):
-        # State of connection of two peers - either in a slot queue or active.
-        INIT = -1               # The INIT state is for when the protocol is first instatiated.
-        CONNECTING = 0
-        READY = 1
+        """ State of connection of two peers - either in a slot queue or active. """
+        CREATED = 0
+        CONNECTING = 1
+        READY = 2
 
     class RateLimitKeys(str, Enum):
         GLOBAL = 'global'

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -139,7 +139,7 @@ class HathorProtocol:
         self.connection_type = connection_type
 
         # Connection State
-        self.connection_state = HathorProtocol.ConnectionState.INIT
+        self.connection_state = HathorProtocol.ConnectionState.CREATED
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -72,6 +72,19 @@ class HathorProtocol:
         PEER_ID = PeerIdState
         READY = ReadyState
 
+    class ConnectionType(Enum):
+        # Types of Connection as inputs for an instance of the Hathor Protocol
+        OUTGOING = 0
+        INCOMING = 1
+        DISCOVERED = 2
+        CHECK_ENTRYPOINTS = 3
+
+    class ConnectionState(Enum):
+        # State of connection of two peers - either in a slot queue or active.
+        INIT = -1               # The INIT state is for when the protocol is first instatiated.
+        CONNECTING = 0
+        READY = 1
+
     class RateLimitKeys(str, Enum):
         GLOBAL = 'global'
 
@@ -95,6 +108,7 @@ class HathorProtocol:
     idle_timeout: int
     sync_version: Optional[SyncVersion]  # version chosen to be used on this connection
     capabilities: set[str]  # capabilities received from the peer in HelloState
+    connection_state: ConnectionState  # in slot queue, connecting or ready/in-slot.
 
     @property
     def peer(self) -> PublicPeer:
@@ -108,7 +122,7 @@ class HathorProtocol:
         *,
         settings: HathorSettings,
         use_ssl: bool,
-        inbound: bool,
+        connection_type: ConnectionType,
     ) -> None:
         self._settings = settings
         self.my_peer = my_peer
@@ -120,8 +134,12 @@ class HathorProtocol:
         assert self.connections.reactor is not None
         self.reactor = self.connections.reactor
 
-        # Indicate whether it is an inbound connection (true) or an outbound connection (false).
-        self.inbound = inbound
+        # Type of Connection
+        # 0 == Outgoing, 1 == Incoming, 2 == Discovered, 3 == For Checking Entrypoints.
+        self.connection_type = connection_type
+
+        # Connection State
+        self.connection_state = HathorProtocol.ConnectionState.INIT
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor_tests/others/test_metrics.py
+++ b/hathor_tests/others/test_metrics.py
@@ -209,7 +209,7 @@ class MetricsTest(unittest.TestCase):
                 my_peer=my_peer,
                 p2p_manager=manager.connections,
                 use_ssl=False,
-                inbound=False,
+                connection_type=HathorProtocol.ConnectionType.OUTGOING,
                 settings=self._settings
             )
             protocol._peer = PrivatePeer.auto_generated().to_public_peer()

--- a/hathor_tests/p2p/test_sync_v2.py
+++ b/hathor_tests/p2p/test_sync_v2.py
@@ -7,6 +7,7 @@ from twisted.internet.defer import Deferred, succeed
 from twisted.python.failure import Failure
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connection_slot import Slot
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.protocol import HathorProtocol

--- a/hathor_tests/p2p/test_sync_v2.py
+++ b/hathor_tests/p2p/test_sync_v2.py
@@ -695,3 +695,8 @@ class RandomSimulatorTestCase(SimulatorTestCase):
 
         # It passed through the cap of check_entrypoints. It mush be capped.
         self.assertTrue(amount_check_ep_conn == max_check_ep_connections)
+
+    def test_example_usage_of_Slot(self) -> None:
+        _settings = HathorSettings(P2PKH_VERSION_BYTE=bytes(1), MULTISIG_VERSION_BYTE=bytes(1), NETWORK_NAME="testnet")
+        slot = Slot(HathorProtocol.ConnectionType.OUTGOING, _settings, max_connections=50)
+        assert slot.max_slot_connections == 50

--- a/hathor_tests/p2p/test_sync_v2.py
+++ b/hathor_tests/p2p/test_sync_v2.py
@@ -528,9 +528,9 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         # Number of peers and thresholds of connections in slots and pool
         max_number_outgoing_connections = 45  # Note: After around 100, no more peer ids in the pool ?
         max_connections = _settings.PEER_MAX_CONNECTIONS
-        max_incoming_connections = _settings.PEER_MAX_INCOMING_CONNECTIONS
-        max_outgoing_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
-        max_check_entrypoints = _settings.PEER_MAX_CHECK_PEER_CONNECTIONS
+        max_incoming_connections = _settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
+        max_outgoing_connections = _settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_check_entrypoints = _settings.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
 
         # Full-Node: May receive incoming connections, deliver outgoing connections, etc.
         full_node = self.create_peer()
@@ -590,8 +590,8 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         _settings = HathorSettings(P2PKH_VERSION_BYTE=bytes(1), MULTISIG_VERSION_BYTE=bytes(1), NETWORK_NAME="testnet")
 
         # Create exactly the amount of peers that the slot can handle
-        max_number_outgoing_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
-        max_check_ep_connections = _settings.PEER_MAX_CHECK_PEER_CONNECTIONS
+        max_number_outgoing_connections = _settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_check_ep_connections = _settings.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
         full_node = self.create_peer()
 
         out_peerList = []
@@ -649,8 +649,8 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         _settings = HathorSettings(P2PKH_VERSION_BYTE=bytes(1), MULTISIG_VERSION_BYTE=bytes(1), NETWORK_NAME="testnet")
 
         # Create exactly the amount of peers that the outgoing slot can handle
-        max_number_outgoing_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
-        max_check_ep_connections = _settings.PEER_MAX_CHECK_PEER_CONNECTIONS
+        max_number_outgoing_connections = _settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_check_ep_connections = _settings.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
         full_node = self.create_peer()
 
         out_peerList = []

--- a/hathor_tests/p2p/test_sync_v2.py
+++ b/hathor_tests/p2p/test_sync_v2.py
@@ -522,12 +522,12 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         """
 
         # Get the settings of the max_connections allowed. Put dummy values in HathorSettings.
-        _settings = HathorSettings(bytes(1), bytes(1), "testnet")
+        _settings = HathorSettings(P2PKH_VERSION_BYTE=bytes(1), MULTISIG_VERSION_BYTE=bytes(1), NETWORK_NAME="testnet")
 
         # Number of peers and thresholds of connections in slots and pool
         max_number_outgoing_connections = 45  # Note: After around 100, no more peer ids in the pool ?
         max_connections = _settings.PEER_MAX_CONNECTIONS
-        max_incoming_connections = _settings.PEER_MAX_ENTRYPOINTS
+        max_incoming_connections = _settings.PEER_MAX_INCOMING_CONNECTIONS
         max_outgoing_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
         max_check_entrypoints = _settings.PEER_MAX_CHECK_PEER_CONNECTIONS
 
@@ -586,7 +586,7 @@ class RandomSimulatorTestCase(SimulatorTestCase):
             Checks whether the check_entrypoints slot gets updated after outgoing slot full.
         """
 
-        _settings = HathorSettings(bytes(1), bytes(1), "testnet")
+        _settings = HathorSettings(P2PKH_VERSION_BYTE=bytes(1), MULTISIG_VERSION_BYTE=bytes(1), NETWORK_NAME="testnet")
 
         # Create exactly the amount of peers that the slot can handle
         max_number_outgoing_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS
@@ -645,7 +645,7 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         self.assertTrue(amount_check_ep_conn + max_number_outgoing_connections == total_conn)
 
     def test_check_ep_overflow(self) -> None:
-        _settings = HathorSettings(bytes(1), bytes(1), "testnet")
+        _settings = HathorSettings(P2PKH_VERSION_BYTE=bytes(1), MULTISIG_VERSION_BYTE=bytes(1), NETWORK_NAME="testnet")
 
         # Create exactly the amount of peers that the outgoing slot can handle
         max_number_outgoing_connections = _settings.PEER_MAX_OUTGOING_CONNECTIONS

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -366,7 +366,16 @@ class HathorSettings(BaseModel):
     PEER_CONNECTION_RETRY_MAX_RETRY_INTERVAL: int = 300
 
     # Number max of connections in the p2p network
-    PEER_MAX_CONNECTIONS: int = 125
+    PEER_MAX_CONNECTIONS: int = 85
+
+    # Max Number of each connection slot (int):
+    P2P_PEER_MAX_INCOMING_CONNECTIONS: int = 50
+    P2P_PEER_MAX_OUTGOING_CONNECTIONS: int = 60
+    P2P_PEER_MAX_DISCOVERED_PEERS_CONNECTIONS: int = 10
+    P2P_PEER_MAX_CHECK_PEER_CONNECTIONS: int = 5
+
+    # Queue size for each connection slot:
+    P2P_QUEUE_SIZE: int = 100
 
     # Maximum period without receiving any messages from ther peer (in seconds).
     PEER_IDLE_TIMEOUT: int = 60


### PR DESCRIPTION
### Motivation

The current status of Hathor's P2P network doesn't distinguish the different types of connections established between two peers, such that the base code only limits the number of connections established with a given full-node, regardless of type. A malicious attacker could jeopardize the system by creating multiple connections with a given node, jamming its capability to respond and/or create new connections.

This PR implements Connection Pool Slots, subdividing the existing pool into four main groups: 

- Outgoing Connections Slot (full node --> peer)
- Incoming Connections Slot (peer --> full node)
- Discovered Connections Slot: Outgoing connections established in bootstrap and/or by DNS query 
- Check Entrypoints:  When the outgoing slot is full, the impeding connections are transferred to the Check Entrypoints Slot, which will analyze the protocols and their entrypoints, checking whether they are legit peers.

### Acceptance Criteria

- Outgoing, Incoming, Discovered, and Check Entrypoint slots each with a set limit of connections
- Check Entrypoint slot with queue to store entrypoints for future attempt to connect

### Checklist

If this review is accepted, the code seems to be production-ready.
