### PR TITLE
chore(nano): remove deprecated ctx.timestamp

### DIFF
--- a/hathor/nanocontracts/context.py
+++ b/hathor/nanocontracts/context.py
@@ -150,14 +150,6 @@ class Context:
                 assert_never(self.caller_id)
 
     @property
-    def timestamp(self) -> int:
-        """
-        Get the timestamp of the block executing the nano transaction.
-        DEPRECATED: Use `ctx.block.timestamp` instead.
-        """
-        return self.block.timestamp
-
-    @property
     def actions(self) -> MappingProxyType[TokenUid, tuple[NCAction, ...]]:
         """Get a mapping of actions per token."""
         return self.__actions

--- a/hathor/nanocontracts/resources/blueprint.py
+++ b/hathor/nanocontracts/resources/blueprint.py
@@ -23,7 +23,7 @@ from hathor.cli.openapi_files.register import register_resource
 from hathor.nanocontracts import types as nc_types
 from hathor.nanocontracts.blueprint import NC_FIELDS_ATTR
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.exception import BlueprintDoesNotExist
+from hathor.nanocontracts.exception import BlueprintDoesNotExist, OCBBlueprintNotConfirmed
 from hathor.nanocontracts.types import blueprint_id_from_bytes
 from hathor.nanocontracts.utils import is_nc_public_method, is_nc_view_method
 from hathor.utils.api import ErrorResponse, QueryParams, Response
@@ -93,6 +93,10 @@ class BlueprintInfoResource(Resource):
         except BlueprintDoesNotExist:
             request.setResponseCode(404)
             error_response = ErrorResponse(success=False, error=f'Blueprint not found: {params.blueprint_id}')
+            return error_response.json_dumpb()
+        except OCBBlueprintNotConfirmed:
+            request.setResponseCode(404)
+            error_response = ErrorResponse(success=False, error=f'Blueprint found but not confirmed: {params.blueprint_id}')
             return error_response.json_dumpb()
 
         attributes: dict[str, str] = {}

--- a/tests/nanocontracts/test_exposed_properties.py
+++ b/tests/nanocontracts/test_exposed_properties.py
@@ -37,7 +37,6 @@ KNOWN_CASES = [
     'hathor.nanocontracts.context.Context.get_caller_contract_id',
     'hathor.nanocontracts.context.Context.get_single_action',
     'hathor.nanocontracts.context.Context.some_new_attribute',
-    'hathor.nanocontracts.context.Context.timestamp',
     'hathor.nanocontracts.context.Context.to_json',
     'hathor.nanocontracts.context.Context.vertex',
     'hathor.nanocontracts.exception.NCFail.add_note',


### PR DESCRIPTION
### Motivation

Remove deprecated property in preparation for nano on mainnet.

### Acceptance Criteria

- Remove deprecated `ctx.timestamp` property.
- Add `OCBBlueprintNotConfirmed` handling on blueprint API.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 