### PR TITLE
feat(nano): implement headers support [part 9]

### DIFF
--- a/hathor/dag_builder/vertex_exporter.py
+++ b/hathor/dag_builder/vertex_exporter.py
@@ -28,7 +28,6 @@ from hathor.dag_builder.types import DAGNodeType, VertexResolverType, WalletFact
 from hathor.dag_builder.utils import get_literal, is_literal
 from hathor.nanocontracts import Blueprint, OnChainBlueprint
 from hathor.nanocontracts.catalog import NCBlueprintCatalog
-from hathor.nanocontracts.exception import BlueprintDoesNotExist
 from hathor.nanocontracts.on_chain_blueprint import Code
 from hathor.nanocontracts.types import BlueprintId, ContractId, VertexId
 from hathor.nanocontracts.utils import derive_child_contract_id, load_builtin_blueprint_for_ocb
@@ -440,10 +439,9 @@ class VertexExporter:
 
     def _get_blueprint_class(self, blueprint_id: BlueprintId) -> type[Blueprint]:
         """Get a blueprint class from the catalog or from our own on-chain blueprints."""
-        try:
-            return self._nc_catalog.get_blueprint_class(blueprint_id)
-        except BlueprintDoesNotExist:
-            ocb = self._vertice_per_id.get(blueprint_id)
-            if ocb is None or not isinstance(ocb, OnChainBlueprint):
-                raise SyntaxError(f'{blueprint_id.hex()} is not a valid blueprint id')
-            return ocb.get_blueprint_class()
+        if blueprint_class := self._nc_catalog.get_blueprint_class(blueprint_id):
+            return blueprint_class
+        ocb = self._vertice_per_id.get(blueprint_id)
+        if ocb is None or not isinstance(ocb, OnChainBlueprint):
+            raise SyntaxError(f'{blueprint_id.hex()} is not a valid blueprint id')
+        return ocb.get_blueprint_class()

--- a/hathor/merged_mining/coordinator.py
+++ b/hathor/merged_mining/coordinator.py
@@ -233,7 +233,7 @@ class SingleMinerJob(NamedTuple):
         bitcoin_header, coinbase_tx = self._make_bitcoin_block_and_coinbase(work)
         header = bytes(bitcoin_header)
         header_head, header_tail = header[:36], header[-12:]
-        block_base_hash = self.hathor_block.get_base_hash()
+        block_base_hash = self.hathor_block.get_mining_base_hash()
         coinbase = bytes(coinbase_tx)
         assert block_base_hash in coinbase
         coinbase_head, coinbase_tail = coinbase.split(block_base_hash)
@@ -619,7 +619,7 @@ class MergedMiningStratumProtocol(asyncio.Protocol):
         self.last_submit_at = time.time()
 
         bitcoin_block_header = job.build_bitcoin_block_header(work)
-        block_base_hash = job.hathor_block.get_base_hash()
+        block_base_hash = job.hathor_block.get_mining_base_hash()
         block_hash = Hash(bitcoin_block_header.hash)
         self.log.debug('work received', bitcoin_header=bytes(bitcoin_block_header).hex(),
                        hathor_block=job.hathor_block, block_base_hash=block_base_hash.hex(),
@@ -1068,7 +1068,7 @@ class MergedJob(NamedTuple):
             hathor_block.update_hash()
 
         # build coinbase transaction with hathor block hash
-        hathor_block_hash = hathor_block.get_base_hash()
+        hathor_block_hash = hathor_block.get_mining_base_hash()
         coinbase_tx = self.bitcoin_coord.make_coinbase_transaction(
             hathor_block_hash,
             payback_script_bitcoin,

--- a/hathor/nanocontracts/balance_rules.py
+++ b/hathor/nanocontracts/balance_rules.py
@@ -20,7 +20,7 @@ from typing import Generic, TypeVar
 from typing_extensions import assert_never, override
 
 from hathor.conf.settings import HATHOR_TOKEN_UID, HathorSettings
-from hathor.nanocontracts.exception import NCInvalidActionExecution
+from hathor.nanocontracts.exception import NCInvalidAction
 from hathor.nanocontracts.storage import NCChangesTracker
 from hathor.nanocontracts.types import (
     BaseAction,
@@ -159,18 +159,18 @@ class _GrantAuthorityRules(BalanceRules[NCGrantAuthorityAction]):
     @override
     def nc_caller_execution_rule(self, caller_changes_tracker: NCChangesTracker) -> None:
         if self.action.token_uid == HATHOR_TOKEN_UID:
-            raise NCInvalidActionExecution('cannot grant authorities for HTR token')
+            raise NCInvalidAction('cannot grant authorities for HTR token')
 
         balance = caller_changes_tracker.get_balance(self.action.token_uid)
 
         if self.action.mint and not balance.can_mint:
-            raise NCInvalidActionExecution(
+            raise NCInvalidAction(
                 f'{self.action.name} token {self.action.token_uid.hex()} requires mint, '
                 f'but contract does not have that authority'
             )
 
         if self.action.melt and not balance.can_melt:
-            raise NCInvalidActionExecution(
+            raise NCInvalidAction(
                 f'{self.action.name} token {self.action.token_uid.hex()} requires melt, '
                 f'but contract does not have that authority'
             )
@@ -195,15 +195,15 @@ class _AcquireAuthorityRules(BalanceRules[NCAcquireAuthorityAction]):
         balance = callee_changes_tracker.get_balance(self.action.token_uid)
 
         if self.action.mint and not balance.can_mint:
-            raise NCInvalidActionExecution(f'cannot acquire mint authority for token {self.action.token_uid.hex()}')
+            raise NCInvalidAction(f'cannot acquire mint authority for token {self.action.token_uid.hex()}')
 
         if self.action.melt and not balance.can_melt:
-            raise NCInvalidActionExecution(f'cannot acquire melt authority for token {self.action.token_uid.hex()}')
+            raise NCInvalidAction(f'cannot acquire melt authority for token {self.action.token_uid.hex()}')
 
     @override
     def nc_caller_execution_rule(self, caller_changes_tracker: NCChangesTracker) -> None:
         if self.action.token_uid == HATHOR_TOKEN_UID:
-            raise NCInvalidActionExecution('cannot acquire authorities for HTR token')
+            raise NCInvalidAction('cannot acquire authorities for HTR token')
 
         caller_changes_tracker.grant_authorities(
             self.action.token_uid,

--- a/hathor/nanocontracts/catalog.py
+++ b/hathor/nanocontracts/catalog.py
@@ -15,7 +15,6 @@
 from typing import TYPE_CHECKING, Type
 
 from hathor.nanocontracts.blueprints import _blueprints_mapper
-from hathor.nanocontracts.exception import BlueprintDoesNotExist
 from hathor.nanocontracts.types import BlueprintId
 
 if TYPE_CHECKING:
@@ -29,12 +28,9 @@ class NCBlueprintCatalog:
     def __init__(self, blueprints: dict[bytes, Type['Blueprint']]) -> None:
         self.blueprints = blueprints
 
-    def get_blueprint_class(self, blueprint_id: BlueprintId) -> Type['Blueprint']:
-        """Return the blueprint class related to the given blueprint id."""
-        blueprint_class = self.blueprints.get(blueprint_id, None)
-        if blueprint_class is None:
-            raise BlueprintDoesNotExist(blueprint_id.hex())
-        return blueprint_class
+    def get_blueprint_class(self, blueprint_id: BlueprintId) -> Type['Blueprint'] | None:
+        """Return the blueprint class related to the given blueprint id or None if it doesn't exist."""
+        return self.blueprints.get(blueprint_id, None)
 
 
 def generate_catalog_from_settings(settings: 'HathorSettings') -> NCBlueprintCatalog:

--- a/hathor/nanocontracts/exception.py
+++ b/hathor/nanocontracts/exception.py
@@ -26,18 +26,6 @@ class NCError(HathorError):
     pass
 
 
-class NCSerializationError(NCError):
-    pass
-
-
-class NCSerializationArgTooLong(NCSerializationError):
-    pass
-
-
-class NCSerializationTypeError(NCSerializationError):
-    pass
-
-
 class NCTxValidationError(TxValidationError):
     pass
 
@@ -50,30 +38,37 @@ class NCInvalidPubKey(NCTxValidationError):
     pass
 
 
-class NCMethodNotFound(NCTxValidationError):
-    """Raised when a method is not found in a nano contract."""
-    pass
-
-
-class NCInvalidAction(NCTxValidationError):
-    """Raised when an action is invalid."""
-    pass
-
-
-class BlueprintDoesNotExist(NCTxValidationError):
-    pass
-
-
-class NanoContractDoesNotExist(NCTxValidationError):
-    pass
-
-
-class NCViewMethodError(NCError):
-    """Raised when a private method changes the state of the contract."""
-
-
 class NCFail(NCError):
     """Raised by Blueprint's methods to fail execution."""
+
+
+class NanoContractDoesNotExist(NCFail):
+    pass
+
+
+class BlueprintDoesNotExist(NCFail):
+    pass
+
+
+class NCSerializationError(NCFail):
+    pass
+
+
+class NCSerializationArgTooLong(NCSerializationError):
+    pass
+
+
+class NCSerializationTypeError(NCSerializationError):
+    pass
+
+
+class NCViewMethodError(NCFail):
+    """Raised when a view method changes the state of the contract."""
+    pass
+
+
+class NCMethodNotFound(NCFail):
+    """Raised when a method is not found in a nano contract."""
     pass
 
 
@@ -123,8 +118,8 @@ class NCUninitializedContractError(NCFail):
     """Raised when a contract calls a method from an uninitialized contract."""
 
 
-class NCInvalidActionExecution(NCFail):
-    """Raised when an action execution is invalid."""
+class NCInvalidAction(NCFail):
+    """Raised when an action is invalid."""
     pass
 
 

--- a/hathor/nanocontracts/method.py
+++ b/hathor/nanocontracts/method.py
@@ -22,7 +22,7 @@ from typing import Any, TypeVar
 from typing_extensions import Self, assert_never, override
 
 from hathor.nanocontracts import Context
-from hathor.nanocontracts.exception import NCSerializationArgTooLong, NCSerializationError
+from hathor.nanocontracts.exception import NCFail, NCSerializationArgTooLong, NCSerializationError
 from hathor.nanocontracts.nc_types import (
     ESSENTIAL_TYPE_ALIAS_MAP,
     EXTENDED_TYPE_TO_NC_TYPE_MAP,
@@ -263,9 +263,12 @@ class Method:
         return _serialize_map_exception(self.args, args)
 
     def deserialize_args_bytes(self, data: bytes) -> tuple[Any, ...]:
-        """ Shortcut to deserialize args directly from bytes instead of using a deserilizer.
+        """ Shortcut to deserialize args directly from bytes instead of using a deserializer.
         """
-        return _deserialize_map_exception(self.args, data)
+        try:
+            return _deserialize_map_exception(self.args, data)
+        except Exception as e:
+            raise NCFail from e
 
     def serialize_return_bytes(self, return_value: Any) -> bytes:
         """ Shortcut to serialize a return value directly to a bytes instead of using a serializer.
@@ -273,6 +276,6 @@ class Method:
         return _serialize_map_exception(self.return_, return_value)
 
     def deserialize_return_bytes(self, data: bytes) -> Any:
-        """ Shortcut to deserialize a return value directly from bytes instead of using a deserilizer.
+        """ Shortcut to deserialize a return value directly from bytes instead of using a deserializer.
         """
         return _deserialize_map_exception(self.return_, data)

--- a/hathor/nanocontracts/nc_types/__init__.py
+++ b/hathor/nanocontracts/nc_types/__init__.py
@@ -27,6 +27,7 @@ from hathor.nanocontracts.nc_types.namedtuple_nc_type import NamedTupleNCType
 from hathor.nanocontracts.nc_types.nc_type import NCType
 from hathor.nanocontracts.nc_types.null_nc_type import NullNCType
 from hathor.nanocontracts.nc_types.optional_nc_type import OptionalNCType
+from hathor.nanocontracts.nc_types.signed_data_nc_type import SignedDataNCType
 from hathor.nanocontracts.nc_types.sized_int_nc_type import Int32NCType
 from hathor.nanocontracts.nc_types.str_nc_type import StrNCType
 from hathor.nanocontracts.nc_types.token_uid_nc_type import TokenUidNCType
@@ -38,6 +39,7 @@ from hathor.nanocontracts.types import (
     Amount,
     BlueprintId,
     ContractId,
+    SignedData,
     Timestamp,
     TokenUid,
     TxOutputScript,
@@ -62,6 +64,7 @@ __all__ = [
     'NamedTupleNCType',
     'OptionalNCType',
     'SetNCType',
+    'SignedDataNCType',
     'StrNCType',
     'TupleNCType',
     'TypeAliasMap',
@@ -118,6 +121,7 @@ DEFAULT_TYPE_TO_NC_TYPE_MAP: TypeToNCTypeMap = {
     TokenUid: TokenUidNCType,
     TxOutputScript: BytesLikeNCType[TxOutputScript],
     VertexId: Bytes32NCType,
+    SignedData: SignedDataNCType,
 }
 
 # This mapping includes all supported NCType classes, should only be used for parsing function calls

--- a/hathor/nanocontracts/nc_types/signed_data_nc_type.py
+++ b/hathor/nanocontracts/nc_types/signed_data_nc_type.py
@@ -1,0 +1,90 @@
+#  Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from typing_extensions import Self, override
+
+from hathor.nanocontracts.nc_types.nc_type import NCType
+from hathor.nanocontracts.types import SignedData
+from hathor.serialization import Deserializer, Serializer
+from hathor.serialization.compound_encoding.signed_data import decode_signed_data, encode_signed_data
+from hathor.utils.typing import get_args, get_origin
+
+V = TypeVar('V', bound=NCType)
+
+
+class SignedDataNCType(NCType[SignedData[V]]):
+    """ Represents a SignedData[*] values.
+    """
+    __slots__ = ('_is_hashable', '_value', '_inner_type')
+
+    _value: NCType[V]
+    _inner_type: type[V]
+
+    def __init__(self, inner_nc_type: NCType[V], inner_type: type[V], /) -> None:
+        self._value = inner_nc_type
+        self._is_hashable = inner_nc_type.is_hashable()
+        self._inner_type = inner_type
+
+    @override
+    @classmethod
+    def _from_type(cls, type_: type[SignedData[V]], /, *, type_map: NCType.TypeMap) -> Self:
+        origin_type = get_origin(type_) or type_
+        if not issubclass(origin_type, SignedData):
+            raise TypeError('expected SignedData type')
+        args: tuple[type, ...] = get_args(type_) or tuple()
+        if len(args) != 1:
+            raise TypeError('expected one type argument')
+        inner_type, = args
+        return cls(NCType.from_type(inner_type, type_map=type_map), inner_type)
+
+    @override
+    def _check_value(self, value: SignedData[V], /, *, deep: bool) -> None:
+        if not isinstance(value, SignedData):
+            raise TypeError('expected SignedData')
+        if deep:
+            self._value._check_value(value.data, deep=True)
+
+    @override
+    def _serialize(self, serializer: Serializer, value: SignedData[V], /) -> None:
+        encode_signed_data(serializer, value, self._value.serialize)
+
+    @override
+    def _deserialize(self, deserializer: Deserializer, /) -> SignedData[V]:
+        return decode_signed_data(deserializer, self._value.deserialize, self._inner_type)
+
+    @override
+    def _json_to_value(self, json_value: NCType.Json, /) -> SignedData[V]:
+        if not isinstance(json_value, list):
+            raise ValueError('expected list')
+        if len(json_value) != 2:
+            raise ValueError('expected list of 2 elements')
+        inner_json_value, signature_json_value = json_value
+        data = self._value.json_to_value(inner_json_value)
+        if not isinstance(signature_json_value, str):
+            raise ValueError('expected str for signature')
+        script_input = bytes.fromhex(signature_json_value)
+        # XXX: ignore named-defined because mypy doesn't recognize self._inner_type
+        # NOTE: strangely enough it gives a name-defined error but in some nearly identical situations it gives a
+        #       valid-type error
+        return SignedData[self._inner_type](data, script_input)  # type: ignore[name-defined]
+
+    @override
+    def _value_to_json(self, value: SignedData[V], /) -> NCType.Json:
+        inner_json_value = self._value.value_to_json(value.data)
+        signature_json_value = value.script_input.hex()
+        return [inner_json_value, signature_json_value]

--- a/hathor/nanocontracts/on_chain_blueprint.py
+++ b/hathor/nanocontracts/on_chain_blueprint.py
@@ -374,6 +374,10 @@ class OnChainBlueprint(Transaction):
             'nc_signature': self.nc_signature.hex(),
         }
 
+    @override
+    def get_minimum_number_of_inputs(self) -> int:
+        return 0
+
     def get_method(self, method_name: str) -> Method:
         # XXX: possibly do this by analyzing the source AST instead of using the loaded code
         blueprint_class = self.get_blueprint_class()

--- a/hathor/nanocontracts/types.py
+++ b/hathor/nanocontracts/types.py
@@ -68,12 +68,73 @@ class RawSignedData(InnerTypeMixin[T], Generic[T]):
     """
 
     def __init__(self, data: T, script_input: bytes) -> None:
-        raise NotImplementedError('temporarily removed during nano merge')
+        from hathor.nanocontracts.nc_types import make_nc_type_for_type_extended
+        self.data = data
+        self.script_input = script_input
+        self.__nc_type = make_nc_type_for_type_extended(self.__inner_type__)
+
+    def __eq__(self, other):
+        if not isinstance(other, RawSignedData):
+            return False
+        if self.data != other.data:
+            return False
+        if self.script_input != other.script_input:
+            return False
+        return True
+
+    def get_data_bytes(self) -> bytes:
+        """Return the serialized data."""
+        return self.__nc_type.to_bytes(self.data)
+
+    def get_sighash_all_data(self) -> bytes:
+        """Workaround to be able to pass `self` for ScriptExtras. See the method `checksig`."""
+        return self.get_data_bytes()
+
+    def checksig(self, script: bytes) -> bool:
+        """Check if `self.script_input` satisfies the provided script."""
+        from hathor.transaction.exceptions import ScriptError
+        from hathor.transaction.scripts import ScriptExtras
+        from hathor.transaction.scripts.execute import execute_eval
+        full_data = self.script_input + script
+        log: list[str] = []
+        extras = ScriptExtras(tx=self)  # type: ignore[arg-type]
+        try:
+            execute_eval(full_data, log, extras)
+        except ScriptError:
+            return False
+        else:
+            return True
 
 
 class SignedData(InnerTypeMixin[T], Generic[T]):
     def __init__(self, data: T, script_input: bytes) -> None:
-        raise NotImplementedError('temporarily removed during nano merge')
+        self.data = data
+        self.script_input = script_input
+
+    def __eq__(self, other):
+        if not isinstance(other, SignedData):
+            return False
+        if self.data != other.data:
+            return False
+        if self.script_input != other.script_input:
+            return False
+        return True
+
+    def _get_raw_signed_data(self, contract_id: ContractId) -> RawSignedData:
+        # XXX: for some reason mypy doesn't recognize that self.__inner_type__ is defined even though it should
+        raw_type: type = tuple[ContractId, self.__inner_type__]  # type: ignore[name-defined]
+        raw_data = (contract_id, self.data)
+        return RawSignedData[raw_type](raw_data, self.script_input)  # type: ignore[valid-type]
+
+    def get_data_bytes(self, contract_id: ContractId) -> bytes:
+        """Return the serialized data."""
+        raw_signed_data = self._get_raw_signed_data(contract_id)
+        return raw_signed_data.get_data_bytes()
+
+    def checksig(self, contract_id: ContractId, script: bytes) -> bool:
+        """Check if script_input satisfies the provided script."""
+        raw_signed_data = self._get_raw_signed_data(contract_id)
+        return raw_signed_data.checksig(script)
 
 
 def _set_method_type(fn: Callable, method_type: NCMethodType) -> None:

--- a/hathor/serialization/compound_encoding/signed_data.py
+++ b/hathor/serialization/compound_encoding/signed_data.py
@@ -1,0 +1,59 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+r"""
+A `SignedData[T]` value is encoded the same way as a `tuple[T, bytes]`.
+
+Layout: [value_T][script_bytes].
+
+>>> from hathor.serialization.encoding.utf8 import encode_utf8, decode_utf8
+>>> se = Serializer.build_bytes_serializer()
+>>> value = SignedData[str]('😎', b'foobar')  # foobar is not a valid script but it doesn't matter
+>>> encode_signed_data(se, value, encode_utf8)
+>>> bytes(se.finalize()).hex()
+'04f09f988e06666f6f626172'
+
+Breakdown of the result:
+
+    04f09f988e: '😎'
+    06666f6f626172: b'foobar'
+
+>>> de = Deserializer.build_bytes_deserializer(bytes.fromhex('04f09f988e06666f6f626172'))
+>>> decode_signed_data(de, decode_utf8, str)
+SignedData[str](data='😎', script_input=b'foobar')
+>>> de.finalize()
+"""
+
+from typing import TypeVar
+
+from hathor.nanocontracts.types import SignedData
+from hathor.serialization import Deserializer, Serializer
+from hathor.serialization.encoding.bytes import decode_bytes, encode_bytes
+
+from . import Decoder, Encoder
+
+T = TypeVar('T')
+
+
+def encode_signed_data(serializer: Serializer, value: SignedData[T], encoder: Encoder[T]) -> None:
+    assert isinstance(value, SignedData)
+    encoder(serializer, value.data)
+    encode_bytes(serializer, value.script_input)
+
+
+def decode_signed_data(deserializer: Deserializer, decoder: Decoder[T], inner_type: type[T]) -> SignedData[T]:
+    data = decoder(deserializer)
+    script_input = decode_bytes(deserializer)
+    # XXX: ignore valid-type because mypy doesn't recognize dynamic type annotations, but it's correct
+    return SignedData[inner_type](data, script_input)  # type: ignore[valid-type]

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -515,7 +515,7 @@ class StratumProtocol(JSONRPC):
             })
 
         tx = job.tx.clone()
-        block_base = tx.get_header_without_nonce()
+        block_base = tx.get_mining_header_without_nonce()
         block_base_hash = sha256d_hash(block_base)
         # Stratum sends the nonce as a big-endian hexadecimal string.
         if params.get('aux_pow'):
@@ -600,7 +600,7 @@ class StratumProtocol(JSONRPC):
         else:
             if job:
                 job_data = {
-                    'data': job.tx.get_header_without_nonce().hex(),
+                    'data': job.tx.get_mining_header_without_nonce().hex(),
                     'job_id': job.id.hex,
                     'nonce_size': job.tx.SERIALIZATION_NONCE_SIZE,
                     'weight': float(job.weight),

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -23,17 +23,26 @@ from abc import ABC, abstractmethod
 from enum import IntEnum
 from itertools import chain
 from math import isfinite, log
-from struct import error as StructError, pack
+from struct import pack
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Iterator, Optional, TypeAlias, TypeVar
 
 from structlog import get_logger
+from typing_extensions import Self
 
 from hathor.checkpoint import Checkpoint
 from hathor.conf.get_settings import get_global_settings
 from hathor.transaction.exceptions import InvalidOutputValue, WeightError
+from hathor.transaction.headers import VertexBaseHeader
 from hathor.transaction.static_metadata import VertexStaticMetadata
 from hathor.transaction.transaction_metadata import TransactionMetadata
-from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
+from hathor.transaction.util import (
+    VerboseCallback,
+    bytes_to_output_value,
+    int_to_bytes,
+    output_value_to_bytes,
+    unpack,
+    unpack_len,
+)
 from hathor.transaction.validation_state import ValidationState
 from hathor.types import TokenUid, TxOutputScript, VertexId
 from hathor.util import classproperty
@@ -48,7 +57,6 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 MAX_OUTPUT_VALUE = 2**63  # max value (inclusive) that is possible to encode: 9223372036854775808 ~= 9.22337e+18
-_MAX_OUTPUT_VALUE_32 = 2**31 - 1  # max value (inclusive) before having to use 8 bytes: 2147483647 ~= 2.14748e+09
 
 TX_HASH_SIZE = 32   # 256 bits, 32 bytes
 
@@ -117,6 +125,12 @@ class TxVersion(IntEnum):
             TxVersion.POA_BLOCK: PoaBlock
         }
 
+        settings = get_global_settings()
+        if settings.ENABLE_NANO_CONTRACTS and settings.ENABLE_ON_CHAIN_BLUEPRINTS:
+            # XXX This code should not run on any network except nano-testnet.
+            from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
+            cls_map[TxVersion.ON_CHAIN_BLUEPRINT] = OnChainBlueprint
+
         cls = cls_map.get(self)
 
         if cls is None:
@@ -132,6 +146,10 @@ StaticMetadataT = TypeVar('StaticMetadataT', bound=VertexStaticMetadata, covaria
 
 class GenericVertex(ABC, Generic[StaticMetadataT]):
     """Hathor generic vertex"""
+
+    __slots__ = ['version', 'signal_bits', 'weight', 'timestamp', 'nonce', 'inputs', 'outputs', 'parents', '_hash',
+                 'storage', '_settings', '_metadata', '_static_metadata', 'headers', 'name', 'MAX_NUM_INPUTS',
+                 'MAX_NUM_OUTPUTS', '__weakref__']
 
     # Even though nonce is serialized with different sizes for tx and blocks
     # the same size is used for hashes to enable mining algorithm compatibility
@@ -187,8 +205,13 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         self._hash: VertexId | None = hash  # Stored as bytes.
         self._static_metadata = None
 
+        self.headers: list[VertexBaseHeader] = []
+
         # A name solely for debugging purposes.
         self.name: str | None = None
+
+        self.MAX_NUM_INPUTS = self._settings.MAX_NUM_INPUTS
+        self.MAX_NUM_OUTPUTS = self._settings.MAX_NUM_OUTPUTS
 
     @classproperty
     def log(cls):
@@ -255,10 +278,26 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         buf = self.get_graph_fields_from_struct(buf, verbose=verbose)
         return buf
 
+    def get_header_from_bytes(self, buf: bytes, *, verbose: VerboseCallback = None) -> bytes:
+        """Parse bytes and return the next header in buffer."""
+        from hathor.transaction.vertex_parser import VertexParser
+
+        if len(self.headers) >= self.get_maximum_number_of_headers():
+            raise ValueError('too many headers')
+        header_type = buf[:1]
+        header_class = VertexParser.get_header_parser(header_type, self._settings)
+        header, buf = header_class.deserialize(self, buf)
+        self.headers.append(header)
+        return buf
+
+    def get_maximum_number_of_headers(self) -> int:
+        """Return the maximum number of headers for this vertex."""
+        return 1
+
     @classmethod
     @abstractmethod
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> 'BaseTransaction':
+                           *, verbose: VerboseCallback = None) -> Self:
         """ Create a transaction from its bytes.
 
         :param struct_bytes: Bytes of a serialized transaction
@@ -405,6 +444,10 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
             struct_bytes += parent
         return struct_bytes
 
+    def get_headers_struct(self) -> bytes:
+        """Return the serialization of the headers only."""
+        return b''.join(h.serialize() for h in self.headers)
+
     def get_struct_without_nonce(self) -> bytes:
         """Return a partial serialization of the transaction, without including the nonce field
 
@@ -432,16 +475,12 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         """
         struct_bytes = self.get_struct_without_nonce()
         struct_bytes += self.get_struct_nonce()
+        struct_bytes += self.get_headers_struct()
         return struct_bytes
 
     def get_all_dependencies(self) -> set[bytes]:
         """Set of all tx-hashes needed to fully validate this tx, including parent blocks/txs and inputs."""
         return set(chain(self.parents, (i.tx_id for i in self.inputs)))
-
-    def get_tx_dependencies(self) -> set[bytes]:
-        """Set of all tx-hashes needed to fully validate this, except for block parent, i.e. only tx parents/inputs."""
-        parents = self.parents[1:] if self.is_block else self.parents
-        return set(chain(parents, (i.tx_id for i in self.inputs)))
 
     def get_tx_parents(self) -> set[bytes]:
         """Set of parent tx hashes, typically used for syncing transactions."""
@@ -529,23 +568,26 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         funds_hash.update(self.get_funds_struct())
         return funds_hash.digest()
 
-    def get_graph_hash(self) -> bytes:
-        """Return the sha256 of the graph part of the transaction
+    def get_graph_and_headers_hash(self) -> bytes:
+        """Return the sha256 of the graph part of the transaction + its headers
 
-        :return: the hash of the funds data
+        :return: the hash of the graph and headers data
         :rtype: bytes
         """
-        graph_hash = hashlib.sha256()
-        graph_hash.update(self.get_graph_struct())
-        return graph_hash.digest()
+        h = hashlib.sha256()
+        h.update(self.get_graph_struct())
+        h.update(self.get_headers_struct())
+        return h.digest()
 
-    def get_header_without_nonce(self) -> bytes:
+    def get_mining_header_without_nonce(self) -> bytes:
         """Return the transaction header without the nonce
 
         :return: transaction header without the nonce
         :rtype: bytes
         """
-        return self.get_funds_hash() + self.get_graph_hash()
+        data = self.get_funds_hash() + self.get_graph_and_headers_hash()
+        assert len(data) == 64, 'the mining data should have a fixed size of 64 bytes'
+        return data
 
     def calculate_hash1(self) -> 'HASH':
         """Return the sha256 of the transaction without including the `nonce`
@@ -554,7 +596,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         :rtype: :py:class:`_hashlib.HASH`
         """
         calculate_hash1 = hashlib.sha256()
-        calculate_hash1.update(self.get_header_without_nonce())
+        calculate_hash1.update(self.get_mining_header_without_nonce())
         return calculate_hash1
 
     def calculate_hash2(self, part1: 'HASH') -> bytes:
@@ -825,19 +867,20 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         return ret
 
-    def clone(self, *, include_metadata: bool = True, include_storage: bool = True) -> 'BaseTransaction':
+    def clone(self, *, include_metadata: bool = True, include_storage: bool = True) -> Self:
         """Return exact copy without sharing memory, including metadata if loaded.
 
         :return: Transaction or Block copy
         """
-        new_tx = self.create_from_struct(self.get_struct())
+        new_tx = self.create_from_struct(
+            self.get_struct(),
+            storage=self.storage if include_storage else None,
+        )
         # static_metadata can be safely copied as it is a frozen dataclass
         new_tx.set_static_metadata(self._static_metadata)
         if hasattr(self, '_metadata') and include_metadata:
             assert self._metadata is not None  # FIXME: is this actually true or do we have to check if not None
             new_tx._metadata = self._metadata.clone()
-        if include_storage:
-            new_tx.storage = self.storage
         return new_tx
 
     @abstractmethod
@@ -1089,32 +1132,3 @@ class TxOutput:
         if decode_script:
             data['decoded'] = self.to_human_readable()
         return data
-
-
-def bytes_to_output_value(buf: bytes) -> tuple[int, bytes]:
-    (value_high_byte,), _ = unpack('!b', buf)
-    if value_high_byte < 0:
-        output_struct = '!q'
-        value_sign = -1
-    else:
-        output_struct = '!i'
-        value_sign = 1
-    try:
-        (signed_value,), buf = unpack(output_struct, buf)
-    except StructError as e:
-        raise InvalidOutputValue('Invalid byte struct for output') from e
-    value = signed_value * value_sign
-    assert value >= 0
-    if value < _MAX_OUTPUT_VALUE_32 and value_high_byte < 0:
-        raise ValueError('Value fits in 4 bytes but is using 8 bytes')
-    return value, buf
-
-
-def output_value_to_bytes(number: int) -> bytes:
-    if number <= 0:
-        raise InvalidOutputValue('Invalid value for output')
-
-    if number > _MAX_OUTPUT_VALUE_32:
-        return (-number).to_bytes(8, byteorder='big', signed=True)
-    else:
-        return number.to_bytes(4, byteorder='big', signed=True)  # `signed` makes no difference, but oh well

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -95,9 +95,14 @@ class Block(GenericVertex[BlockStaticMetadata]):
         blc = cls()
         buf = blc.get_fields_from_struct(struct_bytes, verbose=verbose)
 
-        blc.nonce = int.from_bytes(buf, byteorder='big')
-        if len(buf) != cls.SERIALIZATION_NONCE_SIZE:
+        if len(buf) < cls.SERIALIZATION_NONCE_SIZE:
             raise ValueError('Invalid sequence of bytes')
+
+        blc.nonce = int.from_bytes(buf[:cls.SERIALIZATION_NONCE_SIZE], byteorder='big')
+        buf = buf[cls.SERIALIZATION_NONCE_SIZE:]
+
+        while buf:
+            buf = blc.get_header_from_bytes(buf, verbose=verbose)
 
         blc.hash = blc.calculate_hash()
         blc.storage = storage
@@ -291,9 +296,9 @@ class Block(GenericVertex[BlockStaticMetadata]):
             # TODO: check whether self is a parent of any checkpoint-valid block, this is left for a future PR
             pass
 
-    def get_base_hash(self) -> bytes:
+    def get_mining_base_hash(self) -> bytes:
         from hathor.merged_mining.bitcoin import sha256d_hash
-        return sha256d_hash(self.get_header_without_nonce())
+        return sha256d_hash(self.get_mining_header_without_nonce())
 
     def get_height(self) -> int:
         """Return this block's height."""

--- a/hathor/transaction/merge_mined_block.py
+++ b/hathor/transaction/merge_mined_block.py
@@ -79,7 +79,7 @@ class MergeMinedBlock(Block):
 
     def calculate_hash(self) -> bytes:
         assert self.aux_pow is not None
-        return self.aux_pow.calculate_hash(self.get_base_hash())
+        return self.aux_pow.calculate_hash(self.get_mining_base_hash())
 
     def get_struct_nonce(self) -> bytes:
         if not self.aux_pow:

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -1161,14 +1161,14 @@ class TransactionStorage(ABC):
         from hathor.nanocontracts.exception import BlueprintDoesNotExist
         assert self.nc_catalog is not None
 
-        try:
-            return self.nc_catalog.get_blueprint_class(blueprint_id)
-        except BlueprintDoesNotExist as e:
-            self.log.debug('blueprint-id not in the catalog', blueprint_id=blueprint_id.hex())
-            if not self._settings.ENABLE_ON_CHAIN_BLUEPRINTS:
-                raise e
-            self.log.debug('on-chain blueprints enabled, looking for that instead')
-            return self.get_on_chain_blueprint(blueprint_id)
+        if blueprint_class := self.nc_catalog.get_blueprint_class(blueprint_id):
+            return blueprint_class
+
+        self.log.debug('blueprint-id not in the catalog', blueprint_id=blueprint_id.hex())
+        if not self._settings.ENABLE_ON_CHAIN_BLUEPRINTS:
+            raise BlueprintDoesNotExist(blueprint_id.hex())
+        self.log.debug('on-chain blueprints enabled, looking for that instead')
+        return self.get_on_chain_blueprint(blueprint_id)
 
     def get_blueprint_source(self, blueprint_id: BlueprintId) -> str:
         """Returns the source code associated with the given blueprint_id.

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from struct import error as StructError, pack
+from struct import pack
 from typing import Any, Optional
 
 from typing_extensions import override
@@ -22,7 +22,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.transaction.base_transaction import TxInput, TxOutput, TxVersion
 from hathor.transaction.storage import TransactionStorage  # noqa: F401
 from hathor.transaction.transaction import TokenInfo, Transaction
-from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
+from hathor.transaction.util import VerboseCallback, decode_string_utf8, int_to_bytes, unpack, unpack_len
 from hathor.types import TokenUid
 
 # Signal bits (B), version (B), inputs len (B), outputs len (B)
@@ -177,6 +177,10 @@ class TokenCreationTransaction(Transaction):
         struct_bytes += b''.join(tx_outputs)
 
         struct_bytes += self.serialize_token_info()
+
+        for header in self.headers:
+            struct_bytes += header.get_sighash_bytes()
+
         self._sighash_cache = struct_bytes
 
         return struct_bytes
@@ -246,13 +250,3 @@ class TokenCreationTransaction(Transaction):
         token_dict[self.hash] = TokenInfo(0, True, True)
 
         return token_dict
-
-
-def decode_string_utf8(encoded: bytes, key: str) -> str:
-    """ Raises StructError in case it's not a valid utf-8 string
-    """
-    try:
-        decoded = encoded.decode('utf-8')
-        return decoded
-    except UnicodeDecodeError:
-        raise StructError('{} must be a valid utf-8 string.'.format(key))

--- a/hathor/transaction/vertex_parser.py
+++ b/hathor/transaction/vertex_parser.py
@@ -15,7 +15,9 @@
 from __future__ import annotations
 
 from struct import error as StructError
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type
+
+from hathor.transaction.headers import NanoHeader, VertexBaseHeader, VertexHeaderId
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -29,6 +31,23 @@ class VertexParser:
     def __init__(self, *, settings: HathorSettings) -> None:
         self._settings = settings
 
+    @staticmethod
+    def get_supported_headers(settings: HathorSettings) -> dict[VertexHeaderId, Type[VertexBaseHeader]]:
+        """Return a dict of supported headers."""
+        supported_headers: dict[VertexHeaderId, Type[VertexBaseHeader]] = {}
+        if settings.ENABLE_NANO_CONTRACTS:
+            supported_headers[VertexHeaderId.NANO_HEADER] = NanoHeader
+        return supported_headers
+
+    @staticmethod
+    def get_header_parser(header_id_bytes: bytes, settings: HathorSettings) -> Type[VertexBaseHeader]:
+        """Get the parser for a given header type."""
+        header_id = VertexHeaderId(header_id_bytes)
+        supported_headers = VertexParser.get_supported_headers(settings)
+        if header_id not in supported_headers:
+            raise ValueError(f'Header type not supported: {header_id_bytes!r}')
+        return supported_headers[header_id]
+
     def deserialize(self, data: bytes, storage: TransactionStorage | None = None) -> BaseTransaction:
         """ Creates the correct tx subclass from a sequence of bytes
         """
@@ -41,5 +60,5 @@ class VertexParser:
                 raise StructError(f"invalid vertex version: {tx_version}")
             cls = tx_version.get_cls()
             return cls.create_from_struct(data, storage=storage)
-        except ValueError:
-            raise StructError('Invalid bytes to create transaction subclass.')
+        except ValueError as e:
+            raise StructError('Invalid bytes to create transaction subclass.') from e

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -39,4 +39,4 @@ class MergeMinedBlockVerifier:
             else self._settings.OLD_MAX_MERKLE_PATH_LENGTH
         )
 
-        block.aux_pow.verify(block.get_base_hash(), max_merkle_path_length)
+        block.aux_pow.verify(block.get_mining_base_hash(), max_merkle_path_length)

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -13,10 +13,10 @@
 #  limitations under the License.
 
 from hathor.conf.settings import HathorSettings
-from hathor.transaction.exceptions import InvalidToken, TransactionDataError
+from hathor.transaction.exceptions import InvalidToken
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.transaction import TokenInfo
-from hathor.transaction.util import clean_token_string
+from hathor.transaction.util import validate_token_name_and_symbol
 from hathor.types import TokenUid
 
 
@@ -42,15 +42,4 @@ class TokenCreationTransactionVerifier:
     def verify_token_info(self, tx: TokenCreationTransaction) -> None:
         """ Validates token info
         """
-        name_len = len(tx.token_name)
-        symbol_len = len(tx.token_symbol)
-        if name_len == 0 or name_len > self._settings.MAX_LENGTH_TOKEN_NAME:
-            raise TransactionDataError('Invalid token name length ({})'.format(name_len))
-        if symbol_len == 0 or symbol_len > self._settings.MAX_LENGTH_TOKEN_SYMBOL:
-            raise TransactionDataError('Invalid token symbol length ({})'.format(symbol_len))
-
-        # Can't create token with hathor name or symbol
-        if clean_token_string(tx.token_name) == clean_token_string(self._settings.HATHOR_TOKEN_NAME):
-            raise TransactionDataError('Invalid token name ({})'.format(tx.token_name))
-        if clean_token_string(tx.token_symbol) == clean_token_string(self._settings.HATHOR_TOKEN_SYMBOL):
-            raise TransactionDataError('Invalid token symbol ({})'.format(tx.token_symbol))
+        validate_token_name_and_symbol(self._settings, tx.token_name, tx.token_symbol)

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -99,6 +99,7 @@ class VerificationService:
 
         Used by `self.validate_basic`. Should not modify the validation state."""
         self.verifiers.vertex.verify_version(vertex)
+        self.verifiers.vertex.verify_headers(vertex)
 
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -1,5 +1,3 @@
-import pytest
-
 from hathor.manager import HathorManager
 from hathor.simulator import FakeConnection
 from hathor.simulator.trigger import All as AllTriggers, StopWhenSynced, Trigger
@@ -95,7 +93,6 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         for node in nodes[1:]:
             self.assertTipsEqual(nodes[0], node)
 
-    @pytest.mark.flaky(max_runs=5, min_passes=1)
     def test_new_syncing_peer(self) -> None:
         nodes = []
         miners = []
@@ -142,7 +139,9 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         for miner in miners:
             miner.stop()
 
-        self.assertTrue(self.simulator.run(3600, trigger=AllTriggers(stop_triggers)))
+        # TODO Add self.assertTrue(...) when the trigger is fixed. Same as in test_many_miners_since_beginning.
+        #      For further information, see https://github.com/HathorNetwork/hathor-core/pull/815.
+        self.simulator.run(3600, trigger=AllTriggers(stop_triggers))
 
         for idx, node in enumerate(nodes):
             self.log.debug(f'checking node {idx}')

--- a/tests/test_utils/test_leb128.py
+++ b/tests/test_utils/test_leb128.py
@@ -1,0 +1,217 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import random
+
+import pytest
+
+from hathor.utils import leb128
+
+
+@pytest.mark.parametrize(
+    ['value', 'expected'],
+    [
+        (2, bytes([2])),
+        (-2, bytes([0x7e])),
+        (63, bytes([63])),
+        (64, bytes([64 + 0x80, 0x00])),
+        (-64, bytes([64])),
+        (-65, bytes([0xbf, 0x7f])),
+        (127, bytes([127 + 0x80, 0])),
+        (-127, bytes([1 + 0x80, 0x7f])),
+        (128, bytes([0 + 0x80, 1])),
+        (-128, bytes([0 + 0x80, 0x7f])),
+        (129, bytes([1 + 0x80, 1])),
+        (-129, bytes([0x7f + 0x80, 0x7e])),
+    ],
+)
+def test_encode_dwarf_examples_signed(value: int, expected: bytes) -> None:
+    """
+    Examples from the DWARF 5 standard, section 7.6, table 7.8.
+    https://dwarfstd.org/doc/DWARF5.pdf
+    """
+    assert leb128.encode_signed(value) == expected
+
+
+@pytest.mark.parametrize(
+    ['value', 'expected'],
+    [
+        (2, bytes([2])),
+        (63, bytes([63])),
+        (64, bytes([64])),
+        (127, bytes([127])),
+        (128, bytes([0 + 0x80, 1])),
+        (129, bytes([1 + 0x80, 1])),
+    ],
+)
+def test_encode_dwarf_examples_unsigned(value: int, expected: bytes) -> None:
+    """
+    Examples from the DWARF 5 standard, section 7.6, table 7.8.
+    https://dwarfstd.org/doc/DWARF5.pdf
+    """
+    assert leb128.encode_unsigned(value) == expected
+
+
+def _assert_round_trip_signed(n: int) -> None:
+    assert leb128.decode_signed(leb128.encode_signed(n) + b'extra bytes') == (n, b'extra bytes'), n
+
+
+def _assert_round_trip_unsigned(n: int) -> None:
+    assert leb128.decode_unsigned(leb128.encode_signed(n) + b'extra bytes') == (n, b'extra bytes'), n
+
+
+@pytest.mark.parametrize(
+    ['value'],
+    [
+        (0,),
+        (2,),
+        (-2,),
+        (127,),
+        (-127,),
+        (128,),
+        (-128,),
+        (129,),
+        (-129,),
+    ]
+)
+def test_round_trip_dwarf_examples_signed(value: int) -> None:
+    _assert_round_trip_signed(value)
+
+
+@pytest.mark.parametrize(
+    ['value'],
+    [
+        (0,),
+        (2,),
+        (64,),
+        (65,),
+        (127,),
+        (128,),
+        (129,),
+    ]
+)
+def test_round_trip_dwarf_examples_unsigned(value: int) -> None:
+    _assert_round_trip_unsigned(value)
+
+
+def test_round_trip_edge_cases_signed() -> None:
+    for n_bytes in range(0, 33):
+        n = 8 * n_bytes
+        edge_cases = (-(2**n) - 1, -(2**n), 2**n - 1, 2**n)
+        for value in edge_cases:
+            _assert_round_trip_signed(value)
+
+
+def test_round_trip_edge_cases_unsigned() -> None:
+    for n_bytes in range(1, 33):
+        n = 8 * n_bytes
+        edge_cases = (2**n - 1, 2**n, 2**n + 1)
+        for value in edge_cases:
+            _assert_round_trip_unsigned(value)
+
+
+def test_round_trip_random_signed() -> None:
+    for _ in range(1_000_000):
+        n = random.randint(-(2**256) - 1, 2**256)
+        _assert_round_trip_signed(n)
+
+
+def test_round_trip_random_unsigned() -> None:
+    for _ in range(1_000_000):
+        n = random.randint(0, 2**256)
+        _assert_round_trip_unsigned(n)
+
+
+@pytest.mark.parametrize(
+    ['value', 'max_bytes'],
+    [
+        (2, 0),
+        (-2, 0),
+        (63, 0),
+        (-64, 0),
+        (-65, 1),
+        (64, 1),
+        (127, 1),
+        (-127, 1),
+        (128, 1),
+        (-128, 1),
+        (129, 1),
+        (-129, 1),
+        (-8192, 1),
+        (8191, 1),
+        (8192, 2),
+        (-8193, 2),
+    ],
+)
+def test_encode_max_bytes_dwarf_examples_signed(value: int, max_bytes: int) -> None:
+    with pytest.raises(ValueError) as e:
+        leb128.encode_signed(value, max_bytes=max_bytes)
+    assert str(e.value) == f'cannot encode more than {max_bytes} bytes'
+
+
+@pytest.mark.parametrize(
+    ['value', 'max_bytes'],
+    [
+        (2, 0),
+        (64, 0),
+        (65, 0),
+        (127, 0),
+        (128, 1),
+        (129, 1),
+        (16383, 1),
+        (16384, 2),
+    ],
+)
+def test_encode_max_bytes_dwarf_examples_unsigned(value: int, max_bytes: int) -> None:
+    with pytest.raises(ValueError) as e:
+        leb128.encode_unsigned(value, max_bytes=max_bytes)
+    assert str(e.value) == f'cannot encode more than {max_bytes} bytes'
+
+
+@pytest.mark.parametrize(
+    ['buf', 'max_bytes'],
+    [
+        (bytes([2]), 0),
+        (bytes([0x7e]), 0),
+        (bytes([127 + 0x80, 0]), 1),
+        (bytes([1 + 0x80, 0x7f]), 1),
+        (bytes([0 + 0x80, 1]), 1),
+        (bytes([0 + 0x80, 0x7f]), 1),
+        (bytes([1 + 0x80, 1]), 1),
+        (bytes([0x7f + 0x80, 0x7e]), 1),
+    ],
+)
+def test_decode_max_bytes_dwarf_examples_signed(buf: bytes, max_bytes: int) -> None:
+    with pytest.raises(ValueError) as e:
+        leb128.decode_signed(buf, max_bytes=max_bytes)
+    assert str(e.value) == f'cannot decode more than {max_bytes} bytes'
+
+
+@pytest.mark.parametrize(
+    ['buf', 'max_bytes'],
+    [
+        (bytes([2]), 0),
+        (bytes([0x7e]), 0),
+        (bytes([127 + 0x80, 0]), 1),
+        (bytes([1 + 0x80, 0x7f]), 1),
+        (bytes([0 + 0x80, 1]), 1),
+        (bytes([0 + 0x80, 0x7f]), 1),
+        (bytes([1 + 0x80, 1]), 1),
+        (bytes([0x7f + 0x80, 0x7e]), 1),
+    ],
+)
+def test_decode_max_bytes_dwarf_examples_unsigned(buf: bytes, max_bytes: int) -> None:
+    with pytest.raises(ValueError) as e:
+        leb128.decode_unsigned(buf, max_bytes=max_bytes)
+    assert str(e.value) == f'cannot decode more than {max_bytes} bytes'

--- a/tests/tx/test_stratum.py
+++ b/tests/tx/test_stratum.py
@@ -232,7 +232,7 @@ class StratumClientTest(unittest.TestCase):
         self.protocol = StratumClient(reactor=self.clock)
         self.protocol.makeConnection(self.transport)
         self.job_request_params = {
-            'data': self.block.get_header_without_nonce().hex(),
+            'data': self.block.get_mining_header_without_nonce().hex(),
             'job_id': 'a734d03fe4b64739be2894742f3de20f',
             'nonce_size': Block.SERIALIZATION_NONCE_SIZE,
             'weight': self.block.weight,

--- a/tests/tx/test_token_validation.py
+++ b/tests/tx/test_token_validation.py
@@ -1,0 +1,43 @@
+
+import pytest
+
+from hathor.conf.get_settings import get_global_settings
+from hathor.transaction.exceptions import TransactionDataError
+from hathor.transaction.util import validate_token_name_and_symbol
+
+
+def test_token_name():
+    settings = get_global_settings()
+
+    validate_token_name_and_symbol(settings, 'TOKEN', 'TKN')
+    validate_token_name_and_symbol(settings, 'TOKEN', 'X')
+    validate_token_name_and_symbol(settings, 'TOKEN', 'XY')
+    validate_token_name_and_symbol(settings, 'TOKEN', 'XYZ')
+    validate_token_name_and_symbol(settings, 'TOKEN', 'XYZW')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, '', 'X')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, 'TOKEN', '')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, 'HATHOR', 'X')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, ' HATHOR', 'X')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, ' HATHOR ', 'X')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, 'HATHOR ', 'X')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, 'TOKEN', 'HTR')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, 'TOKEN', ' HTR')
+
+    with pytest.raises(TransactionDataError):
+        validate_token_name_and_symbol(settings, 'TOKEN', 'HTR ')

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -290,7 +290,7 @@ class TransactionTest(unittest.TestCase):
             storage=self.tx_storage,
         )
 
-        assert b1.get_base_hash() != b2.get_base_hash()
+        assert b1.get_mining_base_hash() != b2.get_mining_base_hash()
 
         header_head = b'\x00' * 32
         header_tail = b'\x00' * 12
@@ -298,9 +298,9 @@ class TransactionTest(unittest.TestCase):
         coinbase_parts = [
             b'\x00' * 42,
             MAGIC_NUMBER,
-            b1.get_base_hash(),
+            b1.get_mining_base_hash(),
             MAGIC_NUMBER,
-            b2.get_base_hash(),
+            b2.get_mining_base_hash(),
             b'\x00' * 18,
         ]
 
@@ -793,21 +793,17 @@ class TransactionTest(unittest.TestCase):
         assert isinstance(e.value.__cause__, TransactionDataError)
 
     def test_output_serialization(self):
-        from hathor.transaction.base_transaction import (
-            _MAX_OUTPUT_VALUE_32,
-            MAX_OUTPUT_VALUE,
-            bytes_to_output_value,
-            output_value_to_bytes,
-        )
-        max_32 = output_value_to_bytes(_MAX_OUTPUT_VALUE_32)
+        from hathor.serialization.encoding.output_value import MAX_OUTPUT_VALUE_32
+        from hathor.transaction.base_transaction import MAX_OUTPUT_VALUE, bytes_to_output_value, output_value_to_bytes
+        max_32 = output_value_to_bytes(MAX_OUTPUT_VALUE_32)
         self.assertEqual(len(max_32), 4)
         value, buf = bytes_to_output_value(max_32)
-        self.assertEqual(value, _MAX_OUTPUT_VALUE_32)
+        self.assertEqual(value, MAX_OUTPUT_VALUE_32)
 
-        over_32 = output_value_to_bytes(_MAX_OUTPUT_VALUE_32 + 1)
+        over_32 = output_value_to_bytes(MAX_OUTPUT_VALUE_32 + 1)
         self.assertEqual(len(over_32), 8)
         value, buf = bytes_to_output_value(over_32)
-        self.assertEqual(value, _MAX_OUTPUT_VALUE_32 + 1)
+        self.assertEqual(value, MAX_OUTPUT_VALUE_32 + 1)
 
         max_64 = output_value_to_bytes(MAX_OUTPUT_VALUE)
         self.assertEqual(len(max_64), 8)

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -114,12 +114,14 @@ class VerificationTest(unittest.TestCase):
         block = self._get_valid_block()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
 
         verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
         verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
@@ -127,6 +129,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
 
         # Block methods
         verify_weight_wrapped.assert_called_once()
@@ -213,12 +216,14 @@ class VerificationTest(unittest.TestCase):
         block = self._get_valid_block()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
 
         verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
         verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
@@ -226,6 +231,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
 
         # Block methods
         verify_weight_wrapped.assert_called_once()
@@ -259,6 +265,7 @@ class VerificationTest(unittest.TestCase):
         block = self._get_valid_block()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
@@ -275,6 +282,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
@@ -292,6 +300,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         verify_outputs_wrapped.assert_called_once()
 
         # Block methods
@@ -311,12 +320,14 @@ class VerificationTest(unittest.TestCase):
         block = self._get_valid_merge_mined_block()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
 
         verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
         verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
@@ -324,6 +335,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
 
         # Block methods
         verify_weight_wrapped.assert_called_once()
@@ -416,12 +428,14 @@ class VerificationTest(unittest.TestCase):
         block = self._get_valid_merge_mined_block()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
 
         verify_weight_wrapped = Mock(wraps=self.verifiers.block.verify_weight)
         verify_reward_wrapped = Mock(wraps=self.verifiers.block.verify_reward)
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
@@ -429,6 +443,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
 
         # Block methods
         verify_weight_wrapped.assert_called_once()
@@ -462,6 +477,7 @@ class VerificationTest(unittest.TestCase):
         block = self._get_valid_merge_mined_block()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_pow_wrapped = Mock(wraps=self.verifiers.vertex.verify_pow)
@@ -480,6 +496,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_pow', verify_pow_wrapped),
             patch.object(BlockVerifier, 'verify_no_inputs', verify_no_inputs_wrapped),
@@ -498,6 +515,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         verify_outputs_wrapped.assert_called_once()
 
         # Block methods
@@ -520,6 +538,7 @@ class VerificationTest(unittest.TestCase):
         tx = self._get_valid_tx()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
@@ -532,6 +551,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
@@ -545,6 +565,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
@@ -643,6 +664,7 @@ class VerificationTest(unittest.TestCase):
         tx = self._get_valid_tx()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
@@ -655,6 +677,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
@@ -668,6 +691,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
@@ -723,6 +747,7 @@ class VerificationTest(unittest.TestCase):
         tx = self._get_valid_tx()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
@@ -741,6 +766,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
@@ -760,6 +786,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         assert verify_outputs_wrapped.call_count == 2
 
         # Transaction methods
@@ -816,6 +843,7 @@ class VerificationTest(unittest.TestCase):
         tx = self._get_valid_token_creation_tx()
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
@@ -828,6 +856,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
@@ -841,6 +870,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
@@ -946,6 +976,7 @@ class VerificationTest(unittest.TestCase):
         tx.get_metadata().validation = ValidationState.INITIAL
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
@@ -958,6 +989,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
@@ -971,6 +1003,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         verify_outputs_wrapped.assert_called_once()
 
         # Transaction methods
@@ -1026,6 +1059,7 @@ class VerificationTest(unittest.TestCase):
         tx.get_metadata().validation = ValidationState.INITIAL
 
         verify_version_wrapped = Mock(wraps=self.verifiers.vertex.verify_version)
+        verify_headers_wrapped = Mock(wraps=self.verifiers.vertex.verify_headers)
         verify_outputs_wrapped = Mock(wraps=self.verifiers.vertex.verify_outputs)
 
         verify_parents_basic_wrapped = Mock(wraps=self.verifiers.tx.verify_parents_basic)
@@ -1047,6 +1081,7 @@ class VerificationTest(unittest.TestCase):
 
         with (
             patch.object(VertexVerifier, 'verify_version', verify_version_wrapped),
+            patch.object(VertexVerifier, 'verify_headers', verify_headers_wrapped),
             patch.object(VertexVerifier, 'verify_outputs', verify_outputs_wrapped),
             patch.object(TransactionVerifier, 'verify_parents_basic', verify_parents_basic_wrapped),
             patch.object(TransactionVerifier, 'verify_weight', verify_weight_wrapped),
@@ -1068,6 +1103,7 @@ class VerificationTest(unittest.TestCase):
 
         # Vertex methods
         verify_version_wrapped.assert_called_once()
+        verify_headers_wrapped.assert_called_once()
         assert verify_outputs_wrapped.call_count == 2
 
         # Transaction methods


### PR DESCRIPTION
### Motivation

Add support for vertex headers, plus some other smaller changes.

### Acceptance Criteria

- Add support for vertex headers, currently only enabled on nano testnet.
- Refactor `NCCatalog.get_blueprint_class` so it returns `None` instead of raising an exception.
- Refactor nano exceptions.
- Add signed data types.
- Rename `get_header_without_nonce` to `get_mining_header_without_nonce` and `get_base_hash` to `get_mining_base_hash`.
- Other smaller changes.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 