### PR TITLE
chore(nano): remove deprecated get_balance

### DIFF
--- a/hathor/nanocontracts/blueprint_env.py
+++ b/hathor/nanocontracts/blueprint_env.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, final
 
-from typing_extensions import deprecated
-
 from hathor.nanocontracts.storage import NCContractStorage
 from hathor.nanocontracts.types import Amount, BlueprintId, ContractId, NCAction, TokenUid
 
@@ -64,24 +62,6 @@ class BlueprintEnvironment:
         if contract_id is None:
             contract_id = self.get_contract_id()
         return self.__runner.get_blueprint_id(contract_id)
-
-    @final
-    @deprecated('use explicit methods instead, `get_balance_before_current_call` or `get_current_balance`')
-    def get_balance(
-        self,
-        token_uid: Optional[TokenUid] = None,
-        *,
-        contract_id: Optional[ContractId] = None,
-    ) -> Amount:
-        """
-        Return the balance for a given token before the current call, that is,
-        excluding any actions and changes in the current call.
-        This is equivalent to `get_balance_before_current_call`.
-
-        For instance, if a contract has 50 HTR and the call is requesting to withdraw 3 HTR,
-        then this method will return 50 HTR.
-        """
-        return self.get_balance_before_current_call(token_uid, contract_id=contract_id)
 
     def get_balance_before_current_call(
         self,

--- a/hathor/nanocontracts/runner/runner.py
+++ b/hathor/nanocontracts/runner/runner.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any, Callable, Concatenate, ParamSpec, TypeVar
 
-from typing_extensions import assert_never, deprecated
+from typing_extensions import assert_never
 
 from hathor.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 from hathor.nanocontracts.balance_rules import BalanceRules
@@ -666,15 +666,6 @@ class Runner:
 
         self._call_info.post_call(call_record)
         return ret
-
-    @deprecated('use explicit methods instead, `get_balance_before_current_call` or `get_current_balance`')
-    def get_balance(self, contract_id: ContractId | None, token_uid: TokenUid | None) -> Balance:
-        """
-        Return the contract balance for a given token before the current call, that is,
-        excluding any actions and changes in the current call.
-        This is equivalent to `get_balance_before_current_call`.
-        """
-        return self.get_balance_before_current_call(contract_id, token_uid)
 
     def get_balance_before_current_call(self, contract_id: ContractId | None, token_uid: TokenUid | None) -> Balance:
         """

--- a/tests/nanocontracts/test_execution_order.py
+++ b/tests/nanocontracts/test_execution_order.py
@@ -34,8 +34,6 @@ class MyBlueprint(Blueprint):
 
     def assert_balance(self, token_uid: TokenUid, *, before: int, current: int) -> None:
         assert self.syscall.get_balance_before_current_call(token_uid) == before
-        # deprecated method, equivalent to get_balance_before_current_call
-        assert self.syscall.get_balance(token_uid) == before
         assert self.syscall.get_current_balance(token_uid) == current
 
     def assert_token_balance(self, *, before: int, current: int) -> None:

--- a/tests/nanocontracts/test_syscalls_in_view.py
+++ b/tests/nanocontracts/test_syscalls_in_view.py
@@ -46,10 +46,6 @@ class MyBlueprint(Blueprint):
         self.syscall.get_blueprint_id()
 
     @view
-    def get_balance(self) -> None:
-        self.syscall.get_balance()
-
-    @view
     def get_balance_before_current_call(self) -> None:
         self.syscall.get_balance_before_current_call()
 


### PR DESCRIPTION
### Motivation

The `get_balance` syscall was deprecated in favor of the explicit methods `get_current_balance` and `get_balance_before_current_call`. This PR removes it.

Originally the task was to remove the `*_before_current_call` syscalls. But I gave more thought into it and I think it's good to keep them both, as it makes it clear for the user that there are different ways of interpreting the balance, and that they should choose the right one for their use case. Otherwise, it requires more knowledge of how our system works (for example, knowing when actions are executed).

### Acceptance Criteria

- Remove `get_balance` syscall.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 