### PR TITLE
feat(nano): add parsed script to tx output data

### DIFF
--- a/hathor/transaction/scripts/base_script.py
+++ b/hathor/transaction/scripts/base_script.py
@@ -37,8 +37,8 @@ class BaseScript(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_address(self) -> Optional[str]:
-        """Get address for this script, not all valid recognizable scripts have addresses."""
+    def get_address(self) -> str:
+        """Get address for this script."""
         raise NotImplementedError
 
     @abstractmethod

--- a/hathor/transaction/scripts/multi_sig.py
+++ b/hathor/transaction/scripts/multi_sig.py
@@ -64,7 +64,7 @@ class MultiSig(BaseScript):
     def get_script(self) -> bytes:
         return MultiSig.create_output_script(decode_address(self.address), self.timelock)
 
-    def get_address(self) -> Optional[str]:
+    def get_address(self) -> str:
         return self.address
 
     def get_timelock(self) -> Optional[int]:

--- a/hathor/transaction/scripts/p2pkh.py
+++ b/hathor/transaction/scripts/p2pkh.py
@@ -60,7 +60,7 @@ class P2PKH(BaseScript):
     def get_script(self) -> bytes:
         return P2PKH.create_output_script(decode_address(self.address), self.timelock)
 
-    def get_address(self) -> Optional[str]:
+    def get_address(self) -> str:
         return self.address
 
     def get_timelock(self) -> Optional[int]:


### PR DESCRIPTION
### Motivation

Blueprint devs requested us to include the address of outputs in the `VertexData` accessible in contracts. This PRs adds the `parsed_script` attribute to `TxOutputData` which includes the address string in base58, when the script is either P2PKH or MultiSig.

### Acceptance Criteria

- On nano contracts, rename `TxOutputData.script` to `raw_scipt` and add `parsed_script`. **ATTENTION:** this would be a breaking change, but we don't have any OCBs using this attribute.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 