### PR TITLE
fix(nano): allow import CallerId on OCBs

### DIFF
--- a/hathor/nanocontracts/allowed_imports.py
+++ b/hathor/nanocontracts/allowed_imports.py
@@ -52,6 +52,7 @@ ALLOWED_IMPORTS: dict[str, dict[str, object]] = {
         BlueprintId=nc.types.BlueprintId,
         ContractId=nc.types.ContractId,
         VertexId=nc.types.VertexId,
+        CallerId=nc.types.CallerId,
         NCDepositAction=nc.types.NCDepositAction,
         NCWithdrawalAction=nc.types.NCWithdrawalAction,
         NCGrantAuthorityAction=nc.types.NCGrantAuthorityAction,


### PR DESCRIPTION
### Motivation

`CallerId` support for OCBs was missing.

### Acceptance Criteria

- Add `CallerId` to allowed imports.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 