### PR TITLE
feat(ocb): metered execution of on-chain blueprints and nano calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,15 @@ doctests:
 	pytest $(pytest_flags) -n0 hathor
 
 .PHONY: tests-lib
-tests-lib: tests-lib-nocov tests-lib-cov
+tests-lib: tests-lib-metered tests-lib-cov
 
 .PHONY: tests-lib-cov
 tests-lib-cov:
-	pytest $(pytest_flags) $(pytest_covflags) $(tests_lib) -m "not no_cover" --durations=10
+	HATHOR_TEST_CONFIG_YAML='./hathor/conf/unittests_unmetered.yml' pytest $(pytest_flags) $(pytest_covflags) $(tests_lib) -m "not needs_metered_exec" --durations=10
 
-.PHONY: tests-lib-nocov
-tests-lib-nocov:
-	pytest $(pytest_flags) $(tests_lib) -m no_cover
+.PHONY: tests-lib-metered
+tests-lib-metered:
+	pytest $(pytest_flags) $(tests_lib) -m "does_metered_call or needs_metered_exec"
 
 .PHONY: tests-quick
 tests-quick:

--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -489,6 +489,9 @@ class HathorSettings(NamedTuple):
     # Max length in bytes allowed for on-chain blueprint code inside the transaction, 24KB (not KiB)
     NC_ON_CHAIN_BLUEPRINT_CODE_MAX_SIZE_COMPRESSED: int = 24_000
 
+    # Whether to measure execution (cpu/fuel and max memory) of NC calls and OCB creation
+    NC_METERED_EXECUTION: bool = True
+
     # TODO: align this with a realistic value later
     # fuel units are arbitrary but it's roughly the number of opcodes, memory_limit is in bytes
     NC_INITIAL_FUEL_TO_LOAD_BLUEPRINT_MODULE: int = 100_000  # 100K opcodes

--- a/hathor/conf/unittests_unmetered.yml
+++ b/hathor/conf/unittests_unmetered.yml
@@ -1,0 +1,2 @@
+extends: unittests.yml
+NC_METERED_EXECUTION: false

--- a/hathor/nanocontracts/on_chain_blueprint.py
+++ b/hathor/nanocontracts/on_chain_blueprint.py
@@ -196,9 +196,11 @@ class OnChainBlueprint(Transaction):
     def _load_blueprint_code_exec(self) -> tuple[object, dict[str, object]]:
         """XXX: DO NOT CALL THIS METHOD UNLESS YOU REALLY KNOW WHAT IT DOES."""
         from hathor.nanocontracts.metered_exec import MeteredExecutor, OutOfFuelError, OutOfMemoryError
-        fuel = self._settings.NC_INITIAL_FUEL_TO_LOAD_BLUEPRINT_MODULE
-        memory_limit = self._settings.NC_MEMORY_LIMIT_TO_LOAD_BLUEPRINT_MODULE
-        metered_executor = MeteredExecutor(fuel=fuel, memory_limit=memory_limit)
+        metered_executor = MeteredExecutor(
+            fuel=self._settings.NC_INITIAL_FUEL_TO_LOAD_BLUEPRINT_MODULE,
+            memory_limit=self._settings.NC_MEMORY_LIMIT_TO_LOAD_BLUEPRINT_MODULE,
+            _no_measure=not self._settings.NC_METERED_EXECUTION,
+        )
         try:
             env = metered_executor.exec(self.code.text)
         except OutOfFuelError as e:

--- a/hathor/nanocontracts/runner/runner.py
+++ b/hathor/nanocontracts/runner/runner.py
@@ -283,7 +283,11 @@ class Runner:
         if not self.has_contract_been_initialized(contract_id):
             raise NCUninitializedContractError('cannot call methods from uninitialized contracts')
 
-        self._metered_executor = MeteredExecutor(fuel=self._initial_fuel, memory_limit=self._memory_limit)
+        self._metered_executor = MeteredExecutor(
+            fuel=self._initial_fuel,
+            memory_limit=self._memory_limit,
+            _no_measure=not self._settings.NC_METERED_EXECUTION,
+        )
 
         blueprint_id = self.get_blueprint_id(contract_id)
 
@@ -702,7 +706,11 @@ class Runner:
             raise NCUninitializedContractError('cannot call methods from uninitialized contracts')
 
         if self._metered_executor is None:
-            self._metered_executor = MeteredExecutor(fuel=self._initial_fuel, memory_limit=self._memory_limit)
+            self._metered_executor = MeteredExecutor(
+                fuel=self._initial_fuel,
+                memory_limit=self._memory_limit,
+                _no_measure=not self._settings.NC_METERED_EXECUTION,
+            )
 
         changes_tracker = self._create_changes_tracker(contract_id)
         blueprint_id = self.get_blueprint_id(contract_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,8 @@ testpaths = ["tests"]
 addopts = "-n auto"
 markers = [
     "slow",
+    "does_metered_call",
+    "needs_metered_exec",
 ]
 norecursedirs = ["tests/nanocontracts/test_blueprints"]
 

--- a/tests/dag_builder/test_dag_builder.py
+++ b/tests/dag_builder/test_dag_builder.py
@@ -353,7 +353,7 @@ if foo:
             """)
         assert str(e.value) == 'unclosed multiline string'
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     def test_on_chain_blueprints(self) -> None:
         bet_code = load_builtin_blueprint_for_ocb('bet.py', 'Bet', test_blueprints)
         private_key = unittest.OCB_TEST_PRIVKEY.hex()

--- a/tests/nanocontracts/blueprints/test_bet.py
+++ b/tests/nanocontracts/blueprints/test_bet.py
@@ -41,7 +41,7 @@ class BetInfo(NamedTuple):
     score: str
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class NCBetBlueprintTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/nanocontracts/blueprints/test_swap_demo.py
+++ b/tests/nanocontracts/blueprints/test_swap_demo.py
@@ -9,7 +9,7 @@ from tests.nanocontracts.test_blueprints.swap_demo import InvalidActions, Invali
 SWAP_NC_TYPE = make_nc_type(int)
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class SwapDemoTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/nanocontracts/on_chain_blueprints/test_bet.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_bet.py
@@ -49,7 +49,7 @@ class BetInfo(NamedTuple):
     score: str
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class OnChainBetBlueprintTestCase(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -186,7 +186,7 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
         self.assertEqual(self.nc_storage.get_obj(b'token_uid', TOKEN_UID_NC_TYPE), self.token_uid)
         self.assertEqual(self.nc_storage.get_obj(b'date_last_bet', TIMESTAMP_NC_TYPE), self.date_last_bet)
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     def test_basic_flow(self) -> None:
         runner = self.runner
 

--- a/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -23,7 +23,7 @@ def _load_file(filename: str) -> bytes:
 ZLIB_BOMB: bytes = _load_file('bomb.zlib')
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class OnChainBlueprintScriptTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
@@ -454,6 +454,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
         self.assertIsInstance(cause, ValueError)
         self.assertEqual(cause.args, ('Decompressed code is too long.',))
 
+    @pytest.mark.needs_metered_exec
     def test_large_list_with_range(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint('''__blueprint__ = list(range(2**30))''')
@@ -461,6 +462,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
         with self.assertRaises(OCBOutOfMemoryDuringLoading):
             blueprint.get_blueprint_class()
 
+    @pytest.mark.needs_metered_exec
     def test_large_list_with_mul(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint('''__blueprint__ = [1] * 2**30''')
@@ -469,6 +471,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
             blueprint.get_blueprint_class()
 
     @pytest.mark.skip(reason='hangs')
+    @pytest.mark.needs_metered_exec
     def test_large_list_with_mul2(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint('''x = ['a']\nwhile True:\n    x = x * 2\n__blueprint__ = x''')
@@ -477,6 +480,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
             blueprint.get_blueprint_class()
 
     @pytest.mark.skip(reason='hangs')
+    @pytest.mark.needs_metered_exec
     def test_large_list_with_sum(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint('''x = ['a']\nwhile True:\n    x = x + x\n__blueprint__ = x''')
@@ -485,6 +489,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
             blueprint.get_blueprint_class()
 
     @pytest.mark.skip(reason='hangs')
+    @pytest.mark.needs_metered_exec
     def test_large_int_with_mul(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint('''__blueprint__ = 1**(2**30**30)''')
@@ -492,23 +497,26 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
         with self.assertRaises(OCBOutOfMemoryDuringLoading):
             blueprint.get_blueprint_class()
 
+    @pytest.mark.needs_metered_exec
     def test_large_string_with_range(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint(
             '''x = 'a'\nfor _ in range(100):\n    x = x * 5\n__blueprint__ = x'''
         )
-        # this should run out of fuel first, since it shouldn't take too much memory
+        # this should run out of memory first, before it consumes all the fuel
         with self.assertRaises(OCBOutOfMemoryDuringLoading):
             blueprint.get_blueprint_class()
 
     @pytest.mark.skip(reason='hangs')
+    @pytest.mark.needs_metered_exec
     def test_large_string_with_mul(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfMemoryDuringLoading
         blueprint = self._create_on_chain_blueprint('''x = 'a'\nwhile True:\n    x = x * 2\n__blueprint__ = x''')
-        # this should run out of fuel first, since it shouldn't take too much memory
+        # this should run out of memory first, before it consumes all the fuel
         with self.assertRaises(OCBOutOfMemoryDuringLoading):
             blueprint.get_blueprint_class()
 
+    @pytest.mark.needs_metered_exec
     def test_large_sum(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfFuelDuringLoading
         blueprint = self._create_on_chain_blueprint('''__blueprint__ = sum(range(2**30))''')
@@ -516,6 +524,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
         with self.assertRaises(OCBOutOfFuelDuringLoading):
             blueprint.get_blueprint_class()
 
+    @pytest.mark.needs_metered_exec
     def test_inf_loop(self) -> None:
         from hathor.nanocontracts.exception import OCBOutOfFuelDuringLoading
         blueprint = self._create_on_chain_blueprint('''a = 0\nwhile True:\n    a += 1\n__blueprint__ = a''')

--- a/tests/nanocontracts/test_blueprint.py
+++ b/tests/nanocontracts/test_blueprint.py
@@ -97,7 +97,7 @@ class MyBlueprint(Blueprint):
         return 1
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class NCBlueprintTestCase(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/nanocontracts/test_call_other_contract.py
+++ b/tests/nanocontracts/test_call_other_contract.py
@@ -133,7 +133,7 @@ class MyBlueprint(Blueprint):
         return self.syscall.call_view_method(self.syscall.get_contract_id(), 'get_counter')
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class NCBlueprintTestCase(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/nanocontracts/test_consensus.py
+++ b/tests/nanocontracts/test_consensus.py
@@ -76,7 +76,7 @@ class MyBlueprint(Blueprint):
             raise NCFail('counter is zero')
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class NCConsensusTestCase(SimulatorTestCase):
     __test__ = True
 

--- a/tests/nanocontracts/test_indexes.py
+++ b/tests/nanocontracts/test_indexes.py
@@ -106,7 +106,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
         trigger = StopAfterNMinedBlocks(self.miner, quantity=confirmations)
         self.assertTrue(self.simulator.run(7200, trigger=trigger))
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     def test_tokens_index(self):
         token_info0 = self.manager.tx_storage.indexes.tokens.get_token_info(self.token_uid)
         new_blocks = 0
@@ -146,13 +146,13 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
         token_info1 = self.manager.tx_storage.indexes.tokens.get_token_info(self._settings.HATHOR_TOKEN_UID)
         self.assertEqual(token_info0.get_total() + 64_00 * new_blocks, token_info1.get_total())
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     def test_remove_voided_nano_tx_from_parents_1(self):
         vertices = self._run_test_remove_voided_nano_tx_from_parents('tx3 < b35')
         v = [node.name for node, _ in vertices.list]
         self.assertTrue(v.index('tx3') < v.index('b35'))
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     def test_remove_voided_nano_tx_from_parents_2(self):
         vertices = self._run_test_remove_voided_nano_tx_from_parents('b35 < tx3')
         v = [node.name for node, _ in vertices.list]

--- a/tests/nanocontracts/test_violations.py
+++ b/tests/nanocontracts/test_violations.py
@@ -31,7 +31,7 @@ class MyBlueprint(Blueprint):
         self.unknown = 1
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class ViolationsTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/resources/nanocontracts/test_blueprint.py
+++ b/tests/resources/nanocontracts/test_blueprint.py
@@ -1,7 +1,7 @@
-import pytest
 from collections.abc import Generator
 from typing import Any
 
+import pytest
 from twisted.internet.defer import Deferred, inlineCallbacks
 
 from hathor.nanocontracts.resources.blueprint import BlueprintInfoResource
@@ -144,7 +144,7 @@ class BuiltinBlueprintInfoTest(BaseBlueprintInfoTest):
         self.create_builtin_blueprint(self.manager, self.blueprint_id, my_blueprint.MyBlueprint)
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class OCBBlueprintInfoTest(BaseBlueprintInfoTest):
     __test__ = True
 

--- a/tests/resources/nanocontracts/test_blueprint_source_code.py
+++ b/tests/resources/nanocontracts/test_blueprint_source_code.py
@@ -88,7 +88,7 @@ class TestBlueprint(Blueprint):
         self.create_builtin_blueprint(self.manager, self.blueprint_id, dummy_blueprint.TestBlueprint)
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class OCBBlueprintSourceCodeTest(BaseBlueprintSourceCodeTest):
     __test__ = True
 

--- a/tests/resources/nanocontracts/test_history.py
+++ b/tests/resources/nanocontracts/test_history.py
@@ -138,7 +138,7 @@ class NanoContractHistoryTest(_BaseResourceTest._ResourceTest):
         add_new_block(self.manager)
         return nc
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     @inlineCallbacks
     def test_success(self):
         parents = [tx.hash for tx in self.genesis_txs]

--- a/tests/resources/nanocontracts/test_nc_creation.py
+++ b/tests/resources/nanocontracts/test_nc_creation.py
@@ -28,7 +28,7 @@ from tests.resources.base_resource import StubSite, _BaseResourceTest
 from tests.utils import get_genesis_key
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class NCCreationResourceTest(_BaseResourceTest._ResourceTest):
 
     def setUp(self):

--- a/tests/resources/nanocontracts/test_on_chain.py
+++ b/tests/resources/nanocontracts/test_on_chain.py
@@ -25,7 +25,7 @@ from tests.nanocontracts import test_blueprints
 from tests.resources.base_resource import StubSite, _BaseResourceTest
 
 
-@pytest.mark.no_cover
+@pytest.mark.does_metered_call
 class BlueprintOnChainResourceTest(_BaseResourceTest._ResourceTest):
 
     def setUp(self):

--- a/tests/resources/nanocontracts/test_state.py
+++ b/tests/resources/nanocontracts/test_state.py
@@ -199,7 +199,7 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         sign_openssl(nano_header, private_key)
         self.manager.cpu_mining_service.resolve(nc)
 
-    @pytest.mark.no_cover
+    @pytest.mark.does_metered_call
     @inlineCallbacks
     def test_success(self):
         parents = [tx.hash for tx in self.genesis_txs]


### PR DESCRIPTION
### Motivation

Currently the Python execution when loading or making calls can have infinite loops and infinite memory allocation.

### Acceptance Criteria

- Introduce a `MeteredExecutor` that can be used to scope and measure executions
- Use `MeteredExecutor.exec` instead of `exec` when loading on-chain blueprints
- Use `MeteredExecutor.call` instead of a direct call when running nano calls (either public/view)

### Unresolved Questions

This PR does not address the following issues, which need to be addressed in order for peers to be able to reach the same consensus:

- NC method calls have some private attributes still accessible (such as `ctx._runner`), those could use `__attr` to be protected
- restrict how classes are built, currently any class can be created deriving from any other class, we can however expose a custom `__build_class__` to control which creations are allowed
- make OP cycle count independent of hathor-core internal code (notably during call between contracts A and B, any hathor-core code that runs in between the point that the code from A stops running and the call of B starts will counts towards the OP cycle, this is unwanted because it means any change in that code affects the cycle count)
- make sure OP cycle count is stable (this can be worked around by using a fixed Python version, but we don't want to use the same Python version forever, so this can only go so far before it will need another workaround or proper solution)
- make sure memory measurement is hardware independent (it might as well be, but we have to make sure)
- make sure memory measurement is system independent (this can be worked around by fixing the system requirement to Linux, but it's like the Python version requirement)
- make sure memory measurement is architecture independent (requiring a specific architecture (amd64 or arch64) could be even more inconvenient than requiring a specific system, since in practice there's a much larger mix of both of these major architectures in use)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 