### PR TITLE
feat(nano): Add HTTP API and CLI to re-run blocks and nano transactions

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -14,7 +14,7 @@
 
 import tempfile
 from enum import IntEnum
-from typing import Any, Callable, NamedTuple, Optional, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeAlias
 
 from structlog import get_logger
 
@@ -55,6 +55,9 @@ from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor.vertex_handler import VertexHandler
 from hathor.wallet import BaseWallet, Wallet
+
+if TYPE_CHECKING:
+    from hathor.nanocontracts.execution import NCBlockExecutor
 
 logger = get_logger()
 
@@ -190,8 +193,6 @@ class Builder:
 
         self._enable_ipv6: bool = False
         self._disable_ipv4: bool = False
-
-        self._nc_anti_mev: bool = True
 
         self._nc_storage_factory: NCStorageFactory | None = None
         self._nc_log_storage: NCLogStorage | None = None
@@ -389,12 +390,8 @@ class Builder:
         return self._nc_storage_factory
 
     def _get_nc_calls_sorter(self) -> NCSorterCallable:
-        if self._nc_anti_mev:
-            from hathor.nanocontracts.sorter.random_sorter import random_nc_calls_sorter
-            return random_nc_calls_sorter
-        else:
-            from hathor.nanocontracts.sorter.timestamp_sorter import timestamp_nc_calls_sorter
-            return timestamp_nc_calls_sorter
+        from hathor.nanocontracts.sorter.random_sorter import random_nc_calls_sorter
+        return random_nc_calls_sorter
 
     def _get_or_create_nc_log_storage(self) -> NCLogStorage:
         if self._nc_log_storage is not None:
@@ -408,18 +405,27 @@ class Builder:
         )
         return self._nc_log_storage
 
+    def _get_or_create_block_executor(self) -> 'NCBlockExecutor':
+        from hathor.nanocontracts.execution import NCBlockExecutor
+        nc_storage_factory = self._get_or_create_nc_storage_factory()
+        return NCBlockExecutor(
+            settings=self._get_or_create_settings(),
+            runner_factory=self._get_or_create_runner_factory(),
+            nc_storage_factory=nc_storage_factory,
+            nc_calls_sorter=self._get_nc_calls_sorter(),
+            feature_service=self._get_or_create_feature_service(),
+        )
+
     def _get_or_create_consensus(self) -> ConsensusAlgorithm:
         if self._consensus is None:
             soft_voided_tx_ids = self._get_soft_voided_tx_ids()
             nc_storage_factory = self._get_or_create_nc_storage_factory()
-            nc_calls_sorter = self._get_nc_calls_sorter()
             self._consensus = ConsensusAlgorithm(
                 nc_storage_factory=nc_storage_factory,
                 soft_voided_tx_ids=soft_voided_tx_ids,
                 settings=self._get_or_create_settings(),
-                runner_factory=self._get_or_create_runner_factory(),
+                block_executor=self._get_or_create_block_executor(),
                 nc_log_storage=self._get_or_create_nc_log_storage(),
-                nc_calls_sorter=nc_calls_sorter,
                 feature_service=self._get_or_create_feature_service(),
                 tx_storage=self._get_or_create_tx_storage(),
             )
@@ -860,16 +866,6 @@ class Builder:
     def disable_ipv4(self) -> 'Builder':
         self.check_if_can_modify()
         self._disable_ipv4 = True
-        return self
-
-    def enable_nc_anti_mev(self) -> 'Builder':
-        self.check_if_can_modify()
-        self._nc_anti_mev = True
-        return self
-
-    def disable_nc_anti_mev(self) -> 'Builder':
-        self.check_if_can_modify()
-        self._nc_anti_mev = False
         return self
 
     def set_soft_voided_tx_ids(self, soft_voided_tx_ids: set[bytes]) -> 'Builder':

--- a/hathor/builder/resources_builder.py
+++ b/hathor/builder/resources_builder.py
@@ -260,6 +260,7 @@ class ResourcesBuilder:
                 BlueprintSourceCodeResource,
                 NanoContractHistoryResource,
                 NanoContractStateResource,
+                NCDryRunResource,
             )
             nc_resource = Resource()
             root.putChild(b'nano_contract', nc_resource)
@@ -273,6 +274,9 @@ class ResourcesBuilder:
             nc_resource.putChild(b'state', NanoContractStateResource(self.manager))
             nc_resource.putChild(b'creation', NCCreationResource(self.manager))
             nc_resource.putChild(b'logs', NCExecLogsResource(self.manager))
+            nc_resource.putChild(b'dry_run', NCDryRunResource(
+                self.manager.tx_storage, self.manager.consensus_algorithm.block_executor
+            ))
 
         if self._args.enable_debug_api:
             debug_resource = Resource()

--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -500,11 +500,14 @@ class BlockConsensusAlgorithm:
                 meta.nc_execution = NCExecutionState.PENDING
                 meta.nc_calls = None
                 meta.nc_events = None
-                if meta.voided_by == {tx.hash, NC_EXECUTION_FAIL_ID}:
+                if meta.voided_by is not None and NC_EXECUTION_FAIL_ID in meta.voided_by:
+                    assert tx.hash in meta.voided_by
                     assert isinstance(tx, Transaction)
-                    self.context.transaction_algorithm.remove_voided_by(tx, tx.hash)
-                    assert meta.voided_by == {NC_EXECUTION_FAIL_ID}
-                    meta.voided_by = None
+                    if not meta.conflict_with:
+                        self.context.transaction_algorithm.remove_voided_by(tx, tx.hash)
+                    meta.voided_by.remove(NC_EXECUTION_FAIL_ID)
+                    if not meta.voided_by:
+                        meta.voided_by = None
             meta.first_block = None
             self.context.save(tx)
             bfs.add_neighbors()

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -39,8 +39,6 @@ if TYPE_CHECKING:
     from hathor.feature_activation.feature_service import FeatureService
     from hathor.nanocontracts import NCStorageFactory
     from hathor.nanocontracts.nc_exec_logs import NCLogStorage
-    from hathor.nanocontracts.runner.runner import RunnerFactory
-    from hathor.nanocontracts.sorter.types import NCSorterCallable
     from hathor.transaction.storage import TransactionStorage
 
 logger = get_logger()
@@ -88,8 +86,7 @@ class ConsensusAlgorithm:
         *,
         settings: HathorSettings,
         tx_storage: TransactionStorage,
-        runner_factory: RunnerFactory,
-        nc_calls_sorter: NCSorterCallable,
+        block_executor: NCBlockExecutor,
         nc_log_storage: NCLogStorage,
         feature_service: FeatureService,
         nc_exec_fail_trace: bool = False,
@@ -100,19 +97,14 @@ class ConsensusAlgorithm:
         self.nc_storage_factory = nc_storage_factory
         self.soft_voided_tx_ids = frozenset(soft_voided_tx_ids)
 
-        # Create NCBlockExecutor (pure) for execution
-        self._block_executor = NCBlockExecutor(
-            settings=settings,
-            runner_factory=runner_factory,
-            nc_storage_factory=nc_storage_factory,
-            nc_calls_sorter=nc_calls_sorter,
-            feature_service=feature_service,
-        )
+        # NCBlockExecutor is a pure executor that yields effects without applying them.
+        # It is created by the builder and injected here.
+        self.block_executor = block_executor
 
         # Create NCConsensusBlockExecutor (with side effects) for consensus
         self._consensus_block_executor = NCConsensusBlockExecutor(
             settings=settings,
-            block_executor=self._block_executor,
+            block_executor=self.block_executor,
             nc_storage_factory=nc_storage_factory,
             nc_log_storage=nc_log_storage,
             nc_exec_fail_trace=nc_exec_fail_trace,
@@ -122,7 +114,6 @@ class ConsensusAlgorithm:
             settings, self._consensus_block_executor, feature_service,
         )
         self.transaction_algorithm_factory = TransactionConsensusAlgorithmFactory()
-        self.nc_calls_sorter = nc_calls_sorter
         self.feature_service = feature_service
 
     def create_context(self) -> ConsensusAlgorithmContext:

--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -19,16 +19,18 @@ from __future__ import annotations
 import hashlib
 import traceback
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Callable, Iterator, Mapping, TypeAlias, cast
 
 from hathor.feature_activation.utils import Features
 from hathor.nanocontracts.exception import NCFail
 from hathor.nanocontracts.nano_runtime_version import NanoRuntimeVersion
 from hathor.transaction import Block, Transaction
-from hathor.transaction.exceptions import TokenNotFound
-from hathor.transaction.nc_execution_state import NCExecutionState
+from hathorlib.nanocontracts.runner.call_info import CallInfo
 from hathorlib.nanocontracts.runner.runner import MAX_SEQNUM_JUMP_SIZE
 from hathorlib.nanocontracts.types import Address, BlueprintId, ContractId, NCRawArgs, VertexId
+
+# Type alias for the skip predicate
+ShouldSkipPredicate = Callable[[Transaction], bool]
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -37,6 +39,8 @@ if TYPE_CHECKING:
     from hathor.nanocontracts.runner.runner import RunnerFactory
     from hathor.nanocontracts.sorter.types import NCSorterCallable
     from hathor.nanocontracts.storage import NCBlockStorage, NCStorageFactory
+    from hathor.nanocontracts.types import TokenUid
+    from hathor.transaction.token_info import TokenDescription
 
 
 # Transaction execution result types (also used as block execution effects)
@@ -49,9 +53,12 @@ class NCTxExecutionSuccess:
 
 @dataclass(slots=True, frozen=True)
 class NCTxExecutionFailure:
-    """Result type for failed NC execution."""
+    """Result type for failed NC execution.
+
+    `call_info` is None for cyclic-dependency failures, which never run a Runner.
+    """
     tx: Transaction
-    runner: 'Runner'
+    call_info: CallInfo | None
     exception: NCFail
     traceback: str
 
@@ -62,7 +69,7 @@ class NCTxExecutionSkipped:
     tx: Transaction
 
 
-NCTxExecutionResult = NCTxExecutionSuccess | NCTxExecutionFailure | NCTxExecutionSkipped
+NCTxExecutionResult: TypeAlias = NCTxExecutionSuccess | NCTxExecutionFailure | NCTxExecutionSkipped
 
 
 # Block execution lifecycle effect types for generator-based execution
@@ -72,7 +79,8 @@ class NCBeginBlock:
     block: Block
     parent_root_id: bytes
     block_storage: 'NCBlockStorage'
-    nc_sorted_calls: list[Transaction]
+    nc_sorted_calls: tuple[Transaction, ...]
+    nc_cyclic_fails: tuple[Transaction, ...]
 
 
 @dataclass(slots=True, frozen=True)
@@ -96,10 +104,34 @@ class NCEndBlock:
     final_root_id: bytes
 
 
-NCBlockEffect = (
+NCBlockEffect: TypeAlias = (
     NCBeginBlock | NCBeginTransaction | NCTxExecutionResult |
     NCEndTransaction | NCEndBlock
 )
+
+
+class _UncommittedRestrictedBlockProxy:
+    """Read-only token overlay for pre-commit validation."""
+
+    def __init__(
+        self,
+        block_storage: 'NCBlockStorage',
+        *,
+        created_tokens: Mapping['TokenUid', 'TokenDescription'],
+    ) -> None:
+        self._block_storage = block_storage
+        self._created_tokens = created_tokens
+
+    def has_token(self, token_id: 'TokenUid') -> bool:
+        if token_id in self._created_tokens:
+            return True
+        return self._block_storage.has_token(token_id)
+
+    def get_token_description(self, token_id: 'TokenUid') -> 'TokenDescription':
+        token_description = self._created_tokens.get(token_id)
+        if token_description is not None:
+            return token_description
+        return self._block_storage.get_token_description(token_id)
 
 
 class NCBlockExecutor:
@@ -135,7 +167,12 @@ class NCBlockExecutor:
         self._nc_calls_sorter = nc_calls_sorter
         self._feature_service = feature_service
 
-    def execute_block(self, block: Block) -> Iterator[NCBlockEffect]:
+    def execute_block(
+        self,
+        block: Block,
+        *,
+        should_skip: ShouldSkipPredicate,
+    ) -> Iterator[NCBlockEffect]:
         """Execute block as generator, yielding effects without applying them.
 
         This is the pure execution method that yields lifecycle events as it processes
@@ -143,18 +180,17 @@ class NCBlockExecutor:
 
         Args:
             block: The block to execute.
+            should_skip: A predicate function that determines if a transaction should be skipped.
+                This allows the caller to provide context-specific voided state tracking.
 
         Yields:
             NCBlockEffect instances representing each step of execution.
         """
-        from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
-
         assert self._settings.ENABLE_NANO_CONTRACTS
         assert not block.is_genesis, "Genesis blocks should be handled separately"
 
         meta = block.get_metadata()
         assert not meta.voided_by
-        assert meta.nc_block_root_id is None
 
         parent = block.get_block_parent()
         parent_meta = parent.get_metadata()
@@ -165,14 +201,13 @@ class NCBlockExecutor:
         for tx in block.iter_transactions_in_this_block():
             if not tx.is_nano_contract():
                 continue
-            tx_meta = tx.get_metadata()
-            assert tx_meta.nc_execution in {None, NCExecutionState.PENDING}
-            if tx_meta.voided_by:
-                assert NC_EXECUTION_FAIL_ID not in tx_meta.voided_by
             nc_calls.append(tx)
 
-        nc_sorted_calls = self._nc_calls_sorter(block, nc_calls) if nc_calls else []
+        sorted_txs = self._nc_calls_sorter(block, nc_calls) if nc_calls else None
+        nc_sorted_calls = sorted_txs.sorted if sorted_txs else tuple()
+        nc_cyclic_txs = sorted_txs.cyclic if sorted_txs else tuple()
         block_storage = self._nc_storage_factory.get_block_storage(parent_root_id)
+        assert block_storage.get_root_id() == parent_root_id
         features = Features.from_vertex(settings=self._settings, feature_service=self._feature_service, vertex=block)
 
         yield NCBeginBlock(
@@ -180,7 +215,23 @@ class NCBlockExecutor:
             parent_root_id=parent_root_id,
             block_storage=block_storage,
             nc_sorted_calls=nc_sorted_calls,
+            nc_cyclic_fails=nc_cyclic_txs,
         )
+
+        for tx in nc_cyclic_txs:
+            yield NCBeginTransaction(tx=tx, rng_seed=b'')
+            try:
+                # Dummy raise just to create an exception context and convert
+                # into the failure effect, analogous to seqnum failures.
+                raise NCFail('cyclic failure detected')
+            except NCFail as e:
+                yield NCTxExecutionFailure(
+                    tx=tx,
+                    call_info=None,
+                    exception=e,
+                    traceback=traceback.format_exc(),
+                )
+            yield NCEndTransaction(tx=tx)
 
         seed_hasher = hashlib.sha256(block.hash)
 
@@ -198,6 +249,7 @@ class NCBlockExecutor:
                 tx=tx,
                 block_storage=block_storage,
                 rng_seed=rng_seed,
+                should_skip=should_skip,
             )
             yield result
 
@@ -220,16 +272,22 @@ class NCBlockExecutor:
         tx: Transaction,
         block_storage: 'NCBlockStorage',
         rng_seed: bytes,
+        should_skip: ShouldSkipPredicate,
     ) -> NCTxExecutionResult:
         """Execute a single NC transaction.
 
-        This method is pure and side-effect free. It does not persist anything,
-        does not call callbacks, and returns all information needed by the caller
-        to handle success/failure cases."""
-        tx_meta = tx.get_metadata()
-        if tx_meta.voided_by:
-            # Skip voided transactions. This might happen if a previous tx in nc_calls fails and
-            # mark this tx as voided.
+        On success, changes are committed to block_storage before returning.
+        Does not call callbacks. Returns all information needed by the caller
+        to handle success/failure cases.
+
+        Args:
+            tx: The transaction to execute.
+            block_storage: The block storage for this execution context.
+            rng_seed: The RNG seed for this transaction.
+            should_skip: Predicate to determine if transaction should be skipped.
+        """
+        if should_skip(tx):
+            # Skip transactions based on the caller-provided predicate.
             # Check if seqnum needs to be updated.
             nc_header = tx.get_nano_header()
             nc_address = Address(nc_header.nc_address)
@@ -286,30 +344,43 @@ class NCBlockExecutor:
                     contract_id, nano_header.nc_method, context, nc_args
                 )
 
-            # after the execution we have the latest state in the storage
-            # and at this point no tokens pending creation
-            self._verify_transparent_balance_after_execution(tx, block_storage)
+            # after the execution we have the latest state in the storage + changes tracker
+            # and at this point no tokens pending creation, so we can validate the balances
+            self._verify_transparent_balance_after_execution(tx, block_storage, runner)
         except NCFail as e:
+            runner.discard_pending_changes()
             return NCTxExecutionFailure(
                 tx=tx,
-                runner=runner,
+                call_info=runner.get_last_call_info(),
                 exception=e,
                 traceback=traceback.format_exc(),
             )
 
+        # Commit is intentionally outside the NCFail handling path.
+        # A failure here indicates critical state corruption and must propagate.
+        runner.commit_pending_changes()
+
         return NCTxExecutionSuccess(tx=tx, runner=runner)
 
     def _verify_transparent_balance_after_execution(
-        self, tx: Transaction, block_storage: 'NCBlockStorage'
+        self,
+        tx: Transaction,
+        block_storage: 'NCBlockStorage',
+        runner: 'Runner',
     ) -> None:
-        """Verify token sums after execution for dynamically created tokens."""
+        """Run strict verify_sum after execution using uncommitted token overlay visibility."""
+        from hathor.transaction.exceptions import TokenNotFound
         from hathor.verification.transaction_verifier import TransactionVerifier
+
+        created_tokens = runner.collect_created_tokens_from_uncommitted_changes()
+        block_proxy = _UncommittedRestrictedBlockProxy(block_storage, created_tokens=created_tokens)
+        block_proxy_as_storage = cast('NCBlockStorage', block_proxy)
+
         try:
-            token_dict = tx.get_complete_token_info(block_storage)
+            token_dict = tx.get_complete_token_info(block_proxy_as_storage)
             TransactionVerifier.verify_transparent_balance(self._settings, tx, token_dict)
         except TokenNotFound as e:
-            # At this point, any nonexistent token would have made a prior validation fail. For example, if there
-            # was a withdrawal of a nonexistent token, it would have failed in the balance validation before.
+            # Missing tokens should have failed in earlier validation paths.
             raise AssertionError from e
         except Exception as e:
             raise NCFail from e

--- a/hathor/nanocontracts/execution/consensus_block_executor.py
+++ b/hathor/nanocontracts/execution/consensus_block_executor.py
@@ -177,10 +177,19 @@ class NCConsensusBlockExecutor:
             self.initialize_empty(block, context)
             return
 
-        # Track NC transactions for final verification (populated from NCBeginBlock)
-        nc_sorted_calls: list[Transaction] = []
+        # Verify block hasn't been executed yet
+        meta = block.get_metadata()
+        assert meta.nc_block_root_id is None
 
-        for effect in self._block_executor.execute_block(block):
+        # Create predicate that reads from database metadata
+        def should_skip(tx: Transaction) -> bool:
+            tx_meta = tx.get_metadata()
+            return bool(tx_meta.voided_by)
+
+        # Track NC transactions for final verification (populated from NCBeginBlock)
+        nc_sorted_calls: tuple[Transaction, ...] = tuple()
+
+        for effect in self._block_executor.execute_block(block, should_skip=should_skip):
             match effect:
                 case NCBeginBlock(nc_sorted_calls=nc_sorted_calls):
                     pass
@@ -222,14 +231,21 @@ class NCConsensusBlockExecutor:
             context: Consensus algorithm context for saving state.
             on_failure: Callback for failed transactions.
         """
+        from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
+
         match effect:
             case NCBeginBlock():
                 # Nothing to apply at block start
                 pass
 
-            case NCBeginTransaction():
-                # Nothing to apply at transaction start
-                pass
+            case NCBeginTransaction(tx=tx):
+                # Verify transaction hasn't been executed yet
+                tx_meta = tx.get_metadata()
+                assert tx_meta.nc_execution in {None, NCExecutionState.PENDING}
+                if tx_meta.voided_by:
+                    # During normal execution, NC_EXECUTION_FAIL_ID should not be in voided_by
+                    # as that is added by the executor itself after a failure
+                    assert NC_EXECUTION_FAIL_ID not in tx_meta.voided_by
 
             case NCTxExecutionSuccess(tx=tx, runner=runner):
                 from hathor.nanocontracts.runner.call_info import CallType
@@ -239,7 +255,8 @@ class NCConsensusBlockExecutor:
                 tx_meta.nc_execution = NCExecutionState.SUCCESS
                 context.save(tx)
 
-                # Commit the runner changes
+                # Persist contract trie nodes to the shared store.
+                # Tx-level block-storage updates were already committed in NCBlockExecutor.
                 # TODO Avoid calling multiple commits for the same contract. The best would be
                 #      to call the commit method once per contract per block, just like we do
                 #      for the block_storage. This ensures we will have a clean database with
@@ -278,9 +295,9 @@ class NCConsensusBlockExecutor:
                     context.save(tx)
 
                 # Save logs
-                self._nc_log_storage.save_logs(tx, call_info, None)
+                self._nc_log_storage.save_logs(tx, call_info.nc_logger.__entries__, None)
 
-            case NCTxExecutionFailure(tx=tx, runner=runner, exception=exception, traceback=tb):
+            case NCTxExecutionFailure(tx=tx, call_info=call_info, exception=exception, traceback=tb):
                 # Log the failure
                 kwargs: dict[str, Any] = {}
                 if tx.name:
@@ -298,8 +315,8 @@ class NCConsensusBlockExecutor:
                 on_failure(tx)
 
                 # Save logs with exception info
-                call_info = runner.get_last_call_info()
-                self._nc_log_storage.save_logs(tx, call_info, (exception, tb))
+                log_entries = call_info.nc_logger.__entries__ if call_info is not None else []
+                self._nc_log_storage.save_logs(tx, log_entries, (exception, tb))
 
             case NCTxExecutionSkipped(tx=tx):
                 tx_meta = tx.get_metadata()

--- a/hathor/nanocontracts/execution/dry_run_block_executor.py
+++ b/hathor/nanocontracts/execution/dry_run_block_executor.py
@@ -1,0 +1,300 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Dry-run execution of NC blocks without state modification."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from typing_extensions import assert_never
+
+from hathor.nanocontracts.execution.block_executor import (
+    NCBeginBlock,
+    NCBeginTransaction,
+    NCEndBlock,
+    NCEndTransaction,
+    NCTxExecutionFailure,
+    NCTxExecutionSkipped,
+    NCTxExecutionSuccess,
+)
+from hathor.nanocontracts.execution.dry_run_models import (
+    DryRunCallRecord,
+    DryRunResult,
+    DryRunTxResult,
+    ExecutionStatus,
+)
+
+if TYPE_CHECKING:
+    from hathor.nanocontracts.execution.block_executor import NCBlockExecutor
+    from hathor.transaction import Block
+
+
+class NCDryRunBlockExecutor:
+    """
+    Executor for dry-running NC block execution.
+
+    This class provides a unified interface for dry-running blocks without
+    modifying state. It wraps NCBlockExecutor and collects execution effects
+    into a structured result.
+    """
+
+    def __init__(self, block_executor: 'NCBlockExecutor') -> None:
+        """
+        Initialize the dry-run executor.
+
+        Args:
+            block_executor: The pure block executor to use for execution.
+        """
+        self._block_executor = block_executor
+
+    def execute(
+        self,
+        block: 'Block',
+        *,
+        include_changes: bool = False,
+        target_tx_hash: Optional[bytes] = None,
+    ) -> DryRunResult:
+        """
+        Execute a dry run of the given block.
+
+        Args:
+            block: The block to dry-run.
+            include_changes: Whether to include storage state changes in call records.
+            target_tx_hash: Optional TX hash when looking up via transaction.
+
+        Returns:
+            DryRunResult containing all execution information.
+        """
+        from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
+        from hathor.transaction import Transaction
+
+        block_meta = block.get_metadata()
+        nc_block_root_id = block_meta.nc_block_root_id
+        expected_root_id = nc_block_root_id or b''
+
+        # Track voided txs in-memory during execution; tx_deps is populated
+        # from the NCBeginBlock effect to avoid a separate BFS traversal.
+        voided_in_block: set[bytes] = set()
+        tx_deps: dict[bytes, set[bytes]] = {}
+
+        def should_skip(tx: Transaction) -> bool:
+            # Check if any dependency (within block's NC txs) was voided
+            deps = tx_deps.get(tx.hash, set())
+            if deps & voided_in_block:
+                return True
+
+            # Mirror consensus's has_only_nc_execution_fail_id semantics: only
+            # txs voided purely by their own NC execution failure are
+            # re-executed; any other void reason (self-conflict, soft void,
+            # voided by another tx) means consensus skipped it and dry-run
+            # must too. Consensus invariant (consensus.py:283): NC_EXECUTION_FAIL_ID
+            # in voided_by implies tx.hash is also in voided_by.
+            meta = tx.get_metadata()
+            if meta.voided_by and meta.voided_by != {NC_EXECUTION_FAIL_ID, tx.hash}:
+                return True
+
+            return False
+
+        # Initialize result containers
+        initial_block_root_id = b''
+        final_block_root_id = b''
+        nc_sorted_calls: list[bytes] = []
+        transactions: list[DryRunTxResult] = []
+        current_rng_seed: Optional[bytes] = None
+
+        for effect in self._block_executor.execute_block(block, should_skip=should_skip):
+            match effect:
+                case NCBeginBlock(parent_root_id=parent_root_id, nc_sorted_calls=calls):
+                    initial_block_root_id = parent_root_id
+                    nc_sorted_calls = [tx.hash for tx in calls]
+                    # Build dependency graph from the already-collected NC txs
+                    nc_tx_set = set(nc_sorted_calls)
+                    for tx in calls:
+                        tx_deps[tx.hash] = {txin.tx_id for txin in tx.inputs} & nc_tx_set
+
+                case NCBeginTransaction(rng_seed=rng_seed):
+                    current_rng_seed = rng_seed
+
+                case NCTxExecutionSuccess(tx=tx, runner=runner):
+                    tx_result = self._build_success_result(
+                        tx, current_rng_seed, runner, include_changes
+                    )
+                    transactions.append(tx_result)
+                    current_rng_seed = None
+
+                case NCTxExecutionFailure(tx=tx, call_info=call_info, exception=exception, traceback=tb):
+                    # Mark this tx as voided for subsequent transactions
+                    voided_in_block.add(tx.hash)
+                    tx_result = self._build_failure_result(
+                        tx, current_rng_seed, call_info, exception, tb, include_changes
+                    )
+                    transactions.append(tx_result)
+                    current_rng_seed = None
+
+                case NCTxExecutionSkipped(tx=tx):
+                    # Also mark skipped txs as voided (propagate through chain)
+                    voided_in_block.add(tx.hash)
+                    tx_result = DryRunTxResult(
+                        tx_hash=tx.hash,
+                        rng_seed=current_rng_seed if current_rng_seed is not None else b'',
+                        execution_status=ExecutionStatus.SKIPPED,
+                    )
+                    transactions.append(tx_result)
+                    current_rng_seed = None
+
+                case NCEndTransaction():
+                    pass
+
+                case NCEndBlock(final_root_id=root_id):
+                    final_block_root_id = root_id
+
+                case _:
+                    assert_never(effect)
+
+        # Compare computed root with expected
+        warning = None
+        if nc_block_root_id is None:
+            root_id_matches = True
+            warning = 'Block has not been executed yet; cannot compare root IDs'
+        else:
+            root_id_matches = final_block_root_id == expected_root_id
+            if not root_id_matches:
+                warning = (
+                    f'Non-deterministic execution detected: computed root {final_block_root_id.hex()} '
+                    f'differs from expected root {expected_root_id.hex()}'
+                )
+
+        return DryRunResult(
+            block_hash=block.hash,
+            block_height=block.get_height(),
+            initial_block_root_id=initial_block_root_id,
+            final_block_root_id=final_block_root_id,
+            expected_block_root_id=expected_root_id,
+            root_id_matches=root_id_matches,
+            nc_sorted_calls=nc_sorted_calls,
+            transactions=transactions,
+            target_tx_hash=target_tx_hash,
+            warning=warning,
+        )
+
+    def _build_success_result(
+        self,
+        tx: Any,
+        rng_seed: Optional[bytes],
+        runner: Any,
+        include_changes: bool,
+    ) -> DryRunTxResult:
+        """Build result for successful execution."""
+        call_info = runner.get_last_call_info()
+        call_records = self._build_call_records(call_info, include_changes)
+        events = self._build_events(call_info)
+
+        return DryRunTxResult(
+            tx_hash=tx.hash,
+            rng_seed=rng_seed if rng_seed is not None else b'',
+            execution_status=ExecutionStatus.SUCCESS,
+            call_records=call_records,
+            events=events,
+        )
+
+    def _build_failure_result(
+        self,
+        tx: Any,
+        rng_seed: Optional[bytes],
+        call_info: Any,
+        exception: Exception,
+        tb: str,
+        include_changes: bool,
+    ) -> DryRunTxResult:
+        """Build result for failed execution.
+
+        `call_info` is None for cyclic-dependency failures, which never run a Runner.
+        """
+        call_records = self._build_call_records(call_info, include_changes) if call_info is not None else []
+        events = self._build_events(call_info) if call_info is not None else []
+
+        return DryRunTxResult(
+            tx_hash=tx.hash,
+            rng_seed=rng_seed if rng_seed is not None else b'',
+            execution_status=ExecutionStatus.FAILURE,
+            call_records=call_records,
+            events=events,
+            exception_type=type(exception).__name__,
+            exception_message=str(exception),
+            traceback=tb,
+        )
+
+    def _build_call_records(self, call_info: Any, include_changes: bool) -> list[DryRunCallRecord]:
+        """Build call records from CallInfo."""
+        records: list[DryRunCallRecord] = []
+        if call_info.calls is None:
+            return records
+
+        for call in call_info.calls:
+            index_updates: list[dict[str, Any]] = []
+            if call.index_updates is not None:
+                for update in call.index_updates:
+                    index_updates.append(update.to_json())
+
+            changes = None
+            if include_changes:
+                changes = self._extract_changes(call.changes_tracker)
+
+            record = DryRunCallRecord(
+                type=call.type.value,
+                depth=call.depth,
+                contract_id=call.contract_id,
+                blueprint_id=call.blueprint_id,
+                method_name=call.method_name,
+                index_updates=index_updates,
+                changes=changes,
+            )
+            records.append(record)
+
+        return records
+
+    def _extract_changes(self, changes_tracker: Any) -> list[dict[str, Any]]:
+        """Extract storage changes from a changes tracker.
+
+        Uses NCType.value_to_json for JSON-serializable output when the NCType is
+        known; falls back to repr() only when nc_type is None (e.g., deletions) or
+        value_to_json raises.
+        """
+        from hathorlib.nanocontracts.storage.changes_tracker import DeletedKey
+
+        changes: list[dict[str, Any]] = []
+        for attr_key, (value, nc_type) in changes_tracker.data.items():
+            change: dict[str, Any] = {'key': attr_key.key.hex()}
+            if value is DeletedKey:
+                change['deleted'] = True
+            elif nc_type is not None:
+                try:
+                    change['value'] = nc_type.value_to_json(value)
+                except Exception:
+                    change['value'] = repr(value)
+            else:
+                change['value'] = repr(value)
+            changes.append(change)
+        return changes
+
+    def _build_events(self, call_info: Any) -> list[dict[str, Any]]:
+        """Build events from CallInfo."""
+        events: list[dict[str, Any]] = []
+        for event in call_info.nc_logger.__events__:
+            events.append({
+                'nc_id': event.nc_id.hex(),
+                'data': event.data.hex(),
+            })
+        return events

--- a/hathor/nanocontracts/execution/dry_run_models.py
+++ b/hathor/nanocontracts/execution/dry_run_models.py
@@ -1,0 +1,75 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Pydantic models for dry-run NC block execution results."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal, Optional
+
+from pydantic import Field
+
+from hathor.api.schemas.base import ResponseModel
+from hathor.utils.pydantic import BaseModel, Hex
+
+
+class ExecutionStatus(StrEnum):
+    SUCCESS = 'success'
+    FAILURE = 'failure'
+    SKIPPED = 'skipped'
+
+
+class DryRunCallRecord(BaseModel):
+    """A single call record from NC execution."""
+    type: str = Field(description="Call type: 'public' or 'view'")
+    depth: int = Field(description="Call depth in the execution stack")
+    contract_id: Hex[bytes] = Field(description="Contract ID")
+    blueprint_id: Hex[bytes] = Field(description="Blueprint ID")
+    method_name: str = Field(description="Name of the called method")
+    index_updates: list[dict[str, Any]] = Field(description="List of index updates from this call")
+    changes: Optional[list[dict[str, Any]]] = Field(
+        default=None, description="Storage state changes (when include_changes=True)"
+    )
+
+
+class DryRunTxResult(BaseModel):
+    """Result of dry-running a single transaction."""
+    tx_hash: Hex[bytes] = Field(description="Transaction hash")
+    rng_seed: Hex[bytes] = Field(description="RNG seed used for this transaction")
+    execution_status: ExecutionStatus = Field(description="Execution status: 'success', 'failure', or 'skipped'")
+    call_records: list[DryRunCallRecord] = Field(default=[], description="List of call records from execution")
+    events: list[dict[str, Any]] = Field(default=[], description="Events emitted during execution")
+    exception_type: Optional[str] = Field(default=None, description="Exception type name on failure")
+    exception_message: Optional[str] = Field(default=None, description="Exception message on failure")
+    traceback: Optional[str] = Field(default=None, description="Traceback string on failure")
+
+
+class DryRunResult(ResponseModel):
+    """Complete result from dry-running a block."""
+    success: Literal[True] = Field(default=True, description="Whether the dry-run completed successfully")
+    block_hash: Hex[bytes] = Field(description="Block hash")
+    block_height: int = Field(description="Block height")
+    initial_block_root_id: Hex[bytes] = Field(description="NC root ID before execution")
+    final_block_root_id: Hex[bytes] = Field(description="NC root ID after execution")
+    expected_block_root_id: Hex[bytes] = Field(description="Expected NC root ID from block metadata")
+    root_id_matches: bool = Field(description="Whether computed root matches expected root")
+    nc_sorted_calls: list[Hex[bytes]] = Field(
+        description="TX hashes in execution order (same order as 'transactions' list)"
+    )
+    transactions: list[DryRunTxResult] = Field(
+        description="Execution results for each NC transaction, in the same order as 'nc_sorted_calls'"
+    )
+    target_tx_hash: Optional[Hex[bytes]] = Field(default=None, description="Target TX hash when queried via tx_hash")
+    warning: Optional[str] = Field(default=None, description="Warning message (e.g., non-determinism detected)")

--- a/hathor/nanocontracts/execution/dry_run_utils.py
+++ b/hathor/nanocontracts/execution/dry_run_utils.py
@@ -1,0 +1,130 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Shared utilities for dry-run block resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from hathor.transaction.storage.exceptions import TransactionDoesNotExist, TransactionIsNotABlock
+from hathor.utils.hex import parse_hash32
+
+if TYPE_CHECKING:
+    from hathor.transaction import Block
+    from hathor.transaction.storage import TransactionStorage
+
+
+class DryRunValidationError(Exception):
+    """Raised when dry-run input validation fails (e.g., invalid hash format)."""
+    pass
+
+
+class DryRunConflictError(Exception):
+    """Raised when the block is in a conflicting state (e.g., voided)."""
+    pass
+
+
+class DryRunNotFoundError(Exception):
+    """Raised when a referenced block or transaction is not found."""
+    pass
+
+
+@dataclass(frozen=True)
+class DryRunTarget:
+    """Result of resolving a dry-run target block."""
+    block: 'Block'
+    target_tx_hash: Optional[bytes] = None
+
+
+def resolve_block_for_dry_run(
+    tx_storage: 'TransactionStorage',
+    *,
+    block_hash: Optional[str] = None,
+    tx_hash: Optional[str] = None,
+) -> DryRunTarget:
+    """Resolve and validate a block for dry-run execution.
+
+    Args:
+        tx_storage: The transaction storage to look up blocks/txs.
+        block_hash: Hex-encoded block hash (mutually exclusive with tx_hash).
+        tx_hash: Hex-encoded transaction hash (mutually exclusive with block_hash).
+
+    Returns:
+        DryRunTarget with the resolved block and optional target tx hash.
+
+    Raises:
+        DryRunValidationError: For invalid input (bad hash, genesis, voided, not NC).
+        DryRunNotFoundError: When the referenced block or transaction is not found.
+    """
+    if tx_hash:
+        return _resolve_via_tx(tx_storage, tx_hash)
+    elif block_hash:
+        return _resolve_via_block(tx_storage, block_hash)
+    else:
+        raise DryRunValidationError('Must specify either block_hash or tx_hash')
+
+
+def _resolve_via_tx(tx_storage: 'TransactionStorage', tx_hash_hex: str) -> DryRunTarget:
+    """Resolve block via a transaction's first_block."""
+    try:
+        tx_hash_bytes = parse_hash32(tx_hash_hex)
+    except ValueError:
+        raise DryRunValidationError('Invalid hash format')
+
+    try:
+        tx = tx_storage.get_transaction(tx_hash_bytes)
+    except TransactionDoesNotExist:
+        raise DryRunNotFoundError(f'Transaction not found: {tx_hash_hex}')
+
+    if not tx.is_nano_contract():
+        raise DryRunValidationError('Transaction is not a nano contract')
+
+    tx_meta = tx.get_metadata()
+    if tx_meta.first_block is None:
+        raise DryRunValidationError('Transaction has no first_block')
+
+    try:
+        block = tx_storage.get_block(tx_meta.first_block)
+    except (TransactionDoesNotExist, TransactionIsNotABlock):
+        raise DryRunNotFoundError(f'Block not found: {tx_meta.first_block.hex()}')
+
+    _validate_block(block)
+    return DryRunTarget(block=block, target_tx_hash=tx_hash_bytes)
+
+
+def _resolve_via_block(tx_storage: 'TransactionStorage', block_hash_hex: str) -> DryRunTarget:
+    """Resolve block directly by hash."""
+    try:
+        block_hash_bytes = parse_hash32(block_hash_hex)
+    except ValueError:
+        raise DryRunValidationError('Invalid hash format')
+
+    try:
+        block = tx_storage.get_block(block_hash_bytes)
+    except (TransactionDoesNotExist, TransactionIsNotABlock):
+        raise DryRunNotFoundError(f'Block not found: {block_hash_hex}')
+
+    _validate_block(block)
+    return DryRunTarget(block=block)
+
+
+def _validate_block(block: 'Block') -> None:
+    """Validate that a block is suitable for dry-run execution."""
+    block_meta = block.get_metadata()
+    if block_meta.voided_by:
+        raise DryRunConflictError('Block is not on best chain (voided)')
+    if block.is_genesis:
+        raise DryRunValidationError('Cannot dry-run genesis block')

--- a/hathor/nanocontracts/nc_exec_logs.py
+++ b/hathor/nanocontracts/nc_exec_logs.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, assert_never
 
 from hathor.nanocontracts import NCFail
-from hathor.nanocontracts.runner import CallInfo
 from hathor.transaction import Transaction
 from hathor.types import VertexId
 
@@ -56,7 +55,12 @@ class NCLogStorage:
         self._path = Path(path).joinpath(NC_EXEC_LOGS_DIR)
         self._config = config
 
-    def save_logs(self, tx: Transaction, call_info: CallInfo, exception_and_tb: tuple[NCFail, str] | None) -> None:
+    def save_logs(
+        self,
+        tx: Transaction,
+        log_entries: list[NCCallBeginEntry | NCLogEntry | NCCallEndEntry],
+        exception_and_tb: tuple[NCFail, str] | None,
+    ) -> None:
         """Persist new NC execution logs."""
         assert tx.is_nano_contract()
         meta = tx.get_metadata()
@@ -85,7 +89,7 @@ class NCLogStorage:
             case _:
                 assert_never(self._config)
 
-        new_entry = NCExecEntry.from_call_info(call_info, tb)
+        new_entry = NCExecEntry(logs=log_entries, error_traceback=tb)
         new_line_dict = {meta.first_block.hex(): new_entry.model_dump()}
         path = self._get_file_path(tx.hash)
 

--- a/hathor/nanocontracts/on_chain_blueprint.py
+++ b/hathor/nanocontracts/on_chain_blueprint.py
@@ -185,7 +185,6 @@ class OnChainBlueprint(Transaction):
 
         self.code: Code = code if code is not None else Code(CodeKind.PYTHON_ZLIB, b'', self._settings)
         self._ast_cache: Optional[ast.Module] = None
-        self._blueprint_loaded_env: Optional[tuple[type[Blueprint], dict[str, object]]] = None
 
     def blueprint_id(self) -> BlueprintId:
         """The blueprint's contract-id is it's own tx-id, this helper method just converts to the right type."""
@@ -241,12 +240,10 @@ class OnChainBlueprint(Transaction):
 
     def _load_blueprint_code(self) -> tuple[type[Blueprint], dict[str, object]]:
         """This method loads the on-chain code (if not loaded) and returns the blueprint class and env."""
-        if self._blueprint_loaded_env is None:
-            blueprint_class, env = self._load_blueprint_code_exec()
-            assert isinstance(blueprint_class, type)
-            assert issubclass(blueprint_class, Blueprint)
-            self._blueprint_loaded_env = blueprint_class, env
-        return self._blueprint_loaded_env
+        blueprint_class, env = self._load_blueprint_code_exec()
+        assert isinstance(blueprint_class, type)
+        assert issubclass(blueprint_class, Blueprint)
+        return blueprint_class, env
 
     def get_blueprint_object_bypass(self) -> object:
         """Loads the code and returns the object exported with @export"""

--- a/hathor/nanocontracts/resources/__init__.py
+++ b/hathor/nanocontracts/resources/__init__.py
@@ -15,6 +15,7 @@
 from hathor.nanocontracts.resources.blueprint import BlueprintInfoResource
 from hathor.nanocontracts.resources.blueprint_source_code import BlueprintSourceCodeResource
 from hathor.nanocontracts.resources.builtin import BlueprintBuiltinResource
+from hathor.nanocontracts.resources.dry_run import NCDryRunResource
 from hathor.nanocontracts.resources.history import NanoContractHistoryResource
 from hathor.nanocontracts.resources.nc_creation import NCCreationResource
 from hathor.nanocontracts.resources.nc_exec_logs import NCExecLogsResource
@@ -29,5 +30,6 @@ __all__ = [
     'NanoContractStateResource',
     'NanoContractHistoryResource',
     'NCCreationResource',
+    'NCDryRunResource',
     'NCExecLogsResource',
 ]

--- a/hathor/nanocontracts/resources/dry_run.py
+++ b/hathor/nanocontracts/resources/dry_run.py
@@ -1,0 +1,120 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""HTTP resource for dry-running NC block execution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+import structlog
+from pydantic import Field, model_validator
+from twisted.internet.defer import Deferred
+from twisted.internet.threads import deferToThread
+
+from hathor._openapi.register import register_resource
+from hathor.api.openapi import api_endpoint
+from hathor.api.schemas.base import ConflictResponse, ErrorResponse, NotFoundResponse, ResponseModel
+from hathor.api_util import Resource
+from hathor.nanocontracts.execution.dry_run_block_executor import NCDryRunBlockExecutor
+from hathor.nanocontracts.execution.dry_run_models import DryRunResult
+from hathor.nanocontracts.execution.dry_run_utils import (
+    DryRunConflictError,
+    DryRunNotFoundError,
+    DryRunValidationError,
+    resolve_block_for_dry_run,
+)
+from hathor.utils.api import QueryParams
+
+logger = structlog.get_logger()
+
+if TYPE_CHECKING:
+    from twisted.web.http import Request
+
+    from hathor.nanocontracts.execution.block_executor import NCBlockExecutor
+    from hathor.transaction.storage import TransactionStorage
+
+
+class NCDryRunParams(QueryParams):
+    """Query parameters for the dry-run endpoint."""
+    block_hash: Optional[str] = Field(default=None, description="Hex-encoded block hash (64 chars)")
+    tx_hash: Optional[str] = Field(default=None, description="Hex-encoded NC transaction hash (64 chars)")
+    include_changes: bool = Field(default=False, description="Include storage state changes in call records")
+
+    @model_validator(mode='after')
+    def check_exactly_one_hash(self) -> 'NCDryRunParams':
+        if self.block_hash and self.tx_hash:
+            raise ValueError('Cannot specify both block_hash and tx_hash')
+        if not self.block_hash and not self.tx_hash:
+            raise ValueError('Must specify either block_hash or tx_hash')
+        return self
+
+
+@register_resource
+class NCDryRunResource(Resource):
+    """Resource for dry-running NC block execution.
+
+    This endpoint allows inspecting what would happen during NC execution
+    without modifying any state.
+    """
+    isLeaf = True
+
+    def __init__(self, tx_storage: 'TransactionStorage', block_executor: 'NCBlockExecutor') -> None:
+        super().__init__()
+        self._tx_storage = tx_storage
+        self._block_executor = block_executor
+
+    @api_endpoint(
+        path='/nano_contract/dry_run',
+        method='GET',
+        operation_id='nano_contracts_dry_run',
+        summary='Dry-run NC block execution',
+        description='Dry-run nano contract execution for a block without modifying state.',
+        tags=['nano_contracts'],
+        visibility='private',  # Rate limits still apply to private endpoints via nginx/proxy config
+        rate_limit_global=[{'rate': '2r/s', 'burst': 5, 'delay': 2}],
+        rate_limit_per_ip=[{'rate': '1r/s', 'burst': 2, 'delay': 1}],
+        query_params_model=NCDryRunParams,
+        response_model=Union[DryRunResult, ErrorResponse, NotFoundResponse, ConflictResponse],
+    )
+    def render_GET(self, request: 'Request', *, params: NCDryRunParams) -> Union[ResponseModel, Deferred[Any]]:
+        request.setHeader(b'cache-control', b'no-store')
+
+        logger.info('nc_dry_run.start', block_hash=params.block_hash, tx_hash=params.tx_hash)
+
+        try:
+            target = resolve_block_for_dry_run(
+                self._tx_storage,
+                block_hash=params.block_hash,
+                tx_hash=params.tx_hash,
+            )
+        except DryRunValidationError as e:
+            return ErrorResponse(error=str(e))
+        except DryRunConflictError as e:
+            return ConflictResponse(error=str(e))
+        except DryRunNotFoundError as e:
+            return NotFoundResponse(error=str(e))
+
+        logger.info('nc_dry_run.resolved', block_hash=target.block.hash.hex())
+
+        # Execute dry run in a thread to avoid blocking the reactor
+        def _execute() -> DryRunResult:
+            dry_run_executor = NCDryRunBlockExecutor(self._block_executor)
+            return dry_run_executor.execute(
+                target.block,
+                include_changes=params.include_changes,
+                target_tx_hash=target.target_tx_hash,
+            )
+
+        return deferToThread(_execute)

--- a/hathor/nanocontracts/sorter/random_sorter.py
+++ b/hathor/nanocontracts/sorter/random_sorter.py
@@ -22,22 +22,28 @@ from sortedcontainers import SortedSet
 from typing_extensions import Self
 
 from hathor.nanocontracts.rng import NanoRNG
+from hathor.nanocontracts.sorter.types import SortedTransactions
 from hathor.transaction import Block, Transaction
 from hathor.types import Address, VertexId
 
 
-def random_nc_calls_sorter(block: Block, nc_calls: list[Transaction]) -> list[Transaction]:
+def random_nc_calls_sorter(block: Block, nc_calls: list[Transaction]) -> SortedTransactions:
     sorter = NCBlockSorter.create_from_block(block, nc_calls)
     seed = hashlib.sha256(block.hash).digest()
 
-    order = sorter.generate_random_topological_order(seed)
+    order, stuck = sorter.generate_random_topological_order(seed)
     tx_by_id = dict((tx.hash, tx) for tx in nc_calls)
-    assert set(order) == set(tx_by_id.keys())
+    assert all((tx_id in order or tx_id in stuck) for tx_id in tx_by_id)
+    sorted_calls = tuple(tx_by_id[_id] for _id in order)
 
-    ret: list[Transaction] = []
-    for _id in order:
-        ret.append(tx_by_id[_id])
-    return ret
+    cycle_failed: list[Transaction] = []
+    for id_ in stuck:
+        # `stuck` may also contain dummy seqnum nodes and non-NC funds transactions that got dragged into
+        # the cycle's reachable set; only NC transactions in the current block should be added.
+        if tx := tx_by_id.get(id_):
+            cycle_failed.append(tx)
+
+    return SortedTransactions(sorted=sorted_calls, cyclic=tuple(cycle_failed))
 
 
 @dataclass(slots=True, kw_only=True)
@@ -158,8 +164,18 @@ class NCBlockSorter:
         """Get all vertices with no outgoing edges."""
         return SortedSet(v.id for v in self.db.values() if not v.outgoing_edges)
 
-    def generate_random_topological_order(self, seed: bytes) -> list[VertexId]:
+    def generate_random_topological_order(self, seed: bytes) -> tuple[list[VertexId], set[VertexId]]:
         """Generate a random topological order according to the DAG.
+
+        Returns a tuple `(order, stuck)` where:
+
+        - `order` is the topological sort of NC transactions that can execute — filtered to NC
+          hashes only; non-NC funds txs and dummy seqnum nodes are skipped.
+        - `stuck` is the set of vertex ids that could not be ordered because they participate in,
+          or transitively depend on, a cyclic dependency. It is empty in the normal case. When
+          non-empty, the caller is expected to fail the NC transactions in that set. `stuck`
+          may also include dummy nodes and non-NC funds txs that got pulled into the cycle's
+          reachable set; callers should filter to the subset they care about.
 
         This method can only be called once because it changes the DAG during its execution.
         """
@@ -170,11 +186,15 @@ class NCBlockSorter:
         rng = NanoRNG(seed)
 
         candidates = self.get_vertices_with_no_outgoing_edges()
-        ret = []
-        for i in range(len(self.db)):
-            assert len(candidates) > 0, 'empty candidates, probably caused by circular dependencies in the graph'
+        ret: list[VertexId] = []
+        popped: set[VertexId] = set()
+
+        i = 0
+        while candidates and i < len(self.db):
+            i += 1
             idx = len(candidates) - rng.randbelow(len(candidates)) - 1
             vertex_id = candidates.pop(idx)
+            popped.add(vertex_id)
 
             # Skip all nodes that do not belong to nc_calls, which are either non-nano txs or dummy nodes.
             if vertex_id in self._nc_hashes:
@@ -189,4 +209,10 @@ class NCBlockSorter:
                 if not in_vertex.outgoing_edges:
                     candidates.add(in_vertex_id)
 
-        return ret
+        # Any vertex not popped still has at least one outgoing edge, and that edge points to
+        # another unpopped vertex (since popping removes the edge from every predecessor). So the
+        # remaining vertices form a subgraph where every vertex has out-degree >= 1, which means
+        # it contains a cycle and every remaining vertex reaches that cycle via outgoing edges —
+        # i.e. the cycle members plus their transitive dependants.
+        stuck = set(self.db.keys()) - popped
+        return ret, stuck

--- a/hathor/nanocontracts/sorter/types.py
+++ b/hathor/nanocontracts/sorter/types.py
@@ -12,11 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from typing import Protocol
 
 from hathor.transaction import Block, Transaction
 
 
+@dataclass(slots=True, frozen=True, kw_only=True)
+class SortedTransactions:
+    sorted: tuple[Transaction, ...]
+    cyclic: tuple[Transaction, ...]
+
+
 class NCSorterCallable(Protocol):
-    def __call__(self, block: Block, nc_calls: list[Transaction]) -> list[Transaction]:
+    def __call__(self, block: Block, nc_calls: list[Transaction]) -> SortedTransactions:
+        """
+        Return the sorted execution order plus any transactions that must fail due to cyclic dependencies.
+
+        `SortedTransactions.cyclic` is empty in the normal case. A non-empty tuple means the sorter
+        detected a cycle in the dependency graph; the caller must mark those transactions as failed
+        NC executions and skip executing them.
+        """
         ...

--- a/hathor/utils/hex.py
+++ b/hathor/utils/hex.py
@@ -1,0 +1,37 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Helpers for parsing hex-encoded bytes from user input."""
+
+from __future__ import annotations
+
+HASH32_HEX_LEN = 64
+
+
+def parse_hash32(value: str) -> bytes:
+    """Parse a hex-encoded 32-byte hash (64 hex characters) into bytes.
+
+    Raises ValueError if the input is not exactly 64 hex characters.
+    """
+    if len(value) != HASH32_HEX_LEN:
+        raise ValueError(
+            f'expected {HASH32_HEX_LEN} hex characters, got {len(value)}'
+        )
+    # bytes.fromhex ignores ASCII whitespace, so a 64-char string with
+    # embedded spaces would decode to fewer than 32 bytes and pass the
+    # length check. Validate the decoded length to reject such inputs.
+    result = bytes.fromhex(value)
+    if len(result) != HASH32_HEX_LEN // 2:
+        raise ValueError('hash must be 64 hex characters with no whitespace')
+    return result

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -20,10 +20,6 @@ from typing import Any, Optional
 
 from structlog import get_logger
 
-from hathor.nanocontracts.blueprint_service import BlueprintService
-from hathor.transaction.storage.rocksdb_storage import CacheConfig
-from hathor_cli.run_node_args import RunNodeArgs
-from hathor_cli.side_dag import SideDagArgs
 from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.event import EventManager
@@ -35,6 +31,8 @@ from hathor.feature_activation.storage.feature_activation_storage import Feature
 from hathor.indexes import IndexesManager, RocksDBIndexesManager
 from hathor.manager import HathorManager
 from hathor.mining.cpu_mining_service import CpuMiningService
+from hathor.nanocontracts.blueprint_service import BlueprintService
+from hathor.nanocontracts.execution import NCBlockExecutor
 from hathor.nanocontracts.nc_exec_logs import NCLogStorage
 from hathor.nanocontracts.runner.runner import RunnerFactory
 from hathor.p2p.manager import ConnectionsManager
@@ -44,14 +42,17 @@ from hathor.p2p.utils import discover_hostname, get_genesis_short_hash
 from hathor.pubsub import PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
 from hathor.stratum import StratumFactory
+from hathor.transaction.json_serializer import VertexJsonSerializer
+from hathor.transaction.storage.rocksdb_storage import CacheConfig
 from hathor.transaction.vertex_children import RocksDBVertexChildrenService
 from hathor.transaction.vertex_parser import VertexParser
 from hathor.util import Random
 from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor.vertex_handler import VertexHandler
-from hathor.transaction.json_serializer import VertexJsonSerializer
 from hathor.wallet import BaseWallet, HDWallet, Wallet
+from hathor_cli.run_node_args import RunNodeArgs
+from hathor_cli.side_dag import SideDagArgs
 
 logger = get_logger()
 
@@ -243,6 +244,14 @@ class CliBuilder:
             blueprint_service=blueprint_service,
         )
 
+        block_executor = NCBlockExecutor(
+            settings=settings,
+            runner_factory=runner_factory,
+            nc_storage_factory=self.nc_storage_factory,
+            nc_calls_sorter=nc_calls_sorter,
+            feature_service=self.feature_service,
+        )
+
         nc_log_storage = NCLogStorage(
             settings=settings,
             path=self.rocksdb_storage.path,
@@ -254,9 +263,8 @@ class CliBuilder:
             self.nc_storage_factory,
             soft_voided_tx_ids,
             settings=settings,
-            runner_factory=runner_factory,
+            block_executor=block_executor,
             nc_log_storage=nc_log_storage,
-            nc_calls_sorter=nc_calls_sorter,
             feature_service=self.feature_service,
             nc_exec_fail_trace=self._args.nc_exec_fail_trace,
             tx_storage=tx_storage,

--- a/hathor_cli/main.py
+++ b/hathor_cli/main.py
@@ -45,6 +45,7 @@ class CliManager:
             multisig_address,
             multisig_signature,
             multisig_spend,
+            nc_dry_run,
             nc_dump,
             nginx_config,
             openapi_json,
@@ -103,6 +104,7 @@ class CliManager:
         self.add_cmd('dev', 'x-export', db_export, 'EXPERIMENTAL: Export database to a simple format.')
         self.add_cmd('dev', 'x-import', db_import, 'EXPERIMENTAL: Import database from exported format.')
         self.add_cmd('dev', 'x-nc-dump', nc_dump, 'EXPERIMENTAL: Dump the nc storage in a text format.')
+        self.add_cmd('dev', 'x-nc-dry-run', nc_dry_run, 'EXPERIMENTAL: Dry-run NC block execution')
         self.add_cmd('dev', 'replay-logs', replay_logs, 'EXPERIMENTAL: re-play json logs as console printed')
         self.add_cmd('dev', 'load-from-logs', load_from_logs,
                      'Load vertices as they are found in a log dump that was parsed with parse-logs')

--- a/hathor_cli/nc_dry_run.py
+++ b/hathor_cli/nc_dry_run.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI command for dry-running NC block execution."""
+
+from __future__ import annotations
+
+import sys
+from argparse import ArgumentParser
+from typing import TYPE_CHECKING, Optional
+
+from hathor_cli.run_node import RunNode
+
+if TYPE_CHECKING:
+    from hathor.nanocontracts.execution.dry_run_models import DryRunResult
+
+
+class NcDryRun(RunNode):
+    """Dry-run NC block execution from the CLI."""
+
+    def start_manager(self) -> None:
+        """Don't start the manager."""
+        pass
+
+    def register_signal_handlers(self) -> None:
+        """Don't register signal handlers."""
+        pass
+
+    @classmethod
+    def create_parser(cls) -> ArgumentParser:
+        parser = super().create_parser()
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            '--block-hash',
+            type=str,
+            help='Hash of the block to dry-run',
+        )
+        group.add_argument(
+            '--tx-hash',
+            type=str,
+            help='Hash of the NC transaction (will dry-run its first_block)',
+        )
+        parser.add_argument(
+            '--output',
+            type=str,
+            default=None,
+            help='Output file path (defaults to stdout)',
+        )
+        parser.add_argument(
+            '--format',
+            choices=['json', 'text'],
+            default='json',
+            help='Output format (json or text)',
+        )
+        parser.add_argument(
+            '--include-changes',
+            action='store_true',
+            help='Include storage state changes in call records',
+        )
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            help='Show verbose output (for text format)',
+        )
+        return parser
+
+    def prepare(self, *, register_resources: bool = False) -> None:
+        super().prepare(register_resources=register_resources)
+
+    def run(self) -> None:
+        from hathor.nanocontracts.execution.dry_run_block_executor import NCDryRunBlockExecutor
+        from hathor.nanocontracts.execution.dry_run_utils import (
+            DryRunConflictError,
+            DryRunNotFoundError,
+            DryRunValidationError,
+            resolve_block_for_dry_run,
+        )
+
+        block_hash_arg: Optional[str] = self._args.block_hash
+        tx_hash_arg: Optional[str] = self._args.tx_hash
+        output_format: str = self._args.format
+        include_changes: bool = self._args.include_changes
+        verbose: bool = self._args.verbose
+        output_path: Optional[str] = self._args.output
+
+        try:
+            target = resolve_block_for_dry_run(
+                self.tx_storage,
+                block_hash=block_hash_arg,
+                tx_hash=tx_hash_arg,
+            )
+        except (DryRunValidationError, DryRunConflictError, DryRunNotFoundError) as e:
+            self.log.error(str(e))
+            sys.exit(1)
+
+        # Execute dry run using shared executor
+        block_executor = self.manager.consensus_algorithm.block_executor
+        try:
+            dry_run_executor = NCDryRunBlockExecutor(block_executor)
+            result = dry_run_executor.execute(
+                target.block,
+                include_changes=include_changes,
+                target_tx_hash=target.target_tx_hash,
+            )
+        except Exception as e:
+            self.log.error('dry-run execution failed', error=str(e))
+            sys.exit(1)
+
+        # Log warning if roots don't match
+        if not result.root_id_matches:
+            self.log.warning(
+                'Non-deterministic execution detected',
+                computed_root=result.final_block_root_id.hex(),
+                expected_root=result.expected_block_root_id.hex(),
+            )
+
+        # Output results
+        if output_format == 'json':
+            output_str = result.model_dump_json(indent=2)
+        else:
+            output_str = format_dry_run_text(result, verbose=verbose)
+
+        if output_path:
+            try:
+                with open(output_path, 'w') as f:
+                    f.write(output_str)
+            except OSError as e:
+                self.log.error('failed to write output file', path=output_path, error=str(e))
+                sys.exit(1)
+            self.log.info('output written', path=output_path)
+        else:
+            print(output_str)
+
+
+def format_dry_run_text(result: 'DryRunResult', verbose: bool = False) -> str:
+    """
+    Format a DryRunResult as human-readable text.
+
+    Args:
+        result: The dry run result to format.
+        verbose: Whether to include verbose output (tracebacks, changes).
+
+    Returns:
+        Formatted text string.
+    """
+    from hathor.nanocontracts.execution.dry_run_models import ExecutionStatus
+
+    lines: list[str] = []
+
+    # Header
+    lines.append(f"Block: {result.block_hash.hex()} (height: {result.block_height})")
+    lines.append(f"Initial Root:  {result.initial_block_root_id.hex()}")
+    lines.append(f"Final Root:    {result.final_block_root_id.hex()}")
+    lines.append(f"Expected Root: {result.expected_block_root_id.hex()}")
+
+    if result.root_id_matches:
+        lines.append('Root Match:    OK')
+    else:
+        lines.append('Root Match:    MISMATCH (non-deterministic execution detected!)')
+        if result.warning:
+            lines.append(f"WARNING: {result.warning}")
+    lines.append('')
+
+    # Execution order
+    lines.append(f'Execution Order: {len(result.nc_sorted_calls)} transactions')
+    for i, tx_hash in enumerate(result.nc_sorted_calls, 1):
+        lines.append(f'  {i}. {tx_hash.hex()}')
+    lines.append('')
+
+    # Transaction details
+    for i, tx in enumerate(result.transactions, 1):
+        lines.append(f"--- Transaction {i}/{len(result.transactions)}: {tx.tx_hash.hex()} ---")
+        lines.append(f"RNG Seed: {tx.rng_seed.hex()}")
+        lines.append(f"Status: {tx.execution_status.upper()}")
+
+        if tx.execution_status == ExecutionStatus.FAILURE:
+            lines.append(f"Exception: {tx.exception_type or 'Unknown'} - {tx.exception_message or ''}")
+            if verbose and tx.traceback:
+                lines.append('Traceback:')
+                for tb_line in tx.traceback.split('\n'):
+                    lines.append(f'  {tb_line}')
+
+        for j, call in enumerate(tx.call_records, 1):
+            lines.append('')
+            lines.append(f"  Call #{j}: {call.method_name} ({call.type}, depth={call.depth})")
+            lines.append(f"    Contract: {call.contract_id.hex()}")
+            lines.append(f"    Blueprint: {call.blueprint_id.hex()}")
+
+            if call.index_updates:
+                lines.append('    Index Updates:')
+                for update in call.index_updates:
+                    update_type = update.get('type', 'UNKNOWN')
+                    if update_type == 'update_token_balance':
+                        token = update.get('token_uid', 'N/A')
+                        amount = update.get('amount', 'N/A')
+                        lines.append(f"      - {update_type}: token={token}, amount={amount}")
+                    else:
+                        lines.append(f"      - {update}")
+
+            if call.changes and verbose:
+                lines.append('    Changes:')
+                for change in call.changes:
+                    lines.append(f"      - {change['key']}: {change['value']}")
+
+        if tx.events:
+            lines.append('  Events:')
+            for event in tx.events:
+                lines.append(f"    - nc_id={event['nc_id']}, data={event['data']}")
+
+        lines.append('')
+
+    return '\n'.join(lines)
+
+
+def main():
+    NcDryRun().run()

--- a/hathor_tests/cli/test_nc_dry_run.py
+++ b/hathor_tests/cli/test_nc_dry_run.py
@@ -1,0 +1,144 @@
+# Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NcDryRun CLI command."""
+
+import io
+import sys
+import tempfile
+
+from hathor_cli.nc_dry_run import NcDryRun
+from hathor_tests import unittest
+
+
+class NcDryRunParserTest(unittest.TestCase):
+    """Test NcDryRun argument parser."""
+
+    def test_parser_block_hash(self):
+        """Test parser with --block-hash argument."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc123'])
+            self.assertEqual(cmd._args.block_hash, 'abc123')
+            self.assertIsNone(cmd._args.tx_hash)
+
+    def test_parser_tx_hash(self):
+        """Test parser with --tx-hash argument."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--tx-hash', 'def456'])
+            self.assertIsNone(cmd._args.block_hash)
+            self.assertEqual(cmd._args.tx_hash, 'def456')
+
+    def test_parser_mutually_exclusive(self):
+        """Test that --block-hash and --tx-hash are mutually exclusive."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Capture stderr to verify error message
+            captured_stderr = io.StringIO()
+            old_stderr = sys.stderr
+            sys.stderr = captured_stderr
+            try:
+                with self.assertRaises(SystemExit) as cm:
+                    NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc', '--tx-hash', 'def'])
+            finally:
+                sys.stderr = old_stderr
+
+            # Argparse exits with code 2 for argument errors
+            self.assertEqual(cm.exception.code, 2)
+            # Verify error message mentions the mutually exclusive constraint
+            stderr_output = captured_stderr.getvalue()
+            self.assertIn('not allowed with argument', stderr_output)
+
+    def test_parser_requires_hash(self):
+        """Test that either --block-hash or --tx-hash is required."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Capture stderr to verify error message
+            captured_stderr = io.StringIO()
+            old_stderr = sys.stderr
+            sys.stderr = captured_stderr
+            try:
+                with self.assertRaises(SystemExit) as cm:
+                    NcDryRun(argv=['--data', temp_dir])
+            finally:
+                sys.stderr = old_stderr
+
+            # Argparse exits with code 2 for argument errors
+            self.assertEqual(cm.exception.code, 2)
+            # Verify error message mentions required arguments
+            stderr_output = captured_stderr.getvalue()
+            self.assertIn('required', stderr_output.lower())
+
+    def test_parser_format_json(self):
+        """Test parser with --format json argument."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc', '--format', 'json'])
+            self.assertEqual(cmd._args.format, 'json')
+
+    def test_parser_format_text(self):
+        """Test parser with --format text argument."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc', '--format', 'text'])
+            self.assertEqual(cmd._args.format, 'text')
+
+    def test_parser_include_changes(self):
+        """Test parser with --include-changes flag."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc', '--include-changes'])
+            self.assertTrue(cmd._args.include_changes)
+
+    def test_parser_verbose(self):
+        """Test parser with --verbose flag."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc', '--verbose'])
+            self.assertTrue(cmd._args.verbose)
+
+    def test_parser_output(self):
+        """Test parser with --output argument."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc', '--output', '/tmp/out.json'])
+            self.assertEqual(cmd._args.output, '/tmp/out.json')
+
+    def test_parser_default_format(self):
+        """Test that default format is json."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc'])
+            self.assertEqual(cmd._args.format, 'json')
+
+    def test_parser_default_include_changes(self):
+        """Test that default include_changes is False."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc'])
+            self.assertFalse(cmd._args.include_changes)
+
+    def test_parser_default_verbose(self):
+        """Test that default verbose is False."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc'])
+            self.assertFalse(cmd._args.verbose)
+
+
+class NcDryRunMethodsTest(unittest.TestCase):
+    """Test NcDryRun methods."""
+
+    def test_start_manager_does_nothing(self):
+        """Test that start_manager does nothing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc'])
+            # Should not raise
+            cmd.start_manager()
+
+    def test_register_signal_handlers_does_nothing(self):
+        """Test that register_signal_handlers does nothing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cmd = NcDryRun(argv=['--data', temp_dir, '--block-hash', 'abc'])
+            # Should not raise
+            cmd.register_signal_handlers()

--- a/hathor_tests/nanocontracts/fixtures/__init__.py
+++ b/hathor_tests/nanocontracts/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Hathor Labs
+# Copyright 2025 Hathor Labs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.transaction import Block, Transaction
-
-
-def timestamp_nc_calls_sorter(block: Block, nc_calls: list[Transaction]) -> list[Transaction]:
-    """Return the nc_calls sorted by (timestamp, hash).
-
-    DEPRECATED: This is used only to keep compatibility with the alpha nano-testnet.
-    """
-    return sorted(nc_calls, key=lambda tx: (tx.timestamp, tx.hash))
+"""Test fixtures for nano contracts."""

--- a/hathor_tests/nanocontracts/fixtures/dry_run.py
+++ b/hathor_tests/nanocontracts/fixtures/dry_run.py
@@ -1,0 +1,361 @@
+# Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for dry-run tests.
+
+This module provides a common DAG setup that can be used by:
+- NCDryRunBlockExecutor tests (detailed validation)
+- NCDryRunResource HTTP API tests (serialization validation)
+- NcDryRun CLI tests (serialization validation)
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts.exception import NCFail
+from hathor.nanocontracts.types import BlueprintId
+from hathor.transaction import Block, Transaction
+
+if TYPE_CHECKING:
+    from hathor.dag_builder.artifacts import DAGArtifacts
+    from hathor.dag_builder.builder import DAGBuilder
+    from hathor.manager import HathorManager
+
+
+class DryRunTestBlueprint(Blueprint):
+    """Test blueprint for dry-run tests.
+
+    Provides multiple methods to test different execution scenarios:
+    - initialize: Create contract with initial state
+    - increment: Modify state (success case)
+    - transfer: Modify state with multiple attributes
+    - fail_if_negative: Conditional failure based on input
+    """
+    counter: int
+    value: int
+    total_calls: int
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        """Initialize the contract with default values."""
+        self.counter = 0
+        self.value = 0
+        self.total_calls = 0
+
+    @public
+    def increment(self, ctx: Context, amount: int) -> None:
+        """Increment value by amount."""
+        self.counter += 1
+        self.value += amount
+        self.total_calls += 1
+
+    @public
+    def fail_if_negative(self, ctx: Context, amount: int) -> None:
+        """Fail if amount is negative, otherwise increment."""
+        if amount < 0:
+            raise NCFail('Amount cannot be negative')
+        self.value += amount
+        self.total_calls += 1
+
+
+@dataclass
+class DryRunDAGFixture:
+    """Container for the DAG artifacts and expected results.
+
+    Attributes:
+        artifacts: The DAG artifacts from the builder
+        blueprint_id: The registered blueprint ID
+        block_with_nc: Block containing NC transactions
+        block_without_nc: Block without NC transactions
+        nc_tx_initialize: The initialize transaction
+        nc_tx_increment: The increment transaction
+        regular_tx: A regular (non-NC) transaction
+        expected_tx_count: Expected number of NC transactions in block_with_nc
+    """
+    artifacts: 'DAGArtifacts'
+    blueprint_id: BlueprintId
+    block_with_nc: Block
+    block_without_nc: Block
+    nc_tx_initialize: Transaction
+    nc_tx_increment: Transaction
+    regular_tx: Transaction
+    expected_tx_count: int = 2
+
+
+@dataclass
+class DryRunExpectedResult:
+    """Expected results for detailed validation in executor tests.
+
+    Attributes:
+        nc_sorted_calls_count: Expected number of NC transactions
+        success_tx_count: Expected number of successful NC transactions
+        failure_tx_count: Expected number of failed NC transactions
+        skipped_tx_count: Expected number of skipped NC transactions
+        root_id_matches: Whether root IDs should match
+        expected_methods: List of method names in execution order
+        expected_state: Expected final state values {attr: value}
+    """
+    nc_sorted_calls_count: int = 0
+    success_tx_count: int = 0
+    failure_tx_count: int = 0
+    skipped_tx_count: int = 0
+    root_id_matches: bool = True
+    expected_methods: list[str] = field(default_factory=list)
+    expected_state: dict[str, int] = field(default_factory=dict)
+
+
+def build_dry_run_dag(
+    dag_builder: 'DAGBuilder',
+    blueprint_id: BlueprintId,
+) -> DryRunDAGFixture:
+    """Build a common DAG for dry-run tests.
+
+    Creates a DAG with:
+    - 15 blocks in the blockchain
+    - 1 contract initialization (tx1)
+    - 1 contract method call (tx2)
+    - 1 regular non-NC transaction (tx3)
+    - Mix of NC and non-NC content in blocks
+
+    The DAG structure:
+        genesis -> b1 -> ... -> b10 -> b11 -> b12 -> b13 -> b14 -> b15
+                                 |
+                                 +-- dummy (funding)
+
+        tx1 (initialize) confirmed in b11
+        tx2 (increment) confirmed in b13
+        tx3 (regular tx) confirmed in b12
+
+    Args:
+        dag_builder: The TestDAGBuilder instance
+        blueprint_id: The registered blueprint ID
+
+    Returns:
+        DryRunDAGFixture with all artifacts and references
+    """
+    artifacts = dag_builder.build_from_str(f'''
+        blockchain genesis b[1..15]
+        b10 < dummy
+
+        # Contract initialization in b11
+        tx1.nc_id = "{blueprint_id.hex()}"
+        tx1.nc_method = initialize()
+        tx1 <-- b11
+
+        # Regular (non-NC) transaction in b12
+        dummy < tx3
+        tx3 <-- b12
+
+        # Contract method call in b13
+        tx2.nc_id = tx1
+        tx2.nc_method = increment(42)
+        b11 < tx2
+        tx2 <-- b13
+    ''')
+
+    # Extract typed vertices
+    b12, = artifacts.get_typed_vertices(['b12'], Block)
+    b13, = artifacts.get_typed_vertices(['b13'], Block)
+    tx1, tx2, tx3 = artifacts.get_typed_vertices(['tx1', 'tx2', 'tx3'], Transaction)
+
+    return DryRunDAGFixture(
+        artifacts=artifacts,
+        blueprint_id=blueprint_id,
+        block_with_nc=b13,
+        block_without_nc=b12,
+        nc_tx_initialize=tx1,
+        nc_tx_increment=tx2,
+        regular_tx=tx3,
+        expected_tx_count=1,  # Only tx2 is in b13
+    )
+
+
+def build_complex_dry_run_dag(
+    dag_builder: 'DAGBuilder',
+    blueprint_id: BlueprintId,
+) -> tuple[DryRunDAGFixture, DryRunExpectedResult]:
+    """Build a more complex DAG for detailed executor tests.
+
+    Creates a DAG with multiple method calls including a failure case.
+
+    The DAG structure:
+        genesis -> b1 -> ... -> b10 -> b11 -> b12 -> b13 -> b14 -> b15
+                                 |
+                                 +-- dummy (funding)
+
+        tx1 (initialize) confirmed in b11
+        tx2 (increment with 100) confirmed in b12
+        tx3 (fail_if_negative with -1) confirmed in b13 - FAILS
+        regular_tx (non-NC) confirmed in b14
+
+    Args:
+        dag_builder: The TestDAGBuilder instance
+        blueprint_id: The registered blueprint ID
+
+    Returns:
+        Tuple of (DryRunDAGFixture, DryRunExpectedResult)
+    """
+    artifacts = dag_builder.build_from_str(f'''
+        blockchain genesis b[1..15]
+        b10 < dummy
+
+        # Contract initialization in b11
+        tx1.nc_id = "{blueprint_id.hex()}"
+        tx1.nc_method = initialize()
+        tx1 <-- b11
+
+        # Successful increment in b12
+        tx2.nc_id = tx1
+        tx2.nc_method = increment(100)
+        b11 < tx2
+        tx2 <-- b12
+
+        # Failed transaction in b13
+        tx3.nc_id = tx1
+        tx3.nc_method = fail_if_negative(-1)
+        tx2 < tx3
+        tx3 <-- b13
+
+        # Regular transaction in b14
+        dummy < regular_tx
+        regular_tx <-- b14
+    ''')
+
+    # Extract typed vertices
+    b13, b14 = artifacts.get_typed_vertices(['b13', 'b14'], Block)
+    tx1, tx2, tx3, regular_tx = artifacts.get_typed_vertices(
+        ['tx1', 'tx2', 'tx3', 'regular_tx'], Transaction
+    )
+
+    fixture = DryRunDAGFixture(
+        artifacts=artifacts,
+        blueprint_id=blueprint_id,
+        block_with_nc=b13,  # b13 has the failed tx3
+        block_without_nc=b14,
+        nc_tx_initialize=tx1,
+        nc_tx_increment=tx2,
+        regular_tx=regular_tx,
+        expected_tx_count=1,  # Only tx3 is in b13
+    )
+
+    expected = DryRunExpectedResult(
+        nc_sorted_calls_count=1,
+        success_tx_count=0,
+        failure_tx_count=1,  # tx3 fails
+        skipped_tx_count=0,
+        root_id_matches=True,
+        expected_methods=['fail_if_negative'],
+        expected_state={'counter': 1, 'value': 100, 'total_calls': 1},
+    )
+
+    return fixture, expected
+
+
+def build_cascade_dry_run_dag(
+    dag_builder: 'DAGBuilder',
+    blueprint_id: BlueprintId,
+) -> tuple[DryRunDAGFixture, DryRunExpectedResult]:
+    """Build a DAG where a failed tx causes a dependent tx to be skipped.
+
+    Creates a DAG where tx_fail and tx_dependent are both confirmed in the same block,
+    and tx_dependent has an input from tx_fail. When tx_fail fails, tx_dependent should
+    be skipped due to the dependency cascade.
+
+    The DAG structure:
+        genesis -> b1 -> ... -> b10 -> b11 -> b12 -> b13 -> b14 -> b15
+                                 |
+                                 +-- dummy (funding)
+
+        tx1 (initialize) confirmed in b11
+        tx_fail (fail_if_negative with -1) confirmed in b13 - FAILS
+        tx_dependent (increment with 10) confirmed in b13 - SKIPPED (depends on tx_fail)
+        regular_tx (non-NC) confirmed in b14
+
+    Args:
+        dag_builder: The TestDAGBuilder instance
+        blueprint_id: The registered blueprint ID
+
+    Returns:
+        Tuple of (DryRunDAGFixture, DryRunExpectedResult)
+    """
+    artifacts = dag_builder.build_from_str(f'''
+        blockchain genesis b[1..15]
+        b10 < dummy
+
+        # Contract initialization in b11
+        tx1.nc_id = "{blueprint_id.hex()}"
+        tx1.nc_method = initialize()
+        tx1 <-- b11
+
+        # Failed transaction in b13
+        tx_fail.nc_id = tx1
+        tx_fail.nc_method = fail_if_negative(-1)
+        b11 < tx_fail
+        tx_fail <-- b13
+
+        # Dependent transaction in b13 (spends an output of tx_fail, so
+        # when tx_fail fails tx_dependent must be skipped via the cascade)
+        tx_dependent.nc_id = tx1
+        tx_dependent.nc_method = increment(10)
+        tx_fail.out[0] <<< tx_dependent
+        tx_dependent <-- b13
+
+        # Regular transaction in b14
+        dummy < regular_tx
+        regular_tx <-- b14
+    ''')
+
+    # Extract typed vertices
+    b13, b14 = artifacts.get_typed_vertices(['b13', 'b14'], Block)
+    tx1, tx_fail, tx_dependent, regular_tx = artifacts.get_typed_vertices(
+        ['tx1', 'tx_fail', 'tx_dependent', 'regular_tx'], Transaction
+    )
+
+    fixture = DryRunDAGFixture(
+        artifacts=artifacts,
+        blueprint_id=blueprint_id,
+        block_with_nc=b13,
+        block_without_nc=b14,
+        nc_tx_initialize=tx1,
+        nc_tx_increment=tx_dependent,
+        regular_tx=regular_tx,
+        expected_tx_count=2,  # tx_fail + tx_dependent in b13
+    )
+
+    expected = DryRunExpectedResult(
+        nc_sorted_calls_count=2,
+        success_tx_count=0,
+        failure_tx_count=1,   # tx_fail fails
+        skipped_tx_count=1,   # tx_dependent skipped
+        root_id_matches=True,
+        expected_methods=['fail_if_negative', 'increment'],
+    )
+
+    return fixture, expected
+
+
+def register_dry_run_blueprint(manager: 'HathorManager') -> BlueprintId:
+    """Register the DryRunTestBlueprint with the manager's NC catalog.
+
+    Args:
+        manager: The HathorManager instance
+
+    Returns:
+        The registered BlueprintId
+    """
+    blueprint_hex = '3cb032600bdf7db784800e4ea911b10676fa2f67591f82bb62628c234e771595'
+    blueprint_id = BlueprintId(bytes.fromhex(blueprint_hex))
+    manager.blueprint_service.register_blueprint(blueprint_id, DryRunTestBlueprint)
+    return blueprint_id

--- a/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
+++ b/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
@@ -29,6 +29,7 @@ from hathor.wallet import KeyPair
 from ...utils import DEFAULT_WORDS
 from .. import test_blueprints
 from ..blueprints.unittest import BlueprintTestCase
+from ..utils import TestRunner
 from .utils import get_ocb_private_key
 
 settings = HathorSettings()
@@ -174,7 +175,7 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
 
         # set expected self objects:
         self.nc_id = ContractId(VertexId(nc_init_tx.hash))
-        self.runner = self.manager.get_nc_runner(block)
+        self.runner = TestRunner.from_runner(self.manager.get_nc_runner(block))
         self.nc_storage = self.runner.get_storage(self.nc_id)
 
     def test_blueprint_initialization(self) -> None:

--- a/hathor_tests/nanocontracts/test_dry_run.py
+++ b/hathor_tests/nanocontracts/test_dry_run.py
@@ -1,0 +1,471 @@
+# Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NCDryRunBlockExecutor.
+
+These tests validate the detailed execution results from the dry-run executor,
+including transaction status, call records, events, and state changes.
+"""
+
+import unittest
+
+from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts.exception import NCFail
+from hathor.nanocontracts.execution.dry_run_block_executor import NCDryRunBlockExecutor
+from hathor.nanocontracts.execution.dry_run_models import (
+    DryRunCallRecord,
+    DryRunResult,
+    DryRunTxResult,
+    ExecutionStatus,
+)
+from hathor.transaction import Block, Transaction
+from hathor_cli.nc_dry_run import format_dry_run_text
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.nanocontracts.fixtures.dry_run import (
+    DryRunTestBlueprint,
+    build_cascade_dry_run_dag,
+    build_complex_dry_run_dag,
+    build_dry_run_dag,
+)
+
+
+class FailingInitBlueprint(Blueprint):
+    """Blueprint whose initialize always raises NCFail."""
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        raise NCFail('initialization always fails')
+
+    @public
+    def noop(self, ctx: Context) -> None:
+        pass
+
+
+class NCDryRunExecutorTest(BlueprintTestCase):
+    """Tests for NCDryRunBlockExecutor with detailed validation."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = self._register_blueprint_class(DryRunTestBlueprint)
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_dry_run_basic_execution(self) -> None:
+        """Test basic dry-run execution returns correct structure."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(fixture.block_with_nc)
+
+        # Validate result structure
+        self.assertTrue(result.success)
+        self.assertEqual(result.block_hash, fixture.block_with_nc.hash)
+        self.assertEqual(result.block_height, fixture.block_with_nc.get_height())
+        self.assertTrue(result.root_id_matches)
+        self.assertIsNone(result.warning)
+
+        # Validate NC sorted calls
+        self.assertEqual(len(result.nc_sorted_calls), fixture.expected_tx_count)
+        self.assertIn(fixture.nc_tx_increment.hash, result.nc_sorted_calls)
+
+        # Validate transactions
+        self.assertEqual(len(result.transactions), fixture.expected_tx_count)
+
+    def test_dry_run_with_target_tx(self) -> None:
+        """Test dry-run with target transaction hash."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(
+            fixture.block_with_nc,
+            target_tx_hash=fixture.nc_tx_increment.hash,
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.target_tx_hash, fixture.nc_tx_increment.hash)
+
+    def test_dry_run_include_changes(self) -> None:
+        """Test dry-run with include_changes flag returns state changes.
+
+        Values must be JSON-native (not Python repr strings) so the HTTP API
+        returns structured data that clients can parse without re-evaluating.
+        """
+        import json
+
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(fixture.block_with_nc, include_changes=True)
+
+        self.assertTrue(result.success)
+
+        # The fixture's increment() writes three int fields: counter, value, total_calls.
+        # Collect every emitted value for assertions below.
+        emitted_values: list[object] = []
+        has_changes = False
+        for tx_result in result.transactions:
+            for call_record in tx_result.call_records:
+                if call_record.changes is not None:
+                    has_changes = True
+                    for change in call_record.changes:
+                        self.assertIn('key', change)
+                        # Each change is either an update (value) or a deletion (deleted).
+                        self.assertTrue(
+                            'value' in change or change.get('deleted') is True,
+                            f'change must carry value or deleted=True: {change}'
+                        )
+                        if 'value' in change:
+                            emitted_values.append(change['value'])
+        self.assertTrue(has_changes, 'Expected at least one call record with changes')
+
+        # Values must be JSON-serializable primitives, not repr() strings.
+        self.assertTrue(emitted_values, 'Expected at least one emitted value')
+        json.dumps(emitted_values)  # raises if any value is not JSON-native
+        # The fixture's int fields should come through as ints.
+        self.assertTrue(
+            any(isinstance(v, int) and not isinstance(v, bool) for v in emitted_values),
+            f'Expected at least one int value from int-typed fields; got {emitted_values!r}'
+        )
+
+    def test_dry_run_multiple_blocks(self) -> None:
+        """Test dry-run can execute multiple different blocks from the same DAG."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+
+        # Execute on block with NC transactions
+        result1 = dry_run_executor.execute(fixture.block_with_nc)
+        self.assertTrue(result1.success)
+        self.assertEqual(len(result1.transactions), fixture.expected_tx_count)
+
+        # Execute on block without NC transactions
+        result2 = dry_run_executor.execute(fixture.block_without_nc)
+        self.assertTrue(result2.success)
+        self.assertEqual(len(result2.transactions), 0)
+
+    def test_dry_run_block_without_nc(self) -> None:
+        """Test dry-run on block without NC transactions."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(fixture.block_without_nc)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.block_hash, fixture.block_without_nc.hash)
+        self.assertEqual(len(result.nc_sorted_calls), 0)
+        self.assertEqual(len(result.transactions), 0)
+        self.assertTrue(result.root_id_matches)
+
+    def test_dry_run_call_records_structure(self) -> None:
+        """Test that call records have correct structure and content."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(fixture.block_with_nc)
+
+        # Find the increment transaction result
+        tx_result = next(
+            (tx for tx in result.transactions if tx.tx_hash == fixture.nc_tx_increment.hash),
+            None,
+        )
+        assert tx_result is not None
+        self.assertEqual(tx_result.execution_status, 'success')
+        self.assertGreater(len(tx_result.call_records), 0)
+
+        # Validate call record structure
+        call_record = tx_result.call_records[0]
+        self.assertEqual(call_record.type, 'public')
+        self.assertEqual(call_record.depth, 0)
+        self.assertEqual(call_record.method_name, 'increment')
+        self.assertIsInstance(call_record.index_updates, list)
+
+    def test_dry_run_failure_cascade(self) -> None:
+        """Test that a failed tx results in FAILURE and dependent txs are SKIPPED."""
+        fixture, expected = build_complex_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(fixture.block_with_nc)
+
+        self.assertTrue(result.success)
+
+        # Count statuses
+        statuses = [tx.execution_status for tx in result.transactions]
+        failure_count = statuses.count(ExecutionStatus.FAILURE)
+        skipped_count = statuses.count(ExecutionStatus.SKIPPED)
+
+        self.assertEqual(failure_count, expected.failure_tx_count)
+        self.assertEqual(skipped_count, expected.skipped_tx_count)
+
+        # Verify the failed tx has exception info
+        failed_txs = [tx for tx in result.transactions if tx.execution_status == ExecutionStatus.FAILURE]
+        for tx in failed_txs:
+            self.assertIsNotNone(tx.exception_type)
+            self.assertIsNotNone(tx.exception_message)
+
+    def test_dry_run_skip_cascade(self) -> None:
+        """Test that a tx depending on a failed tx is SKIPPED via cascade."""
+        fixture, expected = build_cascade_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(fixture.block_with_nc)
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(result.transactions), expected.nc_sorted_calls_count)
+
+        # Count statuses
+        statuses = [tx.execution_status for tx in result.transactions]
+        failure_count = statuses.count(ExecutionStatus.FAILURE)
+        skipped_count = statuses.count(ExecutionStatus.SKIPPED)
+
+        self.assertEqual(failure_count, expected.failure_tx_count)
+        self.assertEqual(skipped_count, expected.skipped_tx_count)
+
+        # Verify the failed tx has exception info
+        failed_txs = [tx for tx in result.transactions if tx.execution_status == ExecutionStatus.FAILURE]
+        self.assertEqual(len(failed_txs), 1)
+        self.assertIsNotNone(failed_txs[0].exception_type)
+
+        # Verify the skipped tx has no exception info
+        skipped_txs = [tx for tx in result.transactions if tx.execution_status == ExecutionStatus.SKIPPED]
+        self.assertEqual(len(skipped_txs), 1)
+        self.assertIsNone(skipped_txs[0].exception_type)
+        self.assertEqual(len(skipped_txs[0].call_records), 0)
+
+    def test_dry_run_contract_dep_does_not_propagate_voided_by(self) -> None:
+        """Verify that a contract dependency (nc_id) does NOT propagate voided_by.
+
+        Scenario: tx_fail_init creates a contract but its initialize() raises NCFail.
+        tx_dep invokes the would-be contract via nc_id=tx_fail_init, but has no UTXO
+        edge to tx_fail_init. Both are confirmed in the same block.
+
+        Expected:
+          - tx_fail_init ends as FAILURE (init raised)
+          - tx_dep is NOT SKIPPED (no UTXO dep, and tx_deps correctly ignores nc_id)
+          - tx_dep ends as FAILURE with a contract-not-found style exception
+            (the contract was never persisted because its creator failed)
+        """
+        failing_blueprint_id = self._register_blueprint_class(FailingInitBlueprint)
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..15]
+            b10 < dummy
+
+            # tx_fail_init creates a contract via FailingInitBlueprint; init raises.
+            tx_fail_init.nc_id = "{failing_blueprint_id.hex()}"
+            tx_fail_init.nc_method = initialize()
+            tx_fail_init <-- b11
+
+            # tx_dep invokes the would-be contract via nc_id. NOTE: no UTXO dep on
+            # tx_fail_init — only an ordering edge so the sorter runs tx_fail_init first.
+            tx_dep.nc_id = tx_fail_init
+            tx_dep.nc_method = noop()
+            tx_fail_init < tx_dep
+            tx_dep <-- b11
+        ''')
+        artifacts.propagate_with(self.manager)
+
+        b11, = artifacts.get_typed_vertices(['b11'], Block)
+        tx_fail_init, tx_dep = artifacts.get_typed_vertices(
+            ['tx_fail_init', 'tx_dep'], Transaction
+        )
+
+        # Verify there is no UTXO edge between them (the whole point of the test).
+        self.assertNotIn(tx_fail_init.hash, {txin.tx_id for txin in tx_dep.inputs})
+
+        block_executor = self.manager.consensus_algorithm.block_executor
+        dry_run_executor = NCDryRunBlockExecutor(block_executor)
+        result = dry_run_executor.execute(b11)
+
+        # Both txs executed, neither skipped.
+        self.assertEqual(len(result.transactions), 2)
+        statuses = {tx.tx_hash: tx.execution_status for tx in result.transactions}
+        self.assertEqual(statuses[tx_fail_init.hash], ExecutionStatus.FAILURE)
+        self.assertEqual(
+            statuses[tx_dep.hash], ExecutionStatus.FAILURE,
+            'tx_dep must fail, not skip: contract dep (nc_id) does not propagate voided_by'
+        )
+
+        # Both FAILURE txs carry exception info.
+        by_hash = {tx.tx_hash: tx for tx in result.transactions}
+        self.assertIsNotNone(by_hash[tx_fail_init.hash].exception_type)
+        self.assertIsNotNone(by_hash[tx_dep.hash].exception_type)
+        self.assertIsNotNone(by_hash[tx_dep.hash].exception_message)
+
+
+class DryRunResultSerializationTest(unittest.TestCase):
+    """Tests for DryRunResult serialization."""
+
+    def test_result_dict_serialization(self) -> None:
+        """Test DryRunResult.dict() produces valid dict."""
+        call_record = DryRunCallRecord(
+            type='public',
+            depth=0,
+            contract_id=b'\xab' * 32,
+            blueprint_id=b'\xde' * 32,
+            method_name='test_method',
+            index_updates=[{'type': 'update_token_balance', 'amount': 100}],
+            changes=[{'key': 'abc', 'value': '123'}],
+        )
+
+        tx_result = DryRunTxResult(
+            tx_hash=b'\xaa' * 32,
+            rng_seed=b'\xdd' * 32,
+            execution_status=ExecutionStatus.SUCCESS,
+            call_records=[call_record],
+            events=[{'nc_id': 'nc1', 'data': 'event_data'}],
+        )
+
+        result = DryRunResult(
+            block_hash=b'\x11' * 32,
+            block_height=100,
+            initial_block_root_id=b'\x44' * 32,
+            final_block_root_id=b'\x66' * 32,
+            expected_block_root_id=b'\x66' * 32,
+            root_id_matches=True,
+            nc_sorted_calls=[b'\xaa' * 32],
+            transactions=[tx_result],
+            target_tx_hash=b'\xaa' * 32,
+            warning=None,
+        )
+
+        result_dict = result.model_dump()
+
+        self.assertEqual(result_dict['success'], True)
+        self.assertEqual(result_dict['block_hash'], '11' * 32)
+        self.assertEqual(result_dict['block_height'], 100)
+        self.assertEqual(result_dict['root_id_matches'], True)
+        self.assertEqual(len(result_dict['transactions']), 1)
+        self.assertEqual(result_dict['transactions'][0]['tx_hash'], 'aa' * 32)
+        self.assertEqual(len(result_dict['transactions'][0]['call_records']), 1)
+
+    def test_result_json_serialization(self) -> None:
+        """Test DryRunResult.json_dumpb() produces valid JSON."""
+        result = DryRunResult(
+            block_hash=b'\x11' * 32,
+            block_height=100,
+            initial_block_root_id=b'\x44' * 32,
+            final_block_root_id=b'\x66' * 32,
+            expected_block_root_id=b'\x66' * 32,
+            root_id_matches=True,
+            nc_sorted_calls=[],
+            transactions=[],
+        )
+
+        json_bytes = result.json_dumpb()
+        self.assertIsInstance(json_bytes, bytes)
+        self.assertIn(b'11' * 32, json_bytes)
+
+    def test_result_model_dump_json(self) -> None:
+        """Test DryRunResult.model_dump_json() produces valid JSON string (used by CLI)."""
+        result = DryRunResult(
+            block_hash=b'\x11' * 32,
+            block_height=100,
+            initial_block_root_id=b'\x44' * 32,
+            final_block_root_id=b'\x66' * 32,
+            expected_block_root_id=b'\x66' * 32,
+            root_id_matches=True,
+            nc_sorted_calls=[],
+            transactions=[],
+        )
+
+        json_str = result.model_dump_json(indent=2)
+        self.assertIsInstance(json_str, str)
+        self.assertIn('11' * 32, json_str)
+
+
+class FormatDryRunTextTest(unittest.TestCase):
+    """Tests for format_dry_run_text function."""
+
+    def test_format_success(self) -> None:
+        """Test format_dry_run_text with successful execution."""
+        call_record = DryRunCallRecord(
+            type='public',
+            depth=0,
+            contract_id=b'\xab' * 32,
+            blueprint_id=b'\xde' * 32,
+            method_name='test_method',
+            index_updates=[],
+        )
+
+        tx_result = DryRunTxResult(
+            tx_hash=b'\xaa' * 32,
+            rng_seed=b'\xdd' * 32,
+            execution_status=ExecutionStatus.SUCCESS,
+            call_records=[call_record],
+            events=[],
+        )
+
+        result = DryRunResult(
+            block_hash=b'\x11' * 32,
+            block_height=100,
+            initial_block_root_id=b'\x44' * 32,
+            final_block_root_id=b'\x66' * 32,
+            expected_block_root_id=b'\x66' * 32,
+            root_id_matches=True,
+            nc_sorted_calls=[b'\xaa' * 32],
+            transactions=[tx_result],
+        )
+
+        text = format_dry_run_text(result)
+
+        self.assertIn('height: 100', text)
+        self.assertIn('Root Match:    OK', text)
+        self.assertIn('Status: SUCCESS', text)
+        self.assertIn('test_method', text)
+
+    def test_format_failure(self) -> None:
+        """Test format_dry_run_text with failure."""
+        tx_result = DryRunTxResult(
+            tx_hash=b'\xaa' * 32,
+            rng_seed=b'\xdd' * 32,
+            execution_status=ExecutionStatus.FAILURE,
+            exception_type='NCFail',
+            exception_message='Test error',
+            traceback='Traceback line 1\nTraceback line 2',
+        )
+
+        result = DryRunResult(
+            block_hash=b'\x11' * 32,
+            block_height=100,
+            initial_block_root_id=b'\x44' * 32,
+            final_block_root_id=b'\x66' * 32,
+            expected_block_root_id=b'\x88' * 32,
+            root_id_matches=False,
+            nc_sorted_calls=[b'\xaa' * 32],
+            transactions=[tx_result],
+            warning='Non-deterministic execution detected',
+        )
+
+        text = format_dry_run_text(result, verbose=True)
+
+        self.assertIn('MISMATCH', text)
+        self.assertIn('Status: FAILURE', text)
+        self.assertIn('NCFail', text)
+        self.assertIn('Test error', text)
+        self.assertIn('Traceback line 1', text)

--- a/hathor_tests/nanocontracts/test_execution_verification.py
+++ b/hathor_tests/nanocontracts/test_execution_verification.py
@@ -40,6 +40,36 @@ class TestExecutionVerification(BlueprintTestCase):
         self.blueprint_id = self._register_blueprint_class(MyBlueprint)
         self.contract_id = self.gen_random_contract_id()
 
+    def test_successful_create_keeps_changes_pending_until_explicit_commit(self) -> None:
+        runner = self.runner._runner
+
+        assert not runner.has_pending_changes()
+        assert not runner.block_storage.has_contract(self.contract_id)
+
+        runner.create_contract(self.contract_id, self.blueprint_id, self.create_context(), 123)
+
+        assert runner.has_pending_changes()
+        assert not runner.block_storage.has_contract(self.contract_id)
+
+        runner.commit_pending_changes()
+
+        assert not runner.has_pending_changes()
+        assert runner.block_storage.has_contract(self.contract_id)
+
+    def test_successful_create_can_be_explicitly_discarded(self) -> None:
+        runner = self.runner._runner
+
+        runner.create_contract(self.contract_id, self.blueprint_id, self.create_context(), 123)
+
+        assert runner.has_pending_changes()
+        assert not runner.block_storage.has_contract(self.contract_id)
+
+        runner.discard_pending_changes()
+
+        assert not runner.has_pending_changes()
+        assert not runner.has_contract_been_initialized(self.contract_id)
+        assert not runner.block_storage.has_contract(self.contract_id)
+
     def test_blueprint_does_not_exist(self) -> None:
         with pytest.raises(BlueprintDoesNotExist):
             self.runner.create_contract(self.contract_id, self.gen_random_blueprint_id(), self.create_context(), 123)
@@ -79,6 +109,18 @@ class TestExecutionVerification(BlueprintTestCase):
             )
         assert isinstance(e.value.__cause__, ValueError)
         assert e.value.__cause__.args[0] == 'trailing data'
+
+    def test_failed_create_does_not_leave_contract_initialized(self) -> None:
+        runner = self.runner._runner
+
+        with pytest.raises(NCFail, match=re.escape("initialize() missing required argument: 'a'")):
+            runner.create_contract(self.contract_id, self.blueprint_id, self.create_context())
+
+        assert not runner.has_pending_changes()
+        assert not runner.has_contract_been_initialized(self.contract_id)
+
+        self.runner.create_contract(self.contract_id, self.blueprint_id, self.create_context(), 123)
+        assert self.runner.has_contract_been_initialized(self.contract_id)
 
     @pytest.mark.xfail(strict=True, reason='not implemented yet')
     def test_wrong_arg_type_but_valid_serialization(self) -> None:

--- a/hathor_tests/nanocontracts/test_fee_tokens.py
+++ b/hathor_tests/nanocontracts/test_fee_tokens.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
 import pytest
 
 from hathor import Blueprint, Context, ContractId, NCActionType, public
 from hathor.exception import InvalidNewTransaction
 from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
+from hathor.nanocontracts.runner import Runner
+from hathor.nanocontracts.storage.contract_storage import Balance
 from hathor.nanocontracts.utils import derive_child_token_id
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.headers import FeeHeader
@@ -102,6 +106,27 @@ class FeeTokensTestCase(BlueprintTestCase):
         assert tx2.get_metadata().first_block == b12.hash
         assert tx2.get_metadata().nc_execution == NCExecutionState.SUCCESS
         assert tx2.get_metadata().voided_by is None
+
+    def test_commit_failure_is_fatal_and_not_converted_to_nc_failure(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..11]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx1 <-- b11
+        ''')
+
+        with patch.object(
+            Runner,
+            'commit_pending_changes',
+            side_effect=RuntimeError('critical commit failure'),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                artifacts.propagate_with(self.manager, up_to='b11')
+            assert exc_info.value.code == -1
 
     def test_postponed_verification_fail_nonexistent(self) -> None:
         artifacts = self.dag_builder.build_from_str(f'''
@@ -200,6 +225,74 @@ class FeeTokensTestCase(BlueprintTestCase):
             block_id=b12.hash,
             reason='InputOutputMismatch: Fee amount is different than expected. (amount=1, expected=0)',
         )
+
+    def test_postponed_token_verification_failure_does_not_contaminate_state(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            tx1.nc_id = "{self.blueprint_id.hex()}"
+            tx1.nc_method = initialize()
+            tx1.nc_deposit = 1 HTR
+
+            tx2.nc_id = tx1
+            tx2.nc_method = create_deposit_token()
+            tx2.fee = 1 HTR
+
+            tx3.nc_id = tx1
+            tx3.nc_method = nop()
+
+            tx1 < b11 < tx2 < b12 < tx3 < b13
+            tx1 <-- b11
+            tx2 <-- b12
+            tx3 <-- b13
+        ''')
+
+        b11, b12, b13 = artifacts.get_typed_vertices(('b11', 'b12', 'b13'), Block)
+        tx1, tx2, tx3 = artifacts.get_typed_vertices(('tx1', 'tx2', 'tx3'), Transaction)
+
+        dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
+        tx2.tokens.append(dbt_id)
+
+        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        tx2.outputs.append(dbt_output)
+
+        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        tx2_nano_header = tx2.get_nano_header()
+        tx2_nano_header.nc_actions.append(dbt_withdraw)
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert tx1.get_metadata().first_block == b11.hash
+        assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx1.get_metadata().voided_by is None
+
+        nc_storage_before = self.manager.get_best_block_nc_storage(tx1.hash)
+        expected_htr_balance = Balance(value=1, can_mint=False, can_melt=False)
+        assert nc_storage_before.get_balance(self._settings.HATHOR_TOKEN_UID) == expected_htr_balance
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert tx2.get_metadata().first_block == b12.hash
+        assert tx2.get_metadata().nc_execution == NCExecutionState.FAILURE
+        assert tx2.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, tx2.hash}
+
+        assert_nc_failure_reason(
+            manager=self.manager,
+            tx_id=tx2.hash,
+            block_id=b12.hash,
+            reason='InputOutputMismatch: Fee amount is different than expected. (amount=1, expected=0)',
+        )
+
+        nc_storage_after_fail = self.manager.get_best_block_nc_storage(tx1.hash)
+        assert nc_storage_after_fail.get_balance(self._settings.HATHOR_TOKEN_UID) == expected_htr_balance
+        assert not nc_storage_after_fail.has_token(dbt_id)
+
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert tx3.get_metadata().first_block == b13.hash
+        assert tx3.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert tx3.get_metadata().voided_by is None
+
+        nc_storage_after_tx3 = self.manager.get_best_block_nc_storage(tx1.hash)
+        assert nc_storage_after_tx3.get_balance(self._settings.HATHOR_TOKEN_UID) == expected_htr_balance
 
     def test_postponed_verification_fail_melt_htr(self) -> None:
         artifacts = self.dag_builder.build_from_str(f'''

--- a/hathor_tests/nanocontracts/test_runtime_v2.py
+++ b/hathor_tests/nanocontracts/test_runtime_v2.py
@@ -74,7 +74,7 @@ class TestRuntimeV2(BlueprintTestCase):
 
         feature_service = self.manager.feature_service
         feature_service._feature_settings = feature_settings
-        self.manager.consensus_algorithm._block_executor._settings = settings
+        self.manager.consensus_algorithm.block_executor._settings = settings
         self.manager.blueprint_service.register_blueprint(self.blueprint_id, MyBlueprint)
 
         dag_builder = TestDAGBuilder.from_manager(self.manager)

--- a/hathor_tests/nanocontracts/test_sorter.py
+++ b/hathor_tests/nanocontracts/test_sorter.py
@@ -23,17 +23,18 @@ class NCBlockSorterTestCase(unittest.TestCase):
             sorter.get_node(node)
 
         seed = self.rng.randbytes(32)
-        order = sorter.copy().generate_random_topological_order(seed)
+        order, stuck = sorter.copy().generate_random_topological_order(seed)
         self.assertEqual(len(self.nodes), len(set(order)))
+        self.assertEqual(stuck, set())
 
-        order2 = sorter.copy().generate_random_topological_order(seed)
+        order2, _ = sorter.copy().generate_random_topological_order(seed)
         self.assertEqual(order, order2)
 
         # There are n! permutations.
         # Therefore, the probability of getting the same order is 1/100!, which is around 1e-158.
         for _ in range(100):
             seed2 = self.rng.randbytes(32)
-            order2 = sorter.copy().generate_random_topological_order(seed2)
+            order2, _ = sorter.copy().generate_random_topological_order(seed2)
             self.assertNotEqual(order, order2)
 
     def test_single_one_step_dependencies(self) -> None:
@@ -46,13 +47,14 @@ class NCBlockSorterTestCase(unittest.TestCase):
             sorter.add_edge(self.nc_nodes[i], self.nodes[i + 1])
 
         seed = self.rng.randbytes(32)
-        order = sorter.copy().generate_random_topological_order(seed)
+        order, stuck = sorter.copy().generate_random_topological_order(seed)
         self.assertEqual(set(self.nc_nodes.values()), set(order))
+        self.assertEqual(stuck, set())
 
         # There's only one valid order. So it must return the same order for any seed.
         for _ in range(100):
             seed2 = self.rng.randbytes(32)
-            order2 = sorter.copy().generate_random_topological_order(seed2)
+            order2, _ = sorter.copy().generate_random_topological_order(seed2)
             self.assertEqual(order, order2)
 
     def test_single_long_dependencies(self) -> None:
@@ -68,13 +70,14 @@ class NCBlockSorterTestCase(unittest.TestCase):
                 sorter.add_edge(self.nodes[i], self.nodes[i + 1])
 
         seed = self.rng.randbytes(32)
-        order = sorter.copy().generate_random_topological_order(seed)
+        order, stuck = sorter.copy().generate_random_topological_order(seed)
         self.assertEqual(set(x for i, x in self.nc_nodes.items() if i % 4 == 0), set(order))
+        self.assertEqual(stuck, set())
 
         # There's only one valid order. So it must return the same order for any seed.
         for _ in range(100):
             seed2 = self.rng.randbytes(32)
-            order2 = sorter.copy().generate_random_topological_order(seed2)
+            order2, _ = sorter.copy().generate_random_topological_order(seed2)
             self.assertEqual(order, order2)
 
     def test_linear_multiple_dependencies(self) -> None:
@@ -86,11 +89,12 @@ class NCBlockSorterTestCase(unittest.TestCase):
         sorter.add_edge(self.nodes[4], self.nc_nodes[5])
 
         seed = self.rng.randbytes(32)
-        order = sorter.copy().generate_random_topological_order(seed)
+        order, stuck = sorter.copy().generate_random_topological_order(seed)
         self.assertEqual(order, [
             self.nc_nodes[5],
             self.nc_nodes[0],
         ])
+        self.assertEqual(stuck, set())
 
     def test_grid_multiple_dependencies(self) -> None:
         sorter = NCBlockSorter(set(self.nc_nodes.values()))
@@ -121,22 +125,45 @@ class NCBlockSorterTestCase(unittest.TestCase):
             layers.append(current)
 
         seed = self.rng.randbytes(32)
-        order = sorter.copy().generate_random_topological_order(seed)
+        order, stuck = sorter.copy().generate_random_topological_order(seed)
         self.assertEqual(order, [
             self.nc_nodes[75],
             self.nc_nodes[57],
             self.nc_nodes[1],
         ])
+        self.assertEqual(stuck, set())
 
         # There's only one valid order. So it must return the same order for any seed.
         for _ in range(100):
             seed2 = self.rng.randbytes(32)
-            order2 = sorter.copy().generate_random_topological_order(seed2)
+            order2, _ = sorter.copy().generate_random_topological_order(seed2)
             self.assertEqual(order, order2)
+
+    def test_simple_cycle(self) -> None:
+        # Two nodes forming a direct cycle: NC0 -> NC1 -> NC0.
+        sorter = NCBlockSorter({self.nc_nodes[0], self.nc_nodes[1]})
+        sorter.add_edge(self.nc_nodes[0], self.nc_nodes[1])
+        sorter.add_edge(self.nc_nodes[1], self.nc_nodes[0])
+
+        order, stuck = sorter.generate_random_topological_order(self.rng.randbytes(32))
+        self.assertEqual(order, [])
+        self.assertEqual(stuck, {self.nc_nodes[0], self.nc_nodes[1]})
+
+    def test_cycle_with_dependants(self) -> None:
+        # NC0 -> NC1 -> NC0 is the cycle, NC2 -> NC0 depends on the cycle, NC3 is independent.
+        ids = {self.nc_nodes[i] for i in (0, 1, 2, 3)}
+        sorter = NCBlockSorter(ids)
+        sorter.add_edge(self.nc_nodes[0], self.nc_nodes[1])
+        sorter.add_edge(self.nc_nodes[1], self.nc_nodes[0])
+        sorter.add_edge(self.nc_nodes[2], self.nc_nodes[0])
+        sorter.get_node(self.nc_nodes[3])
+
+        order, stuck = sorter.generate_random_topological_order(self.rng.randbytes(32))
+        self.assertEqual(order, [self.nc_nodes[3]])
+        self.assertEqual(stuck, {self.nc_nodes[0], self.nc_nodes[1], self.nc_nodes[2]})
 
     def test_dag_dependencies(self) -> None:
         builder = self.get_builder()
-        builder.enable_nc_anti_mev()
         manager = self.create_peer_from_builder(builder)
         dag_builder = TestDAGBuilder.from_manager(manager)
 

--- a/hathor_tests/nanocontracts/test_sorter_determinism2.py
+++ b/hathor_tests/nanocontracts/test_sorter_determinism2.py
@@ -135,8 +135,9 @@ def test_random_sorter_stable_order() -> None:
         '0000142cf4351face7ff5803117f6d4c0375b0b724c576f7ffcbea7058fa9470',
         '000049ba9ba45cf8dccaed7d05b8a383ca392b9329866531da9c45960e699f26',
     ])
-    order = sorter.generate_random_topological_order(seed)
+    order, stuck = sorter.generate_random_topological_order(seed)
     assert order == expected_order
+    assert stuck == set()
 
     # XXX: this is necessary to preserve the consensus of the mainnet
     tx1 = bytes.fromhex('0000142cf4351face7ff5803117f6d4c0375b0b724c576f7ffcbea7058fa9470')

--- a/hathor_tests/nanocontracts/test_syscalls.py
+++ b/hathor_tests/nanocontracts/test_syscalls.py
@@ -336,8 +336,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
             self.get_genesis_tx()
         )
 
-        token_uid = self.runner.call_public_method(nc_id, 'create_fee_token', ctx_create_token,
-                                                   'FeeToken', 'FBT', 1000000, TokenUid(HATHOR_TOKEN_UID))
+        token_uid = self.runner.call_public_method(
+            nc_id, 'create_fee_token', ctx_create_token, 'FeeToken', 'FBT', 1000000, TokenUid(HATHOR_TOKEN_UID)
+        )
 
         htr_balance_key = BalanceKey(nc_id=nc_id, token_uid=HATHOR_TOKEN_UID)
         fbt_balance_key = BalanceKey(nc_id=nc_id, token_uid=token_uid)
@@ -349,8 +350,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
         }
 
         ctx_create_deposit_token = self.create_context()
-        dbt_token_uid = self.runner.call_public_method(nc_id, 'create_deposit_token',
-                                                       ctx_create_deposit_token, 'DepositToken', 'DBT', 100)
+        dbt_token_uid = self.runner.call_public_method(
+            nc_id, 'create_deposit_token', ctx_create_deposit_token, 'DepositToken', 'DBT', 100
+        )
 
         dbt_balance_key = BalanceKey(nc_id=nc_id, token_uid=dbt_token_uid)
 
@@ -361,8 +363,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
             dbt_balance_key: Balance(value=100, can_mint=True, can_melt=True),
         }
 
-        fbt_token2_uid = self.runner.call_public_method(nc_id, 'create_fee_token', self.create_context(),
-                                                        'FeeToken2', 'FB2', 1000000, dbt_token_uid)
+        fbt_token2_uid = self.runner.call_public_method(
+            nc_id, 'create_fee_token', self.create_context(), 'FeeToken2', 'FB2', 1000000, dbt_token_uid
+        )
         fbt2_balance_key = BalanceKey(nc_id=nc_id, token_uid=fbt_token2_uid)
 
         # created fee token paying with deposit token
@@ -436,15 +439,17 @@ class NCNanoContractTestCase(BlueprintTestCase):
             self.get_genesis_tx()
         )
 
-        token_uid = self.runner.call_public_method(nc_id, 'create_fee_token', ctx_create_token,
-                                                   'FeeToken', 'FBT', 1000000, TokenUid(HATHOR_TOKEN_UID))
+        token_uid = self.runner.call_public_method(
+            nc_id, 'create_fee_token', ctx_create_token, 'FeeToken', 'FBT', 1000000, TokenUid(HATHOR_TOKEN_UID)
+        )
 
         htr_balance_key = BalanceKey(nc_id=nc_id, token_uid=HATHOR_TOKEN_UID)
         fbt_balance_key = BalanceKey(nc_id=nc_id, token_uid=token_uid)
 
         ctx_create_deposit_token = self.create_context()
-        dbt_token_uid = self.runner.call_public_method(nc_id, 'create_deposit_token',
-                                                       ctx_create_deposit_token, 'DepositToken', 'DBT', 100)
+        dbt_token_uid = self.runner.call_public_method(
+            nc_id, 'create_deposit_token', ctx_create_deposit_token, 'DepositToken', 'DBT', 100
+        )
 
         dbt_balance_key = BalanceKey(nc_id=nc_id, token_uid=dbt_token_uid)
 
@@ -530,12 +535,14 @@ class NCNanoContractTestCase(BlueprintTestCase):
             self.get_genesis_tx()
         )
 
-        token_uid = self.runner.call_public_method(nc_id, 'create_fee_token', ctx_create_token,
-                                                   'FeeToken', 'FBT', 1000000, TokenUid(HATHOR_TOKEN_UID))
+        token_uid = self.runner.call_public_method(
+            nc_id, 'create_fee_token', ctx_create_token, 'FeeToken', 'FBT', 1000000, TokenUid(HATHOR_TOKEN_UID)
+        )
 
         # Create a deposit token to use as fee payment
-        dbt_token_uid = self.runner.call_public_method(nc_id, 'create_deposit_token', self.create_context(),
-                                                       'DepositToken', 'DBT', 500)
+        dbt_token_uid = self.runner.call_public_method(
+            nc_id, 'create_deposit_token', self.create_context(), 'DepositToken', 'DBT', 500
+        )
 
         htr_balance_key = BalanceKey(nc_id=nc_id, token_uid=HATHOR_TOKEN_UID)
         fbt_balance_key = BalanceKey(nc_id=nc_id, token_uid=token_uid)

--- a/hathor_tests/nanocontracts/utils.py
+++ b/hathor_tests/nanocontracts/utils.py
@@ -31,6 +31,13 @@ class TestRunner:
     MAX_RECURSION_DEPTH = Runner.MAX_RECURSION_DEPTH
     MAX_CALL_COUNTER = Runner.MAX_CALL_COUNTER
 
+    @classmethod
+    def from_runner(cls, runner: Runner) -> 'TestRunner':
+        """Wrap an existing Runner while keeping the legacy auto-commit test behavior."""
+        instance = cls.__new__(cls)
+        instance._runner = runner
+        return instance
+
     def __init__(
         self,
         *,
@@ -59,6 +66,12 @@ class TestRunner:
             seed=seed,
         )
 
+    def _commit_if_needed(self) -> None:
+        # Keep the legacy TestRunner behavior: mutating calls commit immediately.
+        # This must also be safe when the wrapped call already cleaned up after failure.
+        if self._runner.has_pending_changes():
+            self._runner.commit_pending_changes()
+
     def create_contract(
         self,
         contract_id: ContractId,
@@ -67,7 +80,9 @@ class TestRunner:
         *args: Any,
         **kwargs: Any,
     ) -> Any:
-        return self._runner.create_contract(contract_id, blueprint_id, ctx, *args, **kwargs)
+        ret = self._runner.create_contract(contract_id, blueprint_id, ctx, *args, **kwargs)
+        self._commit_if_needed()
+        return ret
 
     def create_contract_with_nc_args(
         self,
@@ -76,7 +91,9 @@ class TestRunner:
         ctx: Context,
         nc_args: NCArgs,
     ) -> Any:
-        return self._runner.create_contract_with_nc_args(contract_id, blueprint_id, ctx, nc_args)
+        ret = self._runner.create_contract_with_nc_args(contract_id, blueprint_id, ctx, nc_args)
+        self._commit_if_needed()
+        return ret
 
     def call_public_method(
         self,
@@ -86,7 +103,9 @@ class TestRunner:
         *args: Any,
         **kwargs: Any,
     ) -> Any:
-        return self._runner.call_public_method(contract_id, method_name, ctx, *args, **kwargs)
+        ret = self._runner.call_public_method(contract_id, method_name, ctx, *args, **kwargs)
+        self._commit_if_needed()
+        return ret
 
     def call_public_method_with_nc_args(
         self,
@@ -95,9 +114,17 @@ class TestRunner:
         ctx: Context,
         nc_args: NCArgs,
     ) -> Any:
-        return self._runner.call_public_method_with_nc_args(contract_id, method_name, ctx, nc_args)
+        ret = self._runner.call_public_method_with_nc_args(contract_id, method_name, ctx, nc_args)
+        self._commit_if_needed()
+        return ret
 
-    def call_view_method(self, contract_id: ContractId, method_name: str, *args: Any, **kwargs: Any) -> Any:
+    def call_view_method(
+        self,
+        contract_id: ContractId,
+        method_name: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
         return self._runner.call_view_method(contract_id, method_name, *args, **kwargs)
 
     def get_current_balance(self, contract_id: ContractId, token_uid: TokenUid | None) -> Balance:

--- a/hathor_tests/others/test_hex.py
+++ b/hathor_tests/others/test_hex.py
@@ -1,0 +1,67 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+
+from hathor.utils.hex import HASH32_HEX_LEN, parse_hash32
+
+
+class ParseHash32Test(unittest.TestCase):
+    def test_valid_lowercase_round_trip(self) -> None:
+        value = 'ab' * 32
+        self.assertEqual(parse_hash32(value), bytes.fromhex(value))
+        self.assertEqual(len(parse_hash32(value)), 32)
+
+    def test_valid_uppercase_round_trip(self) -> None:
+        value = 'AB' * 32
+        self.assertEqual(parse_hash32(value), bytes.fromhex(value))
+
+    def test_mixed_case_accepted(self) -> None:
+        value = 'aB' * 32
+        self.assertEqual(parse_hash32(value), bytes.fromhex(value))
+
+    def test_too_short_raises(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            parse_hash32('ab' * 31)
+        self.assertIn(str(HASH32_HEX_LEN), str(cm.exception))
+
+    def test_too_long_raises(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            parse_hash32('ab' * 33)
+        self.assertIn(str(HASH32_HEX_LEN), str(cm.exception))
+
+    def test_empty_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_hash32('')
+
+    def test_non_hex_chars_raise(self) -> None:
+        # 64 chars but contains non-hex letter 'g'
+        value = 'g' * 64
+        with self.assertRaises(ValueError):
+            parse_hash32(value)
+
+    def test_embedded_whitespace_rejected(self) -> None:
+        # 64 chars where two of them are spaces; bytes.fromhex would skip the
+        # whitespace and decode 31 bytes, the length check must reject this.
+        value = 'a' * 62 + '  '
+        self.assertEqual(len(value), HASH32_HEX_LEN)
+        with self.assertRaises(ValueError) as cm:
+            parse_hash32(value)
+        self.assertIn('whitespace', str(cm.exception))
+
+    def test_embedded_tab_rejected(self) -> None:
+        value = 'a' * 62 + '\t\t'
+        self.assertEqual(len(value), HASH32_HEX_LEN)
+        with self.assertRaises(ValueError):
+            parse_hash32(value)

--- a/hathor_tests/resources/nanocontracts/test_dry_run.py
+++ b/hathor_tests/resources/nanocontracts/test_dry_run.py
@@ -1,0 +1,267 @@
+# Copyright 2025 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NCDryRunResource HTTP API.
+
+These tests focus on validating the HTTP API behavior and JSON serialization,
+not the detailed execution results (which are tested in the executor tests).
+"""
+
+from twisted.internet.defer import inlineCallbacks
+
+from hathor.nanocontracts.resources.dry_run import NCDryRunResource
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.nanocontracts.fixtures.dry_run import build_dry_run_dag, register_dry_run_blueprint
+from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
+
+
+class NCDryRunResourceTest(_BaseResourceTest._ResourceTest):
+    """Tests for NCDryRunResource HTTP API."""
+
+    def setUp(self, *, utxo_index: bool = False, unlock_wallet: bool = True) -> None:
+        super().setUp(utxo_index=utxo_index, unlock_wallet=unlock_wallet)
+        self.manager = self.create_peer('unittests', nc_indexes=True)
+        self.tx_storage = self.manager.tx_storage
+
+        self.blueprint_id = register_dry_run_blueprint(self.manager)
+        self.web = StubSite(NCDryRunResource(
+            self.manager.tx_storage, self.manager.consensus_algorithm.block_executor,
+        ))
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    # =========================================================================
+    # Error handling tests
+    # =========================================================================
+
+    @inlineCallbacks
+    def test_missing_params(self):
+        """Test error when neither block_hash nor tx_hash provided."""
+        response = yield self.web.get('dry_run')
+        self.assertEqual(400, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('Must specify either block_hash or tx_hash', data['error'])
+
+    @inlineCallbacks
+    def test_both_params_error(self):
+        """Test error when both block_hash and tx_hash provided."""
+        response = yield self.web.get('dry_run', {
+            b'block_hash': b'abc123',
+            b'tx_hash': b'def456',
+        })
+        self.assertEqual(400, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('Cannot specify both', data['error'])
+
+    @inlineCallbacks
+    def test_invalid_block_hash(self):
+        """Test error with invalid block_hash."""
+        response = yield self.web.get('dry_run', {
+            b'block_hash': b'not_hex',
+        })
+        self.assertEqual(400, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('Invalid hash format', data['error'])
+
+    @inlineCallbacks
+    def test_invalid_tx_hash(self):
+        """Test error with invalid tx_hash."""
+        response = yield self.web.get('dry_run', {
+            b'tx_hash': b'not_hex',
+        })
+        self.assertEqual(400, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('Invalid hash format', data['error'])
+
+    @inlineCallbacks
+    def test_block_not_found(self):
+        """Test error when block not found."""
+        response = yield self.web.get('dry_run', {
+            b'block_hash': b'00' * 32,
+        })
+        self.assertEqual(404, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('Block not found', data['error'])
+
+    @inlineCallbacks
+    def test_tx_not_found(self):
+        """Test error when transaction not found."""
+        response = yield self.web.get('dry_run', {
+            b'tx_hash': b'00' * 32,
+        })
+        self.assertEqual(404, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('Transaction not found', data['error'])
+
+    @inlineCallbacks
+    def test_genesis_block_error(self):
+        """Test error when trying to dry-run genesis block."""
+        genesis_blocks = [tx for tx in self.tx_storage.get_all_genesis() if tx.is_block]
+        genesis_block = genesis_blocks[0]
+
+        response = yield self.web.get('dry_run', {
+            b'block_hash': genesis_block.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(400, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('genesis block', data['error'])
+
+    @inlineCallbacks
+    def test_tx_not_nano_contract_error(self):
+        """Test error when tx_hash points to a non-NC transaction."""
+        genesis_txs = [tx for tx in self.tx_storage.get_all_genesis() if not tx.is_block]
+        genesis_tx = genesis_txs[0]
+
+        response = yield self.web.get('dry_run', {
+            b'tx_hash': genesis_tx.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(400, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('not a nano contract', data['error'])
+
+    @inlineCallbacks
+    def test_voided_block_conflict(self):
+        """Test 409 Conflict when block is voided (not on best chain)."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        # Mark the block as voided to simulate a non-best-chain state.
+        block = fixture.block_with_nc
+        block_meta = block.get_metadata()
+        block_meta.voided_by = {block.hash}
+        self.tx_storage.save_transaction(block, only_metadata=True)
+
+        response = yield self.web.get('dry_run', {
+            b'block_hash': block.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(409, response.responseCode)
+        data = response.json_value()
+        self.assertFalse(data['success'])
+        self.assertIn('voided', data['error'])
+
+    # =========================================================================
+    # Serialization tests - validate JSON output structure
+    # =========================================================================
+
+    @inlineCallbacks
+    def test_dry_run_block_serialization(self):
+        """Test successful dry-run with block_hash serializes correctly."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        response = yield self.web.get('dry_run', {
+            b'block_hash': fixture.block_with_nc.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(200, response.responseCode)
+
+        # Validate JSON structure (not detailed values)
+        data = response.json_value()
+        self.assertTrue(data['success'])
+        self.assertIn('block_hash', data)
+        self.assertIn('block_height', data)
+        self.assertIn('initial_block_root_id', data)
+        self.assertIn('final_block_root_id', data)
+        self.assertIn('expected_block_root_id', data)
+        self.assertIn('root_id_matches', data)
+        self.assertIn('nc_sorted_calls', data)
+        self.assertIn('transactions', data)
+        self.assertIsInstance(data['transactions'], list)
+
+    @inlineCallbacks
+    def test_dry_run_tx_serialization(self):
+        """Test successful dry-run with tx_hash serializes correctly."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        response = yield self.web.get('dry_run', {
+            b'tx_hash': fixture.nc_tx_increment.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(200, response.responseCode)
+
+        # Validate JSON structure includes target_tx_hash
+        data = response.json_value()
+        self.assertTrue(data['success'])
+        self.assertIn('target_tx_hash', data)
+        self.assertEqual(data['target_tx_hash'], fixture.nc_tx_increment.hash.hex())
+
+    @inlineCallbacks
+    def test_dry_run_include_changes_serialization(self):
+        """Test dry-run with include_changes serializes changes correctly."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        response = yield self.web.get('dry_run', {
+            b'block_hash': fixture.block_with_nc.hash.hex().encode('ascii'),
+            b'include_changes': b'true',
+        })
+        self.assertEqual(200, response.responseCode)
+
+        # Validate JSON structure includes changes
+        data = response.json_value()
+        self.assertTrue(data['success'])
+
+        # Check that changes field is present in call records
+        for tx_result in data['transactions']:
+            self.assertIn('call_records', tx_result)
+            for call_record in tx_result['call_records']:
+                # changes should be present (may be empty list or have items)
+                self.assertIn('changes', call_record)
+
+    @inlineCallbacks
+    def test_dry_run_transaction_result_structure(self):
+        """Test transaction result has all expected fields."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        response = yield self.web.get('dry_run', {
+            b'block_hash': fixture.block_with_nc.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(200, response.responseCode)
+
+        data = response.json_value()
+        self.assertTrue(data['success'])
+        self.assertGreater(len(data['transactions']), 0)
+
+        # Validate transaction result structure
+        for tx_result in data['transactions']:
+            self.assertIn('tx_hash', tx_result)
+            self.assertIn('rng_seed', tx_result)
+            self.assertIn('execution_status', tx_result)
+            self.assertIn(tx_result['execution_status'], ['success', 'failure', 'skipped'])
+            self.assertIn('call_records', tx_result)
+            self.assertIn('events', tx_result)
+
+    @inlineCallbacks
+    def test_dry_run_block_without_nc_serialization(self):
+        """Test dry-run on block without NC transactions serializes correctly."""
+        fixture = build_dry_run_dag(self.dag_builder, self.blueprint_id)
+        fixture.artifacts.propagate_with(self.manager)
+
+        response = yield self.web.get('dry_run', {
+            b'block_hash': fixture.block_without_nc.hash.hex().encode('ascii'),
+        })
+        self.assertEqual(200, response.responseCode)
+
+        # Validate empty transactions list serializes correctly
+        data = response.json_value()
+        self.assertTrue(data['success'])
+        self.assertEqual(data['nc_sorted_calls'], [])
+        self.assertEqual(data['transactions'], [])

--- a/hathorlib/hathorlib/nanocontracts/nc_exec_logs.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_exec_logs.py
@@ -28,7 +28,7 @@ from hathorlib.nanocontracts.types import ContractId
 from hathorlib.utils.pydantic import BaseModel, Hex
 
 if TYPE_CHECKING:
-    from hathorlib.nanocontracts.runner.call_info import CallInfo, CallRecord
+    from hathorlib.nanocontracts.runner.call_info import CallRecord
 
 MAX_EVENT_SIZE: int = 1024  # 1KiB
 
@@ -135,14 +135,6 @@ class NCExecEntry(BaseModel):
     """
     logs: list[NCCallBeginEntry | NCLogEntry | NCCallEndEntry]
     error_traceback: str | None = None
-
-    @staticmethod
-    def from_call_info(call_info: CallInfo, error_tb: str | None) -> NCExecEntry:
-        """Create a NCExecEntry from a CallInfo and an optional traceback."""
-        return NCExecEntry(
-            logs=call_info.nc_logger.__entries__,
-            error_traceback=error_tb,
-        )
 
     def filter(self, log_level: NCLogLevel) -> NCExecEntry:
         """Create a new NCExecEntry while keeping logs with the provided log level or higher."""

--- a/hathorlib/hathorlib/nanocontracts/runner/runner.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/runner.py
@@ -240,10 +240,10 @@ class Runner:
                 'Cannot call initialize from call_public_method(); use create_contract() instead.'
             )
         try:
-            ret = self._unsafe_call_public_method(contract_id, method_name, ctx, nc_args)
-        finally:
-            self._reset_all_changes()
-        return ret
+            return self._unsafe_call_public_method(contract_id, method_name, ctx, nc_args)
+        except Exception:
+            self.discard_pending_changes()
+            raise
 
     def _unsafe_call_public_method(
         self,
@@ -275,9 +275,40 @@ class Runner:
         )
 
         self._validate_balances(ctx)
-        self._commit_all_changes_to_storage()
 
         return ret
+
+    def collect_created_tokens_from_uncommitted_changes(self) -> dict[TokenUid, TokenDescription]:
+        """Collect all tokens created in the current uncommitted execution context."""
+        if self._call_info is None:
+            return {}
+
+        created_tokens: dict[TokenUid, TokenDescription] = {}
+        for change_trackers in self._call_info.change_trackers.values():
+            assert len(change_trackers) == 1
+            created_tokens.update(change_trackers[0]._created_tokens)
+        return created_tokens
+
+    def has_pending_changes(self) -> bool:
+        """Return True when the last successful mutating call still needs finalization."""
+        return self._call_info is not None
+
+    def commit_pending_changes(self) -> None:
+        """Commit pending changes to block storage and finalize execution state."""
+        assert self._call_info is not None, 'no uncommitted changes available to commit'
+        self._commit_all_changes_to_storage()
+        self._reset_all_changes()
+
+    def discard_pending_changes(self) -> None:
+        """Discard pending changes and finalize execution state without committing."""
+        if self._call_info is None:
+            return
+
+        for nc_id in list(self._storages):
+            if not self.block_storage.has_contract(nc_id):
+                self._storages.pop(nc_id, None)
+
+        self._reset_all_changes()
 
     def _check_all_field_initialized(self, blueprint: Blueprint) -> None:
         """ Invoked after the initialize method is called to initialize uninitialized containers.
@@ -916,10 +947,10 @@ class Runner:
 
         self._internal_create_contract(contract_id, blueprint_id)
         try:
-            ret = self._unsafe_call_public_method(contract_id, NC_INITIALIZE_METHOD, ctx, nc_args)
-        finally:
-            self._reset_all_changes()
-        return ret
+            return self._unsafe_call_public_method(contract_id, NC_INITIALIZE_METHOD, ctx, nc_args)
+        except Exception:
+            self.discard_pending_changes()
+            raise
 
     @_forbid_syscall_from_view('create_contract')
     def syscall_create_another_contract(


### PR DESCRIPTION
### Motivation

Add HTTP API and CLI support for dry-running nano contract block execution without modifying state. This allows developers to inspect what would happen during NC execution for debugging and verification purposes.

### Acceptance Criteria

1. Add `/nano_contract/dry_run` HTTP endpoint that accepts either `block_hash` or `tx_hash` and returns detailed execution results
2. Add `x-nc-dry-run` CLI command with `--block-hash` or `--tx-hash` options, supporting JSON and text output formats
3. Add `NCDryRunBlockExecutor` that wraps `NCBlockExecutor` for read-only execution with in-memory voided state tracking
4. Refactor `NCBlockExecutor.execute_block()` to accept a `should_skip` predicate so consensus and dry-run can supply their own skip semantics

### Additional changes in this PR (second commit)

The follow-up commit (`refactor(nano): Inject NCBlockExecutor and split dry-run models`) contains a dependency-injection cleanup that the dry-run feature benefits from:

- **Breaking change to `ConsensusAlgorithm.__init__`**: no longer accepts `runner_factory` + `nc_calls_sorter`. Instead accepts `block_executor: NCBlockExecutor`, which is now built by `Builder` / `CliBuilder` and injected. Direct callers of `ConsensusAlgorithm(...)` must update their construction sites.
- **`ConsensusAlgorithm._block_executor` is now the public attribute `block_executor`** (one test updated accordingly).
- **`NCDryRunResource(manager, block_executor)`**: the dry-run resource receives the executor via constructor injection instead of reaching into `consensus_algorithm._block_executor`.
- **New module `hathor/nanocontracts/execution/dry_run_models.py`**: `ExecutionStatus`, `DryRunCallRecord`, `DryRunTxResult`, and `DryRunResult` moved out of `dry_run_block_executor.py` to keep pydantic models separate from the executor logic.
- **Events are now recorded on dry-run failure**, not only on success.
- **New invariant**: `assert block_storage.get_root_id() == parent_root_id` at the top of `execute_block`.
- **Added `test_dry_run_skip_cascade`** + `build_cascade_dry_run_dag` fixture: verifies a tx spending an output of a failing NC tx is SKIPPED via the dependency cascade in the same block.

This refactor commit can be split into a separate PR on request; the dry-run feature commit stands on its own.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged