### PR TITLE
fix(nano): serialization on state api

### DIFF
--- a/hathor/dag_builder/vertex_exporter.py
+++ b/hathor/dag_builder/vertex_exporter.py
@@ -364,7 +364,7 @@ class VertexExporter:
             from hathor.nanocontracts.api_arguments_parser import parse_nc_method_call
             from hathor.nanocontracts.method import Method
             nc_method_raw = _TEMPLATE_PATTERN.sub(_replace_escaped_vertex_id, nc_method_raw)
-            nc_method, nc_args = parse_nc_method_call(blueprint_class, nc_method_raw)
+            nc_method, nc_args, _ = parse_nc_method_call(blueprint_class, nc_method_raw)
             method = Method.from_callable(getattr(blueprint_class, nc_method))
             nc_args_bytes = method.serialize_args_bytes(nc_args)
 

--- a/hathor/nanocontracts/api_arguments_parser.py
+++ b/hathor/nanocontracts/api_arguments_parser.py
@@ -20,7 +20,7 @@ from hathor.nanocontracts.exception import NCMethodNotFound
 from hathor.nanocontracts.method import Method
 
 
-def parse_nc_method_call(blueprint_class: type[Blueprint], call_info: str) -> tuple[str, Any]:
+def parse_nc_method_call(blueprint_class: type[Blueprint], call_info: str) -> tuple[str, Any, Method]:
     """Parse a string that represents an invocation to a Nano Contract method.
 
     The string must be in the following format: `method(arg1, arg2, arg3)`.
@@ -43,4 +43,4 @@ def parse_nc_method_call(blueprint_class: type[Blueprint], call_info: str) -> tu
     method = Method.from_callable(method_callable)
     parsed_args = method.args.json_to_value(args_json)
 
-    return method_name, parsed_args
+    return method_name, parsed_args, method

--- a/hathor/nanocontracts/resources/state.py
+++ b/hathor/nanocontracts/resources/state.py
@@ -212,10 +212,9 @@ class NanoContractStateResource(Resource):
         calls: dict[str, NCValueSuccessResponse | NCValueErrorResponse] = {}
         for call_info in params.calls:
             try:
-                method_name, method_args = parse_nc_method_call(blueprint_class, call_info)
+                method_name, method_args, method = parse_nc_method_call(blueprint_class, call_info)
                 value = runner.call_view_method(nc_id_bytes, method_name, *method_args)
-                if type(value) is bytes:
-                    value = value.hex()
+                value = method.return_.value_to_json(value)
             except Exception as e:
                 calls[call_info] = NCValueErrorResponse(errmsg=repr(e))
             else:


### PR DESCRIPTION
### Motivation

The nanocontract state API was not properly serializing return values from view method calls. When calling view methods that returned complex types (like tuples), the serialization was only checking if the value was bytes and converting to hex, but didn't handle other types correctly.

### Acceptance Criteria

- View method return values should be properly serialized using the method's return type specification
- The `parse_nc_method_call` function now returns the Method object to enable proper serialization
- Tests confirm that complex return types (like NamedTuples) are correctly serialized

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged