### PR TITLE
chore[prometheus]: collect RocksDB estimated number of keys per column-family

### DIFF
--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -101,6 +101,7 @@ class Metrics:
     send_token_timeouts: int = 0
     # Dict that stores the sizes of each column-family in RocksDB, in bytes
     rocksdb_cfs_sizes: dict[bytes, float] = field(default_factory=dict)
+    rocksdb_cfs_estimate_num_keys: dict[bytes, int] = field(default_factory=dict)
     # TxCache Data
     transaction_cache_hits: int = 0
     transaction_cache_misses: int = 0
@@ -300,6 +301,7 @@ class Metrics:
         self.last_txstorage_data_block = best_block_count
 
         self.rocksdb_cfs_sizes = store.get_sst_files_sizes_by_cf()
+        self.rocksdb_cfs_estimate_num_keys = store.get_estimate_num_keys_by_cf()
 
     def _collect_data(self) -> None:
         """ Call methods that collect data to metrics

--- a/hathor/prometheus.py
+++ b/hathor/prometheus.py
@@ -59,7 +59,8 @@ PEER_CONNECTION_METRICS = {
 }
 
 TX_STORAGE_METRICS = {
-    'total_sst_files_size': 'Storage size in bytes of all SST files of a certain column-family in RocksDB'
+    'total_sst_files_size': 'Storage size in bytes of all SST files of a certain column-family in RocksDB',
+    'estimate_num_keys': 'Estimated number of keys in a certain column-family in RocksDB'
 }
 
 GC_METRICS = {
@@ -196,6 +197,11 @@ class PrometheusMetricsExporter:
             self.tx_storage_metrics['total_sst_files_size'].labels(
                 column_family=cf
             ).set(size)
+
+        for cf, num_keys in self.metrics.rocksdb_cfs_estimate_num_keys.items():
+            self.tx_storage_metrics['estimate_num_keys'].labels(
+                column_family=cf
+            ).set(num_keys)
 
     def _set_new_peer_connection_metrics(self) -> None:
         for name, metric in self.peer_connection_metrics.items():

--- a/hathor/transaction/storage/rocksdb_storage.py
+++ b/hathor/transaction/storage/rocksdb_storage.py
@@ -222,6 +222,24 @@ class TransactionRocksDBStorage(BaseTransactionStorage):
 
         return sizes
 
+    def get_estimate_num_keys_by_cf(
+        self,
+        cfs: Optional[list['rocksdb.ColumnFamilyHandle']] = None
+    ) -> dict[bytes, int]:
+        """Get the estimated number of keys for each Column Family
+
+        :param cfs: The list of column families, defaults to None, in which case all of them are returned
+        :return: A dict containing the names of the cfs and their estimated number of keys
+        """
+        column_families = self._db.column_families if cfs is None else cfs
+
+        estimates: dict[bytes, int] = {}
+
+        for cf in column_families:
+            estimates[cf.name] = int(self._db.get_property(b'rocksdb.estimate-num-keys', cf))
+
+        return estimates
+
     def add_value(self, key: str, value: str) -> None:
         self._db.put((self._cf_attr, key.encode('utf-8')), value.encode('utf-8'))
 


### PR DESCRIPTION
### Motivation

I'm investigating a strange behavior in some fullnodes that are not updating anymore their metric of transactions. Having the number of keys from RocksDB could be a way to cross-check the number of transactions/blocks.

### Acceptance Criteria

- We should have a new metric exported by Prometheus that should look like this:

```
tx_storage_estimate_num_keys{column_family="b'default'"} 0.0
tx_storage_estimate_num_keys{column_family="b'nc-state'"} 1.0
tx_storage_estimate_num_keys{column_family="b'info-index'"} 84692.0
tx_storage_estimate_num_keys{column_family="b'tx'"} 10022.0
tx_storage_estimate_num_keys{column_family="b'meta'"} 10022.0
tx_storage_estimate_num_keys{column_family="b'static-meta'"} 201082.0
tx_storage_estimate_num_keys{column_family="b'attr'"} 23.0
tx_storage_estimate_num_keys{column_family="b'migrations'"} 3.0
tx_storage_estimate_num_keys{column_family="b'event'"} 0.0
tx_storage_estimate_num_keys{column_family="b'event-metadata'"} 1.0
tx_storage_estimate_num_keys{column_family="b'feature-activation-metadata'"} 1.0
tx_storage_estimate_num_keys{column_family="b'tips-all'"} 10586.0
tx_storage_estimate_num_keys{column_family="b'tips-blocks'"} 10584.0
tx_storage_estimate_num_keys{column_family="b'tips-txs'"} 2.0
tx_storage_estimate_num_keys{column_family="b'timestamp-sorted-all'"} 10586.0
tx_storage_estimate_num_keys{column_family="b'timestamp-sorted-blocks'"} 10584.0
tx_storage_estimate_num_keys{column_family="b'timestamp-sorted-txs'"} 2.0
tx_storage_estimate_num_keys{column_family="b'height-index'"} 10584.0
tx_storage_estimate_num_keys{column_family="b'address-index'"} 10584.0
tx_storage_estimate_num_keys{column_family="b'tokens-index'"} 10584.0
```

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 