### PR TITLE
feat(nano): remove create_token syscall alias

### DIFF
--- a/hathor/nanocontracts/blueprint_env.py
+++ b/hathor/nanocontracts/blueprint_env.py
@@ -265,9 +265,6 @@ class BlueprintEnvironment:
             melt_authority=melt_authority,
         )
 
-    # XXX: temporary alias
-    create_token = create_deposit_token
-
     @final
     def create_fee_token(
         self,

--- a/tests/nanocontracts/test_syscalls_in_view.py
+++ b/tests/nanocontracts/test_syscalls_in_view.py
@@ -102,10 +102,6 @@ class MyBlueprint(Blueprint):
         self.syscall.create_deposit_token('', '', 0)
 
     @view
-    def create_token(self) -> None:
-        self.syscall.create_token('', '', 0)
-
-    @view
     def create_fee_token(self) -> None:
         self.syscall.create_fee_token('', '', 0)
 
@@ -176,6 +172,5 @@ class TestSyscallsInView(BlueprintTestCase):
             if method_name in allowed_view_syscalls:
                 self.runner.call_view_method(contract_id, method_name)
             else:
-                method_name_err = method_name if method_name != 'create_token' else 'create_deposit_token'
-                with pytest.raises(NCViewMethodError, match=f'@view method cannot call `syscall.{method_name_err}`'):
+                with pytest.raises(NCViewMethodError, match=f'@view method cannot call `syscall.{method_name}`'):
                     self.runner.call_view_method(contract_id, method_name)


### PR DESCRIPTION
**WARNING: this PR breaks compatibility with nano on testnet-hotel**

### Motivation

A temporary alias was added, it should be removed before nano on `mainnet`, but not before a last release with `testnet-hotel` compatibility.

### Acceptance Criteria

- Remove `self.syscall.create_token` alias to `self.syscall.create_deposit_token` available to Blueprints

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 