### PR TITLE
feat(nano): remove support for using __blueprint__ in OCB code

### DIFF
--- a/hathor/nanocontracts/custom_builtins.py
+++ b/hathor/nanocontracts/custom_builtins.py
@@ -506,8 +506,7 @@ EXEC_BUILTINS: dict[str, Any] = {
 
     # XXX: also required to declare classes
     # XXX: this would be '__main__' for a module that is loaded as the main entrypoint, and the module name otherwise,
-    # since the blueprint code is adhoc, we could as well expose something else, like '__blueprint__'
-    # constant
+    # since the blueprint code is adhoc, we could as well expose something else, like '__blueprint__' constant
     '__name__': BLUEPRINT_EXPORT_NAME,
 
     # make it always True, which is how we'll normally run anyway

--- a/hathor/nanocontracts/utils.py
+++ b/hathor/nanocontracts/utils.py
@@ -71,7 +71,6 @@ def load_builtin_blueprint_for_ocb(filename: str, blueprint_name: str, module: M
     with open(filepath, 'r') as nc_file:
         for line in nc_file.readlines():
             code_text.write(line)
-    code_text.write(f'__blueprint__ = {blueprint_name}\n')
     res = code_text.getvalue()
     code_text.close()
     return res

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -1168,9 +1168,6 @@ class TransactionStorage(ABC):
         """Returns the source code associated with the given blueprint_id.
 
         The blueprint class could be in the catalog (first search), or it could be the tx_id of an on-chain blueprint.
-
-        A point of difference is that an OCB will have a `__blueprint__ = BlueprintName` line, where a built-in
-        blueprint will not.
         """
         import inspect
 

--- a/tests/dag_builder/test_dag_builder.py
+++ b/tests/dag_builder/test_dag_builder.py
@@ -387,12 +387,12 @@ if foo:
             ocb3.ocb_code = ```
                 from hathor.nanocontracts import Blueprint
                 from hathor.nanocontracts.context import Context
-                from hathor.nanocontracts.types import public
+                from hathor.nanocontracts.types import export, public
+                @export
                 class MyBlueprint(Blueprint):
                     @public
                     def initialize(self, ctx: Context) -> None:
                         pass
-                __blueprint__ = MyBlueprint
             ```
         """)
 

--- a/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -441,18 +441,28 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
         assert cm.exception.args[0] == 'full validation failed: Could not correctly parse the script'
 
     def test_blueprint_type_not_a_class(self) -> None:
-        blueprint = self._create_on_chain_blueprint('''__blueprint__ = "Bet"''')
+        blueprint = self._create_on_chain_blueprint(r'''
+from hathor.nanocontracts.types import export
+@export
+def Foo():
+    pass
+''')
         with self.assertRaises(InvalidNewTransaction) as cm:
             self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
-        assert cm.exception.args[0] == 'full validation failed: __blueprint__ is not a class'
+        assert cm.exception.args[0] == 'full validation failed: Could not find a main Blueprint definition'
 
     def test_blueprint_type_not_blueprint_subclass(self) -> None:
-        blueprint = self._create_on_chain_blueprint('''class Foo:\n    ...\n__blueprint__ = Foo''')
+        blueprint = self._create_on_chain_blueprint(r'''
+from hathor.nanocontracts.types import export
+@export
+class Foo():
+    pass
+''')
         with self.assertRaises(InvalidNewTransaction) as cm:
             self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
-        assert cm.exception.args[0] == 'full validation failed: __blueprint__ is not a Blueprint subclass'
+        assert cm.exception.args[0] == 'full validation failed: exported Blueprint is not a Blueprint subclass'
 
     def test_zlib_bomb(self) -> None:
         from struct import error as StructError

--- a/tests/nanocontracts/test_blueprints/address_example.py
+++ b/tests/nanocontracts/test_blueprints/address_example.py
@@ -15,9 +15,10 @@
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCFail
-from hathor.nanocontracts.types import Address, public, view
+from hathor.nanocontracts.types import Address, export, public, view
 
 
+@export
 class AddressExample(Blueprint):
     """Dummy blueprint to test the exposed API.
 
@@ -40,6 +41,3 @@ class AddressExample(Blueprint):
     @public
     def set_last_address_from_str(self, ctx: Context, address: str) -> None:
         self.last_address = Address.from_str(address)
-
-
-__blueprint__ = AddressExample

--- a/tests/nanocontracts/test_blueprints/all_fields.py
+++ b/tests/nanocontracts/test_blueprints/all_fields.py
@@ -27,6 +27,7 @@ from hathor.nanocontracts.types import (
     TokenUid,
     TxOutputScript,
     VertexId,
+    export,
     public,
 )
 
@@ -36,6 +37,7 @@ class MyTuple(NamedTuple):
     b: str
 
 
+@export
 class AllFieldsBlueprint(Blueprint):
     attribute1: OrderedDict[str, int]
     attribute2: list[int]

--- a/tests/nanocontracts/test_blueprints/contract_accessor_blueprint.py
+++ b/tests/nanocontracts/test_blueprints/contract_accessor_blueprint.py
@@ -20,12 +20,14 @@ from hathor.nanocontracts.types import (
     NCArgs,
     NCDepositAction,
     VertexId,
+    export,
     fallback,
     public,
     view,
 )
 
 
+@export
 class MyBlueprint(Blueprint):
     message: str
 
@@ -200,6 +202,3 @@ class MyBlueprint(Blueprint):
     @fallback
     def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> str:
         return f'fallback called for method `{method_name}`'
-
-
-__blueprint__ = MyBlueprint

--- a/tests/nanocontracts/test_blueprints/swap_demo.py
+++ b/tests/nanocontracts/test_blueprints/swap_demo.py
@@ -15,9 +15,10 @@
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCFail
-from hathor.nanocontracts.types import NCDepositAction, NCWithdrawalAction, TokenUid, public, view
+from hathor.nanocontracts.types import NCDepositAction, NCWithdrawalAction, TokenUid, export, public, view
 
 
+@export
 class SwapDemo(Blueprint):
     """Blueprint to execute swaps between tokens.
     This blueprint is here just as a reference for blueprint developers, not for real use.

--- a/tests/nanocontracts/test_blueprints/test_blueprint1.py
+++ b/tests/nanocontracts/test_blueprints/test_blueprint1.py
@@ -14,9 +14,10 @@
 
 from hathor.nanocontracts import Blueprint
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.types import public
+from hathor.nanocontracts.types import export, public
 
 
+@export
 class TestBlueprint1(Blueprint):
     @public
     def initialize(self, ctx: Context, a: int) -> None:

--- a/tests/nanocontracts/test_custom_import.py
+++ b/tests/nanocontracts/test_custom_import.py
@@ -28,8 +28,9 @@ class TestCustomImport(BlueprintTestCase):
         blueprint = '''
             from hathor.nanocontracts import Blueprint
             from hathor.nanocontracts.context import Context
-            from hathor.nanocontracts.types import public
+            from hathor.nanocontracts.types import export, public
 
+            @export
             class MyBlueprint(Blueprint):
                 @public
                 def initialize(self, ctx: Context) -> None:
@@ -37,8 +38,6 @@ class TestCustomImport(BlueprintTestCase):
                     from collections import OrderedDict
                     from hathor.nanocontracts.exception import NCFail
                     from hathor.nanocontracts.types import NCAction, NCActionType
-
-            __blueprint__ = MyBlueprint
         '''
 
         # Wrap our custom builtin so we can spy its calls
@@ -54,7 +53,7 @@ class TestCustomImport(BlueprintTestCase):
         module_level_calls = [
             call('hathor.nanocontracts', ANY, ANY, ('Blueprint',), 0),
             call('hathor.nanocontracts.context', ANY, ANY, ('Context',), 0),
-            call('hathor.nanocontracts.types', ANY, ANY, ('public',), 0),
+            call('hathor.nanocontracts.types', ANY, ANY, ('export', 'public'), 0),
         ]
         assert wrapped_import_function.call_count == 2 * len(module_level_calls)
         wrapped_import_function.assert_has_calls(2 * module_level_calls)
@@ -83,8 +82,9 @@ class TestCustomImport(BlueprintTestCase):
         blueprint = '''
             from hathor.nanocontracts import Blueprint
             from hathor.nanocontracts.context import Context
-            from hathor.nanocontracts.types import public
+            from hathor.nanocontracts.types import export, public
 
+            @export
             class MyBlueprint(Blueprint):
                 @public
                 def initialize(self, ctx: Context) -> None:
@@ -98,8 +98,6 @@ class TestCustomImport(BlueprintTestCase):
                         from hathor.nanocontracts.types import NCAction, NCActionType
 
                     wrapped_builtin_import.assert_not_called()
-
-            __blueprint__ = MyBlueprint
         '''
 
         blueprint_id = self._register_blueprint_contents(

--- a/tests/nanocontracts/test_sorter.py
+++ b/tests/nanocontracts/test_sorter.py
@@ -173,7 +173,9 @@ class NCBlockSorterTestCase(unittest.TestCase):
             ocb1.ocb_code = ```
                 from hathor.nanocontracts import Blueprint
                 from hathor.nanocontracts.context import Context
-                from hathor.nanocontracts.types import public
+                from hathor.nanocontracts.types import export, public
+
+                @export
                 class MyBlueprint(Blueprint):
                     @public
                     def initialize(self, ctx: Context) -> None:
@@ -182,7 +184,6 @@ class NCBlockSorterTestCase(unittest.TestCase):
                     @public
                     def nop(self, ctx: Context) -> None:
                         pass
-                __blueprint__ = MyBlueprint
             ```
         """)
 

--- a/tests/resources/nanocontracts/dummy_blueprint.py
+++ b/tests/resources/nanocontracts/dummy_blueprint.py
@@ -1,8 +1,9 @@
 from hathor.nanocontracts import Blueprint
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.types import public
+from hathor.nanocontracts.types import export, public
 
 
+@export
 class TestBlueprint(Blueprint):
     """ This class is used by the test for the blueprint source code resource
         It must be in a separate file for the assert in the test

--- a/tests/resources/nanocontracts/my_blueprint.py
+++ b/tests/resources/nanocontracts/my_blueprint.py
@@ -2,9 +2,20 @@ from typing import Optional
 
 from hathor.nanocontracts import Blueprint
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.types import Address, Amount, SignedData, Timestamp, TokenUid, TxOutputScript, public, view
+from hathor.nanocontracts.types import (
+    Address,
+    Amount,
+    SignedData,
+    Timestamp,
+    TokenUid,
+    TxOutputScript,
+    export,
+    public,
+    view,
+)
 
 
+@export
 class MyBlueprint(Blueprint):
     a_int: int
     a_str: str

--- a/tests/resources/nanocontracts/test_blueprint_source_code.py
+++ b/tests/resources/nanocontracts/test_blueprint_source_code.py
@@ -62,9 +62,10 @@ class BuiltinBlueprintSourceCodeTest(BaseBlueprintSourceCodeTest):
 
     blueprint_source = r'''from hathor.nanocontracts import Blueprint
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.types import public
+from hathor.nanocontracts.types import export, public
 
 
+@export
 class TestBlueprint(Blueprint):
     """ This class is used by the test for the blueprint source code resource
         It must be in a separate file for the assert in the test
@@ -92,9 +93,10 @@ class OCBBlueprintSourceCodeTest(BaseBlueprintSourceCodeTest):
 
     blueprint_source = r'''from hathor.nanocontracts import Blueprint
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.types import public
+from hathor.nanocontracts.types import export, public
 
 
+@export
 class TestBlueprint(Blueprint):
     """ This class is used by the test for the blueprint source code resource
         It must be in a separate file for the assert in the test
@@ -108,7 +110,6 @@ class TestBlueprint(Blueprint):
     @public
     def sum(self, ctx: Context, arg1: int) -> None:
         self.int_attribute += arg1
-__blueprint__ = TestBlueprint
 '''
 
     def setUp(self):

--- a/tests/resources/nanocontracts/test_nc_creation.py
+++ b/tests/resources/nanocontracts/test_nc_creation.py
@@ -76,12 +76,12 @@ class NCCreationResourceTest(_BaseResourceTest._ResourceTest):
             ocb2.ocb_code = ```
                 from hathor.nanocontracts import Blueprint
                 from hathor.nanocontracts.context import Context
-                from hathor.nanocontracts.types import public
+                from hathor.nanocontracts.types import export, public
+                @export
                 class MyBlueprint(Blueprint):
                     @public
                     def initialize(self, ctx: Context) -> None:
                         pass
-                __blueprint__ = MyBlueprint
             ```
         ''')
 


### PR DESCRIPTION
### Motivation

#1395 introduced the use of `@export` to set the main blueprint class of a module, but leaves the old method (`__blueprint__ = MyBlueprint`) as acceptable.

### Acceptance Criteria

- Remove support for `__blueprint__`
- Refactor all remaining cases to use `@export`
- Adjust tests accordingly

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged