### PR TITLE
chore: Adjust '/nano_contract/state' and '/get_block_template' rate limits

### DIFF
--- a/hathor/nanocontracts/resources/state.py
+++ b/hathor/nanocontracts/resources/state.py
@@ -317,14 +317,14 @@ NanoContractStateResource.openapi = {
         'x-rate-limit': {
             'global': [
                 {
-                    'rate': '10r/s',
+                    'rate': '30r/s',
                     'burst': 20,
                     'delay': 10
                 }
             ],
             'per-ip': [
                 {
-                    'rate': '2r/s',
+                    'rate': '5r/s',
                     'burst': 6,
                     'delay': 3
                 }

--- a/hathor/transaction/resources/mining.py
+++ b/hathor/transaction/resources/mining.py
@@ -144,7 +144,7 @@ GetBlockTemplateResource.openapi = {
             'per-ip': [
                 {
                     'rate': '1r/s',
-                    'burst': 1,
+                    'burst': 3,
                     'delay': 3,
                 }
             ]


### PR DESCRIPTION
### Motivation

The motivation was the issue https://github.com/HathorNetwork/on-call-incidents/issues/211

### Acceptance Criteria

- Increase the rate-limits of `/nano_contract/state` to 30r/s global and 5r/s per IP.
- Increase the rate-limits of `/get_block_template` to have a burst of 3

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 