### PR TITLE
feat(p2p): Add misbehavior score for unsolicited vertices

### DIFF
--- a/hathor/p2p/rate_limiter.py
+++ b/hathor/p2p/rate_limiter.py
@@ -71,13 +71,14 @@ class RateLimiter:
             return True
         max_hits, window_seconds = self.keys[key]
 
+        now = self.reactor.seconds()
+
         if key not in self.hits:
-            self.hits[key] = RateLimiterLimit(weight, self.reactor.seconds())
-            return True
+            self.hits[key] = RateLimiterLimit(0, now)
 
         hits, latest_time = self.hits[key]
 
-        dt = self.reactor.seconds() - latest_time
+        dt = now - latest_time
 
         # rate = max_hits / window_seconds (hits per second)
         # x = dt * rate


### PR DESCRIPTION
### Motivation

This PR introduces a misbehavior score but simply close the connection when the threshold is reached. A future PR can enforce better responses to misbehavior (e.g., temporary ban for the peer id or ip address).

### Acceptance Criteria

1. Reject unsolicited vertices.
2. Add `_inbound_relay_enabled: bool` to control whether we request relay from the peer.
3. Add a misbehavior score for each connection which decays to zero in 1h.
4. If a peer misbehaves above a threshold, its connection is closed.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 