### PR TITLE
fix(p2p): stop accepting parentless vertices (aka genesis vertices)

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -179,6 +179,7 @@ class Builder:
 
         self._execution_manager: ExecutionManager | None = None
         self._vertex_handler: VertexHandler | None = None
+        self._network_vertex_parser: VertexParser | None = None
         self._vertex_parser: VertexParser | None = None
         self._consensus: ConsensusAlgorithm | None = None
         self._p2p_manager: ConnectionsManager | None = None
@@ -475,7 +476,7 @@ class Builder:
             self._get_or_create_settings(),
             self._p2p_manager,
             self._sync_v2_support,
-            self._get_or_create_vertex_parser(),
+            self._get_or_create_network_vertex_parser(),
             self._get_or_create_vertex_handler(),
         )
         return self._p2p_manager
@@ -648,10 +649,19 @@ class Builder:
 
         return self._vertex_handler
 
+    def _get_or_create_network_vertex_parser(self) -> VertexParser:
+        if self._network_vertex_parser is None:
+            self._network_vertex_parser = VertexParser(
+                settings=self._get_or_create_settings(),
+                parse_genesis=False,
+            )
+
+        return self._network_vertex_parser
+
     def _get_or_create_vertex_parser(self) -> VertexParser:
         if self._vertex_parser is None:
             self._vertex_parser = VertexParser(
-                settings=self._get_or_create_settings()
+                settings=self._get_or_create_settings(),
             )
 
         return self._vertex_parser

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -776,8 +776,13 @@ class NodeBlockSync(SyncAgent):
         assert self.protocol.connections is not None
 
         blk_bytes = base64.b64decode(payload)
-        blk = self.vertex_parser.deserialize(blk_bytes)
+        try:
+            blk = self.vertex_parser.deserialize(blk_bytes)
+        except struct.error:
+            self.log.warn('received invalid block')
+            return
         if not isinstance(blk, Block):
+            self.log.warn('not a block', hash=blk.hash_hex)
             # Not a block. Punish peer?
             return
         blk.storage = self.tx_storage
@@ -1026,7 +1031,11 @@ class NodeBlockSync(SyncAgent):
 
         # tx_bytes = bytes.fromhex(payload)
         tx_bytes = base64.b64decode(payload)
-        tx = self.vertex_parser.deserialize(tx_bytes)
+        try:
+            tx = self.vertex_parser.deserialize(tx_bytes)
+        except struct.error:
+            self.log.warn('received invalid transaction')
+            return
         if not isinstance(tx, Transaction):
             self.log.warn('not a transaction', hash=tx.hash_hex)
             # Not a transaction. Punish peer?
@@ -1144,7 +1153,7 @@ class NodeBlockSync(SyncAgent):
         try:
             tx = self.vertex_parser.deserialize(data)
         except struct.error:
-            # Invalid data for tx decode
+            self.log.warn('received invalid vertex')
             return
 
         if origin:

--- a/hathor/transaction/vertex_parser.py
+++ b/hathor/transaction/vertex_parser.py
@@ -26,10 +26,13 @@ if TYPE_CHECKING:
 
 
 class VertexParser:
-    __slots__ = ('_settings',)
+    __slots__ = ('_settings', '_parse_genesis')
 
-    def __init__(self, *, settings: HathorSettings) -> None:
+    def __init__(self, *, settings: HathorSettings, parse_genesis: bool = True) -> None:
+        # the parser can be tuned to not accept parsing genesis, which is expected to be the case for parsing network
+        # vertices, since it wouldn't be a valid vertices for p2p protocols
         self._settings = settings
+        self._parse_genesis = parse_genesis
 
     @staticmethod
     def get_supported_headers(settings: HathorSettings) -> dict[VertexHeaderId, Type[VertexBaseHeader]]:
@@ -58,13 +61,16 @@ class VertexParser:
             tx_version = TxVersion(version)
             is_valid = self._settings.CONSENSUS_ALGORITHM.is_vertex_version_valid(
                 tx_version,
-                include_genesis=True,
+                include_genesis=self._parse_genesis,
                 settings=self._settings,
             )
 
             if not is_valid:
                 raise StructError(f"invalid vertex version: {tx_version}")
             cls = tx_version.get_cls()
-            return cls.create_from_struct(data, storage=storage)
+            vertex = cls.create_from_struct(data, storage=storage)
+            if not self._parse_genesis and len(vertex.parents) == 0:
+                raise StructError(f'genesis vertex not allowed: {vertex.is_genesis}')
+            return vertex
         except ValueError as e:
             raise StructError('Invalid bytes to create transaction subclass.') from e


### PR DESCRIPTION
### Motivation

This fixes an issue where an assertion error happens when calculating the static metadata, because it assumes every vertex has parents.

### Acceptance Criteria

- Add an option on `VertexParser` to toggle whether genesis vertices can be parsed
- Add a `network_vertex_parser` for use in sync agents
- Handle `struct.error` when parsing in sync agents, the handling is to ignore the received vertex, ideally it should be to close the connection, but "ignoring" is the status-quo behavior for other types of invalid vertex and also the node might in fact request the genesis tx or block, and that would be a larger change that we can do in the future, for now ignoring is enough

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 