### PR TITLE
chore(nano): migration to prevent use of incompatible storage

### DIFF
--- a/hathor/transaction/storage/migrations/nc_storage_compat1.py
+++ b/hathor/transaction/storage/migrations/nc_storage_compat1.py
@@ -1,0 +1,37 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+
+from hathor.transaction.storage.migrations import BaseMigration
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage import TransactionStorage
+
+logger = get_logger()
+
+
+class Migration(BaseMigration):
+    def skip_empty_db(self) -> bool:
+        return True
+
+    def get_db_name(self) -> str:
+        return 'nc_storage_compat1'
+
+    def run(self, storage: 'TransactionStorage') -> None:
+        raise Exception('Cannot migrate your database due to an incompatible change in the nanocontracts storage. '
+                        'Please, delete your data folder and use the latest available snapshot or sync '
+                        'from scratch.')

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -44,6 +44,7 @@ from hathor.transaction.storage.migrations import (
     add_closest_ancestor_block,
     change_score_acc_weight_metadata,
     include_funds_for_first_block,
+    nc_storage_compat1,
 )
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope, tx_allow_context
 from hathor.transaction.transaction import Transaction
@@ -103,6 +104,7 @@ class TransactionStorage(ABC):
         change_score_acc_weight_metadata.Migration,
         add_closest_ancestor_block.Migration,
         include_funds_for_first_block.Migration,
+        nc_storage_compat1.Migration,
     ]
 
     _migrations: list[BaseMigration]


### PR DESCRIPTION
### Motivation

Some recent changes to the nanocontracts storage make it incompatible with an existing storage (like #1378 and #1312).

### Acceptance Criteria

- Add an "impossible" migration to prevent use of an incompatible storage and force using a recent snapshot or a sync from scratch

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 