### PR TITLE
fix(nano): do not allow dict in tuple/NamedTuple fields

### DIFF
--- a/hathor/nanocontracts/nc_types/__init__.py
+++ b/hathor/nanocontracts/nc_types/__init__.py
@@ -106,7 +106,6 @@ FIELD_TYPE_TO_NC_TYPE_MAP: TypeToNCTypeMap = {
     # builtin types:
     bool: BoolNCType,
     bytes: BytesNCType,
-    dict: DictNCType,
     frozenset: FrozenSetNCType,
     int: VarInt32NCType,
     str: StrNCType,
@@ -133,6 +132,7 @@ FIELD_TYPE_TO_NC_TYPE_MAP: TypeToNCTypeMap = {
 ARG_TYPE_TO_NC_TYPE_MAP: TypeToNCTypeMap = {
     **FIELD_TYPE_TO_NC_TYPE_MAP,
     # bultin types:
+    dict: DictNCType,
     list: ListNCType,
     set: SetNCType,
     # other Python types:

--- a/hathor_tests/nanocontracts/test_all_fields.py
+++ b/hathor_tests/nanocontracts/test_all_fields.py
@@ -156,3 +156,102 @@ class TestAllFields(unittest.TestCase):
         context_exception = cm.exception.__context__
         assert isinstance(context_exception, TypeError)
         assert context_exception.args[0] == r"type None is not supported by any NCType class"
+
+    def test_no_dict_inside_tuple(self) -> None:
+        with self.assertRaises(BlueprintSyntaxError) as cm:
+            class MyInvalidBlueprint(Blueprint):
+                invalid_attribute: tuple[dict[str, int]]
+
+                @public
+                def initialize(self, ctx: Context) -> None:
+                    pass
+
+        assert cm.exception.args[0] == 'unsupported field type: `invalid_attribute: tuple[dict[str, int]]`'
+        context_exception = cm.exception.__context__
+        assert isinstance(context_exception, TypeError)
+        assert context_exception.args[0] == r"type dict[str, int] is not supported by any NCType class"
+
+    def test_no_dict_inside_namedtuple(self) -> None:
+        from typing import NamedTuple
+
+        class Inner(NamedTuple):
+            data: dict[str, int]
+
+        with self.assertRaises(BlueprintSyntaxError) as cm:
+            class MyInvalidBlueprint(Blueprint):
+                invalid_attribute: Inner
+
+                @public
+                def initialize(self, ctx: Context) -> None:
+                    pass
+
+        assert cm.exception.args[0] == 'unsupported field type: `invalid_attribute: Inner`'
+        context_exception = cm.exception.__context__
+        assert isinstance(context_exception, TypeError)
+        assert context_exception.args[0] == r"type dict[str, int] is not supported by any NCType class"
+
+    def test_no_list_inside_tuple(self) -> None:
+        with self.assertRaises(BlueprintSyntaxError) as cm:
+            class MyInvalidBlueprint(Blueprint):
+                invalid_attribute: tuple[list[int]]
+
+                @public
+                def initialize(self, ctx: Context) -> None:
+                    pass
+
+        assert cm.exception.args[0] == 'unsupported field type: `invalid_attribute: tuple[list[int]]`'
+        context_exception = cm.exception.__context__
+        assert isinstance(context_exception, TypeError)
+        assert context_exception.args[0] == r"type list[int] is not supported by any NCType class"
+
+    def test_no_set_inside_tuple(self) -> None:
+        with self.assertRaises(BlueprintSyntaxError) as cm:
+            class MyInvalidBlueprint(Blueprint):
+                invalid_attribute: tuple[set[int]]
+
+                @public
+                def initialize(self, ctx: Context) -> None:
+                    pass
+
+        assert cm.exception.args[0] == 'unsupported field type: `invalid_attribute: tuple[set[int]]`'
+        context_exception = cm.exception.__context__
+        assert isinstance(context_exception, TypeError)
+        assert context_exception.args[0] == r"type set[int] is not supported by any NCType class"
+
+    def test_no_list_inside_namedtuple(self) -> None:
+        from typing import NamedTuple
+
+        class Inner(NamedTuple):
+            data: list[int]
+
+        with self.assertRaises(BlueprintSyntaxError) as cm:
+            class MyInvalidBlueprint(Blueprint):
+                invalid_attribute: Inner
+
+                @public
+                def initialize(self, ctx: Context) -> None:
+                    pass
+
+        assert cm.exception.args[0] == 'unsupported field type: `invalid_attribute: Inner`'
+        context_exception = cm.exception.__context__
+        assert isinstance(context_exception, TypeError)
+        assert context_exception.args[0] == r"type list[int] is not supported by any NCType class"
+
+    def test_no_set_inside_namedtuple(self) -> None:
+        from typing import NamedTuple
+
+        class Inner(NamedTuple):
+            data: set[int]
+
+        with self.assertRaises(BlueprintSyntaxError) as cm:
+            class MyInvalidBlueprint(Blueprint):
+                invalid_attribute: Inner
+
+                @public
+                def initialize(self, ctx: Context) -> None:
+                    pass
+
+        assert cm.exception.args[0] == 'unsupported field type: `invalid_attribute: Inner`'
+        context_exception = cm.exception.__context__
+        assert isinstance(context_exception, TypeError)
+        assert context_exception.args[0] == r"type set[int] is not supported by any NCType class"


### PR DESCRIPTION
### Motivation

Allowing `dict` members in `tuple`/`NamedTuple` Blueprint fields leads to silently not persisting updates to the nano storage, which is the designed behavior but it is unexpected.

### Acceptance Criteria

- Forbid `dict`, just like `list` and `set` already were forbidden.
- Add tests to make sure this behavior is consistent.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 