### PR TITLE
refactor: improve tests reliability

### DIFF
--- a/hathor/dag_builder/artifacts.py
+++ b/hathor/dag_builder/artifacts.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Iterator, NamedTuple, Sequence, TypeVar
 
 from hathor.dag_builder.types import DAGNode
 from hathor.manager import HathorManager
-from hathor.verification.verification_params import VerificationParams
 
 if TYPE_CHECKING:
     from hathor.transaction import BaseTransaction
@@ -60,7 +59,6 @@ class DAGArtifacts:
         *,
         up_to: str | None = None,
         up_to_before: str | None = None,
-        new_relayed_vertex: bool = False
     ) -> None:
         """
         Propagate vertices using the provided manager up to the provided node name, included.  Last propagation is
@@ -82,17 +80,7 @@ class DAGArtifacts:
 
             if found_begin:
                 try:
-                    if new_relayed_vertex:
-                        assert manager.vertex_handler.on_new_relayed_vertex(vertex)
-                    else:
-                        best_block = manager.tx_storage.get_best_block()
-                        best_block_meta = best_block.get_metadata()
-                        params = VerificationParams(
-                            enable_checkdatasig_count=True,
-                            enable_nano=True,
-                            nc_block_root_id=best_block_meta.nc_block_root_id,
-                        )
-                        assert manager.vertex_handler._old_on_new_vertex(vertex, params)
+                    assert manager.vertex_handler.on_new_relayed_vertex(vertex)
                 except Exception as e:
                     raise Exception(f'failed on_new_tx({node.name})') from e
                 self._last_propagated = node.name

--- a/hathor/nanocontracts/__init__.py
+++ b/hathor/nanocontracts/__init__.py
@@ -18,7 +18,7 @@ from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCFail
 from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
 from hathor.nanocontracts.runner import Runner
-from hathor.nanocontracts.storage import NCMemoryStorageFactory, NCRocksDBStorageFactory, NCStorageFactory
+from hathor.nanocontracts.storage import NCRocksDBStorageFactory, NCStorageFactory
 from hathor.nanocontracts.types import TokenUid, VertexId, export, fallback, public, view
 
 # Identifier used in metadata's voided_by when a Nano Contract method fails.
@@ -32,7 +32,6 @@ __all__ = [
     'Runner',
     'OnChainBlueprint',
     'NCFail',
-    'NCMemoryStorageFactory',
     'NCRocksDBStorageFactory',
     'NCStorageFactory',
     'public',

--- a/hathor/nanocontracts/storage/__init__.py
+++ b/hathor/nanocontracts/storage/__init__.py
@@ -15,14 +15,13 @@
 from hathor.nanocontracts.storage.block_storage import NCBlockStorage
 from hathor.nanocontracts.storage.changes_tracker import NCChangesTracker
 from hathor.nanocontracts.storage.contract_storage import NCContractStorage
-from hathor.nanocontracts.storage.factory import NCMemoryStorageFactory, NCRocksDBStorageFactory, NCStorageFactory
+from hathor.nanocontracts.storage.factory import NCRocksDBStorageFactory, NCStorageFactory
 from hathor.nanocontracts.storage.types import DeletedKey
 
 __all__ = [
     'NCBlockStorage',
     'NCContractStorage',
     'NCChangesTracker',
-    'NCMemoryStorageFactory',
     'NCRocksDBStorageFactory',
     'NCStorageFactory',
     'DeletedKey',

--- a/hathor/nanocontracts/storage/backends.py
+++ b/hathor/nanocontracts/storage/backends.py
@@ -43,23 +43,6 @@ class NodeTrieStore(ABC):
         raise NotImplementedError
 
 
-class MemoryNodeTrieStore(NodeTrieStore):
-    def __init__(self) -> None:
-        self._db: dict[bytes, Node] = {}
-
-    def __getitem__(self, key: bytes) -> Node:
-        return self._db[key]
-
-    def __setitem__(self, key: bytes, item: Node) -> None:
-        self._db[key] = item
-
-    def __len__(self) -> int:
-        return len(self._db)
-
-    def __contains__(self, key: bytes) -> bool:
-        return key in self._db
-
-
 class RocksDBNodeTrieStore(NodeTrieStore):
     _CF_NAME = b'nc-state'
     _KEY_LENGTH = b'length'

--- a/hathor/nanocontracts/storage/factory.py
+++ b/hathor/nanocontracts/storage/factory.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Optional
 
-from hathor.nanocontracts.storage.backends import MemoryNodeTrieStore, NodeTrieStore, RocksDBNodeTrieStore
+from hathor.nanocontracts.storage.backends import NodeTrieStore, RocksDBNodeTrieStore
 from hathor.nanocontracts.storage.block_storage import NCBlockStorage
 
 if TYPE_CHECKING:
@@ -60,18 +60,6 @@ class NCStorageFactory(ABC):
         """Create an empty block storage."""
         trie = self._get_trie(None)
         return NCBlockStorage(trie)
-
-
-class NCMemoryStorageFactory(NCStorageFactory):
-    """Factory to create a memory storage for a contract.
-
-    As it is a memory storage, the factory keeps all contract stored data on
-    its attribute `self.data`.
-    """
-
-    def __init__(self) -> None:
-        # This attribute stores data from all contracts.
-        self._store = MemoryNodeTrieStore()
 
 
 class NCRocksDBStorageFactory(NCStorageFactory):

--- a/tests/nanocontracts/blueprints/unittest.py
+++ b/tests/nanocontracts/blueprints/unittest.py
@@ -8,9 +8,6 @@ from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.blueprint_env import BlueprintEnvironment
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig
 from hathor.nanocontracts.on_chain_blueprint import Code, OnChainBlueprint
-from hathor.nanocontracts.storage import NCBlockStorage, NCMemoryStorageFactory
-from hathor.nanocontracts.storage.backends import MemoryNodeTrieStore
-from hathor.nanocontracts.storage.patricia_trie import PatriciaTrie
 from hathor.nanocontracts.types import Address, BlueprintId, ContractId, NCAction, TokenUid, VertexId
 from hathor.nanocontracts.vertex_data import BlockData, VertexData
 from hathor.transaction import Transaction, Vertex
@@ -126,13 +123,7 @@ class BlueprintTestCase(unittest.TestCase):
 
     def build_runner(self) -> TestRunner:
         """Create a Runner instance."""
-        nc_storage_factory = NCMemoryStorageFactory()
-        store = MemoryNodeTrieStore()
-        block_trie = PatriciaTrie(store)
-        block_storage = NCBlockStorage(block_trie)
-        return TestRunner(
-            self.manager.tx_storage, nc_storage_factory, block_storage, settings=self._settings, reactor=self.reactor
-        )
+        return TestRunner(tx_storage=self.manager.tx_storage, settings=self._settings, reactor=self.reactor)
 
     def gen_random_token_uid(self) -> TokenUid:
         """Generate a random token UID (32 bytes)."""

--- a/tests/nanocontracts/test_storage.py
+++ b/tests/nanocontracts/test_storage.py
@@ -1,5 +1,6 @@
 from typing import TypeVar
 
+from hathor.nanocontracts import NCRocksDBStorageFactory
 from hathor.nanocontracts.nc_types import NCType, NullNCType, make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage import NCChangesTracker
 from hathor.nanocontracts.types import Amount, ContractId, Timestamp, VertexId
@@ -13,10 +14,11 @@ INT_NC_TYPE = make_nc_type(int)
 BOOL_NC_TYPE = make_nc_type(bool)
 
 
-class NCMemoryStorageTestCase(unittest.TestCase):
+class NCRocksDBStorageTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        from hathor.nanocontracts.storage import NCMemoryStorageFactory
-        factory = NCMemoryStorageFactory()
+        super().setUp()
+        rocksdb_storage = self.create_rocksdb_storage()
+        factory = NCRocksDBStorageFactory(rocksdb_storage)
         block_storage = factory.get_empty_block_storage()
         self.storage = block_storage.get_empty_contract_storage(ContractId(VertexId(b'')))
         super().setUp()


### PR DESCRIPTION
### Motivation

We had some tests running code that differs from what runs in production, so this PR addresses this by removing said code to make sure tests and production run equally.

Notably all `BlueprintTestCase` tests, which are a great deal of nano-related tests, were using the memory trie instead of the RocksDB trie.

### Acceptance Criteria

- Change way vertices are propagated with the DAGBuilder to use always use the `vertex_handler.on_new_relayed_vertex`, instead of a manual call to an internal method, which differed from what is called in production. The `new_relayed_vertex` arg, which was unused, is removed.
- Remove `MemoryNodeTrieStore` and `NCMemoryStorageFactory` which are not used in production, and update tests accordingly.
- Refactor the `TestRunner` so it's responsible for building its own dependencies.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 