### PR TITLE
fix(nano): temporary alias to keep compatibility with testnet-hotel

### DIFF
--- a/hathor/nanocontracts/blueprint_env.py
+++ b/hathor/nanocontracts/blueprint_env.py
@@ -259,6 +259,9 @@ class BlueprintEnvironment:
             melt_authority
         )
 
+    # XXX: temporary alias
+    create_token = create_deposit_token
+
     @final
     def create_fee_token(
         self,

--- a/tests/nanocontracts/test_syscalls_in_view.py
+++ b/tests/nanocontracts/test_syscalls_in_view.py
@@ -102,6 +102,10 @@ class MyBlueprint(Blueprint):
         self.syscall.create_deposit_token('', '', 0)
 
     @view
+    def create_token(self) -> None:
+        self.syscall.create_token('', '', 0)
+
+    @view
     def create_fee_token(self) -> None:
         self.syscall.create_fee_token('', '', 0)
 
@@ -172,5 +176,6 @@ class TestSyscallsInView(BlueprintTestCase):
             if method_name in allowed_view_syscalls:
                 self.runner.call_view_method(contract_id, method_name)
             else:
-                with pytest.raises(NCViewMethodError, match=f'@view method cannot call `syscall.{method_name}`'):
+                method_name_err = method_name if method_name != 'create_token' else 'create_deposit_token'
+                with pytest.raises(NCViewMethodError, match=f'@view method cannot call `syscall.{method_name_err}`'):
                     self.runner.call_view_method(contract_id, method_name)


### PR DESCRIPTION
### Motivation

We ended up introducing a regression with #1255 when it renamed `self.syscall.create_token` to `self.syscall.create_deposit_token`.

### Acceptance Criteria

- Create an alias so that `self.syscall.create_token` works. We should remove this alias before mainnet when we break compatibility with `testnet-hotel`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 