### PR TITLE
fix(nano): state API regression after ctx.address refactor

### DIFF
--- a/hathor/nanocontracts/resources/state.py
+++ b/hathor/nanocontracts/resources/state.py
@@ -204,9 +204,8 @@ class NanoContractStateResource(Resource):
                 fields[field] = NCValueErrorResponse(errmsg='field not found')
                 continue
 
-            if type(value) is bytes:
-                value = value.hex()
-            fields[field] = NCValueSuccessResponse(value=value)
+            json_value = field_nc_type.value_to_json(value)
+            fields[field] = NCValueSuccessResponse(value=json_value)
 
         # Call view methods.
         runner.disable_call_trace()  # call trace is not required for calling view methods.


### PR DESCRIPTION
### Motivation

When we refactored `ctx.address` into `ctx.caller_id` we also introduced specialized classes `Address(bytes)`, `VertexId(bytes)`, etc, and those broke a `if type(value) is bytes` check, either way that check was not the correct way to do it.

### Acceptance Criteria

- Fix state API to return the value properly formatted (like its NCType specifies)
- Expand the existing test to have fields of types `Address`, `VertexId` and others

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 