### PR TITLE
fix: add missing validation on token_history API

### DIFF
--- a/hathor/wallet/resources/thin_wallet/token_history.py
+++ b/hathor/wallet/resources/thin_wallet/token_history.py
@@ -17,6 +17,7 @@ from twisted.web.http import Request
 from hathor.api_util import Resource, get_args, get_missing_params_msg, parse_args, parse_int, set_cors
 from hathor.cli.openapi_files.register import register_resource
 from hathor.conf.get_settings import get_global_settings
+from hathor.transaction.base_transaction import TX_HASH_SIZE
 from hathor.util import json_dumpb
 
 ARGS = ['id', 'count']
@@ -65,6 +66,9 @@ class TokenHistoryResource(Resource):
         try:
             token_uid = bytes.fromhex(parsed['args']['id'])
         except (ValueError, AttributeError):
+            return json_dumpb({'success': False, 'message': 'Invalid token id'})
+
+        if len(token_uid) != TX_HASH_SIZE:
             return json_dumpb({'success': False, 'message': 'Invalid token id'})
 
         try:

--- a/tests/resources/wallet/test_thin_wallet.py
+++ b/tests/resources/wallet/test_thin_wallet.py
@@ -670,6 +670,13 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
         self.assertFalse(data['success'])
 
+        response = yield resource.get('thin_wallet/token_history', {
+            b'id': b'0000',
+            b'count': b'3'
+        })
+        data = response.json_value()
+        self.assertFalse(data['success'])
+
         # missing timestamp
         response = yield resource.get('thin_wallet/token_history', {
             b'id': b'000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824',


### PR DESCRIPTION
### Motivation

A validation was missing on the `token_history` API, which ends up hitting an assertion in internal code and creating noise for the on call.

### Acceptance Criteria

- Add missing validation on the `tokens_history` API.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 