### PR TITLE
feat(nano): implement feature activation handling

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -271,6 +271,7 @@ class Builder:
             vertex_parser=vertex_parser,
             poa_block_producer=poa_block_producer,
             runner_factory=runner_factory,
+            feature_service=feature_service,
             **kwargs
         )
 
@@ -414,6 +415,7 @@ class Builder:
                 runner_factory=self._get_or_create_runner_factory(),
                 nc_log_storage=self._get_or_create_nc_log_storage(),
                 nc_calls_sorter=nc_calls_sorter,
+                feature_service=self._get_or_create_feature_service(),
             )
 
         return self._consensus

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -254,6 +254,7 @@ class CliBuilder:
             path=self.rocksdb_storage.path,
             config=self._args.nc_exec_logs,
         )
+        self.feature_service = FeatureService(settings=settings, tx_storage=tx_storage)
 
         soft_voided_tx_ids = set(settings.SOFT_VOIDED_TX_IDS)
         consensus_algorithm = ConsensusAlgorithm(
@@ -264,13 +265,12 @@ class CliBuilder:
             runner_factory=runner_factory,
             nc_log_storage=nc_log_storage,
             nc_calls_sorter=nc_calls_sorter,
+            feature_service=self.feature_service,
         )
 
         if self._args.x_enable_event_queue or self._args.enable_event_queue:
             self.log.info('--enable-event-queue flag provided. '
                           'The events detected by the full node will be stored and can be retrieved by clients')
-
-        self.feature_service = FeatureService(settings=settings, tx_storage=tx_storage)
 
         bit_signaling_service = BitSignalingService(
             settings=settings,
@@ -364,6 +364,7 @@ class CliBuilder:
             vertex_parser=vertex_parser,
             poa_block_producer=poa_block_producer,
             runner_factory=runner_factory,
+            feature_service=self.feature_service,
         )
 
         if self._args.x_ipython_kernel:

--- a/hathor/conf/mainnet.py
+++ b/hathor/conf/mainnet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from hathor.checkpoint import Checkpoint as cp
-from hathor.conf.settings import HathorSettings
+from hathor.conf.settings import HathorSettings, NanoContractsSetting
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.settings import Settings as FeatureActivationSettings
@@ -213,6 +213,7 @@ SETTINGS = HathorSettings(
         '00004305882eb3eef6b45f025ff58eb7baa5ca35f7d6f42c8b085482b00474e6',
         '000045ecbab77c9a8d819ff6d26893b9da2774eee5539f17d8fc2394f82b758e',
     ])),
+    ENABLE_NANO_CONTRACTS=NanoContractsSetting.FEATURE_ACTIVATION,
     FEATURE_ACTIVATION=FeatureActivationSettings(
         features={
             Feature.INCREASE_MAX_MERKLE_PATH_LENGTH: Criteria(

--- a/hathor/conf/mainnet.yml
+++ b/hathor/conf/mainnet.yml
@@ -194,6 +194,7 @@ SOFT_VOIDED_TX_IDS:
   - 00004305882eb3eef6b45f025ff58eb7baa5ca35f7d6f42c8b085482b00474e6
   - 000045ecbab77c9a8d819ff6d26893b9da2774eee5539f17d8fc2394f82b758e
 
+ENABLE_NANO_CONTRACTS: feature_activation
 FEATURE_ACTIVATION:
   features:
     INCREASE_MAX_MERKLE_PATH_LENGTH:
@@ -219,3 +220,13 @@ FEATURE_ACTIVATION:
       lock_in_on_timeout: false
       version: 0.64.0
       signal_support_by_default: true
+
+# TODO
+#    NANO_CONTRACTS:
+#      bit: 1
+#      start_height: ???
+#      timeout_height: ???
+#      minimum_activation_height: 0
+#      lock_in_on_timeout: false
+#      version: 0.65.0
+#      signal_support_by_default: true

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -42,6 +42,7 @@ from hathor.exception import (
 )
 from hathor.execution_manager import ExecutionManager
 from hathor.feature_activation.bit_signaling_service import BitSignalingService
+from hathor.feature_activation.feature_service import FeatureService
 from hathor.mining import BlockTemplate, BlockTemplates
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.nanocontracts.exception import NanoContractDoesNotExist
@@ -112,6 +113,7 @@ class HathorManager:
         vertex_handler: VertexHandler,
         vertex_parser: VertexParser,
         runner_factory: RunnerFactory,
+        feature_service: FeatureService,
         hostname: Optional[str] = None,
         wallet: Optional[BaseWallet] = None,
         capabilities: Optional[list[str]] = None,
@@ -200,6 +202,7 @@ class HathorManager:
         self.vertex_handler = vertex_handler
         self.vertex_parser = vertex_parser
         self.runner_factory = runner_factory
+        self.feature_service = feature_service
 
         self.websocket_factory = websocket_factory
 
@@ -820,10 +823,9 @@ class HathorManager:
         :param quiet: if True will not log when a new tx is accepted
         :param propagate_to_peers: if True will relay the tx to other peers if it is accepted
         """
-        from hathor.verification.verification_params import VerificationParams
-
-        params = VerificationParams(enable_checkdatasig_count=True, reject_locked_reward=reject_locked_reward)
-        success = self.vertex_handler._old_on_new_vertex(vertex, params, quiet=quiet)
+        success = self.vertex_handler.on_new_relayed_vertex(
+            vertex, quiet=quiet, reject_locked_reward=reject_locked_reward
+        )
 
         if propagate_to_peers and success:
             self.connections.send_tx_to_peers(vertex)

--- a/hathor/nanocontracts/utils.py
+++ b/hathor/nanocontracts/utils.py
@@ -34,7 +34,7 @@ from hathor.crypto.util import (
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.nanocontracts.types import NC_METHOD_TYPE_ATTR, BlueprintId, ContractId, NCMethodType, TokenUid, VertexId
-from hathor.transaction import Vertex
+from hathor.transaction import Block
 from hathor.transaction.headers import NanoHeader
 from hathor.util import not_none
 
@@ -153,15 +153,15 @@ def sign_openssl_multisig(
     nano_header.nc_script = MultiSig.create_input_data(redeem_script, signatures)
 
 
-def is_nano_active(settings: HathorSettings, vertex: Vertex, feature_service: FeatureService) -> bool:
-    """Return whether the Nano Contracts feature is active according to the provided settings and vertex."""
+def is_nano_active(*, settings: HathorSettings, block: Block, feature_service: FeatureService) -> bool:
+    """Return whether the Nano Contracts feature is active according to the provided settings and block."""
     match settings.ENABLE_NANO_CONTRACTS:
         case NanoContractsSetting.DISABLED:
             return False
         case NanoContractsSetting.ENABLED:
             return True
         case NanoContractsSetting.FEATURE_ACTIVATION:
-            return feature_service.is_feature_active(vertex=vertex, feature=Feature.NANO_CONTRACTS)
+            return feature_service.is_feature_active(vertex=block, feature=Feature.NANO_CONTRACTS)
         case _:  # pragma: no cover
             assert_never(settings.ENABLE_NANO_CONTRACTS)
 

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -46,6 +46,7 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount
 from hathor.types import TokenUid, VertexId
+from hathor.verification.verification_params import VerificationParams
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -306,15 +307,14 @@ class TransactionVerifier:
 
         return result
 
-    def verify_version(self, tx: Transaction) -> None:
+    def verify_version(self, tx: Transaction, params: VerificationParams) -> None:
         """Verify that the vertex version is valid."""
-        from hathor.nanocontracts.utils import is_nano_active
         allowed_tx_versions = {
             TxVersion.REGULAR_TRANSACTION,
             TxVersion.TOKEN_CREATION_TRANSACTION,
         }
 
-        if is_nano_active(self._settings, tx, self._feature_service):
+        if params.enable_nano:
             allowed_tx_versions.add(TxVersion.ON_CHAIN_BLUEPRINT)
 
         if tx.version not in allowed_tx_versions:

--- a/hathor/verification/verification_params.py
+++ b/hathor/verification/verification_params.py
@@ -24,13 +24,15 @@ class VerificationParams:
     enable_checkdatasig_count: bool
     reject_locked_reward: bool = True
     skip_block_weight_verification: bool = False
+    enable_nano: bool = False
 
     @classmethod
-    def default_for_mempool(cls) -> VerificationParams:
-        """This is the appropriate parameters for veriyfing mempool transactions, realtime blocks and API pushes.
+    def default_for_mempool(cls, *, enable_nano: bool = False) -> VerificationParams:
+        """This is the appropriate parameters for verifying mempool transactions, realtime blocks and API pushes.
 
         Other cases should instantiate `VerificationParams` manually with the appropriate parameter values.
         """
         return cls(
             enable_checkdatasig_count=True,
+            enable_nano=enable_nano,
         )

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -170,7 +170,7 @@ class VerificationService:
         if vertex.hash in self._settings.SKIP_VERIFICATION:
             return
 
-        self.verifiers.vertex.verify_headers(vertex)
+        self.verifiers.vertex.verify_headers(vertex, params)
 
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
@@ -256,7 +256,7 @@ class VerificationService:
         self.verifiers.tx.verify_sigops_input(tx, params.enable_checkdatasig_count)
         self.verifiers.tx.verify_inputs(tx)  # need to run verify_inputs first to check if all inputs exist
         self.verifiers.tx.verify_sum(token_dict or tx.get_complete_token_info())
-        self.verifiers.tx.verify_version(tx)
+        self.verifiers.tx.verify_version(tx, params)
         self.verifiers.vertex.verify_parents(tx)
         if params.reject_locked_reward:
             self.verifiers.tx.verify_reward_locked(tx)

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -16,8 +16,7 @@ from typing import Optional
 
 from typing_extensions import assert_never
 
-from hathor.conf.settings import HathorSettings, NanoContractsSetting
-from hathor.feature_activation.feature import Feature
+from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.transaction import BaseTransaction, TxVersion
 from hathor.transaction.exceptions import (
@@ -36,6 +35,7 @@ from hathor.transaction.exceptions import (
     TooManySigOps,
 )
 from hathor.transaction.headers import NanoHeader, VertexBaseHeader
+from hathor.verification.verification_params import VerificationParams
 
 # tx should have 2 parents, both other transactions
 _TX_PARENTS_TXS = 2
@@ -195,7 +195,7 @@ class VertexVerifier:
             raise TooManySigOps('TX[{}]: Maximum number of sigops for all outputs exceeded ({})'.format(
                 vertex.hash_hex, n_txops))
 
-    def get_allowed_headers(self, vertex: BaseTransaction) -> set[type[VertexBaseHeader]]:
+    def get_allowed_headers(self, vertex: BaseTransaction, params: VerificationParams) -> set[type[VertexBaseHeader]]:
         """Return a set of allowed headers for the vertex."""
         allowed_headers: set[type[VertexBaseHeader]] = set()
         match vertex.version:
@@ -208,26 +208,18 @@ class VertexVerifier:
             case TxVersion.ON_CHAIN_BLUEPRINT:
                 pass
             case TxVersion.REGULAR_TRANSACTION | TxVersion.TOKEN_CREATION_TRANSACTION:
-                match self._settings.ENABLE_NANO_CONTRACTS:
-                    case NanoContractsSetting.DISABLED:
-                        pass
-                    case NanoContractsSetting.ENABLED:
-                        allowed_headers.add(NanoHeader)
-                    case NanoContractsSetting.FEATURE_ACTIVATION:
-                        if self._feature_service.is_feature_active(vertex=vertex, feature=Feature.NANO_CONTRACTS):
-                            allowed_headers.add(NanoHeader)
-                    case _ as unreachable:  # pragma: no cover
-                        assert_never(unreachable)
+                if params.enable_nano:
+                    allowed_headers.add(NanoHeader)
             case _:  # pragma: no cover
                 assert_never(vertex.version)
         return allowed_headers
 
-    def verify_headers(self, vertex: BaseTransaction) -> None:
+    def verify_headers(self, vertex: BaseTransaction, params: VerificationParams) -> None:
         """Verify the headers."""
         if len(vertex.headers) > vertex.get_maximum_number_of_headers():
             raise TooManyHeaders('Maximum number of headers exceeded')
 
-        allowed_headers = self.get_allowed_headers(vertex)
+        allowed_headers = self.get_allowed_headers(vertex, params)
         for header in vertex.headers:
             if type(header) not in allowed_headers:
                 raise HeaderNotSupported(

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -46,7 +46,9 @@ class VersionResource(Resource):
         set_cors(request, 'GET')
 
         best_block = self.manager.tx_storage.get_best_block()
-        nano_contracts_enabled = is_nano_active(self._settings, best_block, self.feature_service)
+        nano_contracts_enabled = is_nano_active(
+            settings=self._settings, block=best_block, feature_service=self.feature_service
+        )
 
         data = {
             'version': hathor.__version__,

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -26,6 +26,7 @@ from hathor.exception import HathorError, InvalidNewTransaction
 from hathor.execution_manager import ExecutionManager
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
+from hathor.nanocontracts.utils import is_nano_active
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol
@@ -89,9 +90,14 @@ class VertexHandler:
 
         enable_checkdatasig_count = self._feature_service.is_feature_active(
             vertex=parent_block,
-            feature=Feature.COUNT_CHECKDATASIG_OP
+            feature=Feature.COUNT_CHECKDATASIG_OP,
         )
-        params = VerificationParams(enable_checkdatasig_count=enable_checkdatasig_count)
+
+        enable_nano = is_nano_active(
+            settings=self._settings, block=parent_block, feature_service=self._feature_service
+        )
+
+        params = VerificationParams(enable_checkdatasig_count=enable_checkdatasig_count, enable_nano=enable_nano)
 
         for tx in deps:
             if not self._tx_storage.transaction_exists(tx.hash):
@@ -107,7 +113,9 @@ class VertexHandler:
 
     @cpu.profiler('on_new_mempool_transaction')
     def on_new_mempool_transaction(self, tx: Transaction) -> bool:
-        params = VerificationParams.default_for_mempool()
+        best_block = self._tx_storage.get_best_block()
+        enable_nano = is_nano_active(settings=self._settings, block=best_block, feature_service=self._feature_service)
+        params = VerificationParams.default_for_mempool(enable_nano=enable_nano)
         return self._old_on_new_vertex(tx, params)
 
     @cpu.profiler('on_new_relayed_vertex')
@@ -116,9 +124,14 @@ class VertexHandler:
         vertex: BaseTransaction,
         *,
         quiet: bool = False,
+        reject_locked_reward: bool = True,
     ) -> bool:
+        best_block = self._tx_storage.get_best_block()
+        enable_nano = is_nano_active(settings=self._settings, block=best_block, feature_service=self._feature_service)
         # XXX: checkdatasig enabled for relayed vertices
-        params = VerificationParams.default_for_mempool()
+        params = VerificationParams(
+            enable_checkdatasig_count=True, reject_locked_reward=reject_locked_reward, enable_nano=enable_nano
+        )
         return self._old_on_new_vertex(vertex, params, quiet=quiet)
 
     @cpu.profiler('_old_on_new_vertex')

--- a/tests/nanocontracts/test_actions.py
+++ b/tests/nanocontracts/test_actions.py
@@ -31,6 +31,7 @@ from hathor.transaction.exceptions import InvalidToken
 from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.util import not_none
 from hathor.verification.nano_header_verifier import MAX_ACTIONS_LEN
+from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import HDWallet
 from tests import unittest
 from tests.dag_builder.builder import TestDAGBuilder
@@ -76,6 +77,7 @@ class TestActions(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
+        self.verification_params = VerificationParams.default_for_mempool(enable_nano=True)
 
         self.bp_id = b'1' * 32
         self.manager = self.create_peer('unittests', nc_log_config=NCLogConfig.FAILED, wallet_index=True)

--- a/tests/nanocontracts/test_nano_feature_activation.py
+++ b/tests/nanocontracts/test_nano_feature_activation.py
@@ -1,0 +1,187 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from hathor.conf.settings import NanoContractsSetting
+from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
+from hathor.exception import InvalidNewTransaction
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.model.criteria import Criteria
+from hathor.feature_activation.model.feature_state import FeatureState
+from hathor.feature_activation.settings import Settings as FeatureSettings
+from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts.types import BlueprintId
+from hathor.transaction import Block, Transaction
+from hathor.transaction.nc_execution_state import NCExecutionState
+from tests import unittest
+from tests.dag_builder.builder import TestDAGBuilder
+
+
+class MyBluprint(Blueprint):
+    @public
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public
+    def nop(self, ctx: Context) -> None:
+        pass
+
+
+class TestNanoFeatureActivation(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        feature_settings = FeatureSettings(
+            evaluation_interval=4,
+            default_threshold=3,
+            features={
+                Feature.NANO_CONTRACTS: Criteria(
+                    bit=2,
+                    start_height=4,
+                    timeout_height=12,
+                    signal_support_by_default=True,
+                    version='0.0.0'
+                )
+            }
+        )
+
+        settings = self._settings._replace(
+            ENABLE_NANO_CONTRACTS=NanoContractsSetting.FEATURE_ACTIVATION,
+            FEATURE_ACTIVATION=feature_settings,
+        )
+        daa = DifficultyAdjustmentAlgorithm(settings=self._settings, test_mode=TestMode.TEST_ALL_WEIGHT)
+        builder = self.get_builder(settings).set_daa(daa)
+
+        self.manager = self.create_peer_from_builder(builder)
+        self.vertex_handler = self.manager.vertex_handler
+        self.feature_service = self.manager.feature_service
+        self.bit_signaling_service = self.manager._bit_signaling_service
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+        self.blueprint_id = BlueprintId(self.rng.randbytes(32))
+        assert self.manager.tx_storage.nc_catalog is not None
+        self.manager.tx_storage.nc_catalog.blueprints[self.blueprint_id] = MyBluprint
+
+    def test_activation(self) -> None:
+        private_key = unittest.OCB_TEST_PRIVKEY.hex()
+        password = unittest.OCB_TEST_PASSWORD.hex()
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..13]
+            blockchain b10 a[11..12]
+            b10 < dummy < b11
+
+            nc1.nc_id = "{self.blueprint_id.hex()}"
+            nc1.nc_method = initialize()
+
+            ocb1.ocb_private_key = "{private_key}"
+            ocb1.ocb_password = "{password}"
+            ocb1.ocb_code = test_blueprint1.py, TestBlueprint1
+
+            b12 < nc1 < ocb1
+
+            nc1 <-- b13
+            ocb1 <-- b13
+
+            a11.weight = 10
+            b13 < a11
+        ''')
+
+        b3, b4, b7, b8, b11, b12, b13, a11 = artifacts.get_typed_vertices(
+            ('b3', 'b4', 'b7', 'b8', 'b11', 'b12', 'b13', 'a11'),
+            Block,
+        )
+        nc1, ocb1 = artifacts.get_typed_vertices(('nc1', 'ocb1'), Transaction)
+
+        artifacts.propagate_with(self.manager, up_to='b3')
+        assert self.feature_service.get_state(block=b3, feature=Feature.NANO_CONTRACTS) is FeatureState.DEFINED
+
+        artifacts.propagate_with(self.manager, up_to='b4')
+        assert self.feature_service.get_state(block=b4, feature=Feature.NANO_CONTRACTS) is FeatureState.STARTED
+
+        signaling_blocks = ('b5', 'b6', 'b7')
+        for block_name in signaling_blocks:
+            block = artifacts.by_name[block_name].vertex
+            assert isinstance(block, Block)
+            block.storage = self.manager.tx_storage
+            block.signal_bits = self.bit_signaling_service.generate_signal_bits(block=block.get_block_parent())
+            artifacts.propagate_with(self.manager, up_to=block_name)
+
+        assert self.feature_service.get_state(block=b7, feature=Feature.NANO_CONTRACTS) is FeatureState.STARTED
+
+        artifacts.propagate_with(self.manager, up_to='b8')
+        assert self.feature_service.get_state(block=b8, feature=Feature.NANO_CONTRACTS) is FeatureState.LOCKED_IN
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert self.feature_service.get_state(block=b11, feature=Feature.NANO_CONTRACTS) is FeatureState.LOCKED_IN
+
+        # At this point, the feature is not active, so the nc txs are rejected on the mempool.
+        msg = 'full validation failed: Header `NanoHeader` not supported by `Transaction`'
+        with pytest.raises(InvalidNewTransaction, match=msg):
+            self.vertex_handler.on_new_relayed_vertex(nc1)
+        assert nc1.get_metadata().validation.is_initial()
+        assert nc1.get_metadata().voided_by is None
+
+        msg = 'full validation failed: invalid vertex version: 6'
+        with pytest.raises(InvalidNewTransaction, match=msg):
+            self.vertex_handler.on_new_relayed_vertex(ocb1)
+        assert ocb1.get_metadata().validation.is_initial()
+        assert ocb1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert self.feature_service.get_state(block=b12, feature=Feature.NANO_CONTRACTS) is FeatureState.ACTIVE
+
+        # Now, the nc txs are accepted on the mempool.
+        artifacts.propagate_with(self.manager, up_to='nc1')
+        assert nc1.get_metadata().validation.is_valid()
+        assert nc1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='ocb1')
+        assert ocb1.get_metadata().validation.is_valid()
+        assert ocb1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert nc1.get_metadata().nc_execution is NCExecutionState.SUCCESS
+
+        artifacts.propagate_with(self.manager, up_to='a11')
+        assert a11.get_metadata().validation.is_valid()
+        assert a11.get_metadata().voided_by is None
+        assert b12.get_metadata().voided_by == {b12.hash}
+        assert b13.get_metadata().validation.is_invalid()
+        assert ocb1.get_metadata().validation.is_invalid()
+        assert ocb1.get_metadata().validation.is_invalid()
+
+        # The nc txs are removed from the mempool.
+        assert not self.manager.tx_storage.transaction_exists(b13.hash)
+        assert not self.manager.tx_storage.transaction_exists(nc1.hash)
+        assert not self.manager.tx_storage.transaction_exists(ocb1.hash)
+        assert nc1 not in list(self.manager.tx_storage.iter_mempool_tips_from_best_index())
+        assert ocb1 not in list(self.manager.tx_storage.iter_mempool_tips_from_best_index())
+
+        # The nc txs are re-accepted on the mempool.
+        artifacts.propagate_with(self.manager, up_to='a12')
+
+        nc1._metadata = None
+        self.vertex_handler.on_new_relayed_vertex(nc1)
+        assert nc1.get_metadata().validation.is_valid()
+        assert nc1.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(nc1.hash)
+        assert nc1 in list(self.manager.tx_storage.iter_mempool_tips_from_best_index())
+
+        ocb1._metadata = None
+        self.vertex_handler.on_new_relayed_vertex(ocb1)
+        assert ocb1.get_metadata().validation.is_valid()
+        assert ocb1.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(ocb1.hash)
+        assert ocb1 in list(self.manager.tx_storage.iter_mempool_tips_from_best_index())


### PR DESCRIPTION
### Motivation

Implement the ability to use Feature Activation for Blocks for activating Nano Contracts.

### Acceptance Criteria

- Update Nano feature activation to use block mechanism instead of transaction mechanism. This is compatible with testnet-hotel because it's less restrictive.
- Change nano config on mainnet from `DISABLED` to `FEATURE_ACTIVATION`. The feature config itself it not yet set.
- Refactor block consensus to initialize the feature activation block with an empty trie, while maintaining compatibility with previous code.
- On consensus, change `_compute_vertices_that_became_invalid` and related functions to methods.
- Add a nano activation mempool rule to remove invalid nano transactions.
- Refactor nano-related verification to use a verification param that is set
  - using the parent block for txs that come inside a block
  - using the best block for mempool txs.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 