### PR TITLE
fix(nano): Fix NCCreationResource to get contract information from the global state

### DIFF
--- a/tests/nanocontracts/test_blueprints/test_blueprint1.py
+++ b/tests/nanocontracts/test_blueprints/test_blueprint1.py
@@ -24,3 +24,8 @@ class TestBlueprint1(Blueprint):
     @public
     def nop(self, ctx: Context) -> None:
         pass
+
+    @public
+    def create_child_contract(self, ctx: Context) -> None:
+        blueprint_id = self.syscall.get_blueprint_id()
+        self.syscall.create_contract(blueprint_id, b'', [], 0)

--- a/tests/resources/nanocontracts/test_nc_creation.py
+++ b/tests/resources/nanocontracts/test_nc_creation.py
@@ -45,7 +45,7 @@ class NCCreationResourceTest(_BaseResourceTest._ResourceTest):
         password = unittest.OCB_TEST_PASSWORD.hex()
         dag_builder = TestDAGBuilder.from_manager(self.manager)
         artifacts = dag_builder.build_from_str(f'''
-            blockchain genesis b[1..11]
+            blockchain genesis b[1..12]
             b10 < dummy
 
             ocb1.ocb_private_key = "{private_key}"
@@ -71,6 +71,8 @@ class NCCreationResourceTest(_BaseResourceTest._ResourceTest):
 
             ocb1 <-- ocb2 <-- b11
             b11 < nc1 < nc2 < nc3 < nc4 < nc5
+
+            nc1 <-- nc2 <-- nc3 <-- nc4 <-- nc5 <-- b12
 
             ocb1.ocb_code = "{bet_code.encode().hex()}"
             ocb2.ocb_code = ```
@@ -150,7 +152,7 @@ class NCCreationResourceTest(_BaseResourceTest._ResourceTest):
             nc2.nc_method = initialize(0)
 
             nc3.nc_id = nc2
-            nc3.nc_method = nop()
+            nc3.nc_method = create_child_contract()
 
             nc4.nc_id = nc1
             nc4.nc_method = nop()


### PR DESCRIPTION
### Motivation

NCCreationResource was previously getting contract information from the vertex that created that contract. But this does not work for contracts created by contracts. This PR fixes that.

### Acceptance Criteria

1. If a contract creation vertex is not found, get contract information from the best block's global state. In this case, the `created_at` is set to zero.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 