### PR TITLE
chore(nano): avoid storage incompatibility when nano is not enabled

### DIFF
--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -104,7 +104,6 @@ class TransactionStorage(ABC):
         change_score_acc_weight_metadata.Migration,
         add_closest_ancestor_block.Migration,
         include_funds_for_first_block.Migration,
-        nc_storage_compat1.Migration,
     ]
 
     _migrations: list[BaseMigration]
@@ -153,7 +152,10 @@ class TransactionStorage(ABC):
         self._saving_genesis = False
 
         # Migrations instances
-        self._migrations = [cls() for cls in self._migration_factories]
+        migration_factories = self._migration_factories[:]
+        if settings.ENABLE_NANO_CONTRACTS:
+            migration_factories.append(nc_storage_compat1.Migration)
+        self._migrations = [cls() for cls in migration_factories]
 
         # XXX: sanity check
         migration_names = set()


### PR DESCRIPTION
### Motivation

The "impossible migration" introduced in #1380 was having an effect on mainnet even though it only affects the nano storage which doesn't exist yet in mainnet.

### Acceptance Criteria

- Only include migration if `settings.ENABLE_NANO_CONTRACTS`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 