### PR TITLE
Release v0.65.1

### DIFF
--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -200,7 +200,7 @@ class ResourcesBuilder:
 
         resources = [
             (b'status', StatusResource(self.manager), root),
-            (b'version', VersionResource(self.manager), root),
+            (b'version', VersionResource(self.manager, self._feature_service), root),
             (b'create_tx', CreateTxResource(self.manager), root),
             (b'decode_tx', DecodeTxResource(self.manager), root),
             (b'validate_address', ValidateAddressResource(self.manager), root),

--- a/hathor/cli/openapi_files/openapi_base.json
+++ b/hathor/cli/openapi_files/openapi_base.json
@@ -7,7 +7,7 @@
         ],
 	"info": {
             "title": "Hathor API",
-            "version": "0.65.0"
+            "version": "0.65.1"
 	},
 	"consumes": [
             "application/json"

--- a/hathor/nanocontracts/utils.py
+++ b/hathor/nanocontracts/utils.py
@@ -16,14 +16,18 @@ from __future__ import annotations
 
 import hashlib
 from types import ModuleType
-from typing import Callable
+from typing import Callable, assert_never
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from pycoin.key.Key import Key as PycoinKey
 
+from hathor.conf.settings import HathorSettings, NanoContractsSetting
 from hathor.crypto.util import decode_address, get_address_from_public_key_bytes, get_public_key_bytes_compressed
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.feature_service import FeatureService
 from hathor.nanocontracts.types import NC_METHOD_TYPE_ATTR, BlueprintId, ContractId, NCMethodType, TokenUid, VertexId
+from hathor.transaction import Vertex
 from hathor.transaction.headers import NanoHeader
 from hathor.util import not_none
 
@@ -139,3 +143,16 @@ def sign_openssl_multisig(
     signatures = [privkey.sign(data, ec.ECDSA(hashes.SHA256())) for privkey in sign_privkeys]
 
     nano_header.nc_script = MultiSig.create_input_data(redeem_script, signatures)
+
+
+def is_nano_active(settings: HathorSettings, vertex: Vertex, feature_service: FeatureService) -> bool:
+    """Return whether the Nano Contracts feature is active according to the provided settings and vertex."""
+    match settings.ENABLE_NANO_CONTRACTS:
+        case NanoContractsSetting.DISABLED:
+            return False
+        case NanoContractsSetting.ENABLED:
+            return True
+        case NanoContractsSetting.FEATURE_ACTIVATION:
+            return feature_service.is_feature_active(vertex=vertex, feature=Feature.NANO_CONTRACTS)
+        case _:  # pragma: no cover
+            assert_never(settings.ENABLE_NANO_CONTRACTS)

--- a/hathor/version.py
+++ b/hathor/version.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from structlog import get_logger
 
-BASE_VERSION = '0.65.0'
+BASE_VERSION = '0.65.1'
 
 DEFAULT_VERSION_SUFFIX = "local"
 BUILD_VERSION_FILE_PATH = "./BUILD_VERSION"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathor"
-version = "0.65.0"
+version = "0.65.1"
 description = "Hathor Network full-node"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"

--- a/tests/resources/test_version.py
+++ b/tests/resources/test_version.py
@@ -1,7 +1,7 @@
 import shutil
 import subprocess
 import tempfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from twisted.internet.defer import inlineCallbacks
 
@@ -14,7 +14,7 @@ from tests.resources.base_resource import StubSite, _BaseResourceTest
 class VersionTest(_BaseResourceTest._ResourceTest):
     def setUp(self):
         super().setUp()
-        self.web = StubSite(VersionResource(self.manager))
+        self.web = StubSite(VersionResource(self.manager, Mock()))
         self.tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):


### PR DESCRIPTION
This release fixes the `/version` API, where the value of `nano_contracts_enabled` was the settings value and not the actual boolean state of the network.

# Changes

- #1387

# Checklist

- [x] I've read and followed the release process described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/hathor-core.md#stable-release
- [x] The QA process was run successfully during the tests of the corresponding release-candidate(s)