### PR TITLE
fix(events): nano scenarios on simulator

### DIFF
--- a/hathor/cli/events_simulator/events_simulator.py
+++ b/hathor/cli/events_simulator/events_simulator.py
@@ -57,11 +57,13 @@ def execute(args: Namespace, reactor: 'ReactorProtocol') -> None:
         possible_scenarios = [scenario.name for scenario in Scenario]
         raise ValueError(f'Invalid scenario "{args.scenario}". Choose one of {possible_scenarios}') from e
 
+    settings = get_global_settings()._replace(REWARD_SPEND_MIN_BLOCKS=scenario.get_reward_spend_min_blocks())
     log = logger.new()
     simulator = Simulator(args.seed)
     simulator.start()
     builder = simulator.get_default_builder() \
-        .enable_event_queue()
+        .enable_event_queue() \
+        .set_settings(settings)
 
     manager = simulator.create_peer(builder)
     event_ws_factory = manager._event_manager._event_ws_factory
@@ -70,7 +72,7 @@ def execute(args: Namespace, reactor: 'ReactorProtocol') -> None:
     forwarding_ws_factory = EventForwardingWebsocketFactory(
         simulator=simulator,
         peer_id='simulator_peer_id',
-        settings=get_global_settings(),
+        settings=settings,
         reactor=reactor,
         event_storage=event_ws_factory._event_storage
     )

--- a/hathor/cli/events_simulator/scenario.py
+++ b/hathor/cli/events_simulator/scenario.py
@@ -51,6 +51,10 @@ class Scenario(Enum):
 
         return simulate_fn(simulator, manager)
 
+    def get_reward_spend_min_blocks(self) -> int:
+        """Get the REWARD_SPEND_MIN_BLOCKS settings required for this scenario."""
+        return 1 if self in (Scenario.NC_EVENTS, Scenario.NC_EVENTS_REORG) else 10
+
 
 def simulate_only_load(simulator: 'Simulator', _manager: 'HathorManager') -> Optional['DAGArtifacts']:
     simulator.run(60)


### PR DESCRIPTION
### Motivation

Nano-related scenarios are currently broken on the `events_simulator` CLI. This PR fixes this.

### Acceptance Criteria

- Configure the correct reward lock for nano scenarios.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 