### PR TITLE
feat(cli): add hidden CLI option to show nc-exec fail traces

### DIFF
--- a/hathor/builder/cli_builder.py
+++ b/hathor/builder/cli_builder.py
@@ -266,6 +266,7 @@ class CliBuilder:
             nc_log_storage=nc_log_storage,
             nc_calls_sorter=nc_calls_sorter,
             feature_service=self.feature_service,
+            nc_exec_fail_trace=self._args.nc_exec_fail_trace,
         )
 
         if self._args.x_enable_event_queue or self._args.enable_event_queue:

--- a/hathor/cli/run_node.py
+++ b/hathor/cli/run_node.py
@@ -174,6 +174,7 @@ class RunNode:
         possible_nc_exec_logs = [config.value for config in NCLogConfig]
         parser.add_argument('--nc-exec-logs', default=NCLogConfig.NONE, choices=possible_nc_exec_logs,
                             help=f'Enable saving Nano Contracts execution logs. One of {possible_nc_exec_logs}')
+        parser.add_argument('--nc-exec-fail-trace', action='store_true', help=SUPPRESS)
         return parser
 
     def prepare(self, *, register_resources: bool = True) -> None:

--- a/hathor/cli/run_node_args.py
+++ b/hathor/cli/run_node_args.py
@@ -92,3 +92,4 @@ class RunNodeArgs(BaseModel, extra=Extra.allow):
     localnet: bool
     nc_indexes: bool
     nc_exec_logs: NCLogConfig
+    nc_exec_fail_trace: bool

--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -53,12 +53,15 @@ class BlockConsensusAlgorithm:
         runner_factory: RunnerFactory,
         nc_log_storage: NCLogStorage,
         feature_service: FeatureService,
+        *,
+        nc_exec_fail_trace: bool = False,
     ) -> None:
         self._settings = settings
         self.context = context
         self._runner_factory = runner_factory
         self._nc_log_storage = nc_log_storage
         self.feature_service = feature_service
+        self.nc_exec_fail_trace = nc_exec_fail_trace
 
     @classproperty
     def log(cls) -> Any:
@@ -242,6 +245,8 @@ class BlockConsensusAlgorithm:
                 kwargs: dict[str, Any] = {}
                 if tx.name:
                     kwargs['__name'] = tx.name
+                if self.nc_exec_fail_trace:
+                    kwargs['exc_info'] = True
                 self.log.info(
                     'nc execution failed',
                     tx=tx.hash.hex(),
@@ -845,7 +850,7 @@ class BlockConsensusAlgorithm:
 
 
 class BlockConsensusAlgorithmFactory:
-    __slots__ = ('settings', 'nc_log_storage', '_runner_factory', 'feature_service')
+    __slots__ = ('settings', 'nc_log_storage', '_runner_factory', 'feature_service', 'nc_exec_fail_trace')
 
     def __init__(
         self,
@@ -853,11 +858,14 @@ class BlockConsensusAlgorithmFactory:
         runner_factory: RunnerFactory,
         nc_log_storage: NCLogStorage,
         feature_service: FeatureService,
+        *,
+        nc_exec_fail_trace: bool = False,
     ) -> None:
         self.settings = settings
         self._runner_factory = runner_factory
         self.nc_log_storage = nc_log_storage
         self.feature_service = feature_service
+        self.nc_exec_fail_trace = nc_exec_fail_trace
 
     def __call__(self, context: 'ConsensusAlgorithmContext') -> BlockConsensusAlgorithm:
         return BlockConsensusAlgorithm(

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -80,6 +80,7 @@ class ConsensusAlgorithm:
         nc_calls_sorter: NCSorterCallable,
         nc_log_storage: NCLogStorage,
         feature_service: FeatureService,
+        nc_exec_fail_trace: bool = False,
     ) -> None:
         self._settings = settings
         self.log = logger.new()
@@ -87,7 +88,7 @@ class ConsensusAlgorithm:
         self.nc_storage_factory = nc_storage_factory
         self.soft_voided_tx_ids = frozenset(soft_voided_tx_ids)
         self.block_algorithm_factory = BlockConsensusAlgorithmFactory(
-            settings, runner_factory, nc_log_storage, feature_service
+            settings, runner_factory, nc_log_storage, feature_service, nc_exec_fail_trace=nc_exec_fail_trace,
         )
         self.transaction_algorithm_factory = TransactionConsensusAlgorithmFactory()
         self.nc_calls_sorter = nc_calls_sorter


### PR DESCRIPTION
### Motivation

I've been doing this manually for a while, it's really helpful for debugging. With an option to enable it from the CLI it will be useful for users of Docker images, so no code change is needed to show the stack traces.

### Acceptance Criteria

- Add a hidden `--nc-exec-fail-trace` CLI option that translates to `exc_info=True` when logging a nano execution failure (the equivalent env var is `HATHOR_NC_EXEC_FAIL_TRACE=true`)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 