### PR TITLE
feat(nano): implement new `get_current_code_blueprint_id` syscall

### DIFF
--- a/hathor/nanocontracts/blueprint_env.py
+++ b/hathor/nanocontracts/blueprint_env.py
@@ -58,13 +58,27 @@ class BlueprintEnvironment:
         return self.__runner.syscall_get_rng()
 
     def get_contract_id(self) -> ContractId:
-        """Return the contract id of this nano contract."""
+        """Return the ContractId of the current nano contract."""
         return self.__runner.get_current_contract_id()
 
     def get_blueprint_id(self) -> BlueprintId:
-        """Return the blueprint id of this nano contract."""
+        """
+        Return the BlueprintId of the current nano contract.
+
+        This means that during a proxy call, this method will return the BlueprintId of the caller's blueprint,
+        NOT the BlueprintId of the Blueprint that owns the running code.
+        """
         contract_id = self.get_contract_id()
         return self.__runner.get_blueprint_id(contract_id)
+
+    def get_current_code_blueprint_id(self) -> BlueprintId:
+        """
+        Return the BlueprintId of the Blueprint that owns the currently running code.
+
+        This means that during a proxy call, this method will return the BlueprintId of the Blueprint that owns the
+        running code, NOT the BlueprintId of the current nano contract.
+        """
+        return self.__runner.get_current_code_blueprint_id()
 
     def get_balance_before_current_call(self, token_uid: TokenUid | None = None) -> Amount:
         """

--- a/hathor/nanocontracts/runner/runner.py
+++ b/hathor/nanocontracts/runner/runner.py
@@ -229,6 +229,11 @@ class Runner:
         nc_storage = self.get_current_changes_tracker_or_storage(contract_id)
         return nc_storage.get_blueprint_id()
 
+    def get_current_code_blueprint_id(self) -> BlueprintId:
+        """Return the blueprint id of the blueprint that owns the executing code."""
+        current_call_record = self.get_current_call_record()
+        return current_call_record.blueprint_id
+
     def _build_call_info(self, contract_id: ContractId) -> CallInfo:
         from hathor.nanocontracts.nc_exec_logs import NCLogger
         return CallInfo(
@@ -374,9 +379,11 @@ class Runner:
             raise NCInvalidInitializeMethodCall('cannot call initialize from another contract')
 
         contract_id = self.get_current_contract_id()
-
         if blueprint_id == self.get_blueprint_id(contract_id):
-            raise NCInvalidSyscall('cannot call the same blueprint')
+            raise NCInvalidSyscall('cannot call the same blueprint of the running contract')
+
+        if blueprint_id == self.get_current_code_blueprint_id():
+            raise NCInvalidSyscall('cannot call the same blueprint of the running blueprint')
 
         return self._unsafe_call_another_contract_public_method(
             contract_id=contract_id,

--- a/tests/nanocontracts/test_syscalls_in_view.py
+++ b/tests/nanocontracts/test_syscalls_in_view.py
@@ -45,6 +45,10 @@ class MyBlueprint(Blueprint):
         self.syscall.get_blueprint_id()
 
     @view
+    def get_current_code_blueprint_id(self) -> None:
+        self.syscall.get_current_code_blueprint_id()
+
+    @view
     def get_balance_before_current_call(self) -> None:
         self.syscall.get_balance_before_current_call()
 
@@ -168,6 +172,7 @@ class TestSyscallsInView(BlueprintTestCase):
             'can_melt_before_current_call',
             'call_view_method',
             'get_contract',
+            'get_current_code_blueprint_id',
         }
 
         for method_name, method in BlueprintEnvironment.__dict__.items():


### PR DESCRIPTION
### Motivation

This is a 2-in-1 PR:

- It fixes an issue where making a double proxy call would bypass the `BlueprintId` validation, meaning a contract would be able to call a method on itself when it should fail with `NCInvalidSyscall('cannot call the same blueprint')` instead. This is not a security problem, but rather a minor inconvenience as we could help developers prevent such mistakes.
- Introduce a new `get_current_code_blueprint_id` syscall to get the `BlueprintId` of the currently running code instead of currently running contract. The same method is used to fix the issue above.

### Acceptance Criteria

- Implement new `get_current_code_blueprint_id` syscall.
- Fix `BlueprintId` validation when making double proxy calls.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 