### PR TITLE
fix(nano): fix nano_contracts_enabled on /version api

### DIFF
--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -200,7 +200,7 @@ class ResourcesBuilder:
 
         resources = [
             (b'status', StatusResource(self.manager), root),
-            (b'version', VersionResource(self.manager), root),
+            (b'version', VersionResource(self.manager, self._feature_service), root),
             (b'create_tx', CreateTxResource(self.manager), root),
             (b'decode_tx', DecodeTxResource(self.manager), root),
             (b'validate_address', ValidateAddressResource(self.manager), root),

--- a/hathor/nanocontracts/utils.py
+++ b/hathor/nanocontracts/utils.py
@@ -16,14 +16,18 @@ from __future__ import annotations
 
 import hashlib
 from types import ModuleType
-from typing import Callable
+from typing import Callable, assert_never
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from pycoin.key.Key import Key as PycoinKey
 
+from hathor.conf.settings import HathorSettings, NanoContractsSetting
 from hathor.crypto.util import decode_address, get_address_from_public_key_bytes, get_public_key_bytes_compressed
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.feature_service import FeatureService
 from hathor.nanocontracts.types import NC_METHOD_TYPE_ATTR, BlueprintId, ContractId, NCMethodType, TokenUid, VertexId
+from hathor.transaction import Vertex
 from hathor.transaction.headers import NanoHeader
 from hathor.util import not_none
 
@@ -139,3 +143,16 @@ def sign_openssl_multisig(
     signatures = [privkey.sign(data, ec.ECDSA(hashes.SHA256())) for privkey in sign_privkeys]
 
     nano_header.nc_script = MultiSig.create_input_data(redeem_script, signatures)
+
+
+def is_nano_active(settings: HathorSettings, vertex: Vertex, feature_service: FeatureService) -> bool:
+    """Return whether the Nano Contracts feature is active according to the provided settings and vertex."""
+    match settings.ENABLE_NANO_CONTRACTS:
+        case NanoContractsSetting.DISABLED:
+            return False
+        case NanoContractsSetting.ENABLED:
+            return True
+        case NanoContractsSetting.FEATURE_ACTIVATION:
+            return feature_service.is_feature_active(vertex=vertex, feature=Feature.NANO_CONTRACTS)
+        case _:  # pragma: no cover
+            assert_never(settings.ENABLE_NANO_CONTRACTS)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -14,10 +14,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, assert_never
+from typing import TYPE_CHECKING
 
 from hathor.daa import DifficultyAdjustmentAlgorithm
-from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.profiler import get_cpu_profiler
 from hathor.reward_lock import get_spent_reward_locked_info
@@ -267,22 +266,14 @@ class TransactionVerifier:
 
     def verify_version(self, tx: Transaction) -> None:
         """Verify that the vertex version is valid."""
-        from hathor.conf.settings import NanoContractsSetting
+        from hathor.nanocontracts.utils import is_nano_active
         allowed_tx_versions = {
             TxVersion.REGULAR_TRANSACTION,
             TxVersion.TOKEN_CREATION_TRANSACTION,
         }
 
-        match self._settings.ENABLE_NANO_CONTRACTS:
-            case NanoContractsSetting.DISABLED:
-                pass
-            case NanoContractsSetting.ENABLED:
-                allowed_tx_versions.add(TxVersion.ON_CHAIN_BLUEPRINT)
-            case NanoContractsSetting.FEATURE_ACTIVATION:
-                if self._feature_service.is_feature_active(vertex=tx, feature=Feature.NANO_CONTRACTS):
-                    allowed_tx_versions.add(TxVersion.ON_CHAIN_BLUEPRINT)
-            case _ as unreachable:
-                assert_never(unreachable)
+        if is_nano_active(self._settings, tx, self._feature_service):
+            allowed_tx_versions.add(TxVersion.ON_CHAIN_BLUEPRINT)
 
         if tx.version not in allowed_tx_versions:
             raise InvalidVersionError(f'invalid vertex version: {tx.version}')

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -1,7 +1,7 @@
 import shutil
 import subprocess
 import tempfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from twisted.internet.defer import inlineCallbacks
 
@@ -14,7 +14,7 @@ from tests.resources.base_resource import StubSite, _BaseResourceTest
 class VersionTest(_BaseResourceTest._ResourceTest):
     def setUp(self):
         super().setUp()
-        self.web = StubSite(VersionResource(self.manager))
+        self.web = StubSite(VersionResource(self.manager, Mock()))
         self.tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):


### PR DESCRIPTION
### Motivation

The `/version` API was indirectly changed to return a string enum instead of a bool for the `nano_contracts_enabled` key, which made all clients believe the nano feature is active for all networks. This PR fixes this.

### Acceptance Criteria

- Refactor `is_nano_active` logic into its own utils function.
- Change the `nano_contracts_enabled` key on the `/version` API to return a bool instead of an string enum.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 