### PR TITLE
feat(nano): Add a mempool verification to check allowed actions

### DIFF
--- a/hathor/verification/nano_header_verifier.py
+++ b/hathor/verification/nano_header_verifier.py
@@ -22,6 +22,7 @@ from hathor.nanocontracts.exception import (
     NanoContractDoesNotExist,
     NCError,
     NCFail,
+    NCForbiddenAction,
     NCInvalidAction,
     NCInvalidMethodCall,
     NCInvalidSeqnum,
@@ -32,6 +33,7 @@ from hathor.nanocontracts.exception import (
 from hathor.nanocontracts.method import Method
 from hathor.nanocontracts.runner.runner import MAX_SEQNUM_JUMP_SIZE
 from hathor.nanocontracts.types import (
+    NC_ALLOWED_ACTIONS_ATTR,
     NC_FALLBACK_METHOD,
     Address,
     BaseAuthorityAction,
@@ -174,12 +176,14 @@ class NanoHeaderVerifier:
 
         method_name = nano_header.nc_method
         method = getattr(blueprint_class, method_name, None)
+        allowed_actions: set[NCActionType]
         if method is None:
             if not allow_fallback:
                 raise NCMethodNotFound(f'method `{method_name}` not found and no fallback is allowed')
-            fallback_method = getattr(blueprint_class, NC_FALLBACK_METHOD, None)
-            if fallback_method is None:
+            method = getattr(blueprint_class, NC_FALLBACK_METHOD, None)
+            if method is None:
                 raise NCMethodNotFound(f'method `{method_name}` not found and no fallback is provided')
+            method_name = 'fallback'
         else:
             if not is_nc_public_method(method):
                 raise NCInvalidMethodCall(f'method `{method_name}` is not a public method')
@@ -188,6 +192,13 @@ class NanoHeaderVerifier:
                 parser.deserialize_args_bytes(nano_header.nc_args_bytes)
             except NCFail as e:
                 raise NCTxValidationError from e
+
+        allowed_actions = getattr(method, NC_ALLOWED_ACTIONS_ATTR, set())
+        assert isinstance(allowed_actions, set)
+        for action in nano_header.nc_actions:
+            if action.type not in allowed_actions:
+                exception = NCForbiddenAction(f'action {action.type} is forbidden on method `{method_name}`')
+                raise NCTxValidationError from exception
 
     def verify_seqnum(self, tx: BaseTransaction, params: VerificationParams) -> None:
         if not params.harden_nano_restrictions:


### PR DESCRIPTION
### Motivation

As nano tx with not allowed actions are certainly going to fail execution, there's no need to accept them to enter the mempool.

### Acceptance Criteria

1. Forbid nano tx with not allowed actions in the mempool.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 