### PR TITLE
feat(nano): use decorator to export a Blueprint

### DIFF
--- a/hathor/nanocontracts/__init__.py
+++ b/hathor/nanocontracts/__init__.py
@@ -19,7 +19,7 @@ from hathor.nanocontracts.exception import NCFail
 from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
 from hathor.nanocontracts.runner import Runner
 from hathor.nanocontracts.storage import NCMemoryStorageFactory, NCRocksDBStorageFactory, NCStorageFactory
-from hathor.nanocontracts.types import TokenUid, VertexId, fallback, public, view
+from hathor.nanocontracts.types import TokenUid, VertexId, export, fallback, public, view
 
 # Identifier used in metadata's voided_by when a Nano Contract method fails.
 NC_EXECUTION_FAIL_ID: bytes = b'nc-fail'
@@ -38,6 +38,7 @@ __all__ = [
     'public',
     'fallback',
     'view',
+    'export',
     'NC_EXECUTION_FAIL_ID',
     'HATHOR_TOKEN_UID',
 ]

--- a/hathor/nanocontracts/allowed_imports.py
+++ b/hathor/nanocontracts/allowed_imports.py
@@ -46,6 +46,7 @@ ALLOWED_IMPORTS: dict[str, dict[str, object]] = {
         SignedData=nc.types.SignedData,
         public=nc.public,
         view=nc.view,
+        export=nc.export,
         fallback=nc.fallback,
         Address=nc.types.Address,
         Amount=nc.types.Amount,

--- a/hathor/nanocontracts/custom_builtins.py
+++ b/hathor/nanocontracts/custom_builtins.py
@@ -36,7 +36,7 @@ from typing_extensions import Self, TypeVarTuple
 from hathor.nanocontracts.allowed_imports import ALLOWED_IMPORTS
 from hathor.nanocontracts.exception import NCDisabledBuiltinError
 from hathor.nanocontracts.faux_immutable import FauxImmutable
-from hathor.nanocontracts.on_chain_blueprint import BLUEPRINT_CLASS_NAME
+from hathor.nanocontracts.types import BLUEPRINT_EXPORT_NAME
 
 T = TypeVar('T')
 Ts = TypeVarTuple('Ts')
@@ -503,7 +503,7 @@ EXEC_BUILTINS: dict[str, Any] = {
     # XXX: this would be '__main__' for a module that is loaded as the main entrypoint, and the module name otherwise,
     # since the blueprint code is adhoc, we could as well expose something else, like '__blueprint__'
     # constant
-    '__name__': BLUEPRINT_CLASS_NAME,
+    '__name__': BLUEPRINT_EXPORT_NAME,
 
     # make it always True, which is how we'll normally run anyway
     '__debug__': True,

--- a/hathor/nanocontracts/on_chain_blueprint.py
+++ b/hathor/nanocontracts/on_chain_blueprint.py
@@ -30,7 +30,7 @@ from hathor.crypto.util import get_address_b58_from_public_key_bytes, get_public
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.exception import OCBOutOfFuelDuringLoading, OCBOutOfMemoryDuringLoading
 from hathor.nanocontracts.method import Method
-from hathor.nanocontracts.types import BlueprintId, blueprint_id_from_bytes
+from hathor.nanocontracts.types import BLUEPRINT_EXPORT_NAME, BlueprintId, blueprint_id_from_bytes
 from hathor.transaction import Transaction, TxInput, TxOutput, TxVersion
 from hathor.transaction.util import VerboseCallback, int_to_bytes, unpack, unpack_len
 
@@ -43,9 +43,6 @@ logger = get_logger()
 
 # used to allow new versions of the serialization format in the future
 ON_CHAIN_BLUEPRINT_VERSION: int = 1
-
-# this is the name we expect the source code to expose for the Blueprint class
-BLUEPRINT_CLASS_NAME: str = '__blueprint__'
 
 # source compatibility with Python 3.11
 PYTHON_CODE_COMPAT_VERSION = (3, 11)
@@ -207,7 +204,7 @@ class OnChainBlueprint(Transaction):
         except OutOfMemoryError as e:
             self.log.error('loading blueprint module failed, memory limit exceeded')
             raise OCBOutOfMemoryDuringLoading from e
-        blueprint_class = env[BLUEPRINT_CLASS_NAME]
+        blueprint_class = env[BLUEPRINT_EXPORT_NAME]
         return blueprint_class, env
 
     def _load_blueprint_code(self) -> tuple[type[Blueprint], dict[str, object]]:
@@ -220,7 +217,7 @@ class OnChainBlueprint(Transaction):
         return self._blueprint_loaded_env
 
     def get_blueprint_object_bypass(self) -> object:
-        """Loads the code and returns the object defined in __blueprint__"""
+        """Loads the code and returns the object exported with @export"""
         blueprint_class, _ = self._load_blueprint_code_exec()
         return blueprint_class
 

--- a/tests/nanocontracts/test_blueprints/bet.py
+++ b/tests/nanocontracts/test_blueprints/bet.py
@@ -27,6 +27,7 @@ from hathor.nanocontracts.types import (
     Timestamp,
     TokenUid,
     TxOutputScript,
+    export,
     public,
     view,
 )
@@ -63,6 +64,7 @@ class InvalidOracleSignature(NCFail):
     pass
 
 
+@export
 class Bet(Blueprint):
     """Bet blueprint with final result provided by an oracle.
 
@@ -221,6 +223,3 @@ class Bet(Blueprint):
         address_total = self.bets_address.get((self.final_result, address), 0)
         percentage = address_total / result_total
         return Amount(floor(percentage * self.total))
-
-
-__blueprint__ = Bet

--- a/tests/nanocontracts/test_exposed_properties.py
+++ b/tests/nanocontracts/test_exposed_properties.py
@@ -116,6 +116,7 @@ KNOWN_CASES = [
     'hathor.nanocontracts.types.SignedData.checksig',
     'hathor.nanocontracts.types.SignedData.get_data_bytes',
     'hathor.nanocontracts.types.SignedData.some_new_attribute',
+    'hathor.nanocontracts.types.export.some_new_attribute',
     'hathor.nanocontracts.types.fallback.some_new_attribute',
     'hathor.nanocontracts.types.public.some_new_attribute',
     'hathor.nanocontracts.types.view.some_new_attribute',


### PR DESCRIPTION
### Motivation

The current method of assigning to `__blueprint__` has some drawbacks. This proposal uses a decorator which should already be familiar because of `@view` and `@public` decorators.

### Acceptance Criteria

- Move `hathor.nanocontracts.on_chain_blueprints.BLUEPRINT_CLASS_NAME` to `hathor.nanocontracts.types.BLUEPRINT_EXPORT_NAME`
- Introduce `hathor.nanocontracts.export` which just sets `__blueprint__` at the module where it is called, which means it is backwards compatible:
  ```python
  @export
  class Foo(Blueprint):
      pass
  ```
  Has the same runtime effect of:
  ```python
  class Foo(Blueprint):
      pass
  __blueprint__ = Foo

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 