### PR TITLE
fix(nano): API was not processing initialize method correctly

### DIFF
--- a/hathor/nanocontracts/resources/blueprint.py
+++ b/hathor/nanocontracts/resources/blueprint.py
@@ -119,17 +119,21 @@ class BlueprintInfoResource(Resource):
                 continue
 
             method_args = []
-            argspec = inspect.getfullargspec(method)
-            for arg_name in argspec.args[1:]:
-                arg_type = argspec.annotations[arg_name]
+            signature = inspect.signature(method)
+            for parameter in signature.parameters.values():
+                if parameter.name == 'self':
+                    continue
+                arg_type = parameter.annotation
                 if arg_type is Context:
                     continue
                 method_args.append(MethodArgInfo(
-                    name=arg_name,
+                    name=parameter.name,
                     type=self.get_type_name(arg_type),
                 ))
 
-            return_type = argspec.annotations.get('return', None)
+            return_type = signature.return_annotation
+            if return_type is inspect._empty:
+                return_type = None
 
             method_info = MethodInfo(
                 args=method_args,

--- a/tests/resources/nanocontracts/my_blueprint.py
+++ b/tests/resources/nanocontracts/my_blueprint.py
@@ -32,7 +32,7 @@ class MyBlueprint(Blueprint):
     a_optional_int: Optional[int]
 
     @public
-    def initialize(self, ctx: Context) -> None:
+    def initialize(self, ctx: Context, arg1: int) -> None:
         pass
 
     @public

--- a/tests/resources/nanocontracts/test_blueprint.py
+++ b/tests/resources/nanocontracts/test_blueprint.py
@@ -74,7 +74,10 @@ class BaseBlueprintInfoTest(GenericNanoResourceTest):
         })
         self.assertEqual(data['public_methods'], {
             'initialize': {
-                'args': [],
+                'args': [{
+                    'name': 'arg1',
+                    'type': 'int',
+                }],
                 'return_type': 'null',
                 'docstring': None,
             },


### PR DESCRIPTION
### Motivation

Blueprint endpoint was always returning empty arguments for initialize method.

### Acceptance Criteria

- Update test so the issue can show up
- Use `inspect.signature` instead of `inspect.getfullargspec` because it can properly take into account wrapped functions

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 