### PR TITLE
feat(nano): reduce NC_EVENT max size to 1KiB

### DIFF
--- a/hathor/nanocontracts/nc_exec_logs.py
+++ b/hathor/nanocontracts/nc_exec_logs.py
@@ -36,7 +36,7 @@ from hathor.utils.pydantic import BaseModel
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
 
-MAX_EVENT_SIZE: int = 100 * 1024  # 100KiB
+MAX_EVENT_SIZE: int = 1024  # 1KiB
 
 
 @unique


### PR DESCRIPTION
### Motivation

The previous limit of 100KiB is high, especially because there's no way to select specific contracts when enabling `NC_EVENT`s.

### Acceptance Criteria

- Reduce limit from `100KiB` to `1KiB`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 