### PR TITLE
refactor: update tx parent generation

### DIFF
--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -551,6 +551,12 @@ class TransactionStorage(ABC):
         self.post_get_validation(tx)
         return tx
 
+    def get_transaction_strict(self, vertex_id: VertexId) -> Transaction:
+        """Return a Transaction."""
+        tx = self.get_transaction(vertex_id)
+        assert isinstance(tx, Transaction)
+        return tx
+
     def get_token_creation_transaction(self, hash_bytes: bytes) -> TokenCreationTransaction:
         """Acquire the lock and get the token creation transaction with hash `hash_bytes`.
 

--- a/tests/others/test_init_manager.py
+++ b/tests/others/test_init_manager.py
@@ -213,6 +213,7 @@ class ManagerInitializationTestCase(unittest.TestCase):
         assert set(tx.hash for tx in manager.tx_storage.get_all_transactions()) == self.all_hashes
 
         # make sure none of its tx tips are voided
-        all_tips = manager.generate_parent_txs(None).get_all_tips()
+        parent_txs = manager.generate_parent_txs(None)
+        all_tips = parent_txs.can_include | set(parent_txs.must_include)
         iter_tips_meta = map(manager.tx_storage.get_metadata, all_tips)
         self.assertFalse(any(tx_meta.voided_by for tx_meta in iter_tips_meta))

--- a/tests/tx/test_generate_tx_parents.py
+++ b/tests/tx/test_generate_tx_parents.py
@@ -1,0 +1,52 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from hathor.transaction import Block, Transaction
+from tests import unittest
+from tests.dag_builder.builder import TestDAGBuilder
+
+
+class GenerateTxParentsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer(network='unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_some_confirmed_txs(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy
+
+            dummy < tx1 < tx2 < tx3 < tx4 < tx5
+
+            dummy <-- tx2 <-- b11
+            tx3 <-- tx4 <-- tx5 <-- b11
+        ''')
+
+        b11, = artifacts.get_typed_vertices(('b11',), Block)
+        dummy, tx1, tx2, tx3, tx4, tx5 = artifacts.get_typed_vertices(
+            ('dummy', 'tx1', 'tx2', 'tx3', 'tx4', 'tx5'), Transaction
+        )
+
+        artifacts.propagate_with(self.manager)
+        assert tx1.get_metadata().first_block is None
+        assert tx2.get_metadata().first_block == b11.hash
+        assert tx3.get_metadata().first_block == b11.hash
+        assert tx4.get_metadata().first_block == b11.hash
+        assert tx5.get_metadata().first_block == b11.hash
+        assert dummy.get_metadata().first_block == b11.hash
+
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == (tx1.hash,)
+        assert parent_txs.can_include == {tx2.hash, tx5.hash}


### PR DESCRIPTION
### Motivation

What was the motivation for the changes in this PR?

### Acceptance Criteria

- Refactor `generate_parent_txs` so it takes unconfirmed txs into account.
- Refactor `ParentTxs`:
  - Remove `get_all_tips()` method, it was only used in a single test.
- Add new `TransactionStorage.get_transaction_strict()`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 