### PR TITLE
fix(nano): authority handling on indexes with contracts

### DIFF
--- a/hathor/dag_builder/builder.py
+++ b/hathor/dag_builder/builder.py
@@ -97,6 +97,9 @@ class DAGBuilder:
             blueprints_module=blueprints_module,
         )
 
+    def get_main_wallet(self) -> BaseWallet:
+        return self._exporter.get_wallet('main')
+
     def parse_tokens(self, tokens: Iterator[Token]) -> None:
         """Parse tokens and update the DAG accordingly."""
         for parts in tokens:

--- a/hathor/indexes/tokens_index.py
+++ b/hathor/indexes/tokens_index.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Iterator, NamedTuple, Optional
+from typing import TYPE_CHECKING, Iterator, NamedTuple, Optional
 
 from hathor.indexes.base_index import BaseIndex
 from hathor.indexes.scope import Scope
 from hathor.transaction import BaseTransaction
+
+if TYPE_CHECKING:
+    from hathor.nanocontracts.runner.types import UpdateAuthoritiesRecord
 
 SCOPE = Scope(
     include_blocks=False,
@@ -62,6 +67,16 @@ class TokenIndexInfo(ABC):
     @abstractmethod
     def iter_melt_utxos(self) -> Iterator[TokenUtxoInfo]:
         """Iterate over melt-authority UTXOs"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def can_mint(self) -> bool:
+        """Return whether this token can be minted, that is, whether any UTXO or contract holds a mint authority."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def can_melt(self) -> bool:
+        """Return whether this token can be melted, that is, whether any UTXO or contract holds a melt authority."""
         raise NotImplementedError
 
 
@@ -115,13 +130,39 @@ class TokensIndex(BaseIndex):
         raise NotImplementedError
 
     @abstractmethod
-    def create_token_info(self, token_uid: bytes, name: str, symbol: str, total: int = 0) -> None:
+    def create_token_info(
+        self,
+        token_uid: bytes,
+        name: str,
+        symbol: str,
+        total: int = 0,
+        n_contracts_can_mint: int = 0,
+        n_contracts_can_melt: int = 0,
+    ) -> None:
         """Create a token info for a new token."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_token_info_from_contract(
+        self,
+        token_uid: bytes,
+        name: str,
+        symbol: str,
+        total: int = 0,
+    ) -> None:
+        """Create a token info for a new token created in a contract."""
         raise NotImplementedError
 
     @abstractmethod
     def destroy_token(self, token_uid: bytes) -> None:
         """Destroy a token."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_authorities_from_contract(self, record: UpdateAuthoritiesRecord, undo: bool = False) -> None:
+        """
+        Handle an UpdateAuthoritiesRecord by incrementing/decrementing the counters of contracts holding authorities.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/hathor/nanocontracts/blueprint_env.py
+++ b/hathor/nanocontracts/blueprint_env.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, final
+from typing import TYPE_CHECKING, Any, Optional, Sequence, final
 
 from hathor.nanocontracts.storage import NCContractStorage
 from hathor.nanocontracts.types import Amount, BlueprintId, ContractId, NCAction, TokenUid
@@ -166,7 +166,7 @@ class BlueprintEnvironment:
         self,
         nc_id: ContractId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         *args: Any,
         **kwargs: Any,
     ) -> Any:
@@ -178,7 +178,7 @@ class BlueprintEnvironment:
         self,
         blueprint_id: BlueprintId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         *args: Any,
         **kwargs: Any,
     ) -> Any:
@@ -190,7 +190,7 @@ class BlueprintEnvironment:
         self,
         blueprint_id: BlueprintId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         nc_args: NCArgs,
     ) -> Any:
         """Execute a proxy call to a public method of another blueprint."""
@@ -221,7 +221,7 @@ class BlueprintEnvironment:
         self,
         blueprint_id: BlueprintId,
         salt: bytes,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         *args: Any,
         **kwargs: Any,
     ) -> tuple[ContractId, Any]:

--- a/hathor/nanocontracts/context.py
+++ b/hathor/nanocontracts/context.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections import defaultdict
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, Any, Sequence, final
 
 from hathor.crypto.util import get_address_b58_from_bytes
 from hathor.nanocontracts.exception import NCFail, NCInvalidContext
@@ -47,7 +47,7 @@ class Context:
 
     def __init__(
         self,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         vertex: BaseTransaction | VertexData,
         address: Address | ContractId,
         timestamp: int,

--- a/hathor/nanocontracts/runner/runner.py
+++ b/hathor/nanocontracts/runner/runner.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Callable, Concatenate, ParamSpec, TypeVar
+from typing import Any, Callable, Concatenate, ParamSpec, Sequence, TypeVar
 
 from typing_extensions import assert_never
 
@@ -45,12 +45,14 @@ from hathor.nanocontracts.runner.types import (
     CallInfo,
     CallRecord,
     CallType,
+    IndexUpdateRecordType,
     NCArgs,
     NCParsedArgs,
     NCRawArgs,
     SyscallCreateContractRecord,
-    SyscallRecordType,
     SyscallUpdateTokensRecord,
+    UpdateAuthoritiesRecord,
+    UpdateAuthoritiesRecordType,
 )
 from hathor.nanocontracts.storage import NCBlockStorage, NCChangesTracker, NCContractStorage, NCStorageFactory
 from hathor.nanocontracts.storage.contract_storage import Balance
@@ -300,7 +302,7 @@ class Runner:
         self,
         contract_id: ContractId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
@@ -329,7 +331,7 @@ class Runner:
         self,
         blueprint_id: BlueprintId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
@@ -349,7 +351,7 @@ class Runner:
         self,
         blueprint_id: BlueprintId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         nc_args: NCArgs,
     ) -> Any:
         if method_name == NC_INITIALIZE_METHOD:
@@ -373,7 +375,7 @@ class Runner:
         contract_id: ContractId,
         blueprint_id: BlueprintId,
         method_name: str,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         nc_args: NCArgs,
     ) -> Any:
         """Invoke another contract's public method without running the usual guard‑safety checks.
@@ -453,16 +455,16 @@ class Runner:
             if call.index_updates is None:
                 assert call.type is CallType.VIEW
                 continue
-            for syscall in call.index_updates:
-                match syscall:
-                    case SyscallCreateContractRecord():
+            for record in call.index_updates:
+                match record:
+                    case SyscallCreateContractRecord() | UpdateAuthoritiesRecord():
                         # Nothing to do here.
                         pass
                     case SyscallUpdateTokensRecord():
-                        calculated_tokens_totals[syscall.token_uid] += syscall.token_amount
-                        calculated_tokens_totals[TokenUid(HATHOR_TOKEN_UID)] += syscall.htr_amount
+                        calculated_tokens_totals[record.token_uid] += record.token_amount
+                        calculated_tokens_totals[TokenUid(HATHOR_TOKEN_UID)] += record.htr_amount
                     case _:
-                        assert_never(syscall)
+                        assert_never(record)
 
         assert calculated_tokens_totals == self._updated_tokens_totals, (
             f'conflicting updated tokens totals: {calculated_tokens_totals, self._updated_tokens_totals}'
@@ -578,6 +580,7 @@ class Runner:
         for action in ctx.__all_actions__:
             rules = BalanceRules.get_rules(self._settings, action)
             rules.nc_callee_execution_rule(changes_tracker)
+            self._handle_index_update(action)
 
         try:
             # Although the context is immutable, we're passing a copy to the blueprint method as an added precaution.
@@ -605,6 +608,31 @@ class Runner:
             return self._unsafe_call_view_method(contract_id, method_name, args, kwargs)
         finally:
             self._reset_all_change_trackers()
+
+    def _handle_index_update(self, action: NCAction) -> None:
+        """For each action in a public method call, create the appropriate index update records."""
+        call_record = self.get_current_call_record()
+        assert call_record.index_updates is not None
+
+        match action:
+            case NCDepositAction() | NCWithdrawalAction():
+                # Since these actions only affect indexes when used via a transaction call
+                # (not when used across contracts), they are handled only once when the tx
+                # is added to indexes (more specifically, to the tokens index).
+                pass
+            case NCGrantAuthorityAction() | NCAcquireAuthorityAction():
+                # Since these actions "duplicate" authorities, they must be
+                # handled everytime they're used, even across contracts.
+                # That's why they account for index update records.
+                record = UpdateAuthoritiesRecord(
+                    token_uid=action.token_uid,
+                    sub_type=UpdateAuthoritiesRecordType.GRANT,
+                    mint=action.mint,
+                    melt=action.melt,
+                )
+                call_record.index_updates.append(record)
+            case _:
+                assert_never(action)
 
     def syscall_call_another_contract_view_method(
         self,
@@ -779,7 +807,7 @@ class Runner:
         self,
         blueprint_id: BlueprintId,
         salt: bytes,
-        actions: list[NCAction],
+        actions: Sequence[NCAction],
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> tuple[ContractId, Any]:
@@ -813,16 +841,35 @@ class Runner:
     @_forbid_syscall_from_view('revoke_authorities')
     def syscall_revoke_authorities(self, token_uid: TokenUid, *, revoke_mint: bool, revoke_melt: bool) -> None:
         """Revoke authorities from this nano contract."""
-        contract_id = self.get_current_contract_id()
+        call_record = self.get_current_call_record()
+        contract_id = call_record.contract_id
         if token_uid == HATHOR_TOKEN_UID:
             raise NCInvalidSyscall(f'contract {contract_id.hex()} cannot revoke authorities from HTR token')
 
         changes_tracker = self.get_current_changes_tracker(contract_id)
+        assert changes_tracker.nc_id == call_record.contract_id
+        balance = changes_tracker.get_balance(token_uid)
+
+        if revoke_mint and not balance.can_mint:
+            raise NCInvalidSyscall(f'contract {call_record.contract_id.hex()} cannot mint {token_uid.hex()} tokens')
+
+        if revoke_melt and not balance.can_melt:
+            raise NCInvalidSyscall(f'contract {call_record.contract_id.hex()} cannot melt {token_uid.hex()} tokens')
+
         changes_tracker.revoke_authorities(
             token_uid,
             revoke_mint=revoke_mint,
             revoke_melt=revoke_melt,
         )
+
+        assert call_record.index_updates is not None
+        syscall_record = UpdateAuthoritiesRecord(
+            token_uid=token_uid,
+            sub_type=UpdateAuthoritiesRecordType.REVOKE,
+            mint=revoke_mint,
+            melt=revoke_melt,
+        )
+        call_record.index_updates.append(syscall_record)
 
     @_forbid_syscall_from_view('mint_tokens')
     def syscall_mint_tokens(self, token_uid: TokenUid, amount: int) -> None:
@@ -849,7 +896,7 @@ class Runner:
 
         assert call_record.index_updates is not None
         syscall_record = SyscallUpdateTokensRecord(
-            type=SyscallRecordType.MINT_TOKENS,
+            type=IndexUpdateRecordType.MINT_TOKENS,
             token_uid=token_uid,
             token_amount=token_amount,
             htr_amount=htr_amount,
@@ -881,7 +928,7 @@ class Runner:
 
         assert call_record.index_updates is not None
         syscall_record = SyscallUpdateTokensRecord(
-            type=SyscallRecordType.MELT_TOKENS,
+            type=IndexUpdateRecordType.MELT_TOKENS,
             token_uid=token_uid,
             token_amount=token_amount,
             htr_amount=htr_amount,
@@ -951,7 +998,7 @@ class Runner:
 
         assert last_call_record.index_updates is not None
         syscall_record = SyscallUpdateTokensRecord(
-            type=SyscallRecordType.CREATE_TOKEN,
+            type=IndexUpdateRecordType.CREATE_TOKEN,
             token_uid=token_id,
             token_amount=token_amount,
             htr_amount=-htr_amount,

--- a/hathor/nanocontracts/runner/types.py
+++ b/hathor/nanocontracts/runner/types.py
@@ -36,11 +36,12 @@ class CallType(StrEnum):
 
 
 @unique
-class SyscallRecordType(StrEnum):
+class IndexUpdateRecordType(StrEnum):
     CREATE_CONTRACT = auto()
     MINT_TOKENS = auto()
     MELT_TOKENS = auto()
     CREATE_TOKEN = auto()
+    UPDATE_AUTHORITIES = auto()
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -50,14 +51,14 @@ class SyscallCreateContractRecord:
 
     def to_json(self) -> dict[str, Any]:
         return dict(
-            type=SyscallRecordType.CREATE_CONTRACT,
+            type=IndexUpdateRecordType.CREATE_CONTRACT,
             blueprint_id=self.blueprint_id.hex(),
             contract_id=self.contract_id.hex(),
         )
 
     @classmethod
     def from_json(cls, json_dict: dict[str, Any]) -> Self:
-        assert json_dict['type'] is SyscallRecordType.CREATE_CONTRACT
+        assert json_dict['type'] == IndexUpdateRecordType.CREATE_CONTRACT
         return cls(
             contract_id=ContractId(VertexId(bytes.fromhex(json_dict['contract_id']))),
             blueprint_id=BlueprintId(VertexId(bytes.fromhex(json_dict['blueprint_id']))),
@@ -67,9 +68,9 @@ class SyscallCreateContractRecord:
 @dataclass(slots=True, frozen=True, kw_only=True)
 class SyscallUpdateTokensRecord:
     type: (
-        Literal[SyscallRecordType.MINT_TOKENS]
-        | Literal[SyscallRecordType.MELT_TOKENS]
-        | Literal[SyscallRecordType.CREATE_TOKEN]
+        Literal[IndexUpdateRecordType.MINT_TOKENS]
+        | Literal[IndexUpdateRecordType.MELT_TOKENS]
+        | Literal[IndexUpdateRecordType.CREATE_TOKEN]
     )
     token_uid: TokenUid
     token_amount: int
@@ -79,9 +80,9 @@ class SyscallUpdateTokensRecord:
 
     def __post_init__(self) -> None:
         match self.type:
-            case SyscallRecordType.MINT_TOKENS | SyscallRecordType.CREATE_TOKEN:
+            case IndexUpdateRecordType.MINT_TOKENS | IndexUpdateRecordType.CREATE_TOKEN:
                 assert self.token_amount > 0 and self.htr_amount < 0
-            case SyscallRecordType.MELT_TOKENS:
+            case IndexUpdateRecordType.MELT_TOKENS:
                 assert self.token_amount < 0 and self.htr_amount > 0
             case _:
                 assert_never(self.type)
@@ -96,7 +97,9 @@ class SyscallUpdateTokensRecord:
 
     @classmethod
     def from_json(cls, json_dict: dict[str, Any]) -> Self:
-        valid_types = (SyscallRecordType.MINT_TOKENS, SyscallRecordType.MINT_TOKENS, SyscallRecordType.CREATE_TOKEN)
+        valid_types = (
+            IndexUpdateRecordType.MINT_TOKENS, IndexUpdateRecordType.MINT_TOKENS, IndexUpdateRecordType.CREATE_TOKEN
+        )
         assert json_dict['type'] in valid_types
         return cls(
             type=json_dict['type'],
@@ -106,16 +109,58 @@ class SyscallUpdateTokensRecord:
         )
 
 
-NCSyscallRecord: TypeAlias = SyscallCreateContractRecord | SyscallUpdateTokensRecord
+@unique
+class UpdateAuthoritiesRecordType(StrEnum):
+    GRANT = auto()
+    REVOKE = auto()
 
 
-def nc_syscall_record_from_json(json_dict: dict[str, Any]) -> NCSyscallRecord:
-    syscall_type = SyscallRecordType(json_dict['type'])
+@dataclass(slots=True, frozen=True, kw_only=True)
+class UpdateAuthoritiesRecord:
+    token_uid: TokenUid
+    sub_type: UpdateAuthoritiesRecordType
+    mint: bool
+    melt: bool
+
+    def __post_init__(self) -> None:
+        assert self.mint or self.melt
+
+    def to_json(self) -> dict[str, Any]:
+        return dict(
+            type=IndexUpdateRecordType.UPDATE_AUTHORITIES,
+            token_uid=self.token_uid.hex(),
+            sub_type=self.sub_type,
+            mint=self.mint,
+            melt=self.melt,
+        )
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, Any]) -> Self:
+        assert json_dict['type'] == IndexUpdateRecordType.UPDATE_AUTHORITIES
+        return cls(
+            token_uid=TokenUid(VertexId(bytes.fromhex(json_dict['token_uid']))),
+            sub_type=UpdateAuthoritiesRecordType(json_dict['sub_type']),
+            mint=json_dict['mint'],
+            melt=json_dict['melt'],
+        )
+
+
+NCIndexUpdateRecord: TypeAlias = SyscallCreateContractRecord | SyscallUpdateTokensRecord | UpdateAuthoritiesRecord
+
+
+def nc_index_update_record_from_json(json_dict: dict[str, Any]) -> NCIndexUpdateRecord:
+    syscall_type = IndexUpdateRecordType(json_dict['type'])
     match syscall_type:
-        case SyscallRecordType.CREATE_CONTRACT:
+        case IndexUpdateRecordType.CREATE_CONTRACT:
             return SyscallCreateContractRecord.from_json(json_dict)
-        case SyscallRecordType.MINT_TOKENS | SyscallRecordType.MELT_TOKENS | SyscallRecordType.CREATE_TOKEN:
+        case (
+            IndexUpdateRecordType.MINT_TOKENS
+            | IndexUpdateRecordType.MELT_TOKENS
+            | IndexUpdateRecordType.CREATE_TOKEN
+        ):
             return SyscallUpdateTokensRecord.from_json(json_dict)
+        case IndexUpdateRecordType.UPDATE_AUTHORITIES:
+            return UpdateAuthoritiesRecord.from_json(json_dict)
         case _:
             raise assert_never(f'invalid syscall record type: "{syscall_type}"')
 
@@ -149,8 +194,8 @@ class CallRecord:
     # Keep track of all changes made by this call.
     changes_tracker: NCChangesTracker
 
-    # A list of syscalls that affect indexes. None when it's a VIEW call.
-    index_updates: list[NCSyscallRecord] | None
+    # A list of actions or syscalls that affect indexes. None when it's a VIEW call.
+    index_updates: list[NCIndexUpdateRecord] | None
 
 
 @dataclass(slots=True, kw_only=True)

--- a/hathor/transaction/types.py
+++ b/hathor/transaction/types.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
 
 if TYPE_CHECKING:
-    from hathor.nanocontracts.runner.types import CallRecord, NCSyscallRecord
+    from hathor.nanocontracts.runner.types import CallRecord, NCIndexUpdateRecord
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -27,7 +27,7 @@ class MetaNCCallRecord:
     blueprint_id: bytes
     contract_id: bytes
     method_name: str
-    index_updates: list[NCSyscallRecord]
+    index_updates: list[NCIndexUpdateRecord]
 
     def to_json(self) -> dict[str, Any]:
         """Convert this record to a json dict."""
@@ -41,12 +41,12 @@ class MetaNCCallRecord:
     @classmethod
     def from_json(cls, json_dict: dict[str, Any]) -> Self:
         """Create an instance from a json dict."""
-        from hathor.nanocontracts.runner.types import nc_syscall_record_from_json
+        from hathor.nanocontracts.runner.types import nc_index_update_record_from_json
         return cls(
             blueprint_id=bytes.fromhex(json_dict['blueprint_id']),
             contract_id=bytes.fromhex(json_dict['contract_id']),
             method_name=json_dict['method_name'],
-            index_updates=[nc_syscall_record_from_json(syscall) for syscall in json_dict['index_updates']]
+            index_updates=[nc_index_update_record_from_json(syscall) for syscall in json_dict['index_updates']]
         )
 
     @classmethod

--- a/hathor/verification/nano_header_verifier.py
+++ b/hathor/verification/nano_header_verifier.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import Sequence
 
 from hathor.conf.settings import HATHOR_TOKEN_UID
 from hathor.nanocontracts.exception import NCInvalidAction, NCInvalidSignature
@@ -94,7 +95,7 @@ class NanoHeaderVerifier:
                 )
 
     @staticmethod
-    def verify_action_list(actions: list[NCAction]) -> None:
+    def verify_action_list(actions: Sequence[NCAction]) -> None:
         """Perform NCAction verifications that do not depend on the tx."""
         if len(actions) > MAX_ACTIONS_LEN:
             raise NCInvalidAction(f'more actions than the max allowed: {len(actions)} > {MAX_ACTIONS_LEN}')

--- a/tests/nanocontracts/blueprints/unittest.py
+++ b/tests/nanocontracts/blueprints/unittest.py
@@ -22,8 +22,6 @@ from tests.nanocontracts.utils import TestRunner
 
 
 class BlueprintTestCase(unittest.TestCase):
-    use_memory_storage = True
-
     def setUp(self):
         super().setUp()
         self.manager = self.build_manager()

--- a/tests/nanocontracts/on_chain_blueprints/test_bet.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_bet.py
@@ -49,8 +49,6 @@ class BetInfo(NamedTuple):
 
 
 class OnChainBetBlueprintTestCase(unittest.TestCase):
-    use_memory_storage = True
-
     def setUp(self) -> None:
         super().setUp()
         self.manager = self.create_peer('unittests')

--- a/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -21,8 +21,6 @@ ZLIB_BOMB: bytes = _load_file('bomb.zlib')
 
 
 class OnChainBlueprintScriptTestCase(unittest.TestCase):
-    use_memory_storage = True
-
     def setUp(self):
         super().setUp()
         self.manager = self.create_peer('unittests')

--- a/tests/nanocontracts/test_actions.py
+++ b/tests/nanocontracts/test_actions.py
@@ -23,21 +23,18 @@ from hathor.indexes.tokens_index import TokensIndex
 from hathor.nanocontracts import NC_EXECUTION_FAIL_ID, Blueprint, Context, public
 from hathor.nanocontracts.catalog import NCBlueprintCatalog
 from hathor.nanocontracts.exception import NCInvalidAction
-from hathor.nanocontracts.method import Method
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig
 from hathor.nanocontracts.storage.contract_storage import Balance, BalanceKey
 from hathor.nanocontracts.types import NCActionType, TokenUid
-from hathor.nanocontracts.utils import sign_pycoin
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import InvalidToken
-from hathor.transaction.headers import NanoHeader
 from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.util import not_none
 from hathor.verification.nano_header_verifier import MAX_ACTIONS_LEN
 from hathor.wallet import HDWallet
 from tests import unittest
 from tests.dag_builder.builder import TestDAGBuilder
-from tests.nanocontracts.utils import assert_nc_failure_reason
+from tests.nanocontracts.utils import assert_nc_failure_reason, set_nano_header
 
 
 class MyBlueprint(Blueprint):
@@ -142,31 +139,19 @@ class TestActions(unittest.TestCase):
         nc_args: tuple[Any, ...] | None = None,
     ) -> None:
         """Configure a nano header for a tx."""
-        assert len(tx.headers) == 0
-        wallet = self.dag_builder._exporter._wallets['main']
+        wallet = self.dag_builder.get_main_wallet()
         assert isinstance(wallet, HDWallet)
-        privkey = wallet.get_key_at_index(0)
-
-        nc_args_bytes = b'\x00'
-        if nc_args is not None:
-            assert nc_method is not None
-            method_parser = Method.from_callable(getattr(MyBlueprint, nc_method))
-            nc_args_bytes = method_parser.serialize_args_bytes(nc_args)
-
-        nano_header = NanoHeader(
+        set_nano_header(
             tx=tx,
-            nc_seqnum=self.nc_seqnum,
+            wallet=wallet,
             nc_id=self.tx0.hash,
-            nc_method=nc_method if nc_method is not None else 'nop',
-            nc_args_bytes=nc_args_bytes,
-            nc_address=b'',
-            nc_script=b'',
-            nc_actions=nc_actions if nc_actions is not None else [],
+            nc_actions=nc_actions,
+            nc_method=nc_method,
+            nc_args=nc_args,
+            blueprint=MyBlueprint,
+            seqnum=self.nc_seqnum
         )
         self.nc_seqnum += 1
-
-        sign_pycoin(nano_header, privkey)
-        tx.headers.append(nano_header)
 
     def _change_tx_balance(
         self,

--- a/tests/nanocontracts/test_authorities_call_another.py
+++ b/tests/nanocontracts/test_authorities_call_another.py
@@ -66,7 +66,7 @@ class CallerBlueprint(Blueprint):
 
     @public
     def revoke_from_other(self, ctx: Context, token_uid: TokenUid, mint: bool, melt: bool) -> None:
-        self.syscall.call_public_method(self.other_id, 'revoke_from_self', [], token_uid, True, True)
+        self.syscall.call_public_method(self.other_id, 'revoke_from_self', [], token_uid, mint, melt)
 
     @public
     def acquire_another(self, ctx: Context, token_uid: TokenUid, mint: bool, melt: bool) -> None:

--- a/tests/nanocontracts/test_authorities_index.py
+++ b/tests/nanocontracts/test_authorities_index.py
@@ -1,0 +1,325 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts.exception import NanoContractDoesNotExist
+from hathor.nanocontracts.storage.contract_storage import Balance
+from hathor.nanocontracts.types import ContractId, NCAcquireAuthorityAction, NCActionType, TokenUid, VertexId
+from hathor.nanocontracts.utils import derive_child_token_id
+from hathor.transaction import Block, Transaction, TxOutput
+from hathor.transaction.headers.nano_header import NanoHeaderAction
+from hathor.transaction.nc_execution_state import NCExecutionState
+from hathor.wallet import HDWallet
+from tests.dag_builder.builder import TestDAGBuilder
+from tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from tests.nanocontracts.utils import set_nano_header
+
+
+class MyBlueprint(Blueprint):
+    token_uid: TokenUid | None
+
+    @public(allow_grant_authority=True)
+    def initialize(self, ctx: Context) -> None:
+        self.token_uid = None
+
+    @public
+    def revoke_all(self, ctx: Context, token_uid: TokenUid | None) -> None:
+        if token_uid is None:
+            assert self.token_uid is not None
+            token_uid = self.token_uid
+        self.syscall.revoke_authorities(token_uid, revoke_mint=True, revoke_melt=True)
+
+    @public(allow_deposit=True)
+    def create_token(self, ctx: Context) -> None:
+        self.token_uid = self.syscall.create_token(token_name='token a', token_symbol='TKA', amount=1000)
+
+    @public(allow_acquire_authority=True)
+    def allow_acquire_authority(self, ctx: Context) -> None:
+        pass
+
+    @public
+    def acquire_authority(self, ctx: Context, other_id: ContractId) -> None:
+        self.token_uid = derive_child_token_id(other_id, 'TKA')
+        actions = [NCAcquireAuthorityAction(token_uid=self.token_uid, mint=True, melt=True)]
+        self.syscall.call_public_method(other_id, 'allow_acquire_authority', actions)
+
+
+class TestAuthoritiesIndex(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.tokens_index = self.manager.tx_storage.indexes.tokens
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
+
+        wallet = self.dag_builder.get_main_wallet()
+        assert isinstance(wallet, HDWallet)
+        self.wallet = wallet
+
+    def test_grant_action_then_revoke(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy < TKA
+
+            tx1.out[0] = 1000 TKA # To force TKA to be a token creation tx
+
+            TKA <-- b11
+            tx1 <-- b12
+        ''')
+        artifacts.propagate_with(self.manager, up_to='dummy')
+        tka, tx1 = artifacts.get_typed_vertices(['TKA', 'tx1'], Transaction)
+
+        # Remove authority outputs so no UTXOs have them
+        assert tka.outputs[-1].is_token_authority()
+        assert tka.outputs[-2].is_token_authority()
+        tka.outputs = tka.outputs[:-2]
+        # HACK: We don't clear the sighash cache on purpose so we don't need to re-sign the tx
+        # tka.clear_sighash_cache()
+
+        # Add GRANT action to TKA
+        set_nano_header(
+            tx=tka,
+            wallet=self.wallet,
+            nc_id=self.blueprint_id,
+            nc_actions=[
+                NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.ALL_AUTHORITIES)
+            ],
+            nc_method='initialize',
+            blueprint=MyBlueprint,
+            seqnum=0,
+        )
+
+        # Before executing TKA, nobody can mint or melt
+        artifacts.propagate_with(self.manager, up_to='TKA')
+        token_info = self.tokens_index.get_token_info(tka.hash)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert not token_info.can_mint()
+        assert not token_info.can_melt()
+
+        # After b11, TKA is executed and holds authorities
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tka.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        storage = self.manager.get_best_block_nc_storage(tka.hash)
+        assert storage.get_balance(tka.hash) == Balance(value=0, can_mint=True, can_melt=True)
+
+        token_info = self.tokens_index.get_token_info(tka.hash)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert token_info.can_mint()
+        assert token_info.can_melt()
+
+        # Even though I'm not setting authority actions here, I have to set the header manually instead of using the
+        # DAG builder because it doesn't know TKA is a NC.
+        set_nano_header(
+            tx=tx1,
+            wallet=self.wallet,
+            nc_id=tka.hash,
+            nc_method='revoke_all',
+            nc_args=(tka.hash,),
+            blueprint=MyBlueprint,
+            seqnum=1,
+        )
+
+        # After b12, all authorities are revoked
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx1.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        storage = self.manager.get_best_block_nc_storage(tka.hash)
+        assert storage.get_balance(tka.hash) == Balance(value=0, can_mint=False, can_melt=False)
+
+        token_info = self.tokens_index.get_token_info(tka.hash)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert not token_info.can_mint()
+        assert not token_info.can_melt()
+
+    def test_grant_action_then_reorg(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            blockchain b10 a[11..12]
+            b10 < dummy < TKA
+            a12.weight = 3 # Necessary to force the reorg
+
+            tx1.out[0] = 1000 TKA # To force TKA to be a token creation tx
+
+            TKA <-- b11
+            b11 < a11
+        ''')
+        artifacts.propagate_with(self.manager, up_to='dummy')
+        b11, a11 = artifacts.get_typed_vertices(['b11', 'a11'], Block)
+        tka = artifacts.get_typed_vertex('TKA', Transaction)
+
+        # Remove authority outputs so no UTXOs have them
+        assert tka.outputs[-1].is_token_authority()
+        assert tka.outputs[-2].is_token_authority()
+        tka.outputs = tka.outputs[:-2]
+        # HACK: We don't clear the sighash cache on purpose so we don't need to re-sign the tx
+        # tka.clear_sighash_cache()
+
+        # Add GRANT action to TKA
+        set_nano_header(
+            tx=tka,
+            wallet=self.wallet,
+            nc_id=self.blueprint_id,
+            nc_actions=[
+                NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.ALL_AUTHORITIES)
+            ],
+            nc_method='initialize',
+            blueprint=MyBlueprint,
+            seqnum=0,
+        )
+
+        # Before executing TKA, nobody can mint or melt
+        artifacts.propagate_with(self.manager, up_to='TKA')
+        token_info = self.tokens_index.get_token_info(tka.hash)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert not token_info.can_mint()
+        assert not token_info.can_melt()
+
+        # After b11, TKA is executed and holds authorities
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert b11.get_metadata().voided_by is None
+        assert tka.get_metadata().first_block == b11.hash
+        assert tka.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        storage = self.manager.get_best_block_nc_storage(tka.hash)
+        assert storage.get_balance(tka.hash) == Balance(value=0, can_mint=True, can_melt=True)
+
+        token_info = self.tokens_index.get_token_info(tka.hash)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert token_info.can_mint()
+        assert token_info.can_melt()
+
+        # After a12, a reorg happens un-executing TKA
+        artifacts.propagate_with(self.manager, up_to='a12')
+        assert b11.get_metadata().voided_by == {b11.hash}
+        assert a11.get_metadata().voided_by is None
+        assert tka.get_metadata().first_block is None
+        assert tka.get_metadata().nc_execution is NCExecutionState.PENDING
+
+        with pytest.raises(NanoContractDoesNotExist):
+            self.manager.get_best_block_nc_storage(tka.hash)
+
+        token_info = self.tokens_index.get_token_info(tka.hash)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert not token_info.can_mint()
+        assert not token_info.can_melt()
+
+    def test_acquire_action_then_revoke(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..14]
+            b10 < dummy
+
+            nc1a.nc_id = "{self.blueprint_id.hex()}"
+            nc1a.nc_method = initialize()
+
+            nc1b.nc_id = nc1a
+            nc1b.nc_method = create_token()
+            nc1b.nc_deposit = 1000 HTR
+
+            nc2a.nc_id = "{self.blueprint_id.hex()}"
+            nc2a.nc_method = initialize()
+
+            nc2b.nc_id = nc2a
+            nc2b.nc_method = acquire_authority(`nc1a`)
+
+            nc1c.nc_id = nc1a
+            nc1c.nc_method = revoke_all(null)
+
+            nc2c.nc_id = nc2a
+            nc2c.nc_method = revoke_all(null)
+
+            nc1a <-- nc1b <-- nc2a <-- nc2b <-- nc1c <-- nc2c
+            nc1b <-- b11
+            nc2b <-- b12
+            nc1c <-- b13
+            nc2c <-- b14
+        ''')
+        artifacts.propagate_with(self.manager, up_to='dummy')
+        nc1a, nc1b, nc1c, nc2a, nc2b, nc2c = artifacts.get_typed_vertices(
+            ['nc1a', 'nc1b', 'nc1c', 'nc2a', 'nc2b', 'nc2c'],
+            Transaction
+        )
+        tka = derive_child_token_id(ContractId(VertexId(nc1a.hash)), 'TKA')
+
+        # Before executing nc1b, the token doesn't exist
+        artifacts.propagate_with(self.manager, up_to='nc1b')
+        with pytest.raises(KeyError):
+            self.tokens_index.get_token_info(tka)
+
+        # After b11, nc1b is executed and holds authorities
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert nc1b.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert nc2b.get_metadata().nc_execution is None
+
+        nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
+        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=True, can_melt=True)
+
+        token_info = self.tokens_index.get_token_info(tka)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert token_info.can_mint()
+        assert token_info.can_melt()
+
+        # After b12, nc2b is executed and also holds authorities
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert nc2b.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
+        nc2_storage = self.manager.get_best_block_nc_storage(nc2a.hash)
+        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=True, can_melt=True)
+        assert nc2_storage.get_balance(tka) == Balance(value=0, can_mint=True, can_melt=True)
+
+        token_info = self.tokens_index.get_token_info(tka)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert token_info.can_mint()
+        assert token_info.can_melt()
+
+        # After b13, authorities are revoked from nc1a
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert nc1c.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
+        nc2_storage = self.manager.get_best_block_nc_storage(nc2a.hash)
+        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=False, can_melt=False)
+        assert nc2_storage.get_balance(tka) == Balance(value=0, can_mint=True, can_melt=True)
+
+        token_info = self.tokens_index.get_token_info(tka)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert token_info.can_mint()
+        assert token_info.can_melt()
+
+        # Finally, after b14, authorities are revoked from nc2a and the token index reflects that nobody can mint/melt
+        artifacts.propagate_with(self.manager, up_to='b14')
+        assert nc2c.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
+        nc2_storage = self.manager.get_best_block_nc_storage(nc2a.hash)
+        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=False, can_melt=False)
+        assert nc2_storage.get_balance(tka) == Balance(value=0, can_mint=False, can_melt=False)
+
+        token_info = self.tokens_index.get_token_info(tka)
+        assert list(token_info.iter_mint_utxos()) == []
+        assert list(token_info.iter_melt_utxos()) == []
+        assert not token_info.can_mint()
+        assert not token_info.can_melt()

--- a/tests/nanocontracts/test_call_other_contract.py
+++ b/tests/nanocontracts/test_call_other_contract.py
@@ -57,7 +57,7 @@ class MyBlueprint(Blueprint):
         if self.contract is None:
             return
 
-        actions: list[NCAction] = []
+        actions = []
         for action in ctx.__all_actions__:
             assert isinstance(action, NCDepositAction)
             amount = 1 + action.amount // 2
@@ -69,7 +69,7 @@ class MyBlueprint(Blueprint):
         if self.contract is None:
             return
 
-        actions: list[NCAction] = []
+        actions = []
         for action in ctx.__all_actions__:
             assert isinstance(action, NCWithdrawalAction)
             balance = self.syscall.get_balance_before_current_call(action.token_uid)
@@ -389,7 +389,7 @@ class NCBlueprintTestCase(unittest.TestCase):
         token2_uid = TokenUid(b'b' * 32)
         token3_uid = TokenUid(b'c' * 32)
 
-        actions: list[NCAction] = [
+        actions = [
             NCDepositAction(token_uid=token1_uid, amount=100),
             NCDepositAction(token_uid=token2_uid, amount=50),
             NCDepositAction(token_uid=token3_uid, amount=25),

--- a/tests/nanocontracts/test_contract_create_contract.py
+++ b/tests/nanocontracts/test_contract_create_contract.py
@@ -7,7 +7,6 @@ from hathor.nanocontracts.storage.contract_storage import Balance
 from hathor.nanocontracts.types import (
     BlueprintId,
     ContractId,
-    NCAction,
     NCActionType,
     NCDepositAction,
     NCGrantAuthorityAction,
@@ -39,7 +38,7 @@ class MyBlueprint1(Blueprint):
             action = ctx.get_single_action(token_uid)
             salt = b'x'
             assert isinstance(action, NCDepositAction)
-            new_actions: list[NCAction] = [NCDepositAction(token_uid=token_uid, amount=action.amount - initial)]
+            new_actions = [NCDepositAction(token_uid=token_uid, amount=action.amount - initial)]
             self.contract, _ = self.syscall.create_contract(
                 blueprint_id, salt, new_actions, blueprint_id, initial - 1, self.token_uid
             )
@@ -49,7 +48,7 @@ class MyBlueprint1(Blueprint):
 
     @public
     def create_children(self, ctx: Context, blueprint_id: BlueprintId, salt: bytes) -> None:
-        new_actions: list[NCAction] = []
+        new_actions = []
         if self.token_uid and self.syscall.can_mint(self.token_uid):
             new_actions.append(NCGrantAuthorityAction(token_uid=self.token_uid, mint=True, melt=True))
         self.syscall.create_contract(blueprint_id, salt + b'1', new_actions, blueprint_id, 0, self.token_uid)
@@ -99,7 +98,7 @@ class NCBlueprintTestCase(BlueprintTestCase):
 
         token_uid = TokenUid(HATHOR_TOKEN_UID)
         deposit = 100
-        actions: list[NCAction] = [NCDepositAction(token_uid=token_uid, amount=deposit)]
+        actions = [NCDepositAction(token_uid=token_uid, amount=deposit)]
         address = self.gen_random_address()
         ctx = Context(actions, self.get_genesis_tx(), address, timestamp=0)
         self.runner.create_contract(nc1_id, self.blueprint1_id, ctx, self.blueprint1_id, counter, None)

--- a/tests/nanocontracts/test_nc_exec_logs.py
+++ b/tests/nanocontracts/test_nc_exec_logs.py
@@ -25,7 +25,7 @@ from hathor.nanocontracts.nc_exec_logs import (
     NCLogLevel,
 )
 from hathor.nanocontracts.runner import CallType
-from hathor.nanocontracts.types import ContractId, NCAction, NCDepositAction, TokenUid, view
+from hathor.nanocontracts.types import ContractId, NCDepositAction, TokenUid, view
 from hathor.transaction import Block, Transaction
 from hathor.util import not_none
 from tests import unittest
@@ -61,7 +61,7 @@ class MyBlueprint1(Blueprint):
     @public(allow_deposit=True)
     def call_another_public(self, ctx: Context, contract_id: ContractId) -> None:
         self.log.debug('call_another_public() called on MyBlueprint1', contract_id=contract_id)
-        actions: list[NCAction] = [NCDepositAction(token_uid=TokenUid(b'\x00'), amount=5)]
+        actions = [NCDepositAction(token_uid=TokenUid(b'\x00'), amount=5)]
         result1 = self.syscall.call_public_method(contract_id, 'sum', actions, 1, 2)
         result2 = self.syscall.call_view_method(contract_id, 'hello_world')
         self.log.debug('results on MyBlueprint1', result1=result1, result2=result2)

--- a/tests/nanocontracts/test_syscalls.py
+++ b/tests/nanocontracts/test_syscalls.py
@@ -158,6 +158,16 @@ class NCNanoContractTestCase(BlueprintTestCase):
             tka_balance_key: Balance(value=667, can_mint=False, can_melt=False),
         }
 
+        # Try revoke mint without having the authority
+        msg = f'contract {nc_id.hex()} cannot mint {token_a_uid.hex()} tokens'
+        with pytest.raises(NCInvalidSyscall, match=msg):
+            self.runner.call_public_method(nc_id, 'revoke', ctx, token_a_uid, True, False)
+
+        # Try revoke melt without having the authority
+        msg = f'contract {nc_id.hex()} cannot melt {token_a_uid.hex()} tokens'
+        with pytest.raises(NCInvalidSyscall, match=msg):
+            self.runner.call_public_method(nc_id, 'revoke', ctx, token_a_uid, False, True)
+
         # Try mint TKA
         msg = f'contract {nc_id.hex()} cannot mint {token_a_uid.hex()} tokens'
         with pytest.raises(NCInvalidSyscall, match=msg):

--- a/tests/nanocontracts/utils.py
+++ b/tests/nanocontracts/utils.py
@@ -1,12 +1,20 @@
+from typing import Any
+
 from hathor.conf.settings import HathorSettings
 from hathor.manager import HathorManager
+from hathor.nanocontracts import Blueprint
+from hathor.nanocontracts.method import Method
 from hathor.nanocontracts.nc_exec_logs import NCExecEntry, NCLogConfig
 from hathor.nanocontracts.runner import Runner
 from hathor.nanocontracts.storage import NCBlockStorage, NCStorageFactory
+from hathor.nanocontracts.utils import sign_pycoin
 from hathor.reactor import ReactorProtocol
+from hathor.transaction import Transaction
+from hathor.transaction.headers.nano_header import NanoHeader, NanoHeaderAction
 from hathor.transaction.storage import TransactionStorage
 from hathor.types import VertexId
 from hathor.util import not_none
+from hathor.wallet import HDWallet
 
 
 class TestRunner(Runner):
@@ -54,3 +62,39 @@ def assert_nc_failure_reason(*, manager: HathorManager, tx_id: VertexId, block_i
         f'found:\n\n'
         f'{failure_entry.error_traceback}'
     )
+
+
+def set_nano_header(
+    *,
+    tx: Transaction,
+    wallet: HDWallet,
+    nc_id: VertexId,
+    nc_actions: list[NanoHeaderAction] | None = None,
+    nc_method: str | None = None,
+    nc_args: tuple[Any, ...] | None = None,
+    blueprint: type[Blueprint] | None = None,
+    seqnum: int = 1,
+) -> None:
+    """Configure a nano header for a tx."""
+    assert len(tx.headers) == 0
+    privkey = wallet.get_key_at_index(0)
+
+    nc_args_bytes = b'\x00'
+    if nc_args is not None:
+        assert nc_method is not None
+        method_parser = Method.from_callable(getattr(blueprint, nc_method))
+        nc_args_bytes = method_parser.serialize_args_bytes(nc_args)
+
+    nano_header = NanoHeader(
+        tx=tx,
+        nc_seqnum=seqnum,
+        nc_id=nc_id,
+        nc_method=nc_method if nc_method is not None else 'nop',
+        nc_args_bytes=nc_args_bytes,
+        nc_address=b'',
+        nc_script=b'',
+        nc_actions=nc_actions if nc_actions is not None else [],
+    )
+
+    sign_pycoin(nano_header, privkey)
+    tx.headers.append(nano_header)

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -373,6 +373,8 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(data['melt'][0]['tx_id'], tx.hash_hex)
         self.assertEqual(data['mint'][0]['index'], 1)
         self.assertEqual(data['melt'][0]['index'], 2)
+        self.assertTrue(data['can_mint'])
+        self.assertTrue(data['can_melt'])
         self.assertEqual(data['total'], amount)
         self.assertEqual(data['name'], token_name)
         self.assertEqual(data['symbol'], token_symbol)


### PR DESCRIPTION
### Motivation

This PR resolves https://github.com/HathorNetwork/nano-hathor-core/issues/251: the tokens API doesn't account for authorities stored in Nano Contracts, only in UTXOs.

**ATTENTION**: We also have to update the clients after this PR. The issue above lists the required changes. This can be done incrementally because the existing keys are kept in the response.

### Acceptance Criteria

1. Rename `NCSyscallRecord` to `NCIndexUpdateRecord` to reflect the fact that now it can include updates caused by actions (not just syscalls).
4. Add new `UpdateAuthoritiesRecord` index update record and its respective handling.
5. Add counters for contracts holding token authorities in the tokens index.
6. Refactor usages of `list[NCAction]` to `Sequence[NCAction]` across syscalls and internal methods — since our usage is immutable we can use `Sequence` which is more flexible because it's covariant over its items, so we don't need to explicitly type the list when writing blueprints.
7. Add new rule preventing a `revoke_authorities` syscall when contracts don't hold the respective authority. Before, such revoke would simply be a no-op — this change is more consistent, prevents mistakes, and is easier to account for in the indexes.
8. Update `/thin_wallet/tokens` API so it also returns bools `can_mint/can_melt` which include contract authorities.
10. NOTE: even though the internal schema of the tokens index is changed, no migration is necessary because nano is disabled on mainnet and testnet, and there are no blueprints with authorities handling in bravo-nano-testnet.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 