### PR TITLE
feat(nano): restrict dunder names

### DIFF
--- a/hathor/verification/on_chain_blueprint_verifier.py
+++ b/hathor/verification/on_chain_blueprint_verifier.py
@@ -57,6 +57,8 @@ class _RestrictionsVisitor(ast.NodeVisitor):
     def visit_Name(self, node: ast.Name) -> None:
         if node.id in AST_NAME_BLACKLIST:
             raise SyntaxError(f'Usage or reference to {node.id} is not allowed.')
+        if '__' in node.id:
+            raise SyntaxError('Using dunder names is not allowed.')
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
@@ -64,6 +66,11 @@ class _RestrictionsVisitor(ast.NodeVisitor):
             if '__' in node.attr:
                 raise SyntaxError('Access to internal attributes and methods is not allowed.')
         self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str):
+            if '__' in node.value:
+                raise SyntaxError('Using dunder names is not allowed.')
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         raise SyntaxError('Async functions are not allowed.')

--- a/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -157,6 +157,16 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
             'Access to internal attributes and methods is not allowed.',
         )
 
+    def test_forbid_dunder_names(self) -> None:
+        self._test_forbid_syntax(
+            '__x__ = 123',
+            'Using dunder names is not allowed.'
+        )
+        self._test_forbid_syntax(
+            'x = "__x__"',
+            'Using dunder names is not allowed.'
+        )
+
     def test_forbid_async_fn(self) -> None:
         self._test_forbid_syntax(
             'async def foo():\n    ...',


### PR DESCRIPTION
### Motivation

Improve security by adding further syntax restrictions to blueprints, preventing usage of double underscores in name nodes such as `__x__ = 123` and string literals such as `x = '__x__'`.

### Acceptance Criteria

- Restrict double underscores in name nodes and string literals.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 