### PR TITLE
tests(nano): add register_blueprint_file test method

### DIFF
--- a/tests/nanocontracts/blueprints/test_bet.py
+++ b/tests/nanocontracts/blueprints/test_bet.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import re
 from typing import NamedTuple, Optional
@@ -23,7 +24,7 @@ from hathor.transaction.scripts import P2PKH
 from hathor.util import not_none
 from hathor.wallet import KeyPair
 from tests.nanocontracts.blueprints.unittest import BlueprintTestCase
-from tests.nanocontracts.test_blueprints.bet import Bet
+from tests.nanocontracts.test_blueprints import bet
 
 settings = HathorSettings()
 
@@ -43,8 +44,7 @@ class BetInfo(NamedTuple):
 class NCBetBlueprintTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()
-        self.blueprint_id = self.gen_random_blueprint_id()
-        self.register_blueprint_class(self.blueprint_id, Bet)
+        self.blueprint_id = self.register_blueprint_file(inspect.getfile(bet))
         self.token_uid = TokenUid(settings.HATHOR_TOKEN_UID)
         self.nc_id = ContractId(VertexId(b'1' * 32))
         self.initialize_contract()

--- a/tests/nanocontracts/blueprints/unittest.py
+++ b/tests/nanocontracts/blueprints/unittest.py
@@ -1,10 +1,13 @@
-from hathor.conf import HathorSettings
+from os import PathLike
+
+from hathor.conf.settings import HATHOR_TOKEN_UID
 from hathor.crypto.util import decode_address
 from hathor.manager import HathorManager
 from hathor.nanocontracts import Context
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.blueprint_env import BlueprintEnvironment
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig
+from hathor.nanocontracts.on_chain_blueprint import Code, OnChainBlueprint
 from hathor.nanocontracts.storage import NCBlockStorage, NCMemoryStorageFactory
 from hathor.nanocontracts.storage.backends import MemoryNodeTrieStore
 from hathor.nanocontracts.storage.patricia_trie import PatriciaTrie
@@ -12,11 +15,10 @@ from hathor.nanocontracts.types import Address, BlueprintId, ContractId, NCActio
 from hathor.nanocontracts.vertex_data import VertexData
 from hathor.transaction import BaseTransaction, Transaction
 from hathor.util import not_none
+from hathor.verification.on_chain_blueprint_verifier import OnChainBlueprintVerifier
 from hathor.wallet import KeyPair
 from tests import unittest
 from tests.nanocontracts.utils import TestRunner
-
-settings = HathorSettings()
 
 
 class BlueprintTestCase(unittest.TestCase):
@@ -30,7 +32,7 @@ class BlueprintTestCase(unittest.TestCase):
         self.reactor = self.manager.reactor
         self.nc_catalog = self.manager.tx_storage.nc_catalog
 
-        self.htr_token_uid = settings.HATHOR_TOKEN_UID
+        self.htr_token_uid = HATHOR_TOKEN_UID
         self.runner = self.build_runner()
         self.now = int(self.reactor.seconds())
 
@@ -72,10 +74,29 @@ class BlueprintTestCase(unittest.TestCase):
         contract = blueprint_class(env)
         return contract
 
-    def register_blueprint_class(self, blueprint_id: BlueprintId, blueprint_class: type[Blueprint]) -> None:
-        """Register a blueprint class with a given id, allowing contracts to be created from it."""
+    def _register_blueprint_class(
+        self,
+        blueprint_class: type[Blueprint],
+        blueprint_id: BlueprintId | None = None,
+    ) -> BlueprintId:
+        """Register a blueprint class with an optional id, allowing contracts to be created from it."""
+        if blueprint_id is None:
+            blueprint_id = self.gen_random_blueprint_id()
+
         assert blueprint_id not in self.nc_catalog.blueprints
         self.nc_catalog.blueprints[blueprint_id] = blueprint_class
+        return blueprint_id
+
+    def register_blueprint_file(self, path: PathLike[str], blueprint_id: BlueprintId | None = None) -> BlueprintId:
+        """Register a blueprint file with an optional id, allowing contracts to be created from it."""
+        with open(path, 'r') as f:
+            code = Code.from_python_code(f.read(), self._settings)
+
+        verifier = OnChainBlueprintVerifier(settings=self._settings)
+        ocb = OnChainBlueprint(hash=b'', code=code)
+        verifier.verify_code(ocb)
+
+        return self._register_blueprint_class(ocb.get_blueprint_class(), blueprint_id)
 
     def build_runner(self) -> TestRunner:
         """Create a Runner instance."""

--- a/tests/nanocontracts/test_allowed_actions.py
+++ b/tests/nanocontracts/test_allowed_actions.py
@@ -65,9 +65,8 @@ class TestAllowedActions(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.blueprint_id = self.gen_random_blueprint_id()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.contract_id = self.gen_random_contract_id()
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
 
         self.token_a = self.gen_random_token_uid()
         self.address = self.gen_random_address()
@@ -139,8 +138,7 @@ class TestAllowedActions(BlueprintTestCase):
                     pass
 
             runner = self.build_runner()
-            blueprint_id = self.gen_random_blueprint_id()
-            self.register_blueprint_class(blueprint_id, MyOtherBlueprint)
+            blueprint_id = self._register_blueprint_class(MyOtherBlueprint)
             runner.create_contract(self.contract_id, blueprint_id, self._get_context())
             method_name = allowed_action.name.lower()
             forbidden_actions = self.all_actions.difference({allowed_action})

--- a/tests/nanocontracts/test_blueprints/bet.py
+++ b/tests/nanocontracts/test_blueprints/bet.py
@@ -219,3 +219,6 @@ class Bet(Blueprint):
         address_total = self.bets_address.get((self.final_result, address), 0)
         percentage = address_total / result_total
         return Amount(floor(percentage * self.total))
+
+
+__blueprint__ = Bet

--- a/tests/nanocontracts/test_contract_create_contract.py
+++ b/tests/nanocontracts/test_contract_create_contract.py
@@ -90,10 +90,8 @@ class MyBlueprint2(Blueprint):
 class NCBlueprintTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()
-        self.blueprint1_id = self.gen_random_blueprint_id()
-        self.blueprint2_id = self.gen_random_blueprint_id()
-        self.register_blueprint_class(self.blueprint1_id, MyBlueprint1)
-        self.register_blueprint_class(self.blueprint2_id, MyBlueprint2)
+        self.blueprint1_id = self._register_blueprint_class(MyBlueprint1)
+        self.blueprint2_id = self._register_blueprint_class(MyBlueprint2)
 
     def test_basic(self) -> None:
         counter = 5

--- a/tests/nanocontracts/test_contract_upgrade.py
+++ b/tests/nanocontracts/test_contract_upgrade.py
@@ -100,15 +100,10 @@ class CodeBlueprint3(Blueprint):
 class NCDelegateCallTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()
-        self.proxy_bp_id = self.gen_random_blueprint_id()
-        self.code1_bp_id = self.gen_random_blueprint_id()
-        self.code2_bp_id = self.gen_random_blueprint_id()
-        self.code3_bp_id = self.gen_random_blueprint_id()
-
-        self.register_blueprint_class(self.proxy_bp_id, ProxyBlueprint)
-        self.register_blueprint_class(self.code1_bp_id, CodeBlueprint1)
-        self.register_blueprint_class(self.code2_bp_id, CodeBlueprint2)
-        self.register_blueprint_class(self.code3_bp_id, CodeBlueprint3)
+        self.proxy_bp_id = self._register_blueprint_class(ProxyBlueprint)
+        self.code1_bp_id = self._register_blueprint_class(CodeBlueprint1)
+        self.code2_bp_id = self._register_blueprint_class(CodeBlueprint2)
+        self.code3_bp_id = self._register_blueprint_class(CodeBlueprint3)
 
     def test_basic(self) -> None:
         code1_id = self.gen_random_contract_id()

--- a/tests/nanocontracts/test_execution_order.py
+++ b/tests/nanocontracts/test_execution_order.py
@@ -127,14 +127,13 @@ class TestExecutionOrder(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.blueprint_id = self.gen_random_blueprint_id()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.contract_id1 = self.gen_random_contract_id()
         self.contract_id2 = self.gen_random_contract_id()
         self.token_a = self.gen_random_token_uid()
         self.tx = self.get_genesis_tx()
         self.address = self.gen_random_address()
 
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
         action = NCDepositAction(token_uid=TokenUid(HATHOR_TOKEN_UID), amount=10)
         self.runner.create_contract(self.contract_id1, self.blueprint_id, self._get_context(action), self.token_a)
         self.runner.create_contract(self.contract_id2, self.blueprint_id, self._get_context(action), self.token_a)

--- a/tests/nanocontracts/test_execution_verification.py
+++ b/tests/nanocontracts/test_execution_verification.py
@@ -35,9 +35,8 @@ class MyBlueprint(Blueprint):
 class TestExecutionVerification(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.blueprint_id = self.gen_random_blueprint_id()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.contract_id = self.gen_random_contract_id()
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
 
     def test_blueprint_does_not_exist(self) -> None:
         with pytest.raises(BlueprintDoesNotExist):

--- a/tests/nanocontracts/test_fallback_method.py
+++ b/tests/nanocontracts/test_fallback_method.py
@@ -71,9 +71,8 @@ class TestFallbackMethod(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.blueprint_id = self.gen_random_blueprint_id()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.contract_id = self.gen_random_contract_id()
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
 
         self.ctx = Context(
             actions=[NCDepositAction(token_uid=TokenUid(HATHOR_TOKEN_UID), amount=123)],

--- a/tests/nanocontracts/test_follow_up_call.py
+++ b/tests/nanocontracts/test_follow_up_call.py
@@ -69,11 +69,8 @@ class TestFollowUpCall(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.blueprint_id1 = self.gen_random_blueprint_id()
-        self.blueprint_id2 = self.gen_random_blueprint_id()
-
-        self.register_blueprint_class(self.blueprint_id1, MyBlueprint1)
-        self.register_blueprint_class(self.blueprint_id2, MyBlueprint2)
+        self.blueprint_id1 = self._register_blueprint_class(MyBlueprint1)
+        self.blueprint_id2 = self._register_blueprint_class(MyBlueprint2)
 
         self.contract_id = self.gen_random_contract_id()
         self.other_id = self.gen_random_contract_id()

--- a/tests/nanocontracts/test_get_contract.py
+++ b/tests/nanocontracts/test_get_contract.py
@@ -46,8 +46,7 @@ class NCGetContractTestCase(BlueprintTestCase):
         super().setUp()
         self.token_uid = TokenUid(settings.HATHOR_TOKEN_UID)
         self.nc_id = ContractId(VertexId(b'1' * 32))
-        self.blueprint_id = self.gen_random_blueprint_id()
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.initialize_contract()
         self.nc_storage = self.runner.get_storage(self.nc_id)
 

--- a/tests/nanocontracts/test_indexes2.py
+++ b/tests/nanocontracts/test_indexes2.py
@@ -37,9 +37,8 @@ class TestIndexes2(BlueprintTestCase):
         assert self.manager.tx_storage.indexes.tokens is not None
         self.tokens_index = self.manager.tx_storage.indexes.tokens
 
-        self.blueprint_id = self.gen_random_blueprint_id()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.dag_builder = TestDAGBuilder.from_manager(self.manager)
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
 
     def test_indexes_tx_affected_twice(self) -> None:
         amount = 10000

--- a/tests/nanocontracts/test_invalid_value_assignment.py
+++ b/tests/nanocontracts/test_invalid_value_assignment.py
@@ -31,8 +31,7 @@ class NCGetContractTestCase(BlueprintTestCase):
         super().setUp()
         self.token_uid = TokenUid(settings.HATHOR_TOKEN_UID)
         self.nc_id = ContractId(VertexId(b'1' * 32))
-        self.blueprint_id = self.gen_random_blueprint_id()
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.runner.create_contract(self.nc_id, self.blueprint_id, self.create_context())
         self.nc_storage = self.runner.get_storage(self.nc_id)
 

--- a/tests/nanocontracts/test_seqnum.py
+++ b/tests/nanocontracts/test_seqnum.py
@@ -24,8 +24,7 @@ class MyBlueprint1(Blueprint):
 class NCBlueprintTestCase(BlueprintTestCase):
     def setUp(self):
         super().setUp()
-        self.blueprint1_id = self.gen_random_blueprint_id()
-        self.register_blueprint_class(self.blueprint1_id, MyBlueprint1)
+        self.blueprint1_id = self._register_blueprint_class(MyBlueprint1)
 
     def test_seqnum_fail_after_success(self) -> None:
         """tx2 will successfully execute, so tx3 will fail because it has the same seqnum."""

--- a/tests/nanocontracts/test_syscalls_in_view.py
+++ b/tests/nanocontracts/test_syscalls_in_view.py
@@ -124,8 +124,7 @@ class TestSyscallsInView(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        self.blueprint_id = self.gen_random_blueprint_id()
-        self.register_blueprint_class(self.blueprint_id, MyBlueprint)
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
 
         self.ctx = Context(
             actions=[],


### PR DESCRIPTION
### Motivation

When blueprint devs are implementing tests, their blueprints are not verified against code restrictions. This PR adds the `register_blueprint_file` method which does this and should be used by blueprints devs from now on instead of `register_blueprint_class`.

### Acceptance Criteria

- Change `register_blueprint_class` test method to `_register_blueprint_class`, making the blueprint ID optional. It should be used by our internal tests.
- Add new `register_blueprint_file` test method, which verifies the blueprint code. It should be used by blueprint devs.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 