### PR TITLE
refactor(nano): simplify index records

### DIFF
--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -326,7 +326,7 @@ class BlockConsensusAlgorithm:
             raise NCFail from e
 
     def nc_update_metadata(self, tx: Transaction, runner: 'Runner') -> None:
-        from hathor.nanocontracts.runner.types import CallType
+        from hathor.nanocontracts.runner.call_info import CallType
 
         meta = tx.get_metadata()
         assert meta.nc_execution == NCExecutionState.SUCCESS

--- a/hathor/indexes/rocksdb_tokens_index.py
+++ b/hathor/indexes/rocksdb_tokens_index.py
@@ -28,7 +28,7 @@ from hathor.indexes.rocksdb_utils import (
     to_internal_token_uid,
 )
 from hathor.indexes.tokens_index import TokenIndexInfo, TokensIndex, TokenUtxoInfo
-from hathor.nanocontracts.runner.types import UpdateAuthoritiesRecord, UpdateAuthoritiesRecordType
+from hathor.nanocontracts.runner.index_records import IndexRecordType, UpdateAuthoritiesRecord
 from hathor.nanocontracts.types import (
     NCAcquireAuthorityAction,
     NCDepositAction,
@@ -270,7 +270,7 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         name: str,
         symbol: str,
         version: TokenVersion,
-        total: int = 0,
+        total: int,
     ) -> None:
         self.create_token_info(
             token_uid=token_uid,
@@ -515,13 +515,13 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         dict_info = self._get_value_info(record.token_uid)
 
         increment: int
-        match record.sub_type:
-            case UpdateAuthoritiesRecordType.GRANT:
+        match record.type:
+            case IndexRecordType.GRANT_AUTHORITIES:
                 increment = 1
-            case UpdateAuthoritiesRecordType.REVOKE:
+            case IndexRecordType.REVOKE_AUTHORITIES:
                 increment = -1
             case _:
-                assert_never(record.sub_type)
+                assert_never(record.type)
 
         if undo:
             increment *= -1

--- a/hathor/indexes/tokens_index.py
+++ b/hathor/indexes/tokens_index.py
@@ -23,7 +23,7 @@ from hathor.transaction import BaseTransaction
 from hathor.transaction.token_info import TokenVersion
 
 if TYPE_CHECKING:
-    from hathor.nanocontracts.runner.types import UpdateAuthoritiesRecord
+    from hathor.nanocontracts.runner.index_records import UpdateAuthoritiesRecord
 
 SCOPE = Scope(
     include_blocks=False,
@@ -157,7 +157,7 @@ class TokensIndex(BaseIndex):
         name: str,
         symbol: str,
         version: TokenVersion,
-        total: int = 0,
+        total: int,
     ) -> None:
         """Create a token info for a new token created in a contract."""
         raise NotImplementedError

--- a/hathor/nanocontracts/runner/__init__.py
+++ b/hathor/nanocontracts/runner/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from hathor.nanocontracts.runner.call_info import CallInfo, CallRecord, CallType
 from hathor.nanocontracts.runner.runner import Runner
-from hathor.nanocontracts.runner.types import CallInfo, CallRecord, CallType
 
 __all__ = [
     'CallType',

--- a/hathor/nanocontracts/runner/index_records.py
+++ b/hathor/nanocontracts/runner/index_records.py
@@ -1,0 +1,168 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dataclasses import dataclass, field
+from enum import StrEnum, auto, unique
+from typing import Any, Self, TypeAlias
+
+from typing_extensions import Literal, assert_never
+
+from hathor.nanocontracts.types import BlueprintId, ContractId, TokenUid, VertexId
+from hathor.transaction.token_info import TokenVersion
+
+
+@unique
+class IndexRecordType(StrEnum):
+    CREATE_CONTRACT = auto()
+    CREATE_TOKEN = auto()
+    UPDATE_TOKEN_BALANCE = auto()
+    GRANT_AUTHORITIES = auto()
+    REVOKE_AUTHORITIES = auto()
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class CreateContractRecord:
+    """Record for contract creation."""
+    type: Literal[IndexRecordType.CREATE_CONTRACT] = field(default=IndexRecordType.CREATE_CONTRACT, init=False)
+    blueprint_id: BlueprintId
+    contract_id: ContractId
+
+    def __post_init__(self) -> None:
+        assert self.type == IndexRecordType.CREATE_CONTRACT
+
+    def to_json(self) -> dict[str, Any]:
+        return dict(
+            type=IndexRecordType.CREATE_CONTRACT,
+            blueprint_id=self.blueprint_id.hex(),
+            contract_id=self.contract_id.hex(),
+        )
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, Any]) -> Self:
+        return cls(
+            contract_id=ContractId(VertexId(bytes.fromhex(json_dict['contract_id']))),
+            blueprint_id=BlueprintId(VertexId(bytes.fromhex(json_dict['blueprint_id']))),
+        )
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class CreateTokenRecord:
+    """Record for token creation."""
+    type: Literal[IndexRecordType.CREATE_TOKEN] = field(default=IndexRecordType.CREATE_TOKEN, init=False)
+    token_uid: TokenUid
+    amount: int
+    token_symbol: str
+    token_name: str
+    token_version: Literal[TokenVersion.DEPOSIT] | Literal[TokenVersion.FEE]
+
+    def __post_init__(self) -> None:
+        assert self.type == IndexRecordType.CREATE_TOKEN
+        assert self.token_version in (TokenVersion.DEPOSIT, TokenVersion.FEE)
+        assert self.amount > 0
+
+    def to_json(self) -> dict[str, Any]:
+        return dict(
+            type=self.type,
+            token_uid=self.token_uid.hex(),
+            amount=self.amount,
+            token_name=self.token_name,
+            token_symbol=self.token_symbol,
+            token_version=self.token_version,
+        )
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, Any]) -> Self:
+        return cls(
+            token_uid=TokenUid(VertexId(bytes.fromhex(json_dict['token_uid']))),
+            amount=json_dict['amount'],
+            token_version=json_dict['token_version'],
+            token_name=json_dict['token_name'],
+            token_symbol=json_dict['token_symbol'],
+        )
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class UpdateTokenBalanceRecord:
+    """Record for token balance updates."""
+    type: Literal[IndexRecordType.UPDATE_TOKEN_BALANCE] = field(
+        default=IndexRecordType.UPDATE_TOKEN_BALANCE,
+        init=False,
+    )
+    token_uid: TokenUid
+    amount: int
+
+    def __post_init__(self) -> None:
+        assert self.type == IndexRecordType.UPDATE_TOKEN_BALANCE
+
+    def to_json(self) -> dict[str, Any]:
+        return dict(type=self.type, token_uid=self.token_uid.hex(), amount=self.amount)
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, Any]) -> Self:
+        return cls(
+            token_uid=TokenUid(VertexId(bytes.fromhex(json_dict['token_uid']))),
+            amount=json_dict['amount'],
+        )
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class UpdateAuthoritiesRecord:
+    """Record for token authority updates."""
+    type: Literal[IndexRecordType.GRANT_AUTHORITIES] | Literal[IndexRecordType.REVOKE_AUTHORITIES]
+    token_uid: TokenUid
+    mint: bool
+    melt: bool
+
+    def __post_init__(self) -> None:
+        assert self.type in (IndexRecordType.GRANT_AUTHORITIES, IndexRecordType.REVOKE_AUTHORITIES)
+        assert self.mint or self.melt
+
+    def to_json(self) -> dict[str, Any]:
+        return dict(
+            type=self.type,
+            token_uid=self.token_uid.hex(),
+            mint=self.mint,
+            melt=self.melt,
+        )
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, Any]) -> Self:
+        type_ = IndexRecordType(json_dict['type'])
+        assert type_ in (IndexRecordType.GRANT_AUTHORITIES, IndexRecordType.REVOKE_AUTHORITIES)
+        return cls(
+            token_uid=TokenUid(VertexId(bytes.fromhex(json_dict['token_uid']))),
+            type=type_,  # type: ignore[arg-type]
+            mint=json_dict['mint'],
+            melt=json_dict['melt'],
+        )
+
+
+NCIndexUpdateRecord: TypeAlias = (
+    CreateContractRecord | CreateTokenRecord | UpdateTokenBalanceRecord | UpdateAuthoritiesRecord
+)
+
+
+def nc_index_update_record_from_json(json_dict: dict[str, Any]) -> NCIndexUpdateRecord:
+    record_type = IndexRecordType(json_dict['type'])
+    match record_type:
+        case IndexRecordType.CREATE_CONTRACT:
+            return CreateContractRecord.from_json(json_dict)
+        case IndexRecordType.CREATE_TOKEN:
+            return CreateTokenRecord.from_json(json_dict)
+        case IndexRecordType.UPDATE_TOKEN_BALANCE:
+            return UpdateTokenBalanceRecord.from_json(json_dict)
+        case IndexRecordType.GRANT_AUTHORITIES | IndexRecordType.REVOKE_AUTHORITIES:
+            return UpdateAuthoritiesRecord.from_json(json_dict)
+        case _:
+            assert_never(record_type)

--- a/hathor/transaction/types.py
+++ b/hathor/transaction/types.py
@@ -18,7 +18,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
 
 if TYPE_CHECKING:
-    from hathor.nanocontracts.runner.types import CallRecord, NCIndexUpdateRecord
+    from hathor.nanocontracts.runner.call_info import CallRecord
+    from hathor.nanocontracts.runner.index_records import NCIndexUpdateRecord
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -35,13 +36,13 @@ class MetaNCCallRecord:
             blueprint_id=self.blueprint_id.hex(),
             contract_id=self.contract_id.hex(),
             method_name=self.method_name,
-            index_updates=[syscall.to_json() for syscall in self.index_updates]
+            index_updates=[record.to_json() for record in self.index_updates]
         )
 
     @classmethod
     def from_json(cls, json_dict: dict[str, Any]) -> Self:
         """Create an instance from a json dict."""
-        from hathor.nanocontracts.runner.types import nc_index_update_record_from_json
+        from hathor.nanocontracts.runner.index_records import nc_index_update_record_from_json
         return cls(
             blueprint_id=bytes.fromhex(json_dict['blueprint_id']),
             contract_id=bytes.fromhex(json_dict['contract_id']),

--- a/tests/nanocontracts/test_fallback_method.py
+++ b/tests/nanocontracts/test_fallback_method.py
@@ -21,7 +21,7 @@ from hathor.nanocontracts import HATHOR_TOKEN_UID, NC_EXECUTION_FAIL_ID, Bluepri
 from hathor.nanocontracts.exception import NCInvalidMethodCall
 from hathor.nanocontracts.method import ArgsOnly
 from hathor.nanocontracts.nc_exec_logs import NCCallBeginEntry, NCCallEndEntry
-from hathor.nanocontracts.runner.types import CallType
+from hathor.nanocontracts.runner.call_info import CallType
 from hathor.nanocontracts.types import ContractId, NCArgs, NCDepositAction, NCParsedArgs, NCRawArgs, TokenUid, fallback
 from hathor.transaction import Block, Transaction
 from tests.dag_builder.builder import TestDAGBuilder


### PR DESCRIPTION
### Motivation

This PR addresses a few shortcomings of the current index update records model used in the nano Runner to update indexes after a nano is executed. The use cases evolved and the model became outdated. It addresses these:

1. The fee charge of an action was using a type that was named after a syscall, not an action.
2. The fee charge was using the `MELT` type, but it's not a melt.
3. Both token creation and balance update were using the same type, but they're handled differently.

In a subsequent PR, the syscall token balance rules which are used for token fees will also be simplified.

### Acceptance Criteria

- Move index update types from the `runner/types.py` file to their own file, `runner/index_records.py`.
- Rename the `runner/types.py` file to `runner/call_info.py`, because now it only contains call info-related types.
- Remodel the index update types to simplify them and make them clearer in intent:
    - `IndexUpdateRecordType` -> becomes `IndexRecordType`, and its options are updated to better reflect the intentions.
    - `UpdateAuthoritiesRecordType` -> is removed and included in `IndexRecordType` for simplification.
    - `SyscallCreateContractRecord` -> becomes `CreateContractRecord`
    - `UpdateAuthoritiesRecord` doesn't change.
    - `SyscallUpdateTokenRecord` -> is now broken into two types, `CreateTokenRecord` and `UpdateTokenBalanceRecord`. It was a single type encompassing two different intentions.
    - The name `Syscall` is removed from type names because now we also have actions that affect indexes. Removing it is more generic.
    - `__post_init__` validations are improved.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 