### PR TITLE
feat(nano): add str utils for Address class

### DIFF
--- a/hathor/nanocontracts/faux_immutable.py
+++ b/hathor/nanocontracts/faux_immutable.py
@@ -21,6 +21,7 @@ from typing_extensions import ParamSpec
 # special attrs:
 SKIP_VALIDATION_ATTR: str = '__skip_faux_immutability_validation__'
 ALLOW_INHERITANCE_ATTR: str = '__allow_faux_inheritance__'
+ALLOW_DUNDER_ATTR: str = '__allow_faux_dunder__'
 
 
 def _validate_faux_immutable_meta(name: str, bases: tuple[type, ...], attrs: dict[str, object]) -> None:
@@ -33,13 +34,15 @@ def _validate_faux_immutable_meta(name: str, bases: tuple[type, ...], attrs: dic
         if attr not in attrs:
             raise TypeError(f'faux-immutable class `{name}` must define `{attr}`')
 
+    custom_allowed_dunder_value: tuple[str, ...] = attrs.pop(ALLOW_DUNDER_ATTR, ())  # type: ignore[assignment]
+    custom_allowed_dunder = frozenset(custom_allowed_dunder_value)
     allowed_dunder = frozenset({
         '__module__',
         '__qualname__',
         '__doc__',
         '__init__',
         '__call__',
-    })
+    }) | custom_allowed_dunder
 
     # pop the attribute so the created class doesn't have it and it isn't inherited
     allow_inheritance = attrs.pop(ALLOW_INHERITANCE_ATTR, False)

--- a/hathor/nanocontracts/types.py
+++ b/hathor/nanocontracts/types.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Any, Callable, Generic, TypeAlias, TypeVar
+from typing import Any, Callable, Generic, Self, TypeAlias, TypeVar
 
 from typing_extensions import override
 
+from hathor.crypto.util import decode_address, get_address_b58_from_bytes
 from hathor.nanocontracts.blueprint_syntax_validation import (
     validate_has_ctx_arg,
     validate_has_not_ctx_arg,
@@ -44,7 +45,23 @@ from hathor.utils.typing import InnerTypeMixin
 # Types to be used by blueprints.
 class Address(bytes, metaclass=FauxImmutableMeta):  # type: ignore[misc]
     __allow_faux_inheritance__ = True
+    __allow_faux_dunder__ = ('__str__', '__repr__')
     __slots__ = ()
+
+    @classmethod
+    def from_str(cls, /, encoded_address: str) -> Self:
+        if not isinstance(encoded_address, str):
+            raise TypeError(f'expected `str` instance, got `{type(encoded_address)}` instance')
+        return cls(decode_address(encoded_address))
+
+    def __str__(self) -> str:
+        encoded_address = get_address_b58_from_bytes(self)
+        return encoded_address
+
+    def __repr__(self) -> str:
+        encoded_address = str(self)  # uses __str__
+        # XXX: should we support `Address(encoded_address)` constructor?
+        return f"Address.from_str({encoded_address!r})"
 
 
 class VertexId(bytes, metaclass=FauxImmutableMeta):  # type: ignore[misc]

--- a/tests/nanocontracts/test_address_example.py
+++ b/tests/nanocontracts/test_address_example.py
@@ -1,0 +1,60 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.crypto.util import get_address_b58_from_bytes
+from hathor.nanocontracts import OnChainBlueprint
+from hathor.transaction import Block, Transaction
+from hathor.transaction.nc_execution_state import NCExecutionState
+from tests import unittest
+from tests.dag_builder.builder import TestDAGBuilder
+
+
+class TestAllFields(unittest.TestCase):
+    def test_all_fields_ocb(self) -> None:
+        private_key = unittest.OCB_TEST_PRIVKEY.hex()
+        password = unittest.OCB_TEST_PASSWORD.hex()
+        manager = self.create_peer('unittests')
+        dag_builder = TestDAGBuilder.from_manager(manager)
+
+        # XXX: using an OCB to make sure any syntax/imports/etc are accepted
+        artifacts = dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            ocb1.ocb_private_key = "{private_key}"
+            ocb1.ocb_password = "{password}"
+            ocb1.ocb_code = address_example.py, AddressExample
+            ocb1 <-- b11
+
+            nc1.nc_id = ocb1
+            nc1.nc_method = initialize()
+            nc1 <-- b12
+        ''')
+        artifacts.propagate_with(manager)
+
+        b11, b12 = artifacts.get_typed_vertices(['b11', 'b12'], Block)
+        ocb1 = artifacts.get_typed_vertex('ocb1', OnChainBlueprint)
+        nc1 = artifacts.get_typed_vertex('nc1', Transaction)
+
+        assert b11.get_metadata().voided_by is None
+        assert ocb1.get_metadata().voided_by is None
+        assert ocb1.get_metadata().first_block == b11.hash
+        assert nc1.get_metadata().voided_by is None
+        assert nc1.get_metadata().first_block == b12.hash
+        assert nc1.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        runner = manager.get_nc_runner(b12)
+        method_address = runner.call_view_method(nc1.hash, 'get_last_address_str')
+        expected_address = get_address_b58_from_bytes(nc1.get_nano_header().nc_address)
+        assert method_address == expected_address

--- a/tests/nanocontracts/test_blueprints/address_example.py
+++ b/tests/nanocontracts/test_blueprints/address_example.py
@@ -1,0 +1,45 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathor.nanocontracts.blueprint import Blueprint
+from hathor.nanocontracts.context import Context
+from hathor.nanocontracts.exception import NCFail
+from hathor.nanocontracts.types import Address, public, view
+
+
+class AddressExample(Blueprint):
+    """Dummy blueprint to test the exposed API.
+
+    This blueprint is very limited, but eventually it should test all API that is exposed.
+    """
+
+    last_address: Address | None
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        caller_address = ctx.get_caller_address()
+        if caller_address is None:
+            raise NCFail('must be initialized from address, not from a contract')
+        self.last_address = caller_address
+
+    @view
+    def get_last_address_str(self) -> str:
+        return str(self.last_address)
+
+    @public
+    def set_last_address_from_str(self, ctx: Context, address: str) -> None:
+        self.last_address = Address.from_str(address)
+
+
+__blueprint__ = AddressExample


### PR DESCRIPTION
### Motivation

Currently there isn't a way to convert to/from string and addresses in Blueprint code. Instead of simply exposing the internal functions to do it, this PR exposes a friendlier API.

### Acceptance Criteria

- add `str(address)` support for `address: Address`
- add `Address.from_str(raw_address)`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 