### PR TITLE
feat: adds version field to thin_wallet tokens resource

### DIFF
--- a/hathor/wallet/resources/thin_wallet/tokens.py
+++ b/hathor/wallet/resources/thin_wallet/tokens.py
@@ -62,6 +62,7 @@ class TokenResource(Resource):
         data = {
             'name': token_info.get_name(),
             'symbol': token_info.get_symbol(),
+            'version': token_info.get_version(),
             'success': True,
             'mint': mint,
             'melt': melt,
@@ -96,6 +97,7 @@ class TokenResource(Resource):
                     'uid': uid.hex(),
                     'name': token_info.get_name(),
                     'symbol': token_info.get_symbol(),
+                    'version': token_info.get_version(),
                 }
             )
 
@@ -186,6 +188,7 @@ TokenResource.openapi = {
                                         'success': True,
                                         'name': 'MyCoin',
                                         'symbol': 'MYC',
+                                        'version': 1,
                                         'mint': [
                                             {
                                                 "tx_id": "00000299670db5814f69cede8b347f83"
@@ -222,12 +225,14 @@ TokenResource.openapi = {
                                                        "50b1fe58093e97bc94a0275fbeb226b2",
                                                 'name': 'MyCoin',
                                                 'symbol': 'MYC',
+                                                'version': 1,
                                             },
                                             {
                                                 'uid': "00000093f76f44c664907a017bbf9ef6"
                                                        "bb289692e30c7cf7361e6872c5ee1796",
                                                 'name': 'New Token',
                                                 'symbol': 'NTK',
+                                                'version': 1,
                                             },
                                         ],
                                     }

--- a/tests/resources/transaction/test_tx.py
+++ b/tests/resources/transaction/test_tx.py
@@ -5,6 +5,7 @@ from hathor.transaction import Transaction
 from hathor.transaction.resources import TransactionResource
 from hathor.transaction.static_metadata import TransactionStaticMetadata
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.token_info import TokenInfoVersion
 from hathor.transaction.validation_state import ValidationState
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import add_blocks_unlock_reward, add_new_transactions
@@ -128,10 +129,12 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         self.manager.tx_storage.save_transaction(tx_input)
 
         token_bytes1 = bytes.fromhex('001c382847d8440d05da95420bee2ebeb32bc437f82a9ae47b0745c8a29a7b0d')
-        self.manager.tx_storage.indexes.tokens._create_token_info(token_bytes1, 'Test Coin', 'TSC')
+        self.manager.tx_storage.indexes.tokens._create_token_info(
+            token_bytes1, 'Test Coin', 'TSC', TokenInfoVersion.DEPOSIT)
 
         token_bytes2 = bytes.fromhex('007231eee3cb6160d95172a409d634d0866eafc8775f5729fff6a61e7850aba5')
-        self.manager.tx_storage.indexes.tokens._create_token_info(token_bytes2, 'NewCoin', 'NCN')
+        self.manager.tx_storage.indexes.tokens._create_token_info(
+            token_bytes2, 'NewCoin', 'NCN', TokenInfoVersion.DEPOSIT)
 
         response = yield self.web.get(
             "transaction", {b'id': b'0033784bc8443ba851fd88d81c6f06774ae529f25c1fa8f026884ad0a0e98011'})
@@ -223,7 +226,8 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         # Both inputs are the same as the last parent, so no need to manually add them
 
         token_bytes1 = bytes.fromhex('000023b318c91dcfd4b967b205dc938f9f5e2fd5114256caacfb8f6dd13db330')
-        self.manager.tx_storage.indexes.tokens._create_token_info(token_bytes1, 'Wat wat', 'WAT')
+        self.manager.tx_storage.indexes.tokens._create_token_info(
+            token_bytes1, 'Wat wat', 'WAT', TokenInfoVersion.DEPOSIT)
 
         response = yield self.web.get(
             "transaction", {b'id': b'00005f234469407614bf0abedec8f722bb5e534949ad37650f6077c899741ed7'})

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -6,6 +6,7 @@ from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
+from hathor.transaction.token_info import TokenInfoVersion
 from hathor.wallet.resources.thin_wallet import (
     AddressHistoryResource,
     SendTokensResource,
@@ -13,7 +14,7 @@ from hathor.wallet.resources.thin_wallet import (
     TokenResource,
 )
 from tests.resources.base_resource import StubSite, TestDummyRequest, _BaseResourceTest
-from tests.utils import add_blocks_unlock_reward, add_new_tx, create_tokens
+from tests.utils import add_blocks_unlock_reward, add_new_tx, create_fee_tokens, create_tokens
 
 
 class SendTokensTest(_BaseResourceTest._ResourceTest):
@@ -355,6 +356,7 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         add_blocks_unlock_reward(self.manager)
         token_name = 'MyTestToken'
         token_symbol = 'MTT'
+        token_info_version = TokenInfoVersion.DEPOSIT
         amount = 150
         tx = create_tokens(
             self.manager,
@@ -376,6 +378,7 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(data['total'], amount)
         self.assertEqual(data['name'], token_name)
         self.assertEqual(data['symbol'], token_symbol)
+        self.assertEqual(data['version'], token_info_version)
 
         # test list of tokens with one token
         response_list2 = yield resource.get('thin_wallet/token')
@@ -385,6 +388,7 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(data_list2['tokens'][0]['name'], token_name)
         self.assertEqual(data_list2['tokens'][0]['symbol'], token_symbol)
         self.assertEqual(data_list2['tokens'][0]['uid'], tx.hash.hex())
+        self.assertEqual(data_list2['tokens'][0]['version'], token_info_version)
 
         token_name2 = 'New Token'
         token_symbol2 = 'NTK'
@@ -411,9 +415,9 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         data_list3 = response_list3.json_value()
         self.assertTrue(data_list3['success'])
         self.assertEqual(len(data_list3['tokens']), 3)
-        token1 = {'uid': tx.hash.hex(), 'name': token_name, 'symbol': token_symbol}
-        token2 = {'uid': tx2.hash.hex(), 'name': token_name2, 'symbol': token_symbol2}
-        token3 = {'uid': tx3.hash.hex(), 'name': token_name3, 'symbol': token_symbol3}
+        token1 = {'uid': tx.hash.hex(), 'name': token_name, 'symbol': token_symbol, 'version': token_info_version}
+        token2 = {'uid': tx2.hash.hex(), 'name': token_name2, 'symbol': token_symbol2, 'version': token_info_version}
+        token3 = {'uid': tx3.hash.hex(), 'name': token_name3, 'symbol': token_symbol3, 'version': token_info_version}
         self.assertIn(token1, data_list3['tokens'])
         self.assertIn(token2, data_list3['tokens'])
         self.assertIn(token3, data_list3['tokens'])
@@ -425,6 +429,30 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         data2 = response2.json_value()
         self.assertEqual(response2.responseCode, 503)
         self.assertFalse(data2['success'])
+
+    @inlineCallbacks
+    def test_fee_token(self):
+        self.manager.wallet.unlock(b'MYPASS')
+        resource = StubSite(TokenResource(self.manager))
+
+        # test success case
+        add_new_blocks(self.manager, 1, advance_clock=1)
+        add_blocks_unlock_reward(self.manager)
+        token_name = 'MyTestToken'
+        token_symbol = 'MTT'
+        token_info_version = TokenInfoVersion.FEE
+        amount = 150
+        tx = create_fee_tokens(
+            self.manager,
+            mint_amount=amount,
+            token_name=token_name,
+            token_symbol=token_symbol,
+        )
+        token_uid = tx.tokens[0]
+        response = yield resource.get('thin_wallet/token', {b'id': token_uid.hex().encode()})
+        data = response.json_value()
+
+        self.assertEqual(data['version'], token_info_version)
 
     @inlineCallbacks
     def test_token_history(self):


### PR DESCRIPTION
Acceptance criteria:

- Adds the token version in the database (rocksdb) when a tx is created.
- Adds version prop to `thin_wallet/tokens` endpoints