### PR TITLE
feat(verification): Forbid transactions in the mempool that spend from voided outputs that are confirmed

### DIFF
--- a/hathor/transaction/exceptions.py
+++ b/hathor/transaction/exceptions.py
@@ -122,6 +122,10 @@ class TooManyBetweenConflicts(TxValidationError):
     """Input has too many between conflicts already."""
 
 
+class InputVoidedAndConfirmed(TxValidationError):
+    """Input is spending from a voided transaction that has been confirmed by a block."""
+
+
 class TooManyOutputs(TxValidationError):
     """More than 256 outputs"""
 

--- a/tests/nanocontracts/test_consensus.py
+++ b/tests/nanocontracts/test_consensus.py
@@ -988,6 +988,9 @@ class NCConsensusTestCase(SimulatorTestCase):
             tx3.nc_id = tx1
             tx3.nc_method = nop(1)
 
+            tx1 < tx2 < tx3
+            b32 < tx3
+
             b31 --> tx1
             b32 --> tx2
             b33 --> tx3


### PR DESCRIPTION
### Motivation

After nano is activated, nano transactions that fail execution will be voided and confirmed by blocks. This scenario was impossible before (except for soft voided transaction) but now they should be way more common. This prevents blocks from confirming transactions that will certainly be voided.

### Acceptance Criteria

1. Reject transactions in the mempool that spend from voided outputs that are confirmed.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 