### PR TITLE
chore: bump version to v0.65.0

### DIFF
--- a/hathor/cli/openapi_files/openapi_base.json
+++ b/hathor/cli/openapi_files/openapi_base.json
@@ -7,7 +7,7 @@
         ],
 	"info": {
             "title": "Hathor API",
-            "version": "0.64.0"
+            "version": "0.65.0"
 	},
 	"consumes": [
             "application/json"

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -19,13 +19,13 @@ from typing import Optional
 
 from structlog import get_logger
 
-BASE_VERSION = '0.64.0'
+BASE_VERSION = '0.65.0'
 
 DEFAULT_VERSION_SUFFIX = "local"
 BUILD_VERSION_FILE_PATH = "./BUILD_VERSION"
 
 # Valid formats: 1.2.3, 1.2.3-rc.1 and nightly-ab49c20f
-BUILD_VERSION_REGEX = r"^(\d+\.\d+\.\d+(-rc\.\d+)?|nightly-[a-f0-9]{7,8})$"
+BUILD_VERSION_REGEX = r"^(\d+\.\d+\.\d+(-(rc|alpha|beta)\.\d+)?|nightly-[a-f0-9]{7,8})$"
 
 
 logger = get_logger()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathor"
-version = "0.64.0"
+version = "0.65.0"
 description = "Hathor Network full-node"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Motivation

We caught an issue during v0.64.0 _after_ the last release-candidate, so we will need another version bump.

### Acceptance Criteria

- Bump version to v0.65.0
- Update `BUILD_VERSION_REGEX` to accept `alpha` and `beta` version-tags, in addition to `rc` (that was previously supported)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 