### PR TITLE
tests(nano): add missing tests for new accessors

### DIFF
--- a/hathor/__init__.py
+++ b/hathor/__init__.py
@@ -42,4 +42,36 @@ from hathor.nanocontracts.types import (
 from hathor.nanocontracts.utils import sha3, verify_ecdsa
 from hathor.version import __version__
 
-__all__ = ['__version__']
+__all__ = [
+    'HATHOR_TOKEN_UID',
+    'Blueprint',
+    'Context',
+    'NCFail',
+    'export',
+    'fallback',
+    'public',
+    'view',
+    'Address',
+    'Amount',
+    'BlueprintId',
+    'CallerId',
+    'ContractId',
+    'NCAcquireAuthorityAction',
+    'NCAction',
+    'NCActionType',
+    'NCArgs',
+    'NCDepositAction',
+    'NCFee',
+    'NCGrantAuthorityAction',
+    'NCParsedArgs',
+    'NCRawArgs',
+    'NCWithdrawalAction',
+    'SignedData',
+    'Timestamp',
+    'TokenUid',
+    'TxOutputScript',
+    'VertexId',
+    'sha3',
+    'verify_ecdsa',
+    '__version__',
+]

--- a/hathor/nanocontracts/initialize_method_accessor.py
+++ b/hathor/nanocontracts/initialize_method_accessor.py
@@ -67,7 +67,7 @@ class InitializeMethodAccessor(FauxImmutable):
         if self.__is_dirty:
             raise NCFail(
                 'accessor for initialize method was already used, '
-                'you must use `create` on the blueprint to call it again'
+                'you must use `setup_new_contract` to call it again'
             )
 
         __set_faux_immutable__(self, '__is_dirty', True)

--- a/tests/nanocontracts/test_blueprints/contract_accessor_blueprint.py
+++ b/tests/nanocontracts/test_blueprints/contract_accessor_blueprint.py
@@ -37,9 +37,6 @@ class MyBlueprint(Blueprint):
     def initialize(self, ctx: Context) -> None:
         self.message = 'initialize called'
 
-    def internal_method(self) -> None:
-        pass
-
     @view
     def simple_view_method(self, name: str) -> str:
         return f'hello "{name}" from simple view method'
@@ -57,16 +54,27 @@ class MyBlueprint(Blueprint):
     @view
     def test_simple_view_method(self, other_id: ContractId, name: str) -> str:
         contract = self.syscall.get_contract(other_id, blueprint_id=None)
-        return contract \
-            .view() \
-            .simple_view_method(name)
+
+        ret1 = contract.view().simple_view_method(name)
+        ret2 = contract.view().simple_view_method.call(name)
+        ret3 = contract.get_view_method('simple_view_method').call(name)
+        ret4 = contract.get_view_method('simple_view_method')(name)
+
+        assert len({ret1, ret2, ret3, ret4}) == 1
+        return ret1
 
     @public
     def test_simple_public_method(self, ctx: Context, other_id: ContractId, name: str) -> str:
         contract = self.syscall.get_contract(other_id, blueprint_id=None)
-        return contract \
-            .public(NCDepositAction(amount=123, token_uid=HATHOR_TOKEN_UID)) \
-            .simple_public_method(name)
+        action = NCDepositAction(amount=123, token_uid=HATHOR_TOKEN_UID)
+
+        ret1 = contract.public(action).simple_public_method(name)
+        ret2 = contract.public(action).simple_public_method.call(name)
+        ret3 = contract.get_public_method('simple_public_method', action).call(name)
+        ret4 = contract.get_public_method('simple_public_method', action)(name)
+
+        assert len({ret1, ret2, ret3, ret4}) == 1
+        return ret1
 
     @public
     def test_simple_public_method_no_actions(self, ctx: Context, other_id: ContractId, name: str) -> str:

--- a/tests/nanocontracts/test_initialize_method_accessor.py
+++ b/tests/nanocontracts/test_initialize_method_accessor.py
@@ -1,0 +1,93 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import re
+
+import pytest
+
+from hathor import HATHOR_TOKEN_UID, Blueprint, BlueprintId, Context, NCDepositAction, NCFail, public
+from tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+
+
+class MyBlueprint1(Blueprint):
+    @public(allow_deposit=True)
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public
+    def test_initialize_method(self, ctx: Context, blueprint_id: BlueprintId, name: str) -> str:
+        action = NCDepositAction(token_uid=HATHOR_TOKEN_UID, amount=123)
+        _, ret = self.syscall.setup_new_contract(blueprint_id, action, salt=b'1').initialize(name)
+        assert isinstance(ret, str)
+        return ret
+
+    @public
+    def test_multiple_initialize_calls_on_setup(self, ctx: Context, blueprint_id: BlueprintId) -> None:
+        setup = self.syscall.setup_new_contract(blueprint_id, salt=b'1')
+        setup.initialize('')
+        setup.initialize('')
+
+    @public
+    def test_multiple_initialize_calls_on_method(self, ctx: Context, blueprint_id: BlueprintId) -> None:
+        method = self.syscall.setup_new_contract(blueprint_id, salt=b'1').initialize
+        method('')
+        method('')
+
+
+class MyBlueprint2(Blueprint):
+    @public(allow_deposit=True)
+    def initialize(self, ctx: Context, name: str) -> str:
+        return f'hello {name}'
+
+
+class TestInitializeMethodAccessor(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.blueprint_id1 = self._register_blueprint_class(MyBlueprint1)
+        self.blueprint_id2 = self._register_blueprint_class(MyBlueprint2)
+        self.contract_id = self.gen_random_contract_id()
+
+        action = NCDepositAction(token_uid=HATHOR_TOKEN_UID, amount=123)
+        self.runner.create_contract(self.contract_id, self.blueprint_id1, self.create_context([action]))
+
+    def test_initialize_method(self) -> None:
+        ret = self.runner.call_public_method(
+            self.contract_id,
+            'test_initialize_method',
+            self.create_context(),
+            self.blueprint_id2,
+            'alice'
+        )
+        assert ret == 'hello alice'
+
+    def test_multiple_initialize_calls_on_setup(self) -> None:
+        msg = 'accessor for initialize method was already used, you must use `setup_new_contract` to call it again'
+        with pytest.raises(NCFail, match=re.escape(msg)):
+            self.runner.call_public_method(
+                self.contract_id,
+                'test_multiple_initialize_calls_on_setup',
+                self.create_context(),
+                self.blueprint_id2,
+            )
+
+    def test_multiple_initialize_calls_on_method(self) -> None:
+        msg = 'accessor for initialize method was already used, you must use `setup_new_contract` to call it again'
+        with pytest.raises(NCFail, match=re.escape(msg)):
+            self.runner.call_public_method(
+                self.contract_id,
+                'test_multiple_initialize_calls_on_method',
+                self.create_context(),
+                self.blueprint_id2,
+            )

--- a/tests/nanocontracts/test_proxy_accessor.py
+++ b/tests/nanocontracts/test_proxy_accessor.py
@@ -1,0 +1,176 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import re
+
+import pytest
+
+from hathor import (
+    HATHOR_TOKEN_UID,
+    Blueprint,
+    BlueprintId,
+    Context,
+    NCArgs,
+    NCDepositAction,
+    NCFail,
+    NCParsedArgs,
+    fallback,
+    public,
+)
+from tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+
+
+class MyBlueprint1(Blueprint):
+    other_blueprint_id: BlueprintId
+
+    @public(allow_deposit=True)
+    def initialize(self, ctx: Context, blueprint_id: BlueprintId) -> None:
+        self.other_blueprint_id = blueprint_id
+
+    @public
+    def test_get_blueprint_id(self, ctx: Context) -> BlueprintId:
+        proxy = self.syscall.get_proxy(self.other_blueprint_id)
+        return proxy.get_blueprint_id()
+
+    @public
+    def test_public_method(self, ctx: Context, name: str) -> str:
+        proxy = self.syscall.get_proxy(self.other_blueprint_id)
+        action = NCDepositAction(amount=123, token_uid=HATHOR_TOKEN_UID)
+
+        ret1 = proxy.public(action).hello(name)
+        ret2 = proxy.public(action).hello.call(name)
+        ret3 = proxy.get_public_method('hello', action).call(name)
+        ret4 = proxy.get_public_method('hello', action)(name)
+
+        nc_args = NCParsedArgs(args=(name,), kwargs={})
+        ret5 = proxy.public(action).hello.call_with_nc_args(nc_args)
+        ret6 = proxy.get_public_method('hello', action).call_with_nc_args(nc_args)
+
+        assert len({ret1, ret2, ret3, ret4, ret5, ret6}) == 1
+        return ret1
+
+    @public
+    def test_multiple_public_calls_on_prepared_call(self, ctx: Context) -> tuple[str, str]:
+        proxy = self.syscall.get_proxy(self.other_blueprint_id)
+        action = NCDepositAction(amount=123, token_uid=HATHOR_TOKEN_UID)
+        prepared_call = proxy.public(action)
+
+        ret1 = prepared_call.hello('')
+        ret2 = prepared_call.hello('')
+        return ret1, ret2
+
+    @public
+    def test_multiple_public_calls_on_method(self, ctx: Context) -> tuple[str, str]:
+        proxy = self.syscall.get_proxy(self.other_blueprint_id)
+        action = NCDepositAction(amount=123, token_uid=HATHOR_TOKEN_UID)
+        prepared_call = proxy.public(action)
+        method = prepared_call.hello
+
+        ret1 = method('')
+        ret2 = method('')
+        return ret1, ret2
+
+    @public
+    def test_fallback_allowed(self, ctx: Context) -> str:
+        proxy = self.syscall.get_proxy(self.other_blueprint_id)
+        return proxy.public().unknown()
+
+    @public
+    def test_fallback_forbidden(self, ctx: Context) -> str:
+        proxy = self.syscall.get_proxy(self.other_blueprint_id)
+        return proxy.public(forbid_fallback=True).unknown()
+
+
+class MyBlueprint2(Blueprint):
+    @public
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public(allow_deposit=True)
+    def hello(self, ctx: Context, name: str) -> str:
+        return f'hello {name}'
+
+    @fallback
+    def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> str:
+        return f'fallback called for method `{method_name}`'
+
+
+class TestProxyAccessor(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.blueprint_id1 = self._register_blueprint_class(MyBlueprint1)
+        self.blueprint_id2 = self._register_blueprint_class(MyBlueprint2)
+        self.contract_id = self.gen_random_contract_id()
+
+        ctx = self.create_context([NCDepositAction(amount=123, token_uid=HATHOR_TOKEN_UID)])
+        self.runner.create_contract(self.contract_id, self.blueprint_id1, ctx, self.blueprint_id2)
+
+    def test_get_blueprint_id(self) -> None:
+        ret = self.runner.call_public_method(
+            self.contract_id,
+            'test_get_blueprint_id',
+            self.create_context(),
+        )
+        assert ret == self.blueprint_id2
+
+    def test_public_method(self) -> None:
+        ret = self.runner.call_public_method(
+            self.contract_id,
+            'test_public_method',
+            self.create_context(),
+            'alice',
+        )
+        assert ret == 'hello alice'
+
+    def test_multiple_public_calls_on_prepared_call(self) -> None:
+        msg = (
+            f'prepared proxy public method for blueprint `{self.blueprint_id2.hex()}` was already used, '
+            f'you must use `public` on the proxy to call it again'
+        )
+        with pytest.raises(NCFail, match=re.escape(msg)):
+            self.runner.call_public_method(
+                self.contract_id,
+                'test_multiple_public_calls_on_prepared_call',
+                self.create_context(),
+            )
+
+    def test_multiple_public_calls_on_method(self) -> None:
+        msg = (
+            'accessor for proxy public method `hello` was already used, '
+            'you must use `public`/`public_method` on the proxy to call it again'
+        )
+        with pytest.raises(NCFail, match=re.escape(msg)):
+            self.runner.call_public_method(
+                self.contract_id,
+                'test_multiple_public_calls_on_method',
+                self.create_context(),
+            )
+
+    def test_fallback_allowed(self) -> None:
+        ret = self.runner.call_public_method(
+            self.contract_id,
+            'test_fallback_allowed',
+            self.create_context(),
+        )
+        assert ret == 'fallback called for method `unknown`'
+
+    def test_fallback_forbidden(self) -> None:
+        msg = 'method `unknown` not found and fallback is forbidden'
+        with pytest.raises(NCFail, match=re.escape(msg)):
+            self.runner.call_public_method(
+                self.contract_id,
+                'test_fallback_forbidden',
+                self.create_context(),
+            )


### PR DESCRIPTION
### Motivation

After new accessors introduced in PR #1451, some tests were missing. This PR adds them without any behavior changes.

### Acceptance Criteria

- Add missing tests for `ContractAccessor`, `ProxyAccessor`, and `InitializeMethodAccessor`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 