### PR TITLE
tests: add new tx parents tests and fix flakies

### DIFF
--- a/tests/tx/test_blockchain.py
+++ b/tests/tx/test_blockchain.py
@@ -120,9 +120,6 @@ class BlockchainTestCase(unittest.TestCase):
             score += weight_to_work(block.weight)
             self.assertAlmostEqual(score, meta.score)
 
-        # Fork block must have the same parents as blocks[0] as well as the same score
-        self.assertEqual(set(blocks[0].parents), set(fork_block1.parents))
-
         # Propagate fork block.
         # This block belongs to case (ii).
         self.assertTrue(manager.propagate_tx(fork_block1))
@@ -217,9 +214,6 @@ class BlockchainTestCase(unittest.TestCase):
         # Mine 4 blocks, starting a fork.
         # All these blocks belong to case (ii).
         sidechain = add_new_blocks(manager, 4, advance_clock=15, parent_block_hash=blocks[0].parents[0])
-
-        # Fork block must have the same parents as blocks[0] as well as the same score
-        self.assertEqual(set(blocks[0].parents), set(sidechain[0].parents))
 
         for block in blocks:
             meta = block.get_metadata(force_reload=True)

--- a/tests/tx/test_generate_tx_parents.py
+++ b/tests/tx/test_generate_tx_parents.py
@@ -18,10 +18,107 @@ from tests.dag_builder.builder import TestDAGBuilder
 
 
 class GenerateTxParentsTestCase(unittest.TestCase):
+    """These tests cover all return cases of `generate_parent_txs`."""
+
     def setUp(self) -> None:
         super().setUp()
         self.manager = self.create_peer(network='unittests')
         self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_two_unconfirmed_genesis(self) -> None:
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == ()
+        assert parent_txs.can_include == [self._settings.GENESIS_TX1_HASH, self._settings.GENESIS_TX2_HASH]
+
+    def test_two_unconfirmed_txs(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..10]
+            b10 < dummy < tx1
+        ''')
+
+        dummy, tx1 = artifacts.get_typed_vertices(('dummy', 'tx1'), Transaction)
+
+        artifacts.propagate_with(self.manager)
+        assert dummy.get_metadata().first_block is None
+        assert tx1.get_metadata().first_block is None
+
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == ()
+        assert parent_txs.can_include == [dummy.hash, tx1.hash]
+
+    def test_zero_unconfirmed_two_confirmed(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy < tx1
+            dummy <-- b11
+            tx1 <-- b11
+        ''')
+
+        b11, = artifacts.get_typed_vertices(('b11',), Block)
+        dummy, tx1 = artifacts.get_typed_vertices(('dummy', 'tx1'), Transaction)
+
+        artifacts.propagate_with(self.manager)
+        assert dummy.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().first_block == b11.hash
+
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == ()
+        assert parent_txs.can_include == [dummy.hash, tx1.hash]
+
+    def test_zero_unconfirmed_one_confirmed(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy
+            dummy <-- tx1 <-- b11
+        ''')
+
+        b11, = artifacts.get_typed_vertices(('b11',), Block)
+        dummy, tx1, = artifacts.get_typed_vertices(('dummy', 'tx1'), Transaction)
+
+        artifacts.propagate_with(self.manager)
+        assert dummy.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().first_block == b11.hash
+
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == (tx1.hash,)
+        assert set(parent_txs.can_include) == {dummy.hash, self._settings.GENESIS_TX1_HASH}
+
+    def test_one_unconfirmed_one_confirmed(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy < tx1
+            dummy <-- b11
+        ''')
+
+        b11, = artifacts.get_typed_vertices(('b11',), Block)
+        dummy, tx1 = artifacts.get_typed_vertices(('dummy', 'tx1'), Transaction)
+
+        artifacts.propagate_with(self.manager)
+        assert dummy.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().first_block is None
+
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == (tx1.hash,)
+        assert parent_txs.can_include == [dummy.hash]
+
+    def test_one_unconfirmed_zero_confirmed(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy
+            dummy <-- b11
+            dummy <-- tx1
+        ''')
+
+        b11, = artifacts.get_typed_vertices(('b11',), Block)
+        dummy, tx1, = artifacts.get_typed_vertices(('dummy', 'tx1'), Transaction)
+
+        artifacts.propagate_with(self.manager)
+        assert dummy.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().first_block is None
+
+        parent_txs = self.manager.generate_parent_txs(timestamp=None)
+        assert parent_txs.must_include == (tx1.hash,)
+        assert set(parent_txs.can_include) == {dummy.hash, self._settings.GENESIS_TX1_HASH}
 
     def test_some_confirmed_txs(self) -> None:
         artifacts = self.dag_builder.build_from_str('''


### PR DESCRIPTION
### Motivation

PR https://github.com/HathorNetwork/hathor-core/pull/1448 was recently merged and caused a lot of flakiness in two tests in `test_blockchain.py`, because the asserted parents and the new algorithm has a slightly different behavior.

I removed those flaky asserts, and in order to make sure everything is correct, I added more tests covering all possible cases of `generate_parent_txs`.

### Acceptance Criteria

- Remove `parents` asserts from `test_blockchain.py` to fix flakiness.
- Add new `generate_parent_txs` testes covering all possible return cases.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 