### PR TITLE
feat(nano): include header-id when generating a sighash

### DIFF
--- a/hathor/transaction/headers/nano_header.py
+++ b/hathor/transaction/headers/nano_header.py
@@ -208,7 +208,7 @@ class NanoHeader(VertexBaseHeader):
         ]
         return b''.join(ret)
 
-    def _serialize_without_header_id(self, *, skip_signature: bool) -> deque[bytes]:
+    def _serialize(self, *, skip_signature: bool) -> bytes:
         """Serialize the header with the option to skip the signature."""
         encoded_method = self.nc_method.encode('ascii')
 
@@ -230,16 +230,14 @@ class NanoHeader(VertexBaseHeader):
             ret.append(self.nc_script)
         else:
             ret.append(leb128.encode_unsigned(0, max_bytes=_NC_SCRIPT_LEN_MAX_BYTES))
-        return ret
-
-    def serialize(self) -> bytes:
-        ret = self._serialize_without_header_id(skip_signature=False)
         ret.appendleft(VertexHeaderId.NANO_HEADER.value)
         return b''.join(ret)
 
+    def serialize(self) -> bytes:
+        return self._serialize(skip_signature=False)
+
     def get_sighash_bytes(self) -> bytes:
-        ret = self._serialize_without_header_id(skip_signature=True)
-        return b''.join(ret)
+        return self._serialize(skip_signature=True)
 
     def is_creating_a_new_contract(self) -> bool:
         """Return true if this transaction is creating a new contract."""

--- a/tests/nanocontracts/test_nanocontract.py
+++ b/tests/nanocontracts/test_nanocontract.py
@@ -34,7 +34,7 @@ from hathor.transaction.exceptions import (
     MissingStackItems,
     TooManySigOps,
 )
-from hathor.transaction.headers import NanoHeader, VertexHeaderId
+from hathor.transaction.headers import NanoHeader
 from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.transaction.scripts import P2PKH, HathorScript, Opcode
 from hathor.transaction.validation_state import ValidationState
@@ -158,7 +158,7 @@ class NCNanoContractTestCase(unittest.TestCase):
         nc = self._get_nc()
         nano_header = nc.get_nano_header()
         sighash_bytes = nano_header.get_sighash_bytes()
-        deserialized, buf = NanoHeader.deserialize(Transaction(), VertexHeaderId.NANO_HEADER.value + sighash_bytes)
+        deserialized, buf = NanoHeader.deserialize(Transaction(), sighash_bytes)
 
         assert len(buf) == 0
         assert deserialized.nc_seqnum == nano_header.nc_seqnum


### PR DESCRIPTION
### Motivation

When generating the sighash bytes for a nano-header the header-id is not included, but it is for a fee-header. This is an inconsistency, although there aren't any security implications.

### Acceptance Criteria

- Include the header-id in `get_sighash_bytes` (or rather, don't exclude it)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 