### PR TITLE
feat(nano): restrict usage of float and complex numbers

### DIFF
--- a/hathor/nanocontracts/custom_builtins.py
+++ b/hathor/nanocontracts/custom_builtins.py
@@ -356,6 +356,11 @@ DISABLED_BUILTINS: frozenset[str] = frozenset({
     # XXX: used to raise SystemExit exception to close the process, we could make it raise a NCFail
     'exit',
 
+    # XXX: floats are not allowed in runtime
+    # O(1)
+    # type float
+    'float',
+
     # XXX: used to dynamically get an attribute, must not be allowed
     'getattr',
 
@@ -580,10 +585,6 @@ EXEC_BUILTINS: dict[str, Any] = {
     # (function: Callable[[S], TypeIs[T]], iterable: Iterable[S], /) -> filter(Iterator[T])
     # (function: Callable[[T], Any], iterable: Iterable[T], /) -> filter(Iterator[T])
     'filter': builtins.filter,
-
-    # O(1)
-    # type float
-    'float': builtins.float,
 
     # O(N) for N=len(value)
     # (value: object, format_spec: str = "", /) -> str

--- a/hathor/verification/on_chain_blueprint_verifier.py
+++ b/hathor/verification/on_chain_blueprint_verifier.py
@@ -101,6 +101,18 @@ class _RestrictionsVisitor(ast.NodeVisitor):
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         raise SyntaxError('Async contexts are not allowed.')
 
+    def visit_Constant(self, node: ast.Constant) -> None:
+        match node.value:
+            case float():
+                raise SyntaxError('Float literals are not allowed.')
+            case complex():
+                raise SyntaxError('Complex literals are not allowed.')
+            case _:
+                self.generic_visit(node)
+
+    def visit_Div(self, node: ast.Div) -> None:
+        raise SyntaxError('Simple / division results in float, use // instead.')
+
 
 class _SearchName(ast.NodeVisitor):
     def __init__(self, name: str) -> None:

--- a/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -378,6 +378,32 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
             syntax_errors=('Async functions are not allowed.',)
         )
 
+    def test_forbid_float_literal(self) -> None:
+        self._test_forbid_syntax(
+            'a = 3.14',
+            syntax_errors=('Float literals are not allowed.',)
+        )
+        self._test_forbid_syntax(
+            'a = 3.',
+            syntax_errors=('Float literals are not allowed.',)
+        )
+        self._test_forbid_syntax(
+            'a = .14',
+            syntax_errors=('Float literals are not allowed.',)
+        )
+
+    def test_forbid_complex_literal(self) -> None:
+        self._test_forbid_syntax(
+            'a = 1j',
+            syntax_errors=('Complex literals are not allowed.',)
+        )
+
+    def test_forbid_float_division(self) -> None:
+        self._test_forbid_syntax(
+            'a = 1 / 2',
+            syntax_errors=('Simple / division results in float, use // instead.',)
+        )
+
     def test_forbid_await_syntax(self) -> None:
         # XXX: it is normally forbidden to use await outside an async context, and since async functions cannot be
         #      defined, it isn't possible to make a realistic code that will fail with await (also applies to other

--- a/tests/nanocontracts/test_blueprints/bet.py
+++ b/tests/nanocontracts/test_blueprints/bet.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from math import floor
 from typing import Optional, TypeAlias
 
 from hathor.nanocontracts.blueprint import Blueprint
@@ -221,5 +220,5 @@ class Bet(Blueprint):
         if result_total == 0:
             return Amount(0)
         address_total = self.bets_address.get((self.final_result, address), 0)
-        percentage = address_total / result_total
-        return Amount(floor(percentage * self.total))
+        winner_amount = Amount(address_total * self.total // result_total)
+        return winner_amount


### PR DESCRIPTION
**WARNING: this causes breakage with testnet-hotel, because some of the published OCBs use the float division operator.**

### Motivation

Some syntax still allows float and complex numbers, which could lead to different results in different hardware. We should lift these restrictions when we have a deterministic float implementation.

### Acceptance Criteria

- Forbid float literals in Blueprint code
- Forbid complex literals in Blueprint code
- Forbid use of float division (`/`) in Blueprint code

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 