### PR TITLE
feat(nano): emit a token-creation event including for nano executions

### DIFF
--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -283,6 +283,9 @@ class BlockConsensusAlgorithm:
                 assert tx.storage.indexes is not None
                 tx.storage.indexes.handle_contract_execution(tx)
 
+                # Pubsub event to indicate execution success
+                self.context.nc_exec_success.append(tx)
+
                 # We only emit events when the nc is successfully executed.
                 assert self.context.nc_events is not None
                 last_call_info = runner.get_last_call_info()

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -195,6 +195,10 @@ class ConsensusAlgorithm:
             tx_affected.storage.indexes.update(tx_affected)
             context.pubsub.publish(HathorEvents.CONSENSUS_TX_UPDATE, tx=tx_affected)
 
+        # signal all transactions of which the execution succeeded
+        for tx_nc_success in context.nc_exec_success:
+            context.pubsub.publish(HathorEvents.NC_EXEC_SUCCESS, tx=tx_nc_success)
+
         # handle custom NC events
         if isinstance(base, Block):
             assert context.nc_events is not None

--- a/hathor/consensus/context.py
+++ b/hathor/consensus/context.py
@@ -51,6 +51,7 @@ class ConsensusAlgorithmContext:
         'txs_affected',
         'reorg_info',
         'nc_events',
+        'nc_exec_success',
     )
 
     consensus: 'ConsensusAlgorithm'
@@ -60,6 +61,7 @@ class ConsensusAlgorithmContext:
     txs_affected: set[BaseTransaction]
     reorg_info: ReorgInfo | None
     nc_events: list[tuple[Transaction, list[NCEvent]]] | None
+    nc_exec_success: list[Transaction]
 
     def __init__(self, consensus: 'ConsensusAlgorithm', pubsub: PubSubManager) -> None:
         self.consensus = consensus
@@ -69,6 +71,7 @@ class ConsensusAlgorithmContext:
         self.txs_affected = set()
         self.reorg_info = None
         self.nc_events = None
+        self.nc_exec_success = []
 
     def save(self, tx: BaseTransaction) -> None:
         """Only metadata is ever saved in a consensus update."""

--- a/hathor/event/model/event_type.py
+++ b/hathor/event/model/event_type.py
@@ -12,9 +12,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum
 
-from hathor.event.model.event_data import BaseEventData, EmptyData, NCEventData, ReorgData, TxData, TxDataWithoutMeta
+from hathor.event.model.event_data import (
+    BaseEventData,
+    EmptyData,
+    NCEventData,
+    ReorgData,
+    TokenCreatedData,
+    TxData,
+    TxDataWithoutMeta,
+)
 from hathor.pubsub import HathorEvents
 
 
@@ -28,15 +38,12 @@ class EventType(Enum):
     VERTEX_REMOVED = 'VERTEX_REMOVED'
     FULL_NODE_CRASHED = 'FULL_NODE_CRASHED'
     NC_EVENT = 'NC_EVENT'
+    TOKEN_CREATED = 'TOKEN_CREATED'
 
     @classmethod
-    def from_hathor_event(cls, hathor_event: HathorEvents) -> 'EventType':
+    def from_hathor_event(cls, hathor_event: HathorEvents) -> EventType | None:
         """Create an Event Queue feature EventType from a PubSub HathorEvents."""
-        event = _HATHOR_EVENT_TO_EVENT_TYPE.get(hathor_event)
-
-        assert event is not None, f'Cannot create EventType from {hathor_event}'
-
-        return event
+        return _HATHOR_EVENT_TO_EVENT_TYPE.get(hathor_event)
 
     def data_type(self) -> type[BaseEventData]:
         return _EVENT_TYPE_TO_EVENT_DATA[self]
@@ -61,4 +68,5 @@ _EVENT_TYPE_TO_EVENT_DATA: dict[EventType, type[BaseEventData]] = {
     EventType.VERTEX_REMOVED: TxDataWithoutMeta,
     EventType.FULL_NODE_CRASHED: EmptyData,
     EventType.NC_EVENT: NCEventData,
+    EventType.TOKEN_CREATED: TokenCreatedData,
 }

--- a/hathor/nanocontracts/runner/index_records.py
+++ b/hathor/nanocontracts/runner/index_records.py
@@ -151,7 +151,10 @@ class UpdateAuthoritiesRecord:
 
 
 NCIndexUpdateRecord: TypeAlias = (
-    CreateContractRecord | CreateTokenRecord | UpdateTokenBalanceRecord | UpdateAuthoritiesRecord
+    CreateContractRecord
+    | CreateTokenRecord
+    | UpdateTokenBalanceRecord
+    | UpdateAuthoritiesRecord
 )
 
 

--- a/hathor_tests/event/test_event_manager.py
+++ b/hathor_tests/event/test_event_manager.py
@@ -1,8 +1,31 @@
+from hathor.event.model.event_data import TokenCreatedData
 from hathor.event.model.event_type import EventType
 from hathor.event.storage import EventRocksDBStorage
+from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts.catalog import NCBlueprintCatalog
+from hathor.nanocontracts.types import ContractId
+from hathor.nanocontracts.utils import derive_child_token_id
 from hathor.pubsub import HathorEvents
+from hathor.transaction import Transaction
+from hathor.transaction.token_info import TokenVersion
 from hathor.util import not_none
 from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.utils import create_tokens
+
+
+class _TokenFactoryBlueprint(Blueprint):
+    @public(allow_deposit=True)
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public(allow_deposit=True)
+    def create_token(self, ctx: Context) -> None:
+        self.syscall.create_deposit_token(
+            token_name='Deposit Token',
+            token_symbol='DBT',
+            amount=100,
+        )
 
 
 class EventManagerTest(unittest.TestCase):
@@ -17,6 +40,7 @@ class EventManagerTest(unittest.TestCase):
             enable_event_queue=True,
             event_storage=self.event_storage
         )
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
 
     def test_if_event_is_persisted(self) -> None:
         block = self.manager.tx_storage.get_best_block()
@@ -85,3 +109,178 @@ class EventManagerTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self._fake_reorg_finished()
             self.run_to_completion()
+
+    def test_nc_token_creation_event(self) -> None:
+        blueprint_id = b'\x01' * 32
+        self.manager.tx_storage.nc_catalog = NCBlueprintCatalog({
+            blueprint_id: _TokenFactoryBlueprint,
+        })
+
+        dag_builder = TestDAGBuilder.from_manager(self.manager)
+        artifacts = dag_builder.build_from_str(f'''
+            blockchain genesis b[1..15]
+            b12 < dummy
+
+            init.nc_id = "{blueprint_id.hex()}"
+            init.nc_method = initialize()
+            init.nc_deposit = 1 HTR
+
+            call.nc_id = init
+            call.nc_method = create_token()
+            call.nc_deposit = 3 HTR
+
+            init < b13 < call < b14
+            init <-- b13
+            call <-- b14
+        ''')
+
+        init_tx, call_tx = artifacts.get_typed_vertices(('init', 'call'), Transaction)
+
+        # stop right after `call` is accepted
+        artifacts.propagate_with(self.manager, up_to='call')
+        self.run_to_completion()
+
+        # the NEW_VERTEX_ACCEPTED must have been emitted
+        tx_events = [
+            event
+            for event in self.event_storage.iter_from_event(0)
+            if EventType(event.type) == EventType.NEW_VERTEX_ACCEPTED
+            and getattr(event.data, 'hash', None) == call_tx.hash_hex
+        ]
+
+        self.assertEqual(len(tx_events), 1)
+
+        expected_token_uid = derive_child_token_id(
+            ContractId(init_tx.hash),
+            token_symbol='DBT',
+        ).hex()
+
+        # but the TOKEN_CREATED must have not
+        token_events = [
+            event
+            for event in self.event_storage.iter_from_event(0)
+            if EventType(event.type) == EventType.TOKEN_CREATED
+            and getattr(event.data, 'token_uid', None) == expected_token_uid
+        ]
+
+        self.assertEqual(len(token_events), 0)
+
+        # only after the block is accepted it will emit the TOKEN_CREATED
+        artifacts.propagate_with(self.manager)
+        self.run_to_completion()
+
+        token_events = [
+            event
+            for event in self.event_storage.iter_from_event(0)
+            if EventType(event.type) == EventType.TOKEN_CREATED
+            and getattr(event.data, 'token_uid', None) == expected_token_uid
+        ]
+
+        self.assertEqual(len(token_events), 1)
+
+        token_event = token_events[0]
+        token_data = token_event.data
+        assert isinstance(token_data, TokenCreatedData)
+
+        self.assertEqual(token_data.token_uid, expected_token_uid)
+        self.assertEqual(token_data.token_name, 'Deposit Token')
+        self.assertEqual(token_data.token_symbol, 'DBT')
+        self.assertEqual(token_data.token_version, TokenVersion.DEPOSIT)
+
+        nc_exec_info = not_none(token_data.nc_exec_info)
+        self.assertEqual(nc_exec_info.nc_tx, call_tx.hash_hex)
+        call_meta = call_tx.get_metadata()
+        assert call_meta.first_block is not None
+        self.assertEqual(nc_exec_info.nc_block, call_meta.first_block.hex())
+
+    def test_nc_token_creation_event_not_emitted_twice(self) -> None:
+        blueprint_id = b'\x01' * 32
+        self.manager.tx_storage.nc_catalog = NCBlueprintCatalog({
+            blueprint_id: _TokenFactoryBlueprint,
+        })
+
+        dag_builder = TestDAGBuilder.from_manager(self.manager)
+        artifacts = dag_builder.build_from_str(f'''
+            blockchain genesis b[1..15]
+            b12 < dummy
+
+            init.nc_id = "{blueprint_id.hex()}"
+            init.nc_method = initialize()
+            init.nc_deposit = 1 HTR
+
+            call.nc_id = init
+            call.nc_method = create_token()
+            call.nc_deposit = 3 HTR
+
+            init < b13 < call < b14
+            init <-- b13
+            call <-- b14
+        ''')
+
+        init_tx, call_tx = artifacts.get_typed_vertices(('init', 'call'), Transaction)
+
+        artifacts.propagate_with(self.manager)
+        self.run_to_completion()
+
+        expected_token_uid = derive_child_token_id(
+            ContractId(init_tx.hash),
+            token_symbol='DBT',
+        ).hex()
+
+        token_events = [
+            event
+            for event in self.event_storage.iter_from_event(0)
+            if EventType(event.type) == EventType.TOKEN_CREATED
+            and getattr(event.data, 'token_uid', None) == expected_token_uid
+        ]
+
+        self.assertEqual(len(token_events), 1)
+
+        self.manager.pubsub.publish(HathorEvents.CONSENSUS_TX_UPDATE, tx=call_tx)
+        self.run_to_completion()
+
+        token_events = [
+            event
+            for event in self.event_storage.iter_from_event(0)
+            if EventType(event.type) == EventType.TOKEN_CREATED
+            and getattr(event.data, 'token_uid', None) == expected_token_uid
+        ]
+
+        self.assertEqual(
+            len(token_events),
+            1,
+            'Token creation event should not be emitted more than once for the same transaction.',
+        )
+
+    def test_token_creation_transaction_emits_token_created_event(self) -> None:
+        tx = create_tokens(
+            self.manager,
+            token_name='Created Token',
+            token_symbol='CTK',
+            mint_amount=123,
+            propagate=True,
+            use_genesis=False,
+        )
+
+        self.run_to_completion()
+
+        expected_token_uid = tx.hash_hex
+
+        token_events = [
+            event
+            for event in self.event_storage.iter_from_event(0)
+            if EventType(event.type) == EventType.TOKEN_CREATED
+            and getattr(event.data, 'token_uid', None) == expected_token_uid
+        ]
+
+        self.assertEqual(len(token_events), 1)
+
+        token_event = token_events[0]
+        token_data = token_event.data
+        assert isinstance(token_data, TokenCreatedData)
+
+        self.assertEqual(token_data.token_uid, expected_token_uid)
+        self.assertIsNone(token_data.nc_exec_info)
+        self.assertEqual(token_data.token_name, 'Created Token')
+        self.assertEqual(token_data.token_symbol, 'CTK')
+        self.assertEqual(token_data.token_version, TokenVersion.DEPOSIT)


### PR DESCRIPTION
### Motivation

Currently there is no way for a wallet observing events from the reliable integration to know when a token has been created from a nano execution.

~Introduce two new events: `TOKEN_CREATED` and `TOKEN_REMOVED` (for reorgs).~

Introduce a new event: `TOKEN_CREATED`. Removal can be inferred from metadata changes.

### Acceptance Criteria

- Emit `TOKEN_CREATED` for both `TokenCreationTransaction`s and nano-contract executions, including token metadata and optional nc_exec_info.
- ~Emit `TOKEN_REMOVED` only when a token-creation tx is voided, and for nano-created tokens when their execution is rolled back (reorg/un-execution).~
- EventArguments and event data models updated with explicit token fields; tests assert the emitted event payloads match expected metadata.


### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 