### PR TITLE
feat(dynamic-transaction-model): fee verification using fee header and nc

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -590,10 +590,12 @@ class Builder:
             settings = self._get_or_create_settings()
             verifiers = self._get_or_create_vertex_verifiers()
             storage = self._get_or_create_tx_storage()
+            nc_storage_factory = self._get_or_create_nc_storage_factory()
             self._verification_service = VerificationService(
                 settings=settings,
                 verifiers=verifiers,
                 tx_storage=storage,
+                nc_storage_factory=nc_storage_factory,
             )
 
         return self._verification_service

--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -292,6 +292,7 @@ class CliBuilder:
             settings=settings,
             verifiers=vertex_verifiers,
             tx_storage=tx_storage,
+            nc_storage_factory=self.nc_storage_factory,
         )
 
         cpu_mining_service = CpuMiningService()

--- a/hathor/cli/mining.py
+++ b/hathor/cli/mining.py
@@ -142,7 +142,7 @@ def execute(args: Namespace) -> None:
             from hathor.verification.vertex_verifiers import VertexVerifiers
             settings = get_global_settings()
             daa = DifficultyAdjustmentAlgorithm(settings=settings)
-            verification_params = VerificationParams.default_for_mempool()
+            verification_params = VerificationParams(nc_block_root_id=None, enable_checkdatasig_count=True)
             verifiers = VertexVerifiers.create_defaults(
                 reactor=Mock(),
                 settings=settings,

--- a/hathor/dag_builder/artifacts.py
+++ b/hathor/dag_builder/artifacts.py
@@ -85,7 +85,13 @@ class DAGArtifacts:
                     if new_relayed_vertex:
                         assert manager.vertex_handler.on_new_relayed_vertex(vertex)
                     else:
-                        params = VerificationParams(enable_checkdatasig_count=True, enable_nano=True)
+                        best_block = manager.tx_storage.get_best_block()
+                        best_block_meta = best_block.get_metadata()
+                        params = VerificationParams(
+                            enable_checkdatasig_count=True,
+                            enable_nano=True,
+                            nc_block_root_id=best_block_meta.nc_block_root_id,
+                        )
                         assert manager.vertex_handler._old_on_new_vertex(vertex, params)
                 except Exception as e:
                     raise Exception(f'failed on_new_tx({node.name})') from e

--- a/hathor/nanocontracts/blueprint_env.py
+++ b/hathor/nanocontracts/blueprint_env.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Collection, Sequence, TypeAlias, final
 
 from hathor.conf.settings import HATHOR_TOKEN_UID
-from hathor.nanocontracts.storage import NCContractStorage
 from hathor.nanocontracts.types import Amount, BlueprintId, ContractId, NCAction, NCFee, TokenUid
 
 if TYPE_CHECKING:
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
     from hathor.nanocontracts.proxy_accessor import ProxyAccessor
     from hathor.nanocontracts.rng import NanoRNG
     from hathor.nanocontracts.runner import Runner
+    from hathor.nanocontracts.storage import NCContractStorage
 
 
 NCAttrCache: TypeAlias = dict[bytes, Any] | None

--- a/hathor/nanocontracts/nc_types/token_version_nc_type.py
+++ b/hathor/nanocontracts/nc_types/token_version_nc_type.py
@@ -1,0 +1,26 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing_extensions import override
+
+from hathor.nanocontracts.nc_types.sized_int_nc_type import Uint8NCType
+from hathor.serialization import Deserializer
+from hathor.transaction.token_info import TokenVersion
+
+
+class TokenVersionNCType(Uint8NCType):
+    @override
+    def _deserialize(self, deserializer: Deserializer, /) -> TokenVersion:
+        value = super()._deserialize(deserializer)
+        return TokenVersion(value)

--- a/hathor/nanocontracts/storage/block_storage.py
+++ b/hathor/nanocontracts/storage/block_storage.py
@@ -19,7 +19,7 @@ from typing import NamedTuple, Optional
 
 from hathor.nanocontracts.exception import NanoContractDoesNotExist
 from hathor.nanocontracts.nc_types.dataclass_nc_type import make_dataclass_nc_type
-from hathor.nanocontracts.nc_types.sized_int_nc_type import Uint8NCType
+from hathor.nanocontracts.nc_types.token_version_nc_type import TokenVersionNCType
 from hathor.nanocontracts.storage.contract_storage import NCContractStorage
 from hathor.nanocontracts.storage.patricia_trie import NodeId, PatriciaTrie
 from hathor.nanocontracts.storage.token_proxy import TokenProxy
@@ -64,7 +64,7 @@ class NCBlockStorage:
     _TOKEN_DESCRIPTION_NC_TYPE = make_dataclass_nc_type(
         TokenDescription,
         extra_nc_types_map={
-            TokenVersion: Uint8NCType,
+            TokenVersion: TokenVersionNCType,
         },
     )
 

--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -47,11 +47,17 @@ class TransactionStreamingClient:
         self.protocol = self.sync_agent.protocol
         self.tx_storage = self.sync_agent.tx_storage
         self.verification_service = self.protocol.node.verification_service
-        # XXX: since it's not straightforward to get the correct block, it's OK to just disable checkdatasig counting,
-        #      it will be correctly enabled when doing a full validation anyway.
-        self.verification_params = VerificationParams(enable_checkdatasig_count=False)
-        self.reactor = sync_agent.reactor
 
+        # XXX: Since it's not straightforward to get the correct block, it's OK to just disable checkdatasig counting,
+        #      it will be correctly enabled when doing a full validation anyway.
+        #      We can also set the `nc_block_root_id` to `None` because we only call `verify_basic`,
+        #      which doesn't need it.
+        self.verification_params = VerificationParams(
+            enable_checkdatasig_count=False,
+            nc_block_root_id=None,
+        )
+
+        self.reactor = sync_agent.reactor
         self.log = logger.new(peer=self.protocol.get_short_peer_id())
 
         # List of blocks from which we will receive transactions.

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -261,7 +261,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         raise NotImplementedError
 
     def is_nano_contract(self) -> bool:
-        """Return True if this transaction is a nano contract or not."""
+        """Return whether this transaction is a nano contract."""
         return False
 
     def has_fees(self) -> bool:

--- a/hathor/transaction/exceptions.py
+++ b/hathor/transaction/exceptions.py
@@ -274,3 +274,7 @@ class FeeHeaderTokenNotFound(InvalidFeeHeader):
 
 class InvalidFeeAmount(InvalidFeeHeader):
     """Invalid fee amount"""
+
+
+class TokenNotFound(TxValidationError):
+    """Token not found."""

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -119,7 +119,10 @@ class CreateTxResource(Resource):
         # need to run verify_inputs first to check if all inputs exist
         verifiers.tx.verify_inputs(tx, skip_script=True)
         verifiers.vertex.verify_parents(tx)
-        verifiers.tx.verify_sum(tx.get_complete_token_info())
+
+        best_block = self.manager.tx_storage.get_best_block()
+        block_storage = self.manager.get_nc_block_storage(best_block)
+        verifiers.tx.verify_sum(self.manager._settings, tx.get_complete_token_info(block_storage))
 
 
 CreateTxResource.openapi = {

--- a/hathor/transaction/storage/migrations/nc_storage_compat2.py
+++ b/hathor/transaction/storage/migrations/nc_storage_compat2.py
@@ -29,7 +29,7 @@ class Migration(BaseMigration):
         return True
 
     def get_db_name(self) -> str:
-        return 'nc_storage_compat1'
+        return 'nc_storage_compat2'
 
     def run(self, storage: 'TransactionStorage') -> None:
         raise Exception('Cannot migrate your database due to an incompatible change in the nanocontracts storage. '

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -44,7 +44,7 @@ from hathor.transaction.storage.migrations import (
     add_closest_ancestor_block,
     change_score_acc_weight_metadata,
     include_funds_for_first_block,
-    nc_storage_compat1,
+    nc_storage_compat2,
 )
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope, tx_allow_context
 from hathor.transaction.transaction import Transaction
@@ -104,7 +104,7 @@ class TransactionStorage(ABC):
         change_score_acc_weight_metadata.Migration,
         add_closest_ancestor_block.Migration,
         include_funds_for_first_block.Migration,
-        nc_storage_compat1.Migration,
+        nc_storage_compat2.Migration,
     ]
 
     _migrations: list[BaseMigration]

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 from typing_extensions import override
 
 from hathor.conf.settings import HathorSettings
+from hathor.nanocontracts.storage import NCBlockStorage
 from hathor.transaction.base_transaction import TxInput, TxOutput, TxVersion
 from hathor.transaction.storage import TransactionStorage  # noqa: F401
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion
@@ -250,10 +251,10 @@ class TokenCreationTransaction(Transaction):
         return json
 
     @override
-    def _get_token_info_from_inputs(self) -> TokenInfoDict:
-        token_dict = super()._get_token_info_from_inputs()
+    def _get_token_info_from_inputs(self, nc_block_storage: NCBlockStorage) -> TokenInfoDict:
+        token_dict = super()._get_token_info_from_inputs(nc_block_storage)
 
         # we add the created token's info to token_dict, as the creation tx allows for mint/melt
-        token_dict[self.hash] = TokenInfo.get_default(version=self.token_version, can_mint=True, can_melt=True)
+        token_dict[self.hash] = TokenInfo(version=self.token_version, can_mint=True, can_melt=True)
 
         return token_dict

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -29,7 +29,7 @@ from hathor.transaction.exceptions import InvalidToken
 from hathor.transaction.headers import NanoHeader, VertexBaseHeader
 from hathor.transaction.headers.fee_header import FeeHeader
 from hathor.transaction.static_metadata import TransactionStaticMetadata
-from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion
+from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion, get_token_version
 from hathor.transaction.util import VerboseCallback, unpack, unpack_len
 from hathor.types import TokenUid, VertexId
 
@@ -37,6 +37,7 @@ T = TypeVar('T', bound=VertexBaseHeader)
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
+    from hathor.nanocontracts.storage import NCBlockStorage
     from hathor.transaction.storage import TransactionStorage  # noqa: F401
 
 # Signal bits (B), version (B), token uids len (B) and inputs len (B), outputs len (B).
@@ -330,14 +331,17 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
         raise InvalidNewTransaction(f'Invalid new transaction {self.hash_hex}: expected to reach a checkpoint but '
                                     'none of its children is checkpoint-valid')
 
-    def get_complete_token_info(self) -> TokenInfoDict:
+    def get_complete_token_info(self, nc_block_storage: NCBlockStorage) -> TokenInfoDict:
         """
         Get a complete token info dict, including data from both inputs and outputs.
+        It uses a block storage with the latest token changes in nano contracts
         """
-        token_dict = self._get_token_info_from_inputs()
-        self._update_token_info_from_nano_actions(token_dict=token_dict)
-        # This one must be called last so token_dict already contains all tokens in inputs and nano actions.
+
+        token_dict = self._get_token_info_from_inputs(nc_block_storage)
+        self._update_token_info_from_nano_actions(token_dict=token_dict, nc_block_storage=nc_block_storage)
+        # These must be called last so token_dict already contains all tokens in inputs and nano actions.
         self._update_token_info_from_outputs(token_dict=token_dict)
+        self._update_token_info_from_fees(token_dict=token_dict)
 
         return token_dict
 
@@ -348,48 +352,71 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
             return 0
         return 1
 
-    def _update_token_info_from_nano_actions(self, *, token_dict: TokenInfoDict) -> None:
+    def _update_token_info_from_nano_actions(
+        self,
+        *,
+        token_dict: TokenInfoDict,
+        nc_block_storage: NCBlockStorage,
+    ) -> None:
         """Update token_dict with nano actions."""
         if not self.is_nano_contract():
             return
 
+        assert self.storage is not None
         from hathor.nanocontracts.balance_rules import BalanceRules
         nano_header = self.get_nano_header()
 
         for action in nano_header.get_actions():
             rules = BalanceRules.get_rules(self._settings, action)
+            if action.token_uid not in token_dict:
+                # we try to load this token version from storage in case it's not in the inputs
+                token_dict[action.token_uid] = TokenInfo(
+                    version=get_token_version(self.storage, nc_block_storage, action.token_uid)
+                )
             rules.verification_rule(token_dict)
 
-    def _get_token_info_from_inputs(self) -> TokenInfoDict:
+    def _update_token_info_from_fees(self, *, token_dict: TokenInfoDict) -> None:
+        """Update token_dict with fees from fee header"""
+
+        if not self.has_fees():
+            return
+
+        fee_header = self.get_fee_header()
+        fees = fee_header.get_fees()
+        # we store the total fee amount from the header to be used in the verify_sum
+        token_dict.fees_from_fee_header = fee_header.total_fee_amount()
+        for fee in fees:
+            token_info = token_dict.get(fee.token_uid)
+            if token_info is None:
+                raise InvalidToken('no inputs/actions for token {}'.format(fee.token_uid.hex()))
+
+            # it should be defined in the inputs/actions
+            if token_info.version not in (None, TokenVersion.NATIVE, TokenVersion.DEPOSIT):
+                raise InvalidToken('token {} cannot be used to pay fees'.format(fee.token_uid.hex()))
+
+            # act as a regular output subtracting from the total amount (which is done with sum in this context)
+            token_info.amount += fee.amount
+            token_dict[fee.token_uid] = token_info
+
+    def _get_token_info_from_inputs(self, nc_block_storage: NCBlockStorage) -> TokenInfoDict:
         """Sum up all tokens present in the inputs and their properties (amount, can_mint, can_melt)
         """
+        assert self.storage is not None
         token_dict = TokenInfoDict()
 
         # add HTR to token dict due to tx melting tokens: there might be an HTR output without any
         # input or authority. If we don't add it, an error will be raised when iterating through
         # the outputs of such tx (error: 'no token creation and no inputs for token 00')
-        token_dict[self._settings.HATHOR_TOKEN_UID] = TokenInfo.get_default()
+        token_dict[self._settings.HATHOR_TOKEN_UID] = TokenInfo(version=TokenVersion.NATIVE)
 
         for tx_input in self.inputs:
             spent_tx = self.get_spent_tx(tx_input)
             spent_output = spent_tx.outputs[tx_input.index]
 
             token_uid = spent_tx.get_token_uid(spent_output.get_token_index())
-            token_version = TokenVersion.NATIVE
+            token_version = get_token_version(self.storage, nc_block_storage, token_uid)
 
-            if token_uid != self._settings.HATHOR_TOKEN_UID:
-                from hathor.transaction.storage.exceptions import TransactionDoesNotExist
-                assert self.storage is not None
-                try:
-                    token_creation_tx = self.storage.get_token_creation_transaction(token_uid)
-                except TransactionDoesNotExist:
-                    raise InvalidToken(f"Token UID {token_uid!r} does not match any token creation transaction")
-                token_version = token_creation_tx.token_version
-
-            token_info = token_dict.get(
-                token_uid,
-                TokenInfo.get_default(version=token_version)
-            )
+            token_info = token_dict.get(token_uid, TokenInfo(version=token_version))
 
             if spent_output.is_token_authority():
                 token_info.can_mint = token_info.can_mint or spent_output.can_mint_token()

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, assert_never
 
 from hathor.daa import DifficultyAdjustmentAlgorithm
@@ -40,6 +39,7 @@ from hathor.transaction.exceptions import (
     RewardLocked,
     ScriptError,
     TimestampError,
+    TokenNotFound,
     TooFewInputs,
     TooManyBetweenConflicts,
     TooManyInputs,
@@ -236,9 +236,18 @@ class TransactionVerifier:
             if output.get_token_index() > len(tx.tokens):
                 raise InvalidToken('token uid index not available: index {}'.format(output.get_token_index()))
 
-    def verify_sum(self, token_dict: TokenInfoDict) -> None:
+    @classmethod
+    def verify_sum(
+        cls,
+        settings: HathorSettings,
+        token_dict: TokenInfoDict,
+        allow_nonexistent_tokens: bool = False,
+    ) -> None:
         """Verify that the sum of outputs is equal of the sum of inputs, for each token. If sum of inputs
         and outputs is not 0, make sure inputs have mint/melt authority.
+
+        When `allow_nonexistent_tokens` flag is set to `True` and a nonexistent token is provided,
+        this method will skip the fee and HTR balance checks.
 
         token_dict sums up all tokens present in the tx and their properties (amount, can_mint, can_melt)
         amount = outputs - inputs, thus:
@@ -249,73 +258,73 @@ class TransactionVerifier:
         """
         deposit = 0
         withdraw = 0
-        withdraw_without_authority = 0
-        fee = token_dict.calculate_fee(self._settings)
+        has_nonexistent_tokens = False
 
         for token_uid, token_info in token_dict.items():
+            cls._check_token_permissions(token_uid, token_info)
             match token_info.version:
+                case None:
+                    # when a token is not found, we can't assert the HTR value, since we don't know its version
+                    if not allow_nonexistent_tokens:
+                        raise TokenNotFound(f'token uid {token_uid.hex()} not found.')
+                    has_nonexistent_tokens = True
+
                 case TokenVersion.NATIVE:
                     continue
-                case TokenVersion.DEPOSIT:
-                    result = self._verify_deposit_token(fee, token_uid, token_info)
-                    deposit += result.deposit
-                    withdraw += result.withdraw
-                    withdraw_without_authority += result.withdraw_without_authority
-                case TokenVersion.FEE:
-                    self._verify_fee_token(token_uid, token_info)
-                case _:
-                    assert_never(token_info)
 
-        is_melting_without_authority = withdraw_without_authority - fee > 0
-        if is_melting_without_authority:
-            raise ForbiddenMelt('Melting tokens without a melt authority is forbidden')
+                case TokenVersion.DEPOSIT:
+                    if token_info.has_been_melted():
+                        withdraw += get_deposit_token_withdraw_amount(settings, token_info.amount)
+                    if token_info.has_been_minted():
+                        deposit += get_deposit_token_deposit_amount(settings, token_info.amount)
+
+                case TokenVersion.FEE:
+                    continue
+
+                case _:
+                    assert_never(token_info.version)
 
         # check whether the deposit/withdraw amount is correct
-        htr_expected_amount = withdraw + withdraw_without_authority - deposit - fee
-        htr_info = token_dict[self._settings.HATHOR_TOKEN_UID]
-        if htr_info.amount != htr_expected_amount:
+        htr_expected_amount = withdraw - deposit
+        htr_info = token_dict[settings.HATHOR_TOKEN_UID]
+        if htr_info.amount < htr_expected_amount:
             raise InputOutputMismatch('HTR balance is different than expected. (amount={}, expected={})'.format(
                 htr_info.amount,
                 htr_expected_amount,
             ))
 
-    def _verify_fee_token(self, token_uid: TokenUid, token_info: TokenInfo) -> None:
-        """Verify fee token can be minted/melted based on its authority."""
+        # in a partial validation, it's not possible to check fees and
+        # htr amount since it depends on verification with all token versions
+        if has_nonexistent_tokens:
+            return
+
+        expected_fee = token_dict.calculate_fee(settings)
+        if expected_fee != token_dict.fees_from_fee_header:
+            raise InputOutputMismatch(f"Fee amount is different than expected. "
+                                      f"(amount={token_dict.fees_from_fee_header}, expected={expected_fee})")
+
+        if htr_info.amount > htr_expected_amount:
+            raise InputOutputMismatch('HTR balance is different than expected. (amount={}, expected={})'.format(
+                htr_info.amount,
+                htr_expected_amount,
+            ))
+
+        assert htr_info.amount == htr_expected_amount
+
+    @staticmethod
+    def _check_token_permissions(token_uid: TokenUid, token_info: TokenInfo) -> None:
+        """Verify whether token can be minted/melted based on its authority."""
+        from hathor.conf.settings import HATHOR_TOKEN_UID
+        if token_info.version == TokenVersion.NATIVE:
+            assert token_uid == HATHOR_TOKEN_UID
+            assert not token_info.can_mint
+            assert not token_info.can_melt
+            return
+        assert token_uid != HATHOR_TOKEN_UID
         if token_info.has_been_melted() and not token_info.can_melt:
             raise ForbiddenMelt.from_token(token_info.amount, token_uid)
         if token_info.has_been_minted() and not token_info.can_mint:
             raise ForbiddenMint(token_info.amount, token_uid)
-
-    def _verify_deposit_token(self, fee: int, token_uid: TokenUid, token_info: TokenInfo) -> DepositTokenVerifyResult:
-        """Verify deposit token operations and calculate withdrawal/deposit amounts."""
-        result = DepositTokenVerifyResult()
-        if token_info.has_been_melted():
-            withdraw_amount = get_deposit_token_withdraw_amount(self._settings, token_info.amount)
-            if token_info.can_melt:
-                result.withdraw += withdraw_amount
-            else:
-                # Any melting operation without authority is forbidden.
-                # It includes trying to pay fee with non-integer amounts.
-                # For example (DBT - Deposit based token)
-                # 1.99 DBT results in 0.01 HTR and (0.99 DBT melted) => this one is forbidden
-                if fee == 0:
-                    raise ForbiddenMelt.from_token(token_info.amount, token_uid)
-                is_integer_amount = (
-                    token_info.amount * self._settings.TOKEN_DEPOSIT_PERCENTAGE).is_integer()
-                if not is_integer_amount:
-                    raise ForbiddenMelt(
-                        "Paying fees with non integer amount is forbidden"
-                    )
-
-                result.withdraw_without_authority += withdraw_amount
-
-        if token_info.has_been_minted():
-            if not token_info.can_mint:
-                raise ForbiddenMint(token_info.amount, token_uid)
-
-            result.deposit += get_deposit_token_deposit_amount(self._settings, token_info.amount)
-
-        return result
 
     def verify_version(self, tx: Transaction, params: VerificationParams) -> None:
         """Verify that the vertex version is valid."""
@@ -391,10 +400,3 @@ class TransactionVerifier:
 
         if between_counter > MAX_BETWEEN_CONFLICTS:
             raise TooManyBetweenConflicts
-
-
-@dataclass(kw_only=True, slots=True)
-class DepositTokenVerifyResult:
-    deposit: int = 0
-    withdraw_without_authority: int = 0
-    withdraw: int = 0

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -15,7 +15,8 @@
 from typing_extensions import assert_never
 
 from hathor.conf.settings import HathorSettings
-from hathor.nanocontracts import OnChainBlueprint
+from hathor.nanocontracts import NCStorageFactory, OnChainBlueprint
+from hathor.nanocontracts.storage import NCBlockStorage
 from hathor.profiler import get_cpu_profiler
 from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.poa import PoaBlock
@@ -23,6 +24,7 @@ from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenInfoDict
 from hathor.transaction.validation_state import ValidationState
+from hathor.verification.fee_header_verifier import FeeHeaderVerifier
 from hathor.verification.verification_params import VerificationParams
 from hathor.verification.vertex_verifiers import VertexVerifiers
 
@@ -30,7 +32,7 @@ cpu = get_cpu_profiler()
 
 
 class VerificationService:
-    __slots__ = ('_settings', 'verifiers', '_tx_storage')
+    __slots__ = ('_settings', 'verifiers', '_tx_storage', '_nc_storage_factory')
 
     def __init__(
         self,
@@ -38,10 +40,12 @@ class VerificationService:
         settings: HathorSettings,
         verifiers: VertexVerifiers,
         tx_storage: TransactionStorage | None = None,
+        nc_storage_factory: NCStorageFactory | None = None,
     ) -> None:
         self._settings = settings
         self.verifiers = verifiers
         self._tx_storage = tx_storage
+        self._nc_storage_factory = nc_storage_factory
 
     def validate_basic(self, vertex: BaseTransaction, params: VerificationParams) -> bool:
         """ Run basic validations (all that are possible without dependencies) and update the validation state.
@@ -258,8 +262,15 @@ class VerificationService:
         self.verify_without_storage(tx, params)
         self.verifiers.tx.verify_sigops_input(tx, params.enable_checkdatasig_count)
         self.verifiers.tx.verify_inputs(tx)  # need to run verify_inputs first to check if all inputs exist
-        self.verifiers.tx.verify_sum(token_dict or tx.get_complete_token_info())
         self.verifiers.tx.verify_version(tx, params)
+
+        block_storage = self._get_block_storage(params)
+        self.verifiers.tx.verify_sum(
+            self._settings,
+            token_dict or tx.get_complete_token_info(block_storage),
+            # if this tx isn't a nano contract we assume we can find all the tokens to validate this tx
+            allow_nonexistent_tokens=tx.is_nano_contract()
+        )
         self.verifiers.vertex.verify_parents(tx)
         self.verifiers.tx.verify_conflict(tx, params)
         if params.reject_locked_reward:
@@ -272,13 +283,16 @@ class VerificationService:
         """
         # we should validate the token info before verifying the tx
         self.verifiers.token_creation_tx.verify_token_info(tx, params)
-        token_dict = tx.get_complete_token_info()
+        token_dict = tx.get_complete_token_info(self._get_block_storage(params))
         self._verify_tx(tx, params, token_dict=token_dict)
         self.verifiers.token_creation_tx.verify_minted_tokens(tx, token_dict)
 
     def verify_without_storage(self, vertex: BaseTransaction, params: VerificationParams) -> None:
         if vertex.hash in self._settings.SKIP_VERIFICATION:
             return
+
+        if vertex.has_fees():
+            self._verify_without_storage_fee_header(vertex)
 
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
@@ -305,7 +319,7 @@ class VerificationService:
 
         if vertex.is_nano_contract():
             assert self._settings.ENABLE_NANO_CONTRACTS
-            self._verify_without_storage_nano_header(vertex, params)
+            self._verify_without_storage_nano_header(vertex)
 
     def _verify_without_storage_base_block(self, block: Block, params: VerificationParams) -> None:
         self.verifiers.block.verify_no_inputs(block)
@@ -344,10 +358,15 @@ class VerificationService:
     ) -> None:
         self._verify_without_storage_tx(tx, params)
 
-    def _verify_without_storage_nano_header(self, tx: BaseTransaction, params: VerificationParams) -> None:
+    def _verify_without_storage_nano_header(self, tx: BaseTransaction) -> None:
         assert tx.is_nano_contract()
         self.verifiers.nano_header.verify_nc_signature(tx)
         self.verifiers.nano_header.verify_actions(tx)
+
+    def _verify_without_storage_fee_header(self, tx: BaseTransaction) -> None:
+        assert tx.has_fees()
+        assert isinstance(tx, Transaction)
+        FeeHeaderVerifier.verify_fee_list(tx.get_fee_header(), tx)
 
     def _verify_without_storage_on_chain_blueprint(
         self,
@@ -358,3 +377,9 @@ class VerificationService:
         self.verifiers.on_chain_blueprint.verify_pubkey_is_allowed(tx)
         self.verifiers.on_chain_blueprint.verify_nc_signature(tx)
         self.verifiers.on_chain_blueprint.verify_code(tx)
+
+    def _get_block_storage(self, params: VerificationParams) -> NCBlockStorage:
+        assert self._nc_storage_factory is not None
+        if params.nc_block_root_id is None:
+            return self._nc_storage_factory.get_empty_block_storage()
+        return self._nc_storage_factory.get_block_storage(params.nc_block_root_id)

--- a/hathor/wallet/resources/send_tokens.py
+++ b/hathor/wallet/resources/send_tokens.py
@@ -43,7 +43,6 @@ class SendTokensResource(Resource):
         # Important to have the manager so we can know the tx_storage
         self.manager = manager
         self._settings = settings
-        self.params = VerificationParams.default_for_mempool()
 
     def render_POST(self, request):
         """ POST request for /wallet/send_tokens/
@@ -134,7 +133,9 @@ class SendTokensResource(Resource):
         tx.weight = weight
         self.manager.cpu_mining_service.resolve(tx)
         tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
-        self.manager.verification_service.verify(tx, self.params)
+        best_block = self.manager.tx_storage.get_best_block()
+        params = VerificationParams.default_for_mempool(best_block=best_block)
+        self.manager.verification_service.verify(tx, params)
         return tx
 
     def _cb_tx_resolve(self, tx, request):

--- a/tests/feature_activation/test_feature_simulation.py
+++ b/tests/feature_activation/test_feature_simulation.py
@@ -299,7 +299,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             non_signaling_block.init_static_metadata_from_storage(settings, manager.tx_storage)
 
             with pytest.raises(BlockMustSignalError):
-                manager.verification_service.verify(non_signaling_block, self.verification_params)
+                manager.verification_service.verify(non_signaling_block, self.get_verification_params(manager))
 
             with pytest.raises(InvalidNewTransaction):
                 manager.propagate_tx(non_signaling_block)

--- a/tests/nanocontracts/blueprints/unittest.py
+++ b/tests/nanocontracts/blueprints/unittest.py
@@ -1,10 +1,9 @@
 from io import TextIOWrapper
 from typing import Sequence
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
 from hathor.crypto.util import decode_address
 from hathor.manager import HathorManager
-from hathor.nanocontracts import Context
+from hathor.nanocontracts import HATHOR_TOKEN_UID, Context
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.blueprint_env import BlueprintEnvironment
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig

--- a/tests/nanocontracts/test_actions.py
+++ b/tests/nanocontracts/test_actions.py
@@ -18,9 +18,8 @@ from unittest.mock import patch
 
 import pytest
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
 from hathor.indexes.tokens_index import TokensIndex
-from hathor.nanocontracts import NC_EXECUTION_FAIL_ID, Blueprint, Context, public
+from hathor.nanocontracts import HATHOR_TOKEN_UID, NC_EXECUTION_FAIL_ID, Blueprint, Context, public
 from hathor.nanocontracts.catalog import NCBlueprintCatalog
 from hathor.nanocontracts.exception import NCInvalidAction
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig
@@ -77,10 +76,10 @@ class TestActions(unittest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.verification_params = VerificationParams.default_for_mempool(enable_nano=True)
 
         self.bp_id = b'1' * 32
         self.manager = self.create_peer('unittests', nc_log_config=NCLogConfig.FAILED, wallet_index=True)
+
         self.manager.tx_storage.nc_catalog = NCBlueprintCatalog({
             self.bp_id: MyBlueprint
         })
@@ -117,6 +116,11 @@ class TestActions(unittest.TestCase):
         self.tx0, self.tx1, self.tx2, self.tka = self.artifacts.get_typed_vertices(
             ['tx0', 'tx1', 'tx2', 'TKA'],
             Transaction,
+        )
+        best_block = self.manager.tx_storage.get_best_block()
+        self.verification_params = VerificationParams.default_for_mempool(
+            enable_nano=True,
+            best_block=best_block,
         )
 
         # We finish a manual setup of tx1, so it can be used directly in verification methods.

--- a/tests/nanocontracts/test_contract_create_contract.py
+++ b/tests/nanocontracts/test_contract_create_contract.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
-from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts import HATHOR_TOKEN_UID, Blueprint, Context, public
 from hathor.nanocontracts.nc_types import NCType, make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage.contract_storage import Balance
 from hathor.nanocontracts.types import (

--- a/tests/nanocontracts/test_execution_order.py
+++ b/tests/nanocontracts/test_execution_order.py
@@ -12,8 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
-from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts import HATHOR_TOKEN_UID, Blueprint, Context, public
 from hathor.nanocontracts.types import (
     ContractId,
     NCAction,

--- a/tests/nanocontracts/test_fallback_method.py
+++ b/tests/nanocontracts/test_fallback_method.py
@@ -17,8 +17,7 @@ from unittest.mock import ANY
 
 import pytest
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
-from hathor.nanocontracts import NC_EXECUTION_FAIL_ID, Blueprint, Context, NCFail, public
+from hathor.nanocontracts import HATHOR_TOKEN_UID, NC_EXECUTION_FAIL_ID, Blueprint, Context, NCFail, public
 from hathor.nanocontracts.exception import NCError, NCInvalidMethodCall
 from hathor.nanocontracts.method import ArgsOnly
 from hathor.nanocontracts.nc_exec_logs import NCCallBeginEntry, NCCallEndEntry

--- a/tests/nanocontracts/test_fee_tokens.py
+++ b/tests/nanocontracts/test_fee_tokens.py
@@ -1,0 +1,477 @@
+# Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from hathor import Blueprint, Context, ContractId, NCActionType, public
+from hathor.exception import InvalidNewTransaction
+from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
+from hathor.nanocontracts.utils import derive_child_token_id
+from hathor.transaction import Block, Transaction, TxInput, TxOutput
+from hathor.transaction.headers import FeeHeader
+from hathor.transaction.headers.fee_header import FeeHeaderEntry
+from hathor.transaction.headers.nano_header import NanoHeaderAction
+from hathor.transaction.nc_execution_state import NCExecutionState
+from hathor.transaction.scripts import Opcode
+from tests.dag_builder.builder import TestDAGBuilder
+from tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from tests.nanocontracts.utils import assert_nc_failure_reason
+
+
+class MyBlueprint(Blueprint):
+    @public(allow_deposit=True)
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public(allow_withdrawal=True)
+    def create_deposit_token(self, ctx: Context) -> None:
+        self.syscall.create_deposit_token(
+            token_name='deposit-based token',
+            token_symbol='DBT',
+            amount=100,
+        )
+
+    @public(allow_withdrawal=True)
+    def create_fee_token(self, ctx: Context) -> None:
+        self.syscall.create_fee_token(
+            token_name='fee-based token',
+            token_symbol='FBT',
+            amount=10 ** 9,
+        )
+
+    @public(allow_withdrawal=True)
+    def nop(self, ctx: Context) -> None:
+        pass
+
+
+class FeeTokensTestCase(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_postponed_verification_success(self) -> None:
+        """Postponed verification means running verify_sum on NC execution-time instead of verification-time."""
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_fee_token()
+            tx2.fee = 1 HTR
+
+            tx1 < tx2
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+
+        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        tx2.outputs.append(fbt_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx2.get_metadata().voided_by is None
+
+    def test_postponed_verification_fail_nonexistent(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = nop()
+            tx2.fee = 1 HTR
+
+            tx1 < tx2
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+
+        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        tx2.outputs.append(fbt_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.FAILURE
+        assert tx2.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, tx2.hash}
+
+        # It fails with a balance error caused by the withdrawal,
+        # because this check runs before the postponed verify_sum.
+        assert_nc_failure_reason(
+            manager=self.manager,
+            tx_id=tx2.hash,
+            block_id=b12.hash,
+            reason='NCInsufficientFunds: negative balance for contract',
+        )
+
+    def test_postponed_verification_fail_with_dbt(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_deposit_token()
+            tx2.fee = 1 HTR
+
+            tx1 < tx2
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
+        tx2.tokens.append(dbt_id)
+
+        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        tx2.outputs.append(dbt_output)
+
+        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(dbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.FAILURE
+        assert tx2.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, tx2.hash}
+
+        assert_nc_failure_reason(
+            manager=self.manager,
+            tx_id=tx2.hash,
+            block_id=b12.hash,
+            reason='InputOutputMismatch: Fee amount is different than expected. (amount=1, expected=0)',
+        )
+
+    def test_postponed_verification_fail_less_htr_balance(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_fee_token()
+            tx2.fee = 1 HTR
+            tx2.out[0] = 1000 HTR
+
+            tx1 < b11 < tx2
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+
+        removed_htr_output = tx2.outputs.pop()
+        assert removed_htr_output.token_data == 0
+        assert removed_htr_output.value == 1000
+        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        tx2.outputs.append(fbt_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        # Verification of minting HTR is not postponed, so it fails in verification-time.
+        with pytest.raises(Exception) as e:
+            artifacts.propagate_with(self.manager, up_to='tx2')
+
+        assert isinstance(e.value.__cause__, InvalidNewTransaction)
+        assert e.value.__cause__.args[0] == (
+            'full validation failed: HTR balance is different than expected. (amount=-1000, expected=0)'
+        )
+
+    def test_postponed_verification_fail_more_htr_balance(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_fee_token()
+            tx2.fee = 1 HTR
+
+            tx1 < tx2
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+
+        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        extra_htr_output = TxOutput(value=1000, script=b'')
+        tx2.outputs.append(fbt_output)
+        tx2.outputs.append(extra_htr_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.FAILURE
+        assert tx2.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, tx2.hash}
+
+        assert_nc_failure_reason(
+            manager=self.manager,
+            tx_id=tx2.hash,
+            block_id=b12.hash,
+            reason='InputOutputMismatch: HTR balance is different than expected. (amount=1000, expected=0)',
+        )
+
+    def test_postponed_verification_pay_fee_with_fbt(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_fee_token()
+
+            tx1 < tx2
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+
+        fbt_output = TxOutput(value=10 ** 9 - 100, script=b'', token_data=1)
+        tx2.outputs.append(fbt_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        fee_entry = FeeHeaderEntry(token_index=1, amount=100)
+        fee_header = FeeHeader(self._settings, tx2, [fee_entry])
+        tx2.headers.append(fee_header)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.FAILURE
+        assert tx2.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, tx2.hash}
+
+        assert_nc_failure_reason(
+            manager=self.manager,
+            tx_id=tx2.hash,
+            block_id=b12.hash,
+            reason=f'InvalidToken: token {fbt_id.hex()} cannot be used to pay fees',
+        )
+
+    def test_postponed_verification_tx_spending_nano(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_fee_token()
+            tx2.fee = 1 HTR
+
+            tx3.fee = 1 HTR
+
+            tx1 < b11 < tx2 < tx3 < b12
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2, tx3 = artifacts.get_typed_vertices(('tx1', 'tx2', 'tx3'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+        tx3.tokens.append(fbt_id)
+
+        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        tx2.outputs.append(fbt_output)
+        tx3.outputs.append(fbt_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        fbt_input = TxInput(tx_id=tx2.hash, index=len(tx2.outputs) - 1, data=bytes([Opcode.OP_1]))
+        tx3.inputs.append(fbt_input)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        with pytest.raises(Exception) as e:
+            artifacts.propagate_with(self.manager, up_to='tx3')
+
+        assert isinstance(e.value.__cause__, InvalidNewTransaction)
+        assert e.value.__cause__.args[0] == f'full validation failed: token uid {fbt_id.hex()} not found.'
+
+        assert self.manager.vertex_handler.on_new_relayed_vertex(b12)
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx2.get_metadata().voided_by is None
+
+        # Now, it's valid and accepted.
+        assert self.manager.vertex_handler.on_new_relayed_vertex(tx3)
+        assert tx3.get_metadata().validation.is_valid()
+        assert tx3.get_metadata().voided_by is None
+
+    async def test_postponed_verification_tx_spending_nano_on_new_block(self) -> None:
+        """
+        This test is analogous to `test_postponed_verification_tx_spending_nano` but both the nano and the tx that
+        spends it are relayed via the `on_new_block` method, simulating a sync from another peer.
+        """
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_fee_token()
+            tx2.fee = 1 HTR
+
+            tx3.fee = 1 HTR
+
+            tx1 < b11 < tx2 < tx3 < b12
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2, tx3 = artifacts.get_typed_vertices(('tx1', 'tx2', 'tx3'), Transaction)
+
+        fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
+        tx2.tokens.append(fbt_id)
+        tx3.tokens.append(fbt_id)
+
+        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        tx2.outputs.append(fbt_output)
+        tx3.outputs.append(fbt_output)
+
+        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(fbt_withdraw)
+
+        fbt_input = TxInput(tx_id=tx2.hash, index=len(tx2.outputs) - 1, data=bytes([Opcode.OP_1]))
+        tx3.inputs.append(fbt_input)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        deferred = self.manager.vertex_handler.on_new_block(block=b12, deps=[tx2, tx3])
+        self.reactor.advance(1)
+
+        msg = f'full validation failed: token uid {fbt_id.hex()} not found.'
+        with pytest.raises(InvalidNewTransaction, match=msg):
+            await deferred
+
+        assert tx2.get_metadata().validation.is_valid()
+        assert tx2.get_metadata().first_block is None
+        assert tx2.get_metadata().nc_execution is None
+        assert tx2.get_metadata().voided_by is None
+
+        assert tx3.get_metadata().validation.is_initial()
+        assert b12.get_metadata().validation.is_initial()
+
+        assert self.manager.tx_storage.transaction_exists(tx2.hash)
+        assert not self.manager.tx_storage.transaction_exists(tx3.hash)
+        assert not self.manager.tx_storage.transaction_exists(b12.hash)

--- a/tests/nanocontracts/test_indexes2.py
+++ b/tests/nanocontracts/test_indexes2.py
@@ -12,8 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
-from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts import HATHOR_TOKEN_UID, Blueprint, Context, public
 from hathor.nanocontracts.types import ContractId, VertexId
 from hathor.nanocontracts.utils import derive_child_token_id
 from hathor.transaction import Transaction

--- a/tests/nanocontracts/test_syscalls.py
+++ b/tests/nanocontracts/test_syscalls.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pytest
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
+from hathor.nanocontracts import HATHOR_TOKEN_UID
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCInsufficientFunds, NCInvalidSyscall

--- a/tests/nanocontracts/test_token_creation.py
+++ b/tests/nanocontracts/test_token_creation.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 
 from hathor.conf import HathorSettings
 from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
@@ -148,7 +149,7 @@ class NCNanoContractTestCase(unittest.TestCase):
             Balance(value=7, can_mint=False, can_melt=False)
         )
 
-        jkl_token_info = JKL._get_token_info_from_inputs()
+        jkl_token_info = JKL._get_token_info_from_inputs(Mock())
         JKL._update_token_info_from_outputs(token_dict=jkl_token_info)
         assert jkl_token_info[settings.HATHOR_TOKEN_UID].amount == -2
 

--- a/tests/poa/test_poa_verification.py
+++ b/tests/poa/test_poa_verification.py
@@ -80,7 +80,7 @@ class PoaVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
             patch.object(PoaBlockVerifier, 'verify_poa', verify_poa_wrapped),
         ):
-            self.manager.verification_service.verify_basic(block, self.verification_params)
+            self.manager.verification_service.verify_basic(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -111,7 +111,7 @@ class PoaVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_without_storage(block, self.verification_params)
+            self.manager.verification_service.verify_without_storage(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -153,7 +153,7 @@ class PoaVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -185,7 +185,7 @@ class PoaVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
             patch.object(PoaBlockVerifier, 'verify_poa', verify_poa_wrapped),
         ):
-            self.manager.verification_service.validate_basic(block, self.verification_params)
+            self.manager.verification_service.validate_basic(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -199,7 +199,7 @@ class PoaVerificationTest(unittest.TestCase):
         self.assertEqual(block.get_metadata().validation, ValidationState.BASIC)
 
         # full validation should still pass and the validation updated to FULL
-        self.manager.verification_service.validate_full(block, self.verification_params)
+        self.manager.verification_service.validate_full(block, self.get_verification_params(self.manager))
         self.assertEqual(block.get_metadata().validation, ValidationState.FULL)
 
         # and if running basic validation again it shouldn't validate or change the validation state
@@ -210,7 +210,7 @@ class PoaVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped2),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped2),
         ):
-            self.manager.verification_service.validate_basic(block, self.verification_params)
+            self.manager.verification_service.validate_basic(block, self.get_verification_params(self.manager))
 
         # Block methods
         verify_weight_wrapped2.assert_not_called()
@@ -256,7 +256,7 @@ class PoaVerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
             patch.object(PoaBlockVerifier, 'verify_poa', verify_poa_wrapped),
         ):
-            self.manager.verification_service.validate_full(block, self.verification_params)
+            self.manager.verification_service.validate_full(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()

--- a/tests/tx/test_genesis.py
+++ b/tests/tx/test_genesis.py
@@ -55,7 +55,7 @@ class GenesisTest(unittest.TestCase):
     def test_verify(self):
         genesis = self.storage.get_all_genesis()
         for g in genesis:
-            self._verification_service.verify_without_storage(g, self.verification_params)
+            self._verification_service.verify_without_storage(g, self.get_verification_params())
 
     def test_output(self):
         # Test if block output is valid

--- a/tests/tx/test_reward_lock.py
+++ b/tests/tx/test_reward_lock.py
@@ -76,7 +76,7 @@ class TransactionTest(unittest.TestCase):
             tx, _ = self._spend_reward_tx(self.manager, reward_block)
             self.assertEqual(tx.static_metadata.min_height, unlock_height)
             with self.assertRaises(RewardLocked):
-                self.manager.verification_service.verify(tx, self.verification_params)
+                self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
             add_new_blocks(self.manager, 1, advance_clock=1)
 
         # now it should be spendable
@@ -136,7 +136,7 @@ class TransactionTest(unittest.TestCase):
         tx, _ = self._spend_reward_tx(self.manager, reward_block)
         self.assertEqual(tx.static_metadata.min_height, unlock_height)
         with self.assertRaises(RewardLocked):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
         with self.assertRaises(InvalidNewTransaction):
             self.assertTrue(self.manager.on_new_tx(tx))
 
@@ -179,7 +179,7 @@ class TransactionTest(unittest.TestCase):
 
         # now the new tx should not pass verification considering the reward lock
         with self.assertRaises(RewardLocked):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # the transaction should have been removed from the mempool
         self.assertNotIn(tx, self.manager.tx_storage.iter_mempool_from_best_index())
@@ -219,7 +219,7 @@ class TransactionTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx)
         self.assertEqual(tx.static_metadata.min_height, unlock_height)
         with self.assertRaises(RewardLocked):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_removed_tx_confirmed_by_orphan_block(self) -> None:
         manager = self.create_peer('unittests')

--- a/tests/tx/test_tokens.py
+++ b/tests/tx/test_tokens.py
@@ -51,7 +51,7 @@ class TokenTest(unittest.TestCase):
 
         self.manager.cpu_mining_service.resolve(block)
         with self.assertRaises(BlockWithTokensError):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
     def test_tx_token_outputs(self):
         genesis_block = self.genesis_blocks[0]
@@ -71,7 +71,7 @@ class TokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # with 1 token uid in list
         tx.tokens = [bytes.fromhex('0023be91834c973d6a6ddd1a0ae411807b7c8ef2a015afb5177ee64b666ce602')]
@@ -81,7 +81,7 @@ class TokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # try hathor authority UTXO
         output = TxOutput(value, script, 0b10000000)
@@ -91,7 +91,7 @@ class TokenTest(unittest.TestCase):
         tx.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_token_transfer(self):
         wallet = self.manager.wallet
@@ -112,7 +112,7 @@ class TokenTest(unittest.TestCase):
         tx2.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx2)
         tx2.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
-        self.manager.verification_service.verify(tx2, self.verification_params)
+        self.manager.verification_service.verify(tx2, self.get_verification_params(self.manager))
 
         # missing tokens
         token_output = TxOutput(utxo.value - 1, script, 1)
@@ -125,7 +125,7 @@ class TokenTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx3)
         tx3.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         with self.assertRaises(InputOutputMismatch):
-            self.manager.verification_service.verify(tx3, self.verification_params)
+            self.manager.verification_service.verify(tx3, self.get_verification_params(self.manager))
 
     def test_token_mint(self):
         wallet = self.manager.wallet
@@ -192,7 +192,7 @@ class TokenTest(unittest.TestCase):
         tx3.inputs[0].data = data
         self.manager.cpu_mining_service.resolve(tx3)
         with self.assertRaises(InputOutputMismatch):
-            self.manager.verification_service.verify(tx3, self.verification_params)
+            self.manager.verification_service.verify(tx3, self.get_verification_params(self.manager))
 
         # try to mint and deposit less tokens than necessary
         mint_amount = 10000000
@@ -218,7 +218,7 @@ class TokenTest(unittest.TestCase):
         tx4.inputs[1].data = data
         self.manager.cpu_mining_service.resolve(tx4)
         with self.assertRaises(InputOutputMismatch):
-            self.manager.verification_service.verify(tx4, self.verification_params)
+            self.manager.verification_service.verify(tx4, self.get_verification_params(self.manager))
 
         # try to mint using melt authority UTXO
         _input1 = TxInput(tx.hash, 2, b'')
@@ -230,7 +230,7 @@ class TokenTest(unittest.TestCase):
         tx5.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx5)
         with self.assertRaises(InputOutputMismatch):
-            self.manager.verification_service.verify(tx5, self.verification_params)
+            self.manager.verification_service.verify(tx5, self.get_verification_params(self.manager))
 
     def test_token_melt(self):
         wallet = self.manager.wallet
@@ -302,7 +302,7 @@ class TokenTest(unittest.TestCase):
         tx3.inputs[1].data = data
         self.manager.cpu_mining_service.resolve(tx3)
         with self.assertRaises(InputOutputMismatch):
-            self.manager.verification_service.verify(tx3, self.verification_params)
+            self.manager.verification_service.verify(tx3, self.get_verification_params(self.manager))
 
         # try to melt using mint authority UTXO
         _input1 = TxInput(tx.hash, 0, b'')
@@ -318,7 +318,7 @@ class TokenTest(unittest.TestCase):
         tx4.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         self.manager.cpu_mining_service.resolve(tx4)
         with self.assertRaises(InputOutputMismatch):
-            self.manager.verification_service.verify(tx4, self.verification_params)
+            self.manager.verification_service.verify(tx4, self.get_verification_params(self.manager))
 
     def test_token_transfer_authority(self):
         wallet = self.manager.wallet
@@ -337,7 +337,7 @@ class TokenTest(unittest.TestCase):
         tx2.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx2)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx2, self.verification_params)
+            self.manager.verification_service.verify(tx2, self.get_verification_params(self.manager))
 
         # input with melt and output with mint
         _input1 = TxInput(tx.hash, 2, b'')
@@ -349,7 +349,7 @@ class TokenTest(unittest.TestCase):
         tx3.inputs[0].data = P2PKH.create_input_data(public_bytes, signature)
         self.manager.cpu_mining_service.resolve(tx3)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx3, self.verification_params)
+            self.manager.verification_service.verify(tx3, self.get_verification_params(self.manager))
 
     def test_token_index_with_conflict(self, mint_amount=0):
         # create a new token and have a mint operation done. The tx that mints the
@@ -453,39 +453,39 @@ class TokenTest(unittest.TestCase):
         # max token name length
         tx.token_name = 'a' * self._settings.MAX_LENGTH_TOKEN_NAME
         update_tx(tx)
-        self.manager.verification_service.verify(tx, self.verification_params)
+        self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # max token symbol length
         tx.token_symbol = 'a' * self._settings.MAX_LENGTH_TOKEN_SYMBOL
         update_tx(tx)
-        self.manager.verification_service.verify(tx, self.verification_params)
+        self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # long token name
         tx.token_name = 'a' * (self._settings.MAX_LENGTH_TOKEN_NAME + 1)
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # long token symbol
         tx.token_name = 'ValidName'
         tx.token_symbol = 'a' * (self._settings.MAX_LENGTH_TOKEN_SYMBOL + 1)
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Hathor token name
         tx.token_name = self._settings.HATHOR_TOKEN_NAME
         tx.token_symbol = 'TST'
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Hathor token symbol
         tx.token_name = 'Test'
         tx.token_symbol = self._settings.HATHOR_TOKEN_SYMBOL
         update_tx(tx)
         with self.assertRaises(TransactionDataError):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Token name unicode
         tx.token_name = 'Test ∞'
@@ -493,7 +493,7 @@ class TokenTest(unittest.TestCase):
         token_info = tx.serialize_token_info()
         TokenCreationTransaction.deserialize_token_info(token_info)
         update_tx(tx)
-        self.manager.verification_service.verify(tx, self.verification_params)
+        self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Token symbol unicode
         tx.token_name = 'Test Token'
@@ -501,7 +501,7 @@ class TokenTest(unittest.TestCase):
         token_info = tx.serialize_token_info()
         TokenCreationTransaction.deserialize_token_info(token_info)
         update_tx(tx)
-        self.manager.verification_service.verify(tx, self.verification_params)
+        self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Hathor token version
         tx.token_name = 'Test'
@@ -509,7 +509,7 @@ class TokenTest(unittest.TestCase):
         tx.token_version = TokenVersion.NATIVE
         update_tx(tx)
         with pytest.raises(TransactionDataError, match=f'Invalid token version \\({tx.token_version}\\)'):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_token_mint_zero(self):
         # try to mint 0 tokens
@@ -550,7 +550,7 @@ class TokenTest(unittest.TestCase):
         tx2.inputs[1].data = data
         self.manager.cpu_mining_service.resolve(tx2)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(tx2, self.verification_params)
+            self.manager.verification_service.verify(tx2, self.get_verification_params(self.manager))
 
     def test_token_info_serialization(self):
         tx = create_tokens(self.manager, self.address_b58, mint_amount=500)
@@ -608,7 +608,7 @@ class TokenTest(unittest.TestCase):
 
         self.manager.cpu_mining_service.resolve(block)
         with self.assertRaises(InvalidToken):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
     def test_voided_token_creation(self):
         tx1 = create_tokens(self.manager, self.address_b58, mint_amount=500, use_genesis=False)

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -78,8 +78,10 @@ class TransactionTest(unittest.TestCase):
         public_bytes, signature = self.wallet.get_input_aux_data(data_to_sign, self.genesis_private_key)
         _input.data = P2PKH.create_input_data(public_bytes, signature)
 
+        best_block = self.manager.tx_storage.get_best_block()
+        block_storage = self.manager.get_nc_block_storage(best_block)
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(tx.get_complete_token_info())
+            self._verifiers.tx.verify_sum(self._settings, tx.get_complete_token_info(block_storage))
 
     def test_input_output_match_more_htr(self):
         genesis_block = self.genesis_blocks[0]
@@ -97,8 +99,10 @@ class TransactionTest(unittest.TestCase):
         public_bytes, signature = self.wallet.get_input_aux_data(data_to_sign, self.genesis_private_key)
         _input.data = P2PKH.create_input_data(public_bytes, signature)
 
+        best_block = self.manager.tx_storage.get_best_block()
+        block_storage = self.manager.get_nc_block_storage(best_block)
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(tx.get_complete_token_info())
+            self._verifiers.tx.verify_sum(self._settings, tx.get_complete_token_info(block_storage))
 
     def test_validation(self):
         # add 100 blocks and check that walking through get_next_block_best_chain yields the same blocks
@@ -238,7 +242,7 @@ class TransactionTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(block)
 
         with self.assertRaises(BlockWithInputs):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
     def test_merge_mined_no_magic(self):
         from hathor.merged_mining import MAGIC_NUMBER
@@ -456,21 +460,21 @@ class TransactionTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx)
         tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         with self.assertRaises(IncorrectParents):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # test with 3 parents
         parents = [tx.hash for tx in self.genesis]
         tx.parents = parents
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(IncorrectParents):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # 2 parents, 1 tx and 1 block
         parents = [self.genesis_txs[0].hash, self.genesis_blocks[0].hash]
         tx.parents = parents
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(IncorrectParents):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_block_unknown_parent(self):
         address = get_address_from_public_key(self.genesis_public_key)
@@ -489,7 +493,7 @@ class TransactionTest(unittest.TestCase):
 
         self.manager.cpu_mining_service.resolve(block)
         with self.assertRaises(ParentDoesNotExist):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
     def test_block_number_parents(self):
         address = get_address_from_public_key(self.genesis_public_key)
@@ -507,7 +511,7 @@ class TransactionTest(unittest.TestCase):
 
         self.manager.cpu_mining_service.resolve(block)
         with self.assertRaises(IncorrectParents):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
     def test_tx_inputs_out_of_range(self):
         # we'll try to spend output 3 from genesis transaction, which does not exist
@@ -530,7 +534,7 @@ class TransactionTest(unittest.TestCase):
         # test with an inexistent index
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InexistentInput):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # now with index equals of len of outputs
         _input = [TxInput(genesis_block.hash, len(genesis_block.outputs), data)]
@@ -538,7 +542,7 @@ class TransactionTest(unittest.TestCase):
         # test with an inexistent index
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InexistentInput):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # now with inexistent tx hash
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
@@ -546,7 +550,7 @@ class TransactionTest(unittest.TestCase):
         tx.inputs = _input
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(InexistentInput):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_tx_inputs_conflict(self):
         # the new tx inputs will try to spend the same output
@@ -569,7 +573,7 @@ class TransactionTest(unittest.TestCase):
 
         self.manager.cpu_mining_service.resolve(tx)
         with self.assertRaises(ConflictingInputs):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_regular_tx(self):
         # this should succeed
@@ -591,7 +595,7 @@ class TransactionTest(unittest.TestCase):
 
         self.manager.cpu_mining_service.resolve(tx)
         tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
-        self.manager.verification_service.verify(tx, self.verification_params)
+        self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_tx_weight_too_high(self):
         parents = [tx.hash for tx in self.genesis_txs]
@@ -626,7 +630,7 @@ class TransactionTest(unittest.TestCase):
         tx.update_hash()
         self.assertTrue(isnan(tx.weight))
         with self.assertRaises(WeightError):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_weight_inf(self):
         # this should succeed
@@ -649,7 +653,7 @@ class TransactionTest(unittest.TestCase):
         tx.update_hash()
         self.assertTrue(isinf(tx.weight))
         with self.assertRaises(WeightError):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_tx_duplicated_parents(self):
         # the new tx will confirm the same tx twice
@@ -672,7 +676,7 @@ class TransactionTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx)
         tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
         with self.assertRaises(DuplicatedParents):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_update_timestamp(self):
         parents = [tx for tx in self.genesis_txs]
@@ -880,7 +884,7 @@ class TransactionTest(unittest.TestCase):
         # 'Manually resolving', to validate verify method
         tx.hash = bytes.fromhex('012cba011be3c29f1c406f9015e42698b97169dbc6652d1f5e4d5c5e83138858')
         with self.assertRaises(InvalidOutputValue):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Invalid output value
         invalid_output = bytes.fromhex('ffffffff')
@@ -1116,7 +1120,7 @@ class TransactionTest(unittest.TestCase):
         tx.update_hash()
         # This calls verify to ensure that verify_sigops_output is being called on verify
         with self.assertRaises(TooManySigOps):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_sigops_output_multi_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1129,7 +1133,7 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(inputs=[_input], outputs=[output2]*num_outputs, storage=self.tx_storage)
         tx.update_hash()
         with self.assertRaises(TooManySigOps):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_sigops_output_single_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1166,7 +1170,7 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(inputs=[input1], outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
         with self.assertRaises(TooManySigOps):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_sigops_input_multi_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1181,7 +1185,7 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(inputs=[input2]*num_inputs, outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
         with self.assertRaises(TooManySigOps):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
     def test_sigops_input_single_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]

--- a/tests/tx/test_tx_deserialization.py
+++ b/tests/tx/test_tx_deserialization.py
@@ -35,7 +35,7 @@ class _BaseTest:
 
             cls = self.get_tx_class()
             tx = cls.create_from_struct(self.tx_bytes, verbose=verbose)
-            self._verification_service.verify_without_storage(tx, self.verification_params)
+            self._verification_service.verify_without_storage(tx, self.get_verification_params())
 
             key, version = v[1]
             self.assertEqual(key, 'version')

--- a/tests/tx/test_verification.py
+++ b/tests/tx/test_verification.py
@@ -124,7 +124,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
-            self.manager.verification_service.verify_basic(block, self.verification_params)
+            self.manager.verification_service.verify_basic(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -154,7 +154,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_without_storage(block, self.verification_params)
+            self.manager.verification_service.verify_without_storage(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -196,7 +196,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_height', verify_height_wrapped),
             patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -226,7 +226,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
-            self.manager.verification_service.validate_basic(block, self.verification_params)
+            self.manager.verification_service.validate_basic(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -239,7 +239,7 @@ class VerificationTest(unittest.TestCase):
         self.assertEqual(block.get_metadata().validation, ValidationState.BASIC)
 
         # full validation should still pass and the validation updated to FULL
-        self.manager.verification_service.validate_full(block, self.verification_params)
+        self.manager.verification_service.validate_full(block, self.get_verification_params(self.manager))
         self.assertEqual(block.get_metadata().validation, ValidationState.FULL)
 
         # and if running basic validation again it shouldn't validate or change the validation state
@@ -250,7 +250,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped2),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped2),
         ):
-            self.manager.verification_service.validate_basic(block, self.verification_params)
+            self.manager.verification_service.validate_basic(block, self.get_verification_params(self.manager))
 
         # Block methods
         verify_weight_wrapped2.assert_not_called()
@@ -294,7 +294,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
             patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
         ):
-            self.manager.verification_service.validate_full(block, self.verification_params)
+            self.manager.verification_service.validate_full(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -327,7 +327,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
-            self.manager.verification_service.verify_basic(block, self.verification_params)
+            self.manager.verification_service.verify_basic(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -357,7 +357,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_data', verify_data_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_without_storage(block, self.verification_params)
+            self.manager.verification_service.verify_without_storage(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -402,7 +402,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
-            self.manager.verification_service.verify(block, self.verification_params)
+            self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -435,7 +435,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped),
         ):
-            self.manager.verification_service.validate_basic(block, self.verification_params)
+            self.manager.verification_service.validate_basic(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -448,7 +448,7 @@ class VerificationTest(unittest.TestCase):
         self.assertEqual(block.get_metadata().validation, ValidationState.BASIC)
 
         # full validation should still pass and the validation updated to FULL
-        self.manager.verification_service.validate_full(block, self.verification_params)
+        self.manager.verification_service.validate_full(block, self.get_verification_params(self.manager))
         self.assertEqual(block.get_metadata().validation, ValidationState.FULL)
 
         # and if running basic validation again it shouldn't validate or change the validation state
@@ -459,7 +459,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_weight', verify_weight_wrapped2),
             patch.object(BlockVerifier, 'verify_reward', verify_reward_wrapped2),
         ):
-            self.manager.verification_service.validate_basic(block, self.verification_params)
+            self.manager.verification_service.validate_basic(block, self.get_verification_params(self.manager))
 
         # Block methods
         verify_weight_wrapped2.assert_not_called()
@@ -506,7 +506,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(BlockVerifier, 'verify_mandatory_signaling', verify_mandatory_signaling_wrapped),
             patch.object(MergeMinedBlockVerifier, 'verify_aux_pow', verify_aux_pow_wrapped),
         ):
-            self.manager.verification_service.validate_full(block, self.verification_params)
+            self.manager.verification_service.validate_full(block, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -554,7 +554,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_basic(tx, self.verification_params)
+            self.manager.verification_service.verify_basic(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -588,7 +588,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_without_storage(tx, self.verification_params)
+            self.manager.verification_service.verify_without_storage(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -636,7 +636,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TransactionVerifier, 'verify_version', verify_tx_version_wrapped),
         ):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -683,7 +683,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.validate_basic(tx, self.verification_params)
+            self.manager.verification_service.validate_basic(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -702,7 +702,7 @@ class VerificationTest(unittest.TestCase):
         self.assertEqual(tx.get_metadata().validation, ValidationState.BASIC)
 
         # full validation should still pass and the validation updated to FULL
-        self.manager.verification_service.validate_full(tx, self.verification_params)
+        self.manager.verification_service.validate_full(tx, self.get_verification_params(self.manager))
         self.assertEqual(tx.get_metadata().validation, ValidationState.FULL)
 
         # and if running basic validation again it shouldn't validate or change the validation state
@@ -723,7 +723,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
-            self.manager.verification_service.validate_basic(tx, self.verification_params)
+            self.manager.verification_service.validate_basic(tx, self.get_verification_params(self.manager))
 
         # Transaction methods
         verify_parents_basic_wrapped2.assert_not_called()
@@ -779,7 +779,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TransactionVerifier, 'verify_version', verify_tx_version_wrapped),
         ):
-            self.manager.verification_service.validate_full(tx, self.verification_params)
+            self.manager.verification_service.validate_full(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -823,7 +823,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
-            self.manager.verification_service.validate_basic(tx, self.verification_params)
+            self.manager.verification_service.validate_basic(tx, self.get_verification_params(self.manager))
 
         # Transaction methods
         verify_parents_basic_wrapped2.assert_not_called()
@@ -862,7 +862,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_basic(tx, self.verification_params)
+            self.manager.verification_service.verify_basic(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -896,7 +896,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.verify_without_storage(tx, self.verification_params)
+            self.manager.verification_service.verify_without_storage(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -948,7 +948,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_minted_tokens', verify_minted_tokens_wrapped),
         ):
-            self.manager.verification_service.verify(tx, self.verification_params)
+            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_outputs_wrapped.assert_called_once()
@@ -998,7 +998,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped),
         ):
-            self.manager.verification_service.validate_basic(tx, self.verification_params)
+            self.manager.verification_service.validate_basic(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()
@@ -1018,7 +1018,7 @@ class VerificationTest(unittest.TestCase):
 
         # full validation should still pass and the validation updated to FULL
         with tx_allow_context(self.manager.tx_storage, allow_scope=TxAllowScope.PARTIAL | TxAllowScope.VALID):
-            self.manager.verification_service.validate_full(tx, self.verification_params)
+            self.manager.verification_service.validate_full(tx, self.get_verification_params(self.manager))
         self.assertEqual(tx.get_metadata().validation, ValidationState.FULL)
 
         # and if running basic validation again it shouldn't validate or change the validation state
@@ -1039,7 +1039,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(VertexVerifier, 'verify_number_of_outputs', verify_number_of_outputs_wrapped2),
             patch.object(VertexVerifier, 'verify_sigops_output', verify_sigops_output_wrapped2),
         ):
-            self.manager.verification_service.validate_basic(tx, self.verification_params)
+            self.manager.verification_service.validate_basic(tx, self.get_verification_params(self.manager))
 
         # Transaction methods
         verify_parents_basic_wrapped2.assert_not_called()
@@ -1100,7 +1100,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_minted_tokens', verify_minted_tokens_wrapped),
         ):
-            self.manager.verification_service.validate_full(tx, self.verification_params)
+            self.manager.verification_service.validate_full(tx, self.get_verification_params(self.manager))
 
         # Vertex methods
         verify_version_basic_wrapped.assert_called_once()

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -8,6 +8,7 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Collection, Iterable, Iterator, Optional
 from unittest import main as ut_main
+from unittest.mock import Mock
 
 from structlog import get_logger
 from twisted.trial import unittest
@@ -119,7 +120,6 @@ class TestCase(unittest.TestCase):
         self.rng = Random(self.seed)
         self._pending_cleanups: list[Callable[..., Any]] = []
         self._settings = get_global_settings()
-        self.verification_params = VerificationParams.default_for_mempool()
 
     def tearDown(self) -> None:
         self.clean_tmpdirs()
@@ -521,3 +521,8 @@ class TestCase(unittest.TestCase):
             return None
 
         return list(hd.keys.keys())[index]
+
+    @staticmethod
+    def get_verification_params(manager: HathorManager | None = None) -> VerificationParams:
+        best_block = manager.tx_storage.get_best_block() if manager else None
+        return VerificationParams.default_for_mempool(best_block=best_block or Mock())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,13 @@ from hathor.manager import HathorManager
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.simulator.utils import add_new_block, add_new_blocks, gen_new_double_spending, gen_new_tx
 from hathor.transaction import BaseTransaction, Block, Transaction, TxInput, TxOutput
+from hathor.transaction.headers import FeeHeader
+from hathor.transaction.headers.fee_header import FeeHeaderEntry
 from hathor.transaction.scripts import P2PKH, HathorScript, Opcode, parse_address_script
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount
 from hathor.util import Random
-from hathor.verification.verification_params import VerificationParams
 
 settings = HathorSettings()
 
@@ -603,6 +604,12 @@ def create_fee_tokens(manager: 'HathorManager', address_b58: Optional[str] = Non
         timestamp=timestamp,
         token_version=TokenVersion.FEE
     )
+
+    tx.headers.append(FeeHeader(
+        settings=manager._settings,
+        tx=tx,
+        fees=[FeeHeaderEntry(token_index=0, amount=fee)])
+    )
     data_to_sign = tx.get_sighash_all()
 
     public_bytes, signature = wallet.get_input_aux_data(data_to_sign, genesis_private_key)
@@ -720,8 +727,6 @@ def add_tx_with_data_script(manager: 'HathorManager', data: list[str], propagate
     manager.cpu_mining_service.resolve(tx)
 
     if propagate:
-        params = VerificationParams.default_for_mempool()
-        manager.verification_service.verify(tx, params)
         manager.propagate_tx(tx)
         assert isinstance(manager.reactor, Clock)
         manager.reactor.advance(8)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -207,7 +207,7 @@ class BasicWalletTest(unittest.TestCase):
         tx2.parents = self.manager.get_new_tx_parents()
         self.manager.cpu_mining_service.resolve(tx2)
         tx2.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
-        self.manager.verification_service.verify(tx2, self.verification_params)
+        self.manager.verification_service.verify(tx2, self.get_verification_params(self.manager))
 
         self.assertNotEqual(len(tx2.inputs), 0)
         token_dict = defaultdict(int)

--- a/tests/wallet/test_wallet_hd.py
+++ b/tests/wallet/test_wallet_hd.py
@@ -27,7 +27,7 @@ class WalletHDTest(unittest.TestCase):
         new_address = self.wallet.get_unused_address()
         out = WalletOutputInfo(decode_address(new_address), self.TOKENS, timelock=None)
         block = add_new_block(self.manager)
-        self.manager.verification_service.verify(block, self.verification_params)
+        self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
         utxo = self.wallet.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((block.hash, 0))
         self.assertIsNotNone(utxo)
         self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.BLOCK_TOKENS))


### PR DESCRIPTION

Depends on [1414](https://github.com/HathorNetwork/hathor-core/pull/1414)
### Motivation

To make fee payment explicit in the transaction this pr adds the `FeeHeader` in the transaction. It carries all the tokens and amounts, indicating they will be used to pay fees.

### Acceptance Criteria
- Should use the `FeeHeader` to manipulate the `token_dict` to make fees act as outputs in the diff.
- The `verify_sum` will have a flag to indicate if it should enforce the HTR amount validation or not. This flag is useful when dealing with nano contracts that might have tokens that aren't created at the verification stage.
- Add a `verify_sum` call when the nano contract executes in the block_consensus
- Adds the `fee_header` verification without storage whithin the `basic` verification
- Specify the block to be used and the source of data in the methods that calls `on_old_new_vertex`
- Change the `VerificationParams` to receive a block or block storage

### Checklist

- [] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 