### PR TITLE
feat(nano): change internal storage hashing to sha256

### DIFF
--- a/hathor/nanocontracts/storage/contract_storage.py
+++ b/hathor/nanocontracts/storage/contract_storage.py
@@ -54,7 +54,7 @@ class AttrKey(TrieKey):
     key: bytes
 
     def __bytes__(self) -> bytes:
-        return _Tag.ATTR.value + hashlib.sha1(self.key).digest()
+        return _Tag.ATTR.value + hashlib.sha256(self.key).digest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,7 +127,7 @@ class MetadataKey(TrieKey):
     key: bytes
 
     def __bytes__(self) -> bytes:
-        return _Tag.METADATA.value + hashlib.sha1(self.key).digest()
+        return _Tag.METADATA.value + hashlib.sha256(self.key).digest()
 
 
 _BLUEPRINT_ID_KEY = b'blueprint_id'

--- a/hathor/nanocontracts/storage/patricia_trie.py
+++ b/hathor/nanocontracts/storage/patricia_trie.py
@@ -69,7 +69,7 @@ class Node:
 
         This method assumes that all children already have their ids calculated.
         """
-        h = hashlib.sha1()
+        h = hashlib.sha256()
         h.update(self.key)
         if self.content is not None:
             h.update(self.content)

--- a/tests/nanocontracts/test_patricia_trie.py
+++ b/tests/nanocontracts/test_patricia_trie.py
@@ -151,7 +151,7 @@ class PatriciaTrieTestCase(unittest.TestCase):
         data = {}
         for v_int in range(20_000):
             v = str(v_int).encode('ascii')
-            k = hashlib.sha1(v).digest()
+            k = hashlib.sha256(v).digest()
             data[k] = v
             trie.update(k, v)
 
@@ -175,7 +175,7 @@ class PatriciaTrieTestCase(unittest.TestCase):
         data = {}
         for v_int in range(20_000):
             v = str(v_int).encode('ascii')
-            k = hashlib.sha1(v).digest()
+            k = hashlib.sha256(v).digest()
             data[k] = v
             trie.update(k, v)
         trie.commit()


### PR DESCRIPTION
### Motivation

Benchmark shows similar (and slightly better) performance in some cases.

### Acceptance Criteria

- Use SHA256 for storage hashing (both the patricia-trie and attribute-keys)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 