### PR TITLE
fix(nano): allow create token and withdraw on same tx

### DIFF
--- a/hathor/dag_builder/default_filler.py
+++ b/hathor/dag_builder/default_filler.py
@@ -238,6 +238,10 @@ class DefaultFiller:
         for token in tokens:
             node = self._get_or_create_node(token)
 
+            if 'token_id' in node.attrs:
+                # Skip token creation when `token_id` is provided.
+                continue
+
             balance = self.calculate_balance(node)
             assert set(balance.keys()).issubset({'HTR', token})
 

--- a/tests/nanocontracts/test_token_creation2.py
+++ b/tests/nanocontracts/test_token_creation2.py
@@ -1,0 +1,213 @@
+# Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathor import Blueprint, Context, ContractId, NCActionType, public
+from hathor.nanocontracts.utils import derive_child_token_id
+from hathor.transaction import Block, Transaction, TxOutput
+from hathor.transaction.headers.nano_header import NanoHeaderAction
+from hathor.transaction.nc_execution_state import NCExecutionState
+from tests.dag_builder.builder import TestDAGBuilder
+from tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+
+
+class MyBlueprint(Blueprint):
+    @public(allow_deposit=True, allow_withdrawal=True)
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public(allow_withdrawal=True)
+    def create_deposit_token(self, ctx: Context) -> None:
+        self.syscall.create_deposit_token(
+            token_name='deposit-based token',
+            token_symbol='DBT',
+            amount=100,
+        )
+
+    @public(allow_withdrawal=True)
+    def nop(self, ctx: Context) -> None:
+        pass
+
+
+class TokenCreationTestCase(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = self._register_blueprint_class(MyBlueprint)
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_create_dbt_and_withdraw_on_another_tx(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_deposit_token()
+
+            tx3.nc_id = tx1
+            tx3.nc_method = nop()
+
+            tx1 < b11 < tx2 < b12 < tx3 < b13
+            tx1 <-- b11
+            tx2 <-- b12
+            tx3 <-- b13
+        ''')
+
+        b11, b12, b13 = artifacts.get_typed_vertices(('b11', 'b12', 'b13'), Block)
+        tx1, tx2, tx3 = artifacts.get_typed_vertices(('tx1', 'tx2', 'tx3'), Transaction)
+
+        dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
+        tx3.tokens.append(dbt_id)
+
+        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        tx3.outputs.append(dbt_output)
+
+        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        tx3_nano_header = tx3.get_nano_header()
+        tx3_nano_header.nc_actions.append(dbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx2.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert tx3.get_metadata().first_block == b13.hash
+        assert tx3.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx3.get_metadata().voided_by is None
+
+    def test_create_dbt_and_withdraw_on_another_tx_before_block(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_deposit_token()
+
+            tx3.nc_id = tx1
+            tx3.nc_method = nop()
+
+            tx1 < b11 < tx2 < tx3 < b12 < b13
+            tx1 <-- b11
+            tx2 <-- b12
+            tx3 <-- b13
+        ''')
+
+        b11, b12, b13 = artifacts.get_typed_vertices(('b11', 'b12', 'b13'), Block)
+        tx1, tx2, tx3 = artifacts.get_typed_vertices(('tx1', 'tx2', 'tx3'), Transaction)
+
+        dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
+        tx3.tokens.append(dbt_id)
+
+        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        tx3.outputs.append(dbt_output)
+
+        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        tx3_nano_header = tx3.get_nano_header()
+        tx3_nano_header.nc_actions.append(dbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx2.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert tx3.get_metadata().first_block == b13.hash
+        assert tx3.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx3.get_metadata().voided_by is None
+
+    def test_create_dbt_and_withdraw_on_same_tx(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_deposit_token()
+
+            tx1 < b11 < tx2 < b12
+            tx1 <-- b11
+            tx2 <-- b12
+        ''')
+
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx1, tx2 = artifacts.get_typed_vertices(('tx1', 'tx2'), Transaction)
+
+        dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
+        tx2.tokens.append(dbt_id)
+
+        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        tx2.outputs.append(dbt_output)
+
+        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(dbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution is NCExecutionState.SUCCESS
+        assert tx2.get_metadata().voided_by is None
+
+    def test_withdraw_nonexistent_token(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..11]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+
+            tx1 <-- b11
+        ''')
+
+        b11, = artifacts.get_typed_vertices(('b11',), Block)
+        tx1, = artifacts.get_typed_vertices(('tx1',), Transaction)
+
+        fake_token_id = self.gen_random_token_uid()
+        tx1.tokens.append(fake_token_id)
+
+        fake_output = TxOutput(value=100, script=b'', token_data=1)
+        tx1.outputs.append(fake_output)
+
+        fake_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        tx1_nano_header = tx1.get_nano_header()
+        tx1_nano_header.nc_actions.append(fake_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution is NCExecutionState.FAILURE
+        assert tx1.get_metadata().voided_by is not None


### PR DESCRIPTION
### Motivation

There's a bug in the token index, where an assertion fails when we try to withdraw a nonexistent token. This PR solves this problem by adding support to unknown tokens to the `TokenIndex`. So all transactions keep being added to the index when they are added to the mempool. If a token does not exist, an unknown token is kept in the index to keep track of the supply and authorities. When the token is created, its information is added to the index too. If the token is never created, this unknown token entry will remain orphan in the index.

### Root cause analysis

1. What's happening?

When adding a nano tx with a withdrawal action and an output of an unknown token is failing, it fails an assert in the token index, therefore causing the full node to crash.

2. Why?

Because the nano tx passes all verifications, leading to an update in the token index as the nano tx is added to the mempool. However, this index update assumes that the token already exists.

This assumption held true before we allowed contracts to dynamically create tokens. But now, it might happen that tokens do not exist when transactions reach mempool. It is actually impossible to know beforehand whether a token will exist or not after the execution.

3. Why?

The nano tx passes all verifications because we check that `sum(txin) + sum(withdrawals) == sum(txout) + sum(deposits)` which is true because the withdrawal of the unknown token balances out the output.

### Acceptance Criteria

- Add a test demonstrating the bug.
- Refactor: Change `_InfoDict` type from a typed dict to a dataclass.
- Add support to unknown tokens to `RocksDBTokenIndex`.
- Skip unknown tokens on `get_token_info()` and `iter_all_tokens()`.
- Add support for `TKN.token_id` to the DAG Builder to skip token creation.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 