### PR TITLE
chore(nano): set up feature activation for Nanocontracts

### DIFF
--- a/hathor/conf/mainnet.yml
+++ b/hathor/conf/mainnet.yml
@@ -215,18 +215,18 @@ FEATURE_ACTIVATION:
       # Expected to be reached around Tuesday, 2025-08-12 17:39:56 GMT
       # Right now the best block is 5_748_286 at Wednesday, 2025-08-06 16:02:56 GMT
       start_height: 5_765_760
-      timeout_height: 5_967_360  # N + 10 * 20160 (10 weeks after the start)
+      timeout_height: 6_350_400  # N + 29 * 20160 (29 weeks after the start)
       minimum_activation_height: 0
       lock_in_on_timeout: false
       version: 0.64.0
       signal_support_by_default: true
 
-# TODO
-#    NANO_CONTRACTS:
-#      bit: 1
-#      start_height: ???
-#      timeout_height: ???
-#      minimum_activation_height: 0
-#      lock_in_on_timeout: false
-#      version: 0.65.0
-#      signal_support_by_default: true
+    NANO_CONTRACTS:
+      bit: 1
+      # Right now the best block is 5_947_110 at Tuesday, 2025-10-14 20:01:09 GMT
+      start_height: 5_947_200
+      timeout_height: 6_350_400  # 20 weeks
+      minimum_activation_height: 6_027_840  # 4 weeks
+      lock_in_on_timeout: false
+      version: 0.67.0
+      signal_support_by_default: true

--- a/hathor/conf/testnet.yml
+++ b/hathor/conf/testnet.yml
@@ -32,15 +32,14 @@ FEATURE_ACTIVATION:
       version: 0.67.0
       signal_support_by_default: true
 
-    # TODO
-    # NANO_CONTRACTS:
-    #   bit: 0
-    #   start_height: -
-    #   timeout_height: -
-    #   minimum_activation_height: 0
-    #   lock_in_on_timeout: false
-    #   version: 0.67.0
-    #   signal_support_by_default: true
+    NANO_CONTRACTS:
+      bit: 0
+      start_height: 14_400
+      timeout_height: 23_040  # 36 evaluation periods (72 hours)
+      minimum_activation_height: 0
+      lock_in_on_timeout: false
+      version: 0.67.0
+      signal_support_by_default: true
 
 ENABLE_NANO_CONTRACTS: feature_activation
 NC_ON_CHAIN_BLUEPRINT_ALLOWED_ADDRESSES:


### PR DESCRIPTION
### Motivation

Release is really close we need the feature activation parameters.

### Acceptance Criteria

- Extend the COUNT_CHECKDATASIG_OP (no downsides since we will require a re-sync)
- Setup Mainnet nano's feature activation to start today, minimum activation in 4 weeks, timeouts in 20 weeks
- Setup Testnet nano's feature activation to start today and timeout in 3 days (should activate in ~4 hours after deployed)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 