### PR TITLE
fix(nano): use Uint32 for Timestamp instead of Int32

### DIFF
--- a/hathor/nanocontracts/nc_types/__init__.py
+++ b/hathor/nanocontracts/nc_types/__init__.py
@@ -28,7 +28,7 @@ from hathor.nanocontracts.nc_types.nc_type import NCType
 from hathor.nanocontracts.nc_types.null_nc_type import NullNCType
 from hathor.nanocontracts.nc_types.optional_nc_type import OptionalNCType
 from hathor.nanocontracts.nc_types.signed_data_nc_type import SignedDataNCType
-from hathor.nanocontracts.nc_types.sized_int_nc_type import Int32NCType
+from hathor.nanocontracts.nc_types.sized_int_nc_type import Int32NCType, Uint32NCType
 from hathor.nanocontracts.nc_types.str_nc_type import StrNCType
 from hathor.nanocontracts.nc_types.token_uid_nc_type import TokenUidNCType
 from hathor.nanocontracts.nc_types.tuple_nc_type import TupleNCType
@@ -72,6 +72,7 @@ __all__ = [
     'TupleNCType',
     'TypeAliasMap',
     'TypeToNCTypeMap',
+    'Uint32NCType',
     'VarInt32NCType',
     'VarUint32NCType',
     'make_nc_type_for_field_type',
@@ -118,7 +119,7 @@ FIELD_TYPE_TO_NC_TYPE_MAP: TypeToNCTypeMap = {
     Amount: VarUint32NCType,
     BlueprintId: Bytes32NCType,
     ContractId: Bytes32NCType,
-    Timestamp: Int32NCType,
+    Timestamp: Uint32NCType,
     TokenUid: TokenUidNCType,
     TxOutputScript: BytesLikeNCType[TxOutputScript],
     VertexId: Bytes32NCType,

--- a/hathor/nanocontracts/nc_types/sized_int_nc_type.py
+++ b/hathor/nanocontracts/nc_types/sized_int_nc_type.py
@@ -96,3 +96,8 @@ class _SizedIntNCType(NCType[int]):
 class Int32NCType(_SizedIntNCType):
     _signed = True
     _byte_size = 4  # 4-bytes -> 32-bits
+
+
+class Uint32NCType(_SizedIntNCType):
+    _signed = False
+    _byte_size = 4  # 4-bytes -> 32-bits


### PR DESCRIPTION
### Motivation

Timestamps don't make use of negative integers, so it's not useful to use a signed integer encoding.

### Acceptance Criteria

- Introduce `Uint32NCType` that is similar to `Int32NCType` but unsigned instead of signed
- Change `Timestamp`'s mapping to `Uint32NCType`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 