### PR TITLE
refactor: Remove BaseTransaction.create_from_struct()

### DIFF
--- a/hathor/nanocontracts/on_chain_blueprint.py
+++ b/hathor/nanocontracts/on_chain_blueprint.py
@@ -191,29 +191,6 @@ class OnChainBlueprint(Transaction):
         """The blueprint's contract-id is it's own tx-id, this helper method just converts to the right type."""
         return blueprint_id_from_bytes(self.hash)
 
-    @classmethod
-    @override
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._common import deserialize_graph_fields
-        from hathor.transaction.vertex_parser._headers import deserialize_headers
-        from hathor.transaction.vertex_parser._on_chain_blueprint import deserialize_ocb_extra_fields
-        from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
-        settings = get_global_settings()
-        tx = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
-        deserialize_tx_funds(deserializer, tx, verbose=verbose)
-        deserialize_ocb_extra_fields(deserializer, tx, verbose=verbose)
-        deserialize_graph_fields(deserializer, tx, verbose=verbose)
-        (tx.nonce,) = deserializer.read_struct('!I')
-        if verbose:
-            verbose('nonce', tx.nonce)
-        deserialize_headers(deserializer, tx, settings)
-        deserializer.finalize()
-        tx.update_hash()
-        return tx
-
     @override
     def get_funds_struct(self) -> bytes:
         from hathor.transaction.vertex_parser._on_chain_blueprint import serialize_ocb_extra_fields

--- a/hathor/p2p/resources/mining.py
+++ b/hathor/p2p/resources/mining.py
@@ -22,7 +22,7 @@ from twisted.web.http import Request
 from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, get_args
 from hathor.crypto.util import decode_address
-from hathor.transaction import Block
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import json_dumpb, json_loadb
 from hathor.wallet.exceptions import InvalidAddress
 
@@ -57,7 +57,7 @@ class MiningResource(Resource):
             post_data = json_loadb(raw_data)
             block_bytes_str = post_data['block_bytes']
             block_bytes = base64.b64decode(block_bytes_str)
-            block = Block.create_from_struct(block_bytes, storage=self.manager.tx_storage)
+            block = vertex_deserializer.deserialize(block_bytes, storage=self.manager.tx_storage)
         except (AttributeError, KeyError, ValueError, JSONDecodeError, binascii.Error, struct.error):
             # XXX ideally, we should catch each error separately and send an specific error
             # message, but we only return 0 or 1 on the API

--- a/hathor/p2p/resources/mining.py
+++ b/hathor/p2p/resources/mining.py
@@ -57,7 +57,8 @@ class MiningResource(Resource):
             post_data = json_loadb(raw_data)
             block_bytes_str = post_data['block_bytes']
             block_bytes = base64.b64decode(block_bytes_str)
-            block = vertex_deserializer.deserialize(block_bytes, storage=self.manager.tx_storage)
+            block = vertex_deserializer.deserialize_block(block_bytes)
+            block.storage = self.manager.tx_storage
         except (AttributeError, KeyError, ValueError, JSONDecodeError, binascii.Error, struct.error):
             # XXX ideally, we should catch each error separately and send an specific error
             # message, but we only return 0 or 1 on the API

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -256,21 +256,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         """Return the maximum number of headers for this vertex."""
         return 2
 
-    @classmethod
-    @abstractmethod
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        """ Create a transaction from its bytes.
-
-        :param struct_bytes: Bytes of a serialized transaction
-        :type struct_bytes: bytes
-
-        :return: A transaction or a block, depending on the class `cls`
-
-        :raises ValueError: when the sequence of bytes is incorrect
-        """
-        raise NotImplementedError
-
     def __eq__(self, other: object) -> bool:
         """Two transactions are equal when their hash matches
 
@@ -811,10 +796,12 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         :return: Transaction or Block copy
         """
-        new_tx = self.create_from_struct(
+        from hathor.transaction.vertex_parser import vertex_deserializer
+        new_tx = vertex_deserializer.deserialize(
             self.get_struct(),
             storage=self.storage if include_storage else None,
         )
+        assert isinstance(new_tx, type(self))
         # static_metadata can be safely copied as it is a frozen dataclass
         new_tx.set_static_metadata(self._static_metadata)
         if hasattr(self, '_metadata') and include_metadata:
@@ -908,8 +895,8 @@ class TxInput:
         """ Creates a TxInput from a serialized input. Returns the input
         and remaining bytes
         """
-        from hathor.transaction.vertex_parser import vertex_serializer
-        return vertex_serializer.deserialize_tx_input(buf, verbose=verbose)
+        from hathor.transaction.vertex_parser import vertex_deserializer
+        return vertex_deserializer.deserialize_tx_input(buf, verbose=verbose)
 
     @classmethod
     def create_from_dict(cls, data: dict) -> 'TxInput':
@@ -992,8 +979,8 @@ class TxOutput:
         """ Creates a TxOutput from a serialized output. Returns the output
         and remaining bytes
         """
-        from hathor.transaction.vertex_parser import vertex_serializer
-        return vertex_serializer.deserialize_tx_output(buf, verbose=verbose)
+        from hathor.transaction.vertex_parser import vertex_deserializer
+        return vertex_deserializer.deserialize_tx_output(buf, verbose=verbose)
 
     def get_token_index(self) -> int:
         """The token uid index in the list"""

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 from typing import TYPE_CHECKING, Any, Iterator, Optional
 
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from hathor.checkpoint import Checkpoint
 from hathor.feature_activation.feature import Feature
@@ -27,7 +27,6 @@ from hathor.transaction import TxOutput, TxVersion
 from hathor.transaction.base_transaction import GenericVertex
 from hathor.transaction.exceptions import CheckpointError
 from hathor.transaction.static_metadata import BlockStaticMetadata
-from hathor.transaction.util import VerboseCallback
 from hathor.utils.int import get_bit_list
 
 if TYPE_CHECKING:
@@ -86,25 +85,6 @@ class Block(GenericVertex[BlockStaticMetadata]):
         serializer = Serializer.build_bytes_serializer()
         serialize_block_graph_fields(serializer, self)
         return bytes(serializer.finalize())
-
-    @classmethod
-    @override
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
-        from hathor.transaction.vertex_parser._headers import deserialize_headers
-        settings = get_global_settings()
-        block = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
-        deserialize_block_funds(deserializer, block, verbose=verbose)
-        deserialize_block_graph_fields(deserializer, block, verbose=verbose)
-        block.nonce = int.from_bytes(deserializer.read_bytes(cls.SERIALIZATION_NONCE_SIZE), byteorder='big')
-        deserialize_headers(deserializer, block, settings)
-        deserializer.finalize()
-        block.update_hash()
-        return block
 
     @property
     def is_block(self) -> bool:

--- a/hathor/transaction/merge_mined_block.py
+++ b/hathor/transaction/merge_mined_block.py
@@ -16,12 +16,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
 
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from hathor.transaction.aux_pow import BitcoinAuxPow
 from hathor.transaction.base_transaction import TxOutput, TxVersion
 from hathor.transaction.block import Block
-from hathor.transaction.util import VerboseCallback
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -58,21 +57,6 @@ class MergeMinedBlock(Block):
             settings=settings
         )
         self.aux_pow = aux_pow
-
-    @classmethod
-    @override
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
-        block = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
-        deserialize_block_funds(deserializer, block, verbose=verbose)
-        deserialize_block_graph_fields(deserializer, block, verbose=verbose)
-        block.aux_pow = BitcoinAuxPow.from_bytes(bytes(deserializer.read_all()))
-        deserializer.finalize()
-        block.hash = block.calculate_hash()
-        return block
 
     @override
     def get_struct_nonce(self) -> bytes:

--- a/hathor/transaction/poa/poa_block.py
+++ b/hathor/transaction/poa/poa_block.py
@@ -12,9 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from hathor.conf.settings import HathorSettings
 from hathor.consensus import poa
@@ -22,9 +22,6 @@ from hathor.consensus.consensus_settings import PoaSettings
 from hathor.serialization import Serializer
 from hathor.transaction import Block, TxOutput, TxVersion
 from hathor.transaction.storage import TransactionStorage
-from hathor.transaction.util import VerboseCallback
-
-_MAX_POA_SIGNATURE_LEN: int = 100
 
 
 class PoaBlock(Block):
@@ -60,28 +57,6 @@ class PoaBlock(Block):
         )
         self.signer_id = signer_id
         self.signature = signature
-
-    @classmethod
-    @override
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional[TransactionStorage] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_poa_block_graph_fields
-        from hathor.transaction.vertex_parser._headers import deserialize_headers
-        settings = get_global_settings()
-        block = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
-        deserialize_block_funds(deserializer, block, verbose=verbose)
-        deserialize_poa_block_graph_fields(
-            deserializer, block, signer_id_len=poa.SIGNER_ID_LEN, max_signature_len=_MAX_POA_SIGNATURE_LEN,
-            verbose=verbose,
-        )
-        block.nonce = int.from_bytes(deserializer.read_bytes(cls.SERIALIZATION_NONCE_SIZE), byteorder='big')
-        deserialize_headers(deserializer, block, settings)
-        deserializer.finalize()
-        block.update_hash()
-        return block
 
     @override
     def get_graph_struct(self) -> bytes:

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Optional
 
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from hathor.conf.settings import HathorSettings
 from hathor.nanocontracts.storage import NCBlockStorage
@@ -83,28 +83,6 @@ class TokenCreationTransaction(Transaction):
         super().update_hash()
         self.tokens = [self.hash]
 
-    @classmethod
-    @override
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._common import deserialize_graph_fields
-        from hathor.transaction.vertex_parser._headers import deserialize_headers
-        from hathor.transaction.vertex_parser._token_creation import deserialize_token_creation_funds
-        settings = get_global_settings()
-        tx = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
-        deserialize_token_creation_funds(deserializer, tx, verbose=verbose)
-        deserialize_graph_fields(deserializer, tx, verbose=verbose)
-        (tx.nonce,) = deserializer.read_struct('!I')
-        if verbose:
-            verbose('nonce', tx.nonce)
-        deserialize_headers(deserializer, tx, settings)
-        deserializer.finalize()
-        tx.update_hash()
-        return tx
-
     @override
     def get_funds_struct(self) -> bytes:
         from hathor.transaction.vertex_parser._token_creation import serialize_token_creation_funds
@@ -126,8 +104,8 @@ class TokenCreationTransaction(Transaction):
             verbose: VerboseCallback = None) -> tuple[str, str, TokenVersion, bytes]:
         """ Gets the token name, symbol and version from serialized format
         """
-        from hathor.transaction.vertex_parser import vertex_serializer
-        return vertex_serializer.deserialize_token_info(buf, verbose=verbose)
+        from hathor.transaction.vertex_parser import vertex_deserializer
+        return vertex_deserializer.deserialize_token_info(buf, verbose=verbose)
 
     def to_json(self, decode_script: bool = False, include_metadata: bool = False) -> dict[str, Any]:
         json = super().to_json(decode_script=decode_script, include_metadata=include_metadata)

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypeVar
 
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from hathor.checkpoint import Checkpoint
 from hathor.crypto.util import get_address_b58_from_bytes
@@ -29,7 +29,6 @@ from hathor.transaction.headers import NanoHeader, VertexBaseHeader
 from hathor.transaction.headers.fee_header import FeeHeader
 from hathor.transaction.static_metadata import TransactionStaticMetadata
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion, get_token_version
-from hathor.transaction.util import VerboseCallback
 from hathor.types import TokenUid, VertexId
 
 T = TypeVar('T', bound=VertexBaseHeader)
@@ -99,28 +98,6 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
         serializer = Serializer.build_bytes_serializer()
         serialize_graph_fields(serializer, self)
         return bytes(serializer.finalize())
-
-    @classmethod
-    @override
-    def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
-                           *, verbose: VerboseCallback = None) -> Self:
-        from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._common import deserialize_graph_fields
-        from hathor.transaction.vertex_parser._headers import deserialize_headers
-        from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
-        settings = get_global_settings()
-        tx = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
-        deserialize_tx_funds(deserializer, tx, verbose=verbose)
-        deserialize_graph_fields(deserializer, tx, verbose=verbose)
-        (tx.nonce,) = deserializer.read_struct('!I')
-        if verbose:
-            verbose('nonce', tx.nonce)
-        deserialize_headers(deserializer, tx, settings)
-        deserializer.finalize()
-        tx.update_hash()
-        return tx
 
     def clear_sighash_cache(self) -> None:
         """Clear caches related to sighash calculation."""

--- a/hathor/transaction/vertex_parser/__init__.py
+++ b/hathor/transaction/vertex_parser/__init__.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from hathor.transaction.vertex_parser import vertex_serializer
+from hathor.transaction.vertex_parser import vertex_deserializer, vertex_serializer
 from hathor.transaction.vertex_parser._vertex_parser import VertexParser
 
-__all__ = ['VertexParser', 'vertex_serializer']
+__all__ = ['VertexParser', 'vertex_deserializer', 'vertex_serializer']

--- a/hathor/transaction/vertex_parser/_vertex_parser.py
+++ b/hathor/transaction/vertex_parser/_vertex_parser.py
@@ -68,6 +68,11 @@ class VertexParser:
                 raise StructError(f"invalid vertex version: {tx_version}")
 
             from hathor.transaction.vertex_parser import vertex_deserializer
-            return vertex_deserializer.deserialize(data, storage=storage, settings=self._settings)
+            vertex = vertex_deserializer.deserialize(data, storage=storage, settings=self._settings)
+            expected_cls = tx_version.get_cls()
+            assert isinstance(vertex, expected_cls), (
+                f'Expected {expected_cls.__name__}, got {type(vertex).__name__}'
+            )
+            return vertex
         except ValueError as e:
             raise StructError('Invalid bytes to create transaction subclass.') from e

--- a/hathor/transaction/vertex_parser/_vertex_parser.py
+++ b/hathor/transaction/vertex_parser/_vertex_parser.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from struct import error as StructError
 from typing import TYPE_CHECKING, Type
 
-from hathor.serialization.exceptions import SerializationError
 from hathor.transaction.headers import FeeHeader, NanoHeader, VertexBaseHeader, VertexHeaderId
 
 if TYPE_CHECKING:
@@ -53,8 +52,9 @@ class VertexParser:
 
     def deserialize(self, data: bytes, storage: TransactionStorage | None = None) -> BaseTransaction:
         """Creates the correct tx subclass from a sequence of bytes."""
-        # version field takes up the second byte only
         from hathor.transaction import TxVersion
+
+        # version field takes up the second byte only
         version = data[1]
         try:
             tx_version = TxVersion(version)
@@ -67,7 +67,7 @@ class VertexParser:
             if not is_valid:
                 raise StructError(f"invalid vertex version: {tx_version}")
 
-            cls = tx_version.get_cls()
-            return cls.create_from_struct(data, storage=storage)
-        except (ValueError, SerializationError) as e:
+            from hathor.transaction.vertex_parser import vertex_deserializer
+            return vertex_deserializer.deserialize(data, storage=storage, settings=self._settings)
+        except ValueError as e:
             raise StructError('Invalid bytes to create transaction subclass.') from e

--- a/hathor/transaction/vertex_parser/vertex_deserializer.py
+++ b/hathor/transaction/vertex_parser/vertex_deserializer.py
@@ -1,0 +1,277 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Public API for vertex binary deserialization.
+
+Usage:
+    from hathor.transaction.vertex_parser import vertex_deserializer
+
+    tx = vertex_deserializer.deserialize(data, storage=storage, settings=settings)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from hathor.serialization import Deserializer
+from hathor.transaction.base_transaction import TxVersion
+from hathor.transaction.util import VerboseCallback
+
+if TYPE_CHECKING:
+    from hathor.conf.settings import HathorSettings
+    from hathor.transaction.base_transaction import BaseTransaction, TxInput, TxOutput
+    from hathor.transaction.block import Block
+    from hathor.transaction.merge_mined_block import MergeMinedBlock
+    from hathor.transaction.storage import TransactionStorage
+    from hathor.transaction.token_creation_tx import TokenCreationTransaction
+    from hathor.transaction.token_info import TokenVersion
+    from hathor.transaction.transaction import Transaction
+
+
+def deserialize(
+    data: bytes,
+    storage: TransactionStorage | None = None,
+    *,
+    settings: HathorSettings | None = None,
+    verbose: VerboseCallback = None,
+) -> BaseTransaction:
+    """Deserialize a vertex from bytes. Dispatches by TxVersion.
+
+    This is the single entry point for deserializing any vertex type.
+    """
+    from hathor.conf.get_settings import get_global_settings
+
+    if settings is None:
+        settings = get_global_settings()
+
+    version = _try_tx_version(data[1])
+
+    match version:
+        case TxVersion.REGULAR_TRANSACTION:
+            vertex: BaseTransaction = deserialize_transaction(data, settings, verbose)
+        case TxVersion.TOKEN_CREATION_TRANSACTION:
+            vertex = deserialize_token_creation_transaction(data, settings, verbose)
+        case TxVersion.ON_CHAIN_BLUEPRINT:
+            vertex = deserialize_on_chain_blueprint(data, settings, verbose)
+        case TxVersion.REGULAR_BLOCK:
+            vertex = deserialize_block(data, settings, verbose)
+        case TxVersion.POA_BLOCK:
+            vertex = deserialize_poa_block(data, settings, verbose)
+        case TxVersion.MERGE_MINED_BLOCK:
+            vertex = deserialize_merge_mined_block(data, verbose)
+        case None:
+            raise ValueError(f'Unknown tx version: {data[1]}')
+
+    if storage is not None:
+        vertex.storage = storage
+    return vertex
+
+
+# ---------------------------------------------------------------------------
+# Per-type deserialization
+# ---------------------------------------------------------------------------
+
+
+def deserialize_transaction(
+    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+) -> Transaction:
+    from hathor.transaction.transaction import Transaction
+    from hathor.transaction.vertex_parser._common import deserialize_graph_fields
+    from hathor.transaction.vertex_parser._headers import deserialize_headers
+    from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
+
+    tx = Transaction()
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    deserialize_tx_funds(deserializer, tx, verbose=verbose)
+    deserialize_graph_fields(deserializer, tx, verbose=verbose)
+    (tx.nonce,) = deserializer.read_struct('!I')
+    if verbose:
+        verbose('nonce', tx.nonce)
+    deserialize_headers(deserializer, tx, settings)
+    deserializer.finalize()
+    tx.update_hash()
+    return tx
+
+
+def deserialize_token_creation_transaction(
+    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+) -> TokenCreationTransaction:
+    from hathor.transaction.token_creation_tx import TokenCreationTransaction
+    from hathor.transaction.vertex_parser._common import deserialize_graph_fields
+    from hathor.transaction.vertex_parser._headers import deserialize_headers
+    from hathor.transaction.vertex_parser._token_creation import deserialize_token_creation_funds
+
+    tctx = TokenCreationTransaction()
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    deserialize_token_creation_funds(deserializer, tctx, verbose=verbose)
+    deserialize_graph_fields(deserializer, tctx, verbose=verbose)
+    (tctx.nonce,) = deserializer.read_struct('!I')
+    if verbose:
+        verbose('nonce', tctx.nonce)
+    deserialize_headers(deserializer, tctx, settings)
+    deserializer.finalize()
+    tctx.update_hash()
+    return tctx
+
+
+def deserialize_on_chain_blueprint(
+    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+) -> Transaction:
+    from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
+    from hathor.transaction.vertex_parser._common import deserialize_graph_fields
+    from hathor.transaction.vertex_parser._headers import deserialize_headers
+    from hathor.transaction.vertex_parser._on_chain_blueprint import deserialize_ocb_extra_fields
+    from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
+
+    ocb = OnChainBlueprint()
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    deserialize_tx_funds(deserializer, ocb, verbose=verbose)
+    deserialize_ocb_extra_fields(deserializer, ocb, verbose=verbose)
+    deserialize_graph_fields(deserializer, ocb, verbose=verbose)
+    (ocb.nonce,) = deserializer.read_struct('!I')
+    if verbose:
+        verbose('nonce', ocb.nonce)
+    deserialize_headers(deserializer, ocb, settings)
+    deserializer.finalize()
+    ocb.update_hash()
+    return ocb
+
+
+def deserialize_block(
+    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+) -> Block:
+    from hathor.transaction.block import Block
+    from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
+    from hathor.transaction.vertex_parser._headers import deserialize_headers
+
+    block = Block()
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    deserialize_block_funds(deserializer, block, verbose=verbose)
+    deserialize_block_graph_fields(deserializer, block, verbose=verbose)
+    block.nonce = int.from_bytes(deserializer.read_bytes(Block.SERIALIZATION_NONCE_SIZE), byteorder='big')
+    deserialize_headers(deserializer, block, settings)
+    deserializer.finalize()
+    block.update_hash()
+    return block
+
+
+def deserialize_poa_block(
+    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+) -> Block:
+    from hathor.consensus.poa.poa import SIGNER_ID_LEN
+    from hathor.transaction.poa.poa_block import PoaBlock
+    from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_poa_block_graph_fields
+    from hathor.transaction.vertex_parser._headers import deserialize_headers
+
+    poa_block = PoaBlock()
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    deserialize_block_funds(deserializer, poa_block, verbose=verbose)
+    deserialize_poa_block_graph_fields(
+        deserializer, poa_block, signer_id_len=SIGNER_ID_LEN, max_signature_len=100, verbose=verbose,
+    )
+    poa_block.nonce = int.from_bytes(
+        deserializer.read_bytes(PoaBlock.SERIALIZATION_NONCE_SIZE), byteorder='big',
+    )
+    deserialize_headers(deserializer, poa_block, settings)
+    deserializer.finalize()
+    poa_block.update_hash()
+    return poa_block
+
+
+def deserialize_merge_mined_block(
+    data: bytes, verbose: VerboseCallback = None,
+) -> MergeMinedBlock:
+    from hathor.transaction.aux_pow import BitcoinAuxPow
+    from hathor.transaction.merge_mined_block import MergeMinedBlock
+    from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
+
+    mm_block = MergeMinedBlock()
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    deserialize_block_funds(deserializer, mm_block, verbose=verbose)
+    deserialize_block_graph_fields(deserializer, mm_block, verbose=verbose)
+    mm_block.aux_pow = BitcoinAuxPow.from_bytes(bytes(deserializer.read_all()))
+    deserializer.finalize()
+    mm_block.hash = mm_block.calculate_hash()
+    return mm_block
+
+
+# ---------------------------------------------------------------------------
+# Component deserialization
+# ---------------------------------------------------------------------------
+
+
+def deserialize_tx_input(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[TxInput, bytes]:
+    """Deserialize a TxInput from bytes."""
+    from hathor.transaction.vertex_parser._common import _deserialize_tx_input
+
+    deserializer = Deserializer.build_bytes_deserializer(buf)
+    txin = _deserialize_tx_input(deserializer, verbose=verbose)
+    remaining = bytes(deserializer.read_all())
+    return txin, remaining
+
+
+def deserialize_tx_output(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[TxOutput, bytes]:
+    """Deserialize a TxOutput from bytes."""
+    from hathor.transaction.vertex_parser._common import _deserialize_tx_output
+
+    deserializer = Deserializer.build_bytes_deserializer(buf)
+    txout = _deserialize_tx_output(deserializer, verbose=verbose)
+    remaining = bytes(deserializer.read_all())
+    return txout, remaining
+
+
+def deserialize_token_info(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[str, str, TokenVersion, bytes]:
+    """Deserialize token info from bytes."""
+    from hathor.transaction.token_info import TokenVersion
+    from hathor.transaction.util import decode_string_utf8, unpack, unpack_len
+
+    (raw_token_version,), buf = unpack('!B', buf)
+    if verbose:
+        verbose('token_version', raw_token_version)
+
+    try:
+        token_version = TokenVersion(raw_token_version)
+    except ValueError:
+        raise ValueError('unknown token version: {}'.format(raw_token_version))
+
+    (name_len,), buf = unpack('!B', buf)
+    if verbose:
+        verbose('token_name_len', name_len)
+    name, buf = unpack_len(name_len, buf)
+    if verbose:
+        verbose('token_name', name)
+    (symbol_len,), buf = unpack('!B', buf)
+    if verbose:
+        verbose('token_symbol_len', symbol_len)
+    symbol, buf = unpack_len(symbol_len, buf)
+    if verbose:
+        verbose('token_symbol', symbol)
+
+    decoded_name = decode_string_utf8(name, 'Token name')
+    decoded_symbol = decode_string_utf8(symbol, 'Token symbol')
+
+    return decoded_name, decoded_symbol, token_version, buf
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_tx_version(version: int) -> TxVersion | None:
+    """Convert a version int to TxVersion, returning None for unknown versions."""
+    try:
+        return TxVersion(version)
+    except (ValueError, AssertionError):
+        return None

--- a/hathor/transaction/vertex_parser/vertex_deserializer.py
+++ b/hathor/transaction/vertex_parser/vertex_deserializer.py
@@ -84,12 +84,16 @@ def deserialize(
 
 
 def deserialize_transaction(
-    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+    data: bytes, settings: HathorSettings | None = None, verbose: VerboseCallback = None,
 ) -> Transaction:
+    from hathor.conf.get_settings import get_global_settings
     from hathor.transaction.transaction import Transaction
     from hathor.transaction.vertex_parser._common import deserialize_graph_fields
     from hathor.transaction.vertex_parser._headers import deserialize_headers
     from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
+
+    if settings is None:
+        settings = get_global_settings()
 
     tx = Transaction()
     deserializer = Deserializer.build_bytes_deserializer(data)
@@ -105,12 +109,16 @@ def deserialize_transaction(
 
 
 def deserialize_token_creation_transaction(
-    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+    data: bytes, settings: HathorSettings | None = None, verbose: VerboseCallback = None,
 ) -> TokenCreationTransaction:
+    from hathor.conf.get_settings import get_global_settings
     from hathor.transaction.token_creation_tx import TokenCreationTransaction
     from hathor.transaction.vertex_parser._common import deserialize_graph_fields
     from hathor.transaction.vertex_parser._headers import deserialize_headers
     from hathor.transaction.vertex_parser._token_creation import deserialize_token_creation_funds
+
+    if settings is None:
+        settings = get_global_settings()
 
     tctx = TokenCreationTransaction()
     deserializer = Deserializer.build_bytes_deserializer(data)
@@ -126,13 +134,17 @@ def deserialize_token_creation_transaction(
 
 
 def deserialize_on_chain_blueprint(
-    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+    data: bytes, settings: HathorSettings | None = None, verbose: VerboseCallback = None,
 ) -> Transaction:
+    from hathor.conf.get_settings import get_global_settings
     from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
     from hathor.transaction.vertex_parser._common import deserialize_graph_fields
     from hathor.transaction.vertex_parser._headers import deserialize_headers
     from hathor.transaction.vertex_parser._on_chain_blueprint import deserialize_ocb_extra_fields
     from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
+
+    if settings is None:
+        settings = get_global_settings()
 
     ocb = OnChainBlueprint()
     deserializer = Deserializer.build_bytes_deserializer(data)
@@ -149,11 +161,15 @@ def deserialize_on_chain_blueprint(
 
 
 def deserialize_block(
-    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+    data: bytes, settings: HathorSettings | None = None, verbose: VerboseCallback = None,
 ) -> Block:
+    from hathor.conf.get_settings import get_global_settings
     from hathor.transaction.block import Block
     from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
     from hathor.transaction.vertex_parser._headers import deserialize_headers
+
+    if settings is None:
+        settings = get_global_settings()
 
     block = Block()
     deserializer = Deserializer.build_bytes_deserializer(data)
@@ -167,12 +183,16 @@ def deserialize_block(
 
 
 def deserialize_poa_block(
-    data: bytes, settings: HathorSettings, verbose: VerboseCallback = None,
+    data: bytes, settings: HathorSettings | None = None, verbose: VerboseCallback = None,
 ) -> Block:
+    from hathor.conf.get_settings import get_global_settings
     from hathor.consensus.poa.poa import SIGNER_ID_LEN
     from hathor.transaction.poa.poa_block import PoaBlock
     from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_poa_block_graph_fields
     from hathor.transaction.vertex_parser._headers import deserialize_headers
+
+    if settings is None:
+        settings = get_global_settings()
 
     poa_block = PoaBlock()
     deserializer = Deserializer.build_bytes_deserializer(data)

--- a/hathor/transaction/vertex_parser/vertex_serializer.py
+++ b/hathor/transaction/vertex_parser/vertex_serializer.py
@@ -1,4 +1,4 @@
-#  Copyright 2026 Hathor Labs
+#  Copyright 2025 Hathor Labs
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,16 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-"""Public API for vertex binary serialization and deserialization.
+"""Public API for vertex binary serialization.
 
 All binary serialization is routed through this module. Vertex classes
 are pure data containers and do not implement serialization methods.
+For deserialization, see ``vertex_deserializer``.
 
 Usage:
     from hathor.transaction.vertex_parser import vertex_serializer
 
     data = vertex_serializer.serialize(tx)
-    tx = vertex_serializer.deserialize(data, storage=storage, settings=settings)
 """
 
 from __future__ import annotations
@@ -31,11 +31,10 @@ from typing import TYPE_CHECKING
 
 from hathor.serialization import Serializer
 from hathor.transaction.base_transaction import TxVersion
-from hathor.transaction.util import VerboseCallback, int_to_bytes
+from hathor.transaction.util import int_to_bytes
 
 if TYPE_CHECKING:
     from hathor.transaction.base_transaction import BaseTransaction, TxInput, TxOutput
-    from hathor.transaction.token_info import TokenVersion
     from hathor.transaction.transaction import Transaction
 
 
@@ -50,7 +49,7 @@ def serialize(vertex: BaseTransaction) -> bytes:
 
 def serialize_funds(serializer: Serializer, vertex: BaseTransaction) -> None:
     """Serialize the funds part of a vertex into the given Serializer."""
-    match TxVersion(vertex.version):
+    match _try_tx_version(vertex.version):
         case TxVersion.ON_CHAIN_BLUEPRINT:
             from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
             from hathor.transaction.vertex_parser._on_chain_blueprint import serialize_ocb_extra_fields
@@ -73,11 +72,13 @@ def serialize_funds(serializer: Serializer, vertex: BaseTransaction) -> None:
             from hathor.transaction.vertex_parser._transaction import serialize_tx_funds
             assert isinstance(vertex, Transaction)
             serialize_tx_funds(serializer, vertex)
+        case None:
+            _write_funds_fallback(serializer, vertex)
 
 
 def serialize_graph(serializer: Serializer, vertex: BaseTransaction) -> None:
     """Serialize the graph part of a vertex into the given Serializer."""
-    match TxVersion(vertex.version):
+    match _try_tx_version(vertex.version):
         case TxVersion.POA_BLOCK:
             from hathor.consensus import poa
             from hathor.transaction.poa.poa_block import PoaBlock
@@ -93,11 +94,13 @@ def serialize_graph(serializer: Serializer, vertex: BaseTransaction) -> None:
         case TxVersion.REGULAR_TRANSACTION | TxVersion.TOKEN_CREATION_TRANSACTION | TxVersion.ON_CHAIN_BLUEPRINT:
             from hathor.transaction.vertex_parser._common import serialize_graph_fields
             serialize_graph_fields(serializer, vertex)
+        case None:
+            _write_graph_fallback(serializer, vertex)
 
 
 def serialize_nonce(serializer: Serializer, vertex: BaseTransaction) -> None:
     """Serialize the nonce/PoW part of a vertex into the given Serializer."""
-    match TxVersion(vertex.version):
+    match _try_tx_version(vertex.version):
         case TxVersion.MERGE_MINED_BLOCK:
             from hathor.transaction.merge_mined_block import MergeMinedBlock
             assert isinstance(vertex, MergeMinedBlock)
@@ -145,7 +148,7 @@ def serialize_sighash(tx: Transaction, *, skip_cache: bool = False) -> bytes:
 
     serializer = Serializer.build_bytes_serializer()
 
-    match TxVersion(tx.version):
+    match _try_tx_version(tx.version):
         case TxVersion.ON_CHAIN_BLUEPRINT:
             from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
             from hathor.transaction.vertex_parser._on_chain_blueprint import serialize_ocb_extra_fields_bytes
@@ -211,60 +214,39 @@ def serialize_token_info(tx: BaseTransaction) -> bytes:
 
 
 # ---------------------------------------------------------------------------
-# Deserialization
+# Internal helpers
 # ---------------------------------------------------------------------------
 
 
-def deserialize_tx_input(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[TxInput, bytes]:
-    """Deserialize a TxInput from bytes. Replaces TxInput.create_from_bytes()."""
-    from hathor.serialization import Deserializer
-    from hathor.transaction.vertex_parser._common import _deserialize_tx_input
-
-    deserializer = Deserializer.build_bytes_deserializer(buf)
-    txin = _deserialize_tx_input(deserializer, verbose=verbose)
-    remaining = bytes(deserializer.read_all())
-    return txin, remaining
-
-
-def deserialize_tx_output(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[TxOutput, bytes]:
-    """Deserialize a TxOutput from bytes. Replaces TxOutput.create_from_bytes()."""
-    from hathor.serialization import Deserializer
-    from hathor.transaction.vertex_parser._common import _deserialize_tx_output
-
-    deserializer = Deserializer.build_bytes_deserializer(buf)
-    txout = _deserialize_tx_output(deserializer, verbose=verbose)
-    remaining = bytes(deserializer.read_all())
-    return txout, remaining
-
-
-def deserialize_token_info(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[str, str, TokenVersion, bytes]:
-    """Deserialize token info from bytes. Replaces TokenCreationTransaction.deserialize_token_info()."""
-    from hathor.transaction.token_info import TokenVersion
-    from hathor.transaction.util import decode_string_utf8, unpack, unpack_len
-
-    (raw_token_version,), buf = unpack('!B', buf)
-    if verbose:
-        verbose('token_version', raw_token_version)
-
+def _try_tx_version(version: int) -> TxVersion | None:
+    """Convert a version int to TxVersion, returning None for unknown versions."""
     try:
-        token_version = TokenVersion(raw_token_version)
-    except ValueError:
-        raise ValueError('unknown token version: {}'.format(raw_token_version))
+        return TxVersion(version)
+    except (ValueError, AssertionError):
+        return None
 
-    (name_len,), buf = unpack('!B', buf)
-    if verbose:
-        verbose('token_name_len', name_len)
-    name, buf = unpack_len(name_len, buf)
-    if verbose:
-        verbose('token_name', name)
-    (symbol_len,), buf = unpack('!B', buf)
-    if verbose:
-        verbose('token_symbol_len', symbol_len)
-    symbol, buf = unpack_len(symbol_len, buf)
-    if verbose:
-        verbose('token_symbol', symbol)
 
-    decoded_name = decode_string_utf8(name, 'Token name')
-    decoded_symbol = decode_string_utf8(symbol, 'Token symbol')
+def _write_funds_fallback(serializer: Serializer, vertex: BaseTransaction) -> None:
+    """Fallback for unknown versions: use isinstance to pick the right serializer."""
+    from hathor.transaction.block import Block
+    from hathor.transaction.transaction import Transaction
+    from hathor.transaction.vertex_parser._block import serialize_block_funds
+    from hathor.transaction.vertex_parser._transaction import serialize_tx_funds
 
-    return decoded_name, decoded_symbol, token_version, buf
+    if isinstance(vertex, Block):
+        serialize_block_funds(serializer, vertex)
+    else:
+        assert isinstance(vertex, Transaction)
+        serialize_tx_funds(serializer, vertex)
+
+
+def _write_graph_fallback(serializer: Serializer, vertex: BaseTransaction) -> None:
+    """Fallback for unknown versions: use isinstance to pick the right serializer."""
+    from hathor.transaction.block import Block
+    from hathor.transaction.vertex_parser._block import serialize_block_graph_fields
+    from hathor.transaction.vertex_parser._common import serialize_graph_fields
+
+    if isinstance(vertex, Block):
+        serialize_block_graph_fields(serializer, vertex)
+    else:
+        serialize_graph_fields(serializer, vertex)

--- a/hathor/wallet/resources/nano_contracts/decode.py
+++ b/hathor/wallet/resources/nano_contracts/decode.py
@@ -17,8 +17,8 @@ import struct
 
 from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, get_args, get_missing_params_msg, set_cors
-from hathor.transaction import Transaction
 from hathor.transaction.scripts import NanoContractMatchValues
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import json_dumpb
 
 
@@ -54,7 +54,7 @@ class NanoContractDecodeResource(Resource):
             tx_bytes = bytes.fromhex(requested_decode)
 
             try:
-                tx = Transaction.create_from_struct(tx_bytes)
+                tx = vertex_deserializer.deserialize(tx_bytes)
             except struct.error:
                 data = {'success': False, 'message': 'Invalid transaction'}
                 return json_dumpb(data)

--- a/hathor/wallet/resources/nano_contracts/decode.py
+++ b/hathor/wallet/resources/nano_contracts/decode.py
@@ -54,7 +54,7 @@ class NanoContractDecodeResource(Resource):
             tx_bytes = bytes.fromhex(requested_decode)
 
             try:
-                tx = vertex_deserializer.deserialize(tx_bytes)
+                tx = vertex_deserializer.deserialize_transaction(tx_bytes)
             except struct.error:
                 data = {'success': False, 'message': 'Invalid transaction'}
                 return json_dumpb(data)

--- a/hathor/wallet/resources/nano_contracts/match_value.py
+++ b/hathor/wallet/resources/nano_contracts/match_value.py
@@ -23,6 +23,7 @@ from hathor.api_util import Resource, get_missing_params_msg, render_options, se
 from hathor.crypto.util import decode_address
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH, NanoContractMatchValues
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import json_dumpb, json_loadb
 from hathor.wallet.exceptions import InvalidAddress
 
@@ -182,7 +183,7 @@ class NanoContractMatchValueResource(Resource):
             return json_dumpb({'success': False, 'message': e.message})
 
         try:
-            tx = Transaction.create_from_struct(decoded_params.tx_bytes)
+            tx = vertex_deserializer.deserialize(decoded_params.tx_bytes)
         except struct.error:
             return json_dumpb({'success': False, 'message': 'Could not decode hex transaction'})
 

--- a/hathor/wallet/resources/nano_contracts/match_value.py
+++ b/hathor/wallet/resources/nano_contracts/match_value.py
@@ -183,7 +183,7 @@ class NanoContractMatchValueResource(Resource):
             return json_dumpb({'success': False, 'message': e.message})
 
         try:
-            tx = vertex_deserializer.deserialize(decoded_params.tx_bytes)
+            tx = vertex_deserializer.deserialize_transaction(decoded_params.tx_bytes)
         except struct.error:
             return json_dumpb({'success': False, 'message': 'Could not decode hex transaction'})
 

--- a/hathor/wallet/resources/sign_tx.py
+++ b/hathor/wallet/resources/sign_tx.py
@@ -17,7 +17,7 @@ import struct
 
 from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, get_args, get_missing_params_msg, set_cors
-from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import json_dumpb
 
 
@@ -59,7 +59,7 @@ class SignTxResource(Resource):
                 prepare_to_send = _prepare_to_send == 'true'
 
             try:
-                tx = Transaction.create_from_struct(tx_bytes)
+                tx = vertex_deserializer.deserialize(tx_bytes)
                 tx.storage = self.manager.tx_storage
                 self.manager.wallet.sign_transaction(tx, self.manager.tx_storage)
 

--- a/hathor/wallet/resources/sign_tx.py
+++ b/hathor/wallet/resources/sign_tx.py
@@ -59,7 +59,7 @@ class SignTxResource(Resource):
                 prepare_to_send = _prepare_to_send == 'true'
 
             try:
-                tx = vertex_deserializer.deserialize(tx_bytes)
+                tx = vertex_deserializer.deserialize_transaction(tx_bytes)
                 tx.storage = self.manager.tx_storage
                 self.manager.wallet.sign_transaction(tx, self.manager.tx_storage)
 

--- a/hathor_cli/mining.py
+++ b/hathor_cli/mining.py
@@ -56,6 +56,7 @@ def execute(args: Namespace) -> None:
 
     from hathor.transaction import Block
     from hathor.transaction.exceptions import HathorError
+    from hathor.transaction.vertex_parser import vertex_deserializer
 
     print('Hathor CPU Miner v1.0.0')
     print('URL: {}'.format(args.url))
@@ -118,7 +119,7 @@ def execute(args: Namespace) -> None:
             continue
 
         block_bytes = base64.b64decode(data['block_bytes'])
-        block = Block.create_from_struct(block_bytes)
+        block = vertex_deserializer.deserialize(block_bytes)
         assert isinstance(block, Block)
         print('Mining block with weight {}'.format(block.weight))
 

--- a/hathor_cli/mining.py
+++ b/hathor_cli/mining.py
@@ -119,8 +119,7 @@ def execute(args: Namespace) -> None:
             continue
 
         block_bytes = base64.b64decode(data['block_bytes'])
-        block = vertex_deserializer.deserialize(block_bytes)
-        assert isinstance(block, Block)
+        block = vertex_deserializer.deserialize_block(block_bytes)
         print('Mining block with weight {}'.format(block.weight))
 
         p = Process(target=worker, args=(q_in, q_out))
@@ -138,11 +137,11 @@ def execute(args: Namespace) -> None:
 
             from hathor.conf.get_settings import get_global_settings
             from hathor.daa import DifficultyAdjustmentAlgorithm
+            from hathor.feature_activation.utils import Features
+            from hathor.transaction.scripts.opcode import OpcodesVersion
             from hathor.verification.verification_params import VerificationParams
             from hathor.verification.verification_service import VerificationService
             from hathor.verification.vertex_verifiers import VertexVerifiers
-            from hathor.feature_activation.utils import Features
-            from hathor.transaction.scripts.opcode import OpcodesVersion
             settings = get_global_settings()
             daa = DifficultyAdjustmentAlgorithm(settings=settings)
             verification_params = VerificationParams(nc_block_root_id=None, features=Features(

--- a/hathor_cli/multisig_signature.py
+++ b/hathor_cli/multisig_signature.py
@@ -26,9 +26,10 @@ def create_parser() -> ArgumentParser:
 
 def execute(args: Namespace, priv_key_password: str) -> None:
     from hathor.transaction import Transaction
+    from hathor.transaction.vertex_parser import vertex_deserializer
     from hathor.wallet.util import generate_signature
 
-    tx = Transaction.create_from_struct(bytes.fromhex(args.partial_tx))
+    tx = vertex_deserializer.deserialize(bytes.fromhex(args.partial_tx))
     assert isinstance(tx, Transaction)
 
     signature = generate_signature(tx, bytes.fromhex(args.private_key), password=priv_key_password.encode())

--- a/hathor_cli/multisig_signature.py
+++ b/hathor_cli/multisig_signature.py
@@ -25,12 +25,10 @@ def create_parser() -> ArgumentParser:
 
 
 def execute(args: Namespace, priv_key_password: str) -> None:
-    from hathor.transaction import Transaction
     from hathor.transaction.vertex_parser import vertex_deserializer
     from hathor.wallet.util import generate_signature
 
-    tx = vertex_deserializer.deserialize(bytes.fromhex(args.partial_tx))
-    assert isinstance(tx, Transaction)
+    tx = vertex_deserializer.deserialize_transaction(bytes.fromhex(args.partial_tx))
 
     signature = generate_signature(tx, bytes.fromhex(args.private_key), password=priv_key_password.encode())
     print('Signature: ', signature.hex())

--- a/hathor_cli/multisig_spend.py
+++ b/hathor_cli/multisig_spend.py
@@ -28,10 +28,10 @@ def create_parser() -> ArgumentParser:
 
 def execute(args: Namespace) -> None:
     from hathor.mining.cpu_mining_service import CpuMiningService
-    from hathor.transaction import Transaction
     from hathor.transaction.scripts import MultiSig
+    from hathor.transaction.vertex_parser import vertex_deserializer
 
-    tx = Transaction.create_from_struct(bytes.fromhex(args.partial_tx))
+    tx = vertex_deserializer.deserialize(bytes.fromhex(args.partial_tx))
 
     signatures = [bytes.fromhex(signature) for signature in args.signatures.split(',')]
     input_data = MultiSig.create_input_data(bytes.fromhex(args.redeem_script), signatures)

--- a/hathor_cli/multisig_spend.py
+++ b/hathor_cli/multisig_spend.py
@@ -31,7 +31,7 @@ def execute(args: Namespace) -> None:
     from hathor.transaction.scripts import MultiSig
     from hathor.transaction.vertex_parser import vertex_deserializer
 
-    tx = vertex_deserializer.deserialize(bytes.fromhex(args.partial_tx))
+    tx = vertex_deserializer.deserialize_transaction(bytes.fromhex(args.partial_tx))
 
     signatures = [bytes.fromhex(signature) for signature in args.signatures.split(',')]
     input_data = MultiSig.create_input_data(bytes.fromhex(args.redeem_script), signatures)

--- a/hathor_cli/twin_tx.py
+++ b/hathor_cli/twin_tx.py
@@ -36,6 +36,7 @@ def create_parser() -> ArgumentParser:
 def execute(args: Namespace) -> None:
     from hathor.mining.cpu_mining_service import CpuMiningService
     from hathor.transaction import Transaction
+    from hathor.transaction.vertex_parser import vertex_deserializer
 
     # Get tx you want to create a twin
     if args.url and args.hash:
@@ -58,7 +59,7 @@ def execute(args: Namespace) -> None:
 
     try:
         # Create new tx from the twin
-        twin = Transaction.create_from_struct(tx_bytes)
+        twin = vertex_deserializer.deserialize(tx_bytes)
 
         assert len(twin.parents) == 2
 

--- a/hathor_cli/twin_tx.py
+++ b/hathor_cli/twin_tx.py
@@ -35,7 +35,6 @@ def create_parser() -> ArgumentParser:
 
 def execute(args: Namespace) -> None:
     from hathor.mining.cpu_mining_service import CpuMiningService
-    from hathor.transaction import Transaction
     from hathor.transaction.vertex_parser import vertex_deserializer
 
     # Get tx you want to create a twin
@@ -59,7 +58,7 @@ def execute(args: Namespace) -> None:
 
     try:
         # Create new tx from the twin
-        twin = vertex_deserializer.deserialize(tx_bytes)
+        twin = vertex_deserializer.deserialize_transaction(tx_bytes)
 
         assert len(twin.parents) == 2
 

--- a/hathor_tests/cli/test_multisig_spend.py
+++ b/hathor_tests/cli/test_multisig_spend.py
@@ -7,6 +7,7 @@ from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import create_output_script
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from hathor_cli.multisig_spend import create_parser, execute
@@ -81,7 +82,7 @@ class MultiSigSpendTest(unittest.TestCase):
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID], wallet_balance)
 
         # Then we create a new tx that spends this tokens from multisig wallet
-        tx = Transaction.create_from_struct(tx1.get_struct())
+        tx = vertex_deserializer.deserialize(tx1.get_struct())
         tx.weight = 10
         tx.parents = self.manager.get_new_tx_parents()
         tx.timestamp = int(self.clock.seconds())
@@ -117,5 +118,5 @@ class MultiSigSpendTest(unittest.TestCase):
 
         tx_raw = output[0].split(':')[1].strip()
 
-        tx = Transaction.create_from_struct(bytes.fromhex(tx_raw))
+        tx = vertex_deserializer.deserialize(bytes.fromhex(tx_raw))
         self.assertTrue(self.manager.propagate_tx(tx))

--- a/hathor_tests/cli/test_twin_tx.py
+++ b/hathor_tests/cli/test_twin_tx.py
@@ -5,7 +5,8 @@ import pytest
 from structlog.testing import capture_logs
 
 from hathor.simulator.utils import add_new_blocks
-from hathor.transaction import Transaction, TransactionMetadata
+from hathor.transaction import TransactionMetadata
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import json_loadb
 from hathor_cli.twin_tx import create_parser, execute
 from hathor_tests import unittest
@@ -45,7 +46,7 @@ class TwinTxTest(unittest.TestCase):
         # Transforming prints str in array
         output = f.getvalue().strip().splitlines()
 
-        twin_tx = Transaction.create_from_struct(bytes.fromhex(output[0]))
+        twin_tx = vertex_deserializer.deserialize(bytes.fromhex(output[0]))
         # Parents are the same but in different order
         self.assertEqual(twin_tx.parents[0], self.tx.parents[1])
         self.assertEqual(twin_tx.parents[1], self.tx.parents[0])
@@ -100,7 +101,7 @@ class TwinTxTest(unittest.TestCase):
         # Transforming prints str in array
         output = f.getvalue().strip().splitlines()
 
-        twin_tx = Transaction.create_from_struct(bytes.fromhex(output[0]))
+        twin_tx = vertex_deserializer.deserialize(bytes.fromhex(output[0]))
         # Parents are differents
         self.assertNotEqual(twin_tx.parents[0], tx['parents'][0])
         self.assertNotEqual(twin_tx.parents[0], tx['parents'][1])

--- a/hathor_tests/nanocontracts/test_nanocontract.py
+++ b/hathor_tests/nanocontracts/test_nanocontract.py
@@ -40,6 +40,7 @@ from hathor.transaction.headers import NanoHeader
 from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.transaction.scripts import P2PKH, HathorScript, Opcode
 from hathor.transaction.validation_state import ValidationState
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.verification.nano_header_verifier import MAX_NC_SCRIPT_SIGOPS_COUNT, MAX_NC_SCRIPT_SIZE
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import KeyPair
@@ -142,10 +143,11 @@ class NCNanoContractTestCase(unittest.TestCase):
         nc = self._get_nc()
 
         nc_bytes = bytes(nc)
-        nc2 = Transaction.create_from_struct(nc_bytes, verbose=print)
+        nc2 = vertex_deserializer.deserialize(nc_bytes, verbose=print)
         self.assertEqual(nc_bytes, bytes(nc2))
 
-        nc2 = Transaction.create_from_struct(nc_bytes)
+        nc2 = vertex_deserializer.deserialize(nc_bytes)
+        assert isinstance(nc2, Transaction)
         self.assertEqual(nc_bytes, bytes(nc2))
 
         nc_header = nc.get_nano_header()

--- a/hathor_tests/p2p/test_double_spending.py
+++ b/hathor_tests/p2p/test_double_spending.py
@@ -4,6 +4,7 @@ from hathor.crypto.util import decode_address
 from hathor.manager import HathorManager
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import not_none
 from hathor_tests import unittest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_tx
@@ -49,14 +50,14 @@ class SyncMethodsTestCase(unittest.TestCase):
         tx1.timestamp = int(self.clock.seconds())
         self.manager1.cpu_mining_service.resolve(tx1)
 
-        tx2 = Transaction.create_from_struct(tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(tx1.get_struct())
         tx2.weight = 10
         tx2.parents = tx2.parents[::-1]
         tx2.timestamp = int(self.clock.seconds())
         self.manager1.cpu_mining_service.resolve(tx2)
         self.assertNotEqual(tx1.hash, tx2.hash)
 
-        tx3 = Transaction.create_from_struct(tx1.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx1.get_struct())
         tx3.weight = 11
         tx3.timestamp = int(self.clock.seconds())
         self.manager1.cpu_mining_service.resolve(tx3)
@@ -247,7 +248,7 @@ class SyncMethodsTestCase(unittest.TestCase):
         # ---
 
         self.clock.advance(1)
-        tx6 = Transaction.create_from_struct(tx3.get_struct())
+        tx6 = vertex_deserializer.deserialize(tx3.get_struct())
         tx6.weight = 1
         tx6.parents = [tx4.hash, tx5.hash]
         tx6.timestamp = int(self.clock.seconds())

--- a/hathor_tests/p2p/test_twin_tx.py
+++ b/hathor_tests/p2p/test_twin_tx.py
@@ -1,6 +1,7 @@
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import not_none
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
@@ -39,7 +40,7 @@ class TwinTransactionTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx1)
 
         # Change of parents only, so it's a twin
-        tx2 = Transaction.create_from_struct(tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(tx1.get_struct())
         tx2.parents = [tx1.parents[1], tx1.parents[0]]
         self.manager.cpu_mining_service.resolve(tx2)
         self.assertNotEqual(tx1.hash, tx2.hash)

--- a/hathor_tests/poa/test_poa.py
+++ b/hathor_tests/poa/test_poa.py
@@ -26,6 +26,7 @@ from hathor.transaction import Block, TxOutput
 from hathor.transaction.exceptions import PoaValidationError
 from hathor.transaction.poa import PoaBlock
 from hathor.transaction.static_metadata import BlockStaticMetadata
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.verification.poa_block_verifier import PoaBlockVerifier
 
 
@@ -41,7 +42,9 @@ def test_get_hashed_poa_data() -> None:
     )
 
     def clone_block() -> PoaBlock:
-        return PoaBlock.create_from_struct(block.get_struct())
+        result = vertex_deserializer.deserialize(block.get_struct())
+        assert isinstance(result, PoaBlock)
+        return result
 
     # Test that each field changes the PoA data
     test_block = clone_block()

--- a/hathor_tests/resources/p2p/test_mining.py
+++ b/hathor_tests/resources/p2p/test_mining.py
@@ -3,7 +3,7 @@ import base64
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.p2p.resources import MiningResource
-from hathor.transaction import Block
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
 
 
@@ -26,7 +26,7 @@ class MiningTest(_BaseResourceTest._ResourceTest):
         block_bytes_str = data_get.get('block_bytes')
 
         block_bytes = base64.b64decode(block_bytes_str)
-        block = Block.create_from_struct(block_bytes)
+        block = vertex_deserializer.deserialize(block_bytes)
         block.weight = 4
         self.manager.cpu_mining_service.resolve(block)
 
@@ -51,7 +51,7 @@ class MiningTest(_BaseResourceTest._ResourceTest):
         block_bytes_str = data_get.get('block_bytes')
 
         block_bytes = base64.b64decode(block_bytes_str)
-        block = Block.create_from_struct(block_bytes)
+        block = vertex_deserializer.deserialize(block_bytes)
         block.weight = 4
         self.manager.cpu_mining_service.resolve(block)
 

--- a/hathor_tests/resources/transaction/test_create_tx.py
+++ b/hathor_tests/resources/transaction/test_create_tx.py
@@ -4,9 +4,9 @@ from twisted.internet.defer import inlineCallbacks
 
 from hathor.daa import TestMode
 from hathor.simulator.utils import add_new_blocks
-from hathor.transaction import Transaction
 from hathor.transaction.resources import CreateTxResource
 from hathor.transaction.scripts import P2PKH, create_base_script
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_tx
 
@@ -102,7 +102,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         data = resp['data']
         hex_data = resp['hex_data']
         struct_bytes = bytes.fromhex(hex_data)
-        tx = Transaction.create_from_struct(struct_bytes)
+        tx = vertex_deserializer.deserialize(struct_bytes)
         tx_data = tx.to_json()
         del tx_data['hash']
         del tx_data['nonce']
@@ -139,7 +139,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         data = resp['data']
         hex_data = resp['hex_data']
         struct_bytes = bytes.fromhex(hex_data)
-        tx = Transaction.create_from_struct(struct_bytes)
+        tx = vertex_deserializer.deserialize(struct_bytes)
         tx_data = tx.to_json()
         del tx_data['hash']
         del tx_data['nonce']
@@ -177,7 +177,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         data = resp['data']
         hex_data = resp['hex_data']
         struct_bytes = bytes.fromhex(hex_data)
-        tx = Transaction.create_from_struct(struct_bytes)
+        tx = vertex_deserializer.deserialize(struct_bytes)
         tx_data = tx.to_json()
         del tx_data['hash']
         del tx_data['nonce']
@@ -214,7 +214,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         data = resp['data']
         hex_data = resp['hex_data']
         struct_bytes = bytes.fromhex(hex_data)
-        orig_tx = Transaction.create_from_struct(struct_bytes)
+        orig_tx = vertex_deserializer.deserialize(struct_bytes)
         tx = orig_tx.clone()
         tx_data = tx.to_json()
         del tx_data['hash']
@@ -259,7 +259,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         data = resp['data']
         hex_data = resp['hex_data']
         struct_bytes = bytes.fromhex(hex_data)
-        orig_tx = Transaction.create_from_struct(struct_bytes)
+        orig_tx = vertex_deserializer.deserialize(struct_bytes)
         tx = orig_tx.clone()
         tx_data = tx.to_json()
         del tx_data['hash']

--- a/hathor_tests/resources/transaction/test_graphviz.py
+++ b/hathor_tests/resources/transaction/test_graphviz.py
@@ -1,8 +1,8 @@
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.simulator.utils import add_new_blocks
-from hathor.transaction import Transaction
 from hathor.transaction.resources import GraphvizFullResource, GraphvizNeighboursResource
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor_tests.resources.base_resource import StubSite, TestDummyRequest, _BaseResourceTest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_transactions
 
@@ -24,7 +24,7 @@ class BaseGraphvizTest(_BaseResourceTest._ResourceTest):
         txs = add_new_transactions(self.manager, 2, advance_clock=2)
         tx = txs[0]
 
-        self.tx2 = Transaction.create_from_struct(tx.get_struct())
+        self.tx2 = vertex_deserializer.deserialize(tx.get_struct())
         self.tx2.parents = [tx.parents[1], tx.parents[0]]
         self.manager.cpu_mining_service.resolve(self.tx2)
 

--- a/hathor_tests/resources/transaction/test_tx.py
+++ b/hathor_tests/resources/transaction/test_tx.py
@@ -1,12 +1,11 @@
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.simulator.utils import add_new_blocks
-from hathor.transaction import Transaction
 from hathor.transaction.resources import TransactionResource
 from hathor.transaction.static_metadata import TransactionStaticMetadata
-from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.validation_state import ValidationState
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_transactions
 
@@ -47,7 +46,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         add_blocks_unlock_reward(self.manager)
         tx = add_new_transactions(self.manager, 1)[0]
 
-        tx2 = Transaction.create_from_struct(tx.get_struct())
+        tx2 = vertex_deserializer.deserialize(tx.get_struct())
         tx2.parents = [tx.parents[1], tx.parents[0]]
         self.manager.cpu_mining_service.resolve(tx2)
 
@@ -81,7 +80,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                   'ac0000000402001976a914b9987a3866a7c26225c57a62b14e901377e2f9e288ac000002b602001976a91479ae26cf2f'
                   '2dc703120a77192fc16eda9ed22e1b88ac40200000218def416095b08602003d3c40fb04737e1a2a848cfd2592490a71cd'
                   '0248b9e7d6a626f45dec86975b00f4dd53f84f1f0091125250b044e49023fbbd0f74f6093cdd2226fdff3e09a1000002be')
-        tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
+        tx = vertex_deserializer.deserialize(bytes.fromhex(tx_hex), self.manager.tx_storage)
         tx.get_metadata().validation = ValidationState.FULL
         tx.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx)
@@ -94,7 +93,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                           'c5bf509661f53f009321b031299d0bc32a192a88ac40200000218def416095ae650200f4dd53f84f1f009112'
                           '5250b044e49023fbbd0f74f6093cdd2226fdff3e09a1001f16fe62e3433bcc74b262c11a1fa94fcb38484f4d'
                           '8fb080f53a0c9c57ddb000000120')
-        tx_parent1 = Transaction.create_from_struct(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
+        tx_parent1 = vertex_deserializer.deserialize(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
         tx_parent1.get_metadata().validation = ValidationState.FULL
         tx_parent1.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx_parent1)
@@ -107,7 +106,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                           'b06f76a91434b13dc4351400faf5025bd29d6ddcc0a98366d188ac40200000218def416095a16502001f16fe'
                           '62e3433bcc74b262c11a1fa94fcb38484f4d8fb080f53a0c9c57ddb00065329457d13410ac711318bd941e16'
                           'd57709926b76e64763bf19c3f13eeac30000016d')
-        tx_parent2 = Transaction.create_from_struct(bytes.fromhex(tx_parent2_hex), self.manager.tx_storage)
+        tx_parent2 = vertex_deserializer.deserialize(bytes.fromhex(tx_parent2_hex), self.manager.tx_storage)
         tx_parent2.get_metadata().validation = ValidationState.FULL
         tx_parent2.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx_parent2)
@@ -123,7 +122,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                         '14b098e763d0d5e3017022389b38955e339a485df688ac0000000100001976a914cec7c7f37a01b66dc63776a2'
                         '5e95ac369b31f46188ac40200000218def416082eba802000e4e54b2922c1fa34b5d427f1e96885612e28673ac'
                         'cfaf6e7ceb2ba91c9c84009c8174d4a46ebcc789d1989e3dec5b68cffeef239fd8cf86ef62728e2eacee000001b6')
-        tx_input = Transaction.create_from_struct(bytes.fromhex(tx_input_hex), self.manager.tx_storage)
+        tx_input = vertex_deserializer.deserialize(bytes.fromhex(tx_input_hex), self.manager.tx_storage)
         tx_input.get_metadata().validation = ValidationState.FULL
         tx_input.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx_input)
@@ -200,7 +199,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                   '588ac0000000281001976a914ee216186a0fad459df6f067f9bfa51ce913e1b0588ac4030c398b4620e3161087c07020000'
                   '7851af043c11e19f28675b010e8cf4d8da3278f126d2429490a804a7fb2c000023b318c91dcfd4b967b205dc938f9f5e2fd'
                   '5114256caacfb8f6dd13db33000020393')
-        tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
+        tx = vertex_deserializer.deserialize(bytes.fromhex(tx_hex), self.manager.tx_storage)
         tx.get_metadata().validation = ValidationState.FULL
         tx.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx)
@@ -216,7 +215,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                           '3f04ee680c996ebbc80af79330c4071288ac0000000800001976a914ed9c36b495444302885969447f0fae5e256'
                           '08ef288ac40311513e4fef9d161087be202000023b318c91dcfd4b967b205dc938f9f5e2fd5114256caacfb8f6d'
                           'd13db3300038c3d3b69ce90bb88c0c4d6a87b9f0c349e5b10c9b7ce6714f996e512ac16400021261')
-        tx_parent1 = Transaction.create_from_struct(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
+        tx_parent1 = vertex_deserializer.deserialize(bytes.fromhex(tx_parent1_hex), self.manager.tx_storage)
         tx_parent1.get_metadata().validation = ValidationState.FULL
         tx_parent1.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx_parent1)
@@ -231,7 +230,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                           '10c9b7ce6714f996e512ac1640000476810205cb3625d62897fcdad620e01d66649869329640f5504d77e960d00'
                           '00d810')
         tx_parent2_bytes = bytes.fromhex(tx_parent2_hex)
-        tx_parent2 = TokenCreationTransaction.create_from_struct(tx_parent2_bytes, self.manager.tx_storage)
+        tx_parent2 = vertex_deserializer.deserialize(tx_parent2_bytes, self.manager.tx_storage)
         tx_parent2.get_metadata().validation = ValidationState.FULL
         tx_parent2.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         self.manager.tx_storage.save_transaction(tx_parent2)
@@ -517,7 +516,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
                   'ac0000000402001976a914b9987a3866a7c26225c57a62b14e901377e2f9e288ac000002b602001976a91479ae26cf2f'
                   '2dc703120a77192fc16eda9ed22e1b88ac40200000218def416095b08602003d3c40fb04737e1a2a848cfd2592490a71cd'
                   '0248b9e7d6a626f45dec86975b00f4dd53f84f1f0091125250b044e49023fbbd0f74f6093cdd2226fdff3e09a1000002be')
-        tx = Transaction.create_from_struct(bytes.fromhex(tx_hex), self.manager.tx_storage)
+        tx = vertex_deserializer.deserialize(bytes.fromhex(tx_hex), self.manager.tx_storage)
         tx.set_validation(ValidationState.BASIC)
         tx.set_static_metadata(TransactionStaticMetadata(min_height=0, closest_ancestor_block=b''))
         with self.manager.tx_storage.allow_partially_validated_context():

--- a/hathor_tests/resources/wallet/test_nano_contract.py
+++ b/hathor_tests/resources/wallet/test_nano_contract.py
@@ -2,8 +2,8 @@ import pytest
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.simulator.utils import add_new_blocks
-from hathor.transaction import Transaction
 from hathor.transaction.resources import DecodeTxResource, PushTxResource
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.util import json_loadb
 from hathor.wallet.resources import SignTxResource
 from hathor.wallet.resources.nano_contracts import (
@@ -81,7 +81,7 @@ class NanoContractsTest(_BaseResourceTest._ResourceTest):
 
         # decode
         genesis_output = [tx for tx in self.manager.tx_storage.get_all_genesis() if tx.is_block][0].outputs[0]
-        partial_tx = Transaction.create_from_struct(bytes.fromhex(nano_contract_hex))
+        partial_tx = vertex_deserializer.deserialize(bytes.fromhex(nano_contract_hex))
         partial_tx.outputs.append(genesis_output)
         response_decode = yield decode_resource.get("wallet/nano_contracts/decode",
                                                     {b'hex_tx': bytes(partial_tx.get_struct().hex(), 'utf-8')})
@@ -111,7 +111,7 @@ class NanoContractsTest(_BaseResourceTest._ResourceTest):
         self.assertIsNotNone(data['hex_tx'])
 
         # Error nano contract not found
-        new_tx = Transaction.create_from_struct(partial_tx.get_struct())
+        new_tx = vertex_deserializer.deserialize(partial_tx.get_struct())
         new_tx.outputs = []
         data_put['hex_tx'] = new_tx.get_struct().hex()
         response = yield match_value_resource.put("wallet/nano_contracts/match_value", data_put)

--- a/hathor_tests/tx/test_indexes.py
+++ b/hathor_tests/tx/test_indexes.py
@@ -5,7 +5,7 @@ from hathor.simulator.utils import add_new_block, add_new_blocks
 from hathor.storage.rocksdb_storage import RocksDBStorage
 from hathor.transaction import Transaction
 from hathor.transaction.vertex_children import RocksDBVertexChildrenService
-from hathor.transaction.vertex_parser import VertexParser
+from hathor.transaction.vertex_parser import VertexParser, vertex_deserializer
 from hathor.util import initialize_hd_wallet, iwindows
 from hathor.wallet import Wallet
 from hathor_tests import unittest
@@ -51,7 +51,7 @@ class BaseIndexesTest(unittest.TestCase):
             {tx2.hash}
         )
 
-        tx3 = Transaction.create_from_struct(tx2.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx2.get_struct())
         tx3.timestamp = tx2.timestamp + 1
         self.assertIn(tx1.hash, tx3.parents)
         self.manager.cpu_mining_service.resolve(tx3)
@@ -103,7 +103,7 @@ class BaseIndexesTest(unittest.TestCase):
             {tx2.hash}
         )
 
-        tx3 = Transaction.create_from_struct(tx2.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx2.get_struct())
         tx3.weight = 3.0
         # tx3.timestamp = tx2.timestamp + 1
         tx3.parents = tx1.parents

--- a/hathor_tests/tx/test_indexes4.py
+++ b/hathor_tests/tx/test_indexes4.py
@@ -1,6 +1,7 @@
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks, gen_new_tx
 from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
 from hathor_tests.utils import add_blocks_unlock_reward
@@ -38,7 +39,7 @@ class SimulatorIndexesTestCase(unittest.TestCase):
         manager.cpu_mining_service.resolve(tx2)
         assert manager.propagate_tx(tx2)
 
-        tx3 = Transaction.create_from_struct(tx2.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx2.get_struct())
         tx3.weight = 3.0
         tx3.parents = tx1.parents
         manager.cpu_mining_service.resolve(tx3)

--- a/hathor_tests/tx/test_multisig.py
+++ b/hathor_tests/tx/test_multisig.py
@@ -7,6 +7,7 @@ from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import ScriptError
 from hathor.transaction.scripts import P2PKH, MultiSig, create_output_script, parse_address_script, script_eval
 from hathor.transaction.scripts.opcode import OpcodesVersion
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from hathor_tests import unittest
@@ -78,7 +79,7 @@ class MultisigTestCase(unittest.TestCase):
                          WalletBalance(0, first_block_amount))
 
         # Then we create a new tx that spends this tokens from multisig wallet
-        tx = Transaction.create_from_struct(tx1.get_struct())
+        tx = vertex_deserializer.deserialize(tx1.get_struct())
         tx.weight = 10
         tx.parents = self.manager.get_new_tx_parents()
         tx.timestamp = int(self.clock.seconds())
@@ -116,7 +117,7 @@ class MultisigTestCase(unittest.TestCase):
         pubkey_obj = private_key_obj.public_key()
         public_key_compressed = get_public_key_bytes_compressed(pubkey_obj)
         p2pkh_input_data = P2PKH.create_input_data(public_key_compressed, signatures[0])
-        tx2 = Transaction.create_from_struct(tx.get_struct())
+        tx2 = vertex_deserializer.deserialize(tx.get_struct())
         tx2.inputs[0].data = p2pkh_input_data
         self.manager.cpu_mining_service.resolve(tx2)
         with self.assertRaises(InvalidNewTransaction):

--- a/hathor_tests/tx/test_tips.py
+++ b/hathor_tests/tx/test_tips.py
@@ -1,7 +1,7 @@
 from itertools import chain
 
 from hathor.simulator.utils import add_new_block, add_new_blocks
-from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor_tests import unittest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
 
@@ -46,7 +46,7 @@ class TipsTestCase(unittest.TestCase):
         # tx2 will be the tip now
         self.assertCountEqual(self.get_tips(), set([tx2.hash]))
 
-        tx3 = Transaction.create_from_struct(tx2.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx2.get_struct())
         tx3.parents = [tx2.parents[1], tx2.parents[0]]
         self.manager.cpu_mining_service.resolve(tx3)
 
@@ -142,7 +142,7 @@ class TipsTestCase(unittest.TestCase):
         self.assertCountEqual(self.get_tips(), set([tx4.hash, tx3.hash]))
 
         # A twin tx with tx4, that will be voided initially, then won't change the tips
-        tx5 = Transaction.create_from_struct(tx4.get_struct())
+        tx5 = vertex_deserializer.deserialize(tx4.get_struct())
         tx5.parents = [tx2.hash, tx3.hash]
         self.manager.cpu_mining_service.resolve(tx5)
         self.manager.propagate_tx(tx5)

--- a/hathor_tests/tx/test_tokens.py
+++ b/hathor_tests/tx/test_tokens.py
@@ -11,6 +11,7 @@ from hathor.transaction.scripts import P2PKH
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount, int_to_bytes
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor_tests import unittest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_double_spending, create_tokens, get_genesis_key
 
@@ -417,7 +418,7 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(400, tokens_index.get_total())
 
         # create conflicting tx by changing parents
-        tx3 = Transaction.create_from_struct(tx2.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx2.get_struct())
         tx3.parents = [tx.parents[1], tx.parents[0]]
         tx3.weight = 3
         self.manager.cpu_mining_service.resolve(tx3)
@@ -520,7 +521,7 @@ class TokenTest(unittest.TestCase):
 
     def test_token_struct(self):
         tx = create_tokens(self.manager, self.address_b58, mint_amount=500)
-        tx2 = TokenCreationTransaction.create_from_struct(tx.get_struct())
+        tx2 = vertex_deserializer.deserialize(tx.get_struct())
         self.assertEqual(tx.hash, tx2.hash)
 
     def test_unknown_authority(self):

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -37,6 +37,7 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.scripts import P2PKH, parse_address_script
 from hathor.transaction.util import int_to_bytes
 from hathor.transaction.validation_state import ValidationState
+from hathor.transaction.vertex_parser import vertex_deserializer, vertex_serializer  # noqa: F401
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import Wallet
 from hathor_tests import unittest
@@ -204,7 +205,7 @@ class TransactionTest(unittest.TestCase):
     def test_struct(self):
         tx = self._gen_tx_spending_genesis_block()
         data = tx.get_struct()
-        tx_read = Transaction.create_from_struct(data)
+        tx_read = vertex_deserializer.deserialize(data)
 
         self.assertEqual(tx, tx_read)
 
@@ -752,7 +753,7 @@ class TransactionTest(unittest.TestCase):
         self.assertTrue(isinstance(str_tx, str))
         self.assertEqual(bytes(tx), tx.get_struct())
 
-        tx_equal = Transaction.create_from_struct(tx.get_struct())
+        tx_equal = vertex_deserializer.deserialize(tx.get_struct())
         self.assertTrue(tx == tx_equal)
         self.assertFalse(tx == tx2)
 
@@ -865,14 +866,14 @@ class TransactionTest(unittest.TestCase):
         assert len_difference == 4, 'new struct is incorrect, len difference={}'.format(len_difference)
 
         with self.assertRaises(ValueError):
-            Transaction.create_from_struct(struct_bytes)
+            vertex_deserializer.deserialize(struct_bytes)
 
         # now use 8 bytes and make sure it's working
         outputs = [TxOutput(MAX_OUTPUT_VALUE, b'')]
         tx = Transaction(outputs=outputs, parents=parents)
         tx.update_hash()
         original_struct = tx.get_struct()
-        tx2 = Transaction.create_from_struct(original_struct)
+        tx2 = vertex_deserializer.deserialize(original_struct)
         tx2.update_hash()
         assert tx == tx2
 

--- a/hathor_tests/tx/test_tx_deserialization.py
+++ b/hathor_tests/tx/test_tx_deserialization.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.transaction import Block, MergeMinedBlock, Transaction, TxVersion
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor_tests import unittest
@@ -23,8 +24,7 @@ class _BaseTest:
             self._verification_service = VerificationService(settings=self._settings, verifiers=verifiers)
 
         def test_deserialize(self):
-            cls = self.get_tx_class()
-            tx = cls.create_from_struct(self.tx_bytes)
+            tx = vertex_deserializer.deserialize(self.tx_bytes)
             self.assertEqual(bytes(tx), self.tx_bytes)
 
         def test_deserialize_verbose(self):
@@ -33,15 +33,14 @@ class _BaseTest:
             def verbose(key, value):
                 v.append((key, value))
 
-            cls = self.get_tx_class()
-            tx = cls.create_from_struct(self.tx_bytes, verbose=verbose)
+            tx = vertex_deserializer.deserialize(self.tx_bytes, verbose=verbose)
             self._verification_service.verify_without_storage(tx, self.get_verification_params())
 
             key, version = v[1]
             self.assertEqual(key, 'version')
 
             tx_version = TxVersion(version)
-            self.assertEqual(tx_version.get_cls(), cls)
+            self.assertEqual(tx_version.get_cls(), self.get_tx_class())
             self.assertEqual(bytes(tx), self.tx_bytes)
 
 

--- a/hathor_tests/tx/test_tx_serialization.py
+++ b/hathor_tests/tx/test_tx_serialization.py
@@ -1,6 +1,7 @@
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
 from hathor_tests.utils import add_blocks_unlock_reward
@@ -36,7 +37,7 @@ class BaseSerializationTest(unittest.TestCase):
 
         # Change of parents only, so it's a twin.
         # With less weight, so the balance will continue because tx1 will be the winner
-        self.tx2 = Transaction.create_from_struct(self.tx1.get_struct())
+        self.tx2 = vertex_deserializer.deserialize(self.tx1.get_struct())
         self.tx2.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         self.tx2.weight = 9
         self.manager.cpu_mining_service.resolve(self.tx2)
@@ -91,9 +92,8 @@ class StructSerializationTest(BaseSerializationTest):
     __test__ = True
 
     def _reserialize(self, tx):
-        cls = tx.__class__
         tx_struct = tx.get_struct()
-        return cls.create_from_struct(tx_struct)
+        return vertex_deserializer.deserialize(tx_struct)
 
     def _assertTxEq(self, tx1, tx2):
         self.log.info('assertEqual tx without metadata', a=tx1.to_json(), b=tx2.to_json())

--- a/hathor_tests/tx/test_verification_mempool.py
+++ b/hathor_tests/tx/test_verification_mempool.py
@@ -31,6 +31,7 @@ from hathor.transaction.exceptions import (
 )
 from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.verification.nano_header_verifier import MAX_SEQNUM_DIFF_MEMPOOL
 from hathor.verification.transaction_verifier import MAX_BETWEEN_CONFLICTS, MAX_WITHIN_CONFLICTS
 from hathor.verification.vertex_verifier import MAX_PAST_TIMESTAMP_ALLOWED
@@ -443,7 +444,8 @@ class VertexHeadersTest(unittest.TestCase):
 
         # blueprint does not exist
         tx1 = artifacts.get_typed_vertex('tx1', Transaction)
-        tx1_copy = Transaction.create_from_struct(bytes(tx1))
+        tx1_copy = vertex_deserializer.deserialize(bytes(tx1))
+        assert isinstance(tx1_copy, Transaction)
         tx1_copy.timestamp = int(self.manager.reactor.seconds())
         self.dag_builder._exporter._vertex_resolver(tx1_copy)
         with self.assertRaises(InvalidNewTransaction) as e:
@@ -478,7 +480,8 @@ class VertexHeadersTest(unittest.TestCase):
 
         # contract does not exist
         tx2 = artifacts.get_typed_vertex('tx2', Transaction)
-        tx2_copy = Transaction.create_from_struct(bytes(tx2))
+        tx2_copy = vertex_deserializer.deserialize(bytes(tx2))
+        assert isinstance(tx2_copy, Transaction)
         tx2_copy.timestamp = int(self.manager.reactor.seconds())
         self.dag_builder._exporter._vertex_resolver(tx2_copy)
         with self.assertRaises(InvalidNewTransaction) as e:
@@ -550,7 +553,7 @@ class VertexHeadersTest(unittest.TestCase):
         # contract has been confirmed
         # try to call an non-existent method but it will be accepted because the blueprint has fallback
         tx2 = artifacts.get_typed_vertex('tx2', Transaction)
-        tx2_copy = Transaction.create_from_struct(bytes(tx2))
+        tx2_copy = vertex_deserializer.deserialize(bytes(tx2))
         tx2_copy.timestamp = int(self.manager.reactor.seconds())
         self.dag_builder._exporter._vertex_resolver(tx2_copy)
         self.manager.vertex_handler.on_new_mempool_transaction(tx2_copy)

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -46,9 +46,9 @@ def resolve_block_bytes(*, block_bytes: bytes, cpu_mining_service: CpuMiningServ
         Return block bytes with hash and nonce after pow
         :rtype: bytes
     """
-    from hathor.transaction import Block
+    from hathor.transaction.vertex_parser import vertex_deserializer
     block_bytes = base64.b64decode(block_bytes)
-    block = Block.create_from_struct(block_bytes)
+    block = vertex_deserializer.deserialize(block_bytes)
     cpu_mining_service.resolve(block)
     return block.get_struct()
 

--- a/hathor_tests/wallet/test_balance_update.py
+++ b/hathor_tests/wallet/test_balance_update.py
@@ -2,6 +2,7 @@ from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.wallet.base_wallet import SpentTx, UnspentTx, WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import PrivateKeyNotFound
 from hathor_tests import unittest
@@ -47,7 +48,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Change of parents only, so it's a twin.
         # With less weight, so the balance will continue because tx1 will be the winner
-        tx2 = Transaction.create_from_struct(self.tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(self.tx1.get_struct())
         tx2.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         tx2.weight = 9
         self.manager.cpu_mining_service.resolve(tx2)
@@ -94,7 +95,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Change of parents only, so it's a twin.
         # Same weight, so both will be voided then the balance increases
-        tx2 = Transaction.create_from_struct(self.tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(self.tx1.get_struct())
         tx2.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         self.manager.cpu_mining_service.resolve(tx2)
 
@@ -122,7 +123,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Change of parents only, so it's a twin.
         # With higher weight, so the balance will continue because tx2 will be the winner
-        tx2 = Transaction.create_from_struct(self.tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(self.tx1.get_struct())
         tx2.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         tx2.weight = 13
         self.manager.cpu_mining_service.resolve(tx2)
@@ -178,7 +179,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
                                                                   force=True, tx_storage=self.manager.tx_storage)
 
         # Change of parents only, so it's a twin.
-        tx3 = Transaction.create_from_struct(tx2.get_struct())
+        tx3 = vertex_deserializer.deserialize(tx2.get_struct())
         tx3.parents = [tx2.parents[1], tx2.parents[0]]
         self.manager.cpu_mining_service.resolve(tx3)
 
@@ -220,7 +221,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx2)
 
         # Change of parents only, so it's a twin.
-        tx3 = Transaction.create_from_struct(self.tx1.get_struct())
+        tx3 = vertex_deserializer.deserialize(self.tx1.get_struct())
         tx3.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         self.manager.cpu_mining_service.resolve(tx3)
 
@@ -252,7 +253,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
                          WalletBalance(0, self.initial_balance))
 
         # Change of parents only, so it's a twin.
-        tx2 = Transaction.create_from_struct(self.tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(self.tx1.get_struct())
         tx2.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         self.manager.cpu_mining_service.resolve(tx2)
 
@@ -300,7 +301,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx2)
 
         # Change of parents only, so it's a twin.
-        tx3 = Transaction.create_from_struct(self.tx1.get_struct())
+        tx3 = vertex_deserializer.deserialize(self.tx1.get_struct())
         tx3.parents = [self.tx1.parents[1], self.tx1.parents[0]]
         tx3.weight = 14
         self.manager.cpu_mining_service.resolve(tx3)
@@ -366,7 +367,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.run_to_completion()
 
         # Change of parents only, so it's a twin.
-        tx5 = Transaction.create_from_struct(tx4.get_struct())
+        tx5 = vertex_deserializer.deserialize(tx4.get_struct())
         tx5.parents = [tx4.parents[1], tx4.parents[0]]
         tx5.weight = 10
         self.manager.cpu_mining_service.resolve(tx5)

--- a/hathor_tests/wallet/test_index.py
+++ b/hathor_tests/wallet/test_index.py
@@ -1,6 +1,7 @@
 from hathor.crypto.util import decode_address
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
+from hathor.transaction.vertex_parser import vertex_deserializer
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
 from hathor_tests.utils import add_blocks_unlock_reward
@@ -33,7 +34,7 @@ class WalletIndexTest(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx1)
 
         # Change of parents only, so it's a twin
-        tx2 = Transaction.create_from_struct(tx1.get_struct())
+        tx2 = vertex_deserializer.deserialize(tx1.get_struct())
         tx2.parents = [tx1.parents[1], tx1.parents[0]]
         self.manager.cpu_mining_service.resolve(tx2)
         self.assertNotEqual(tx1.hash, tx2.hash)


### PR DESCRIPTION
### Motivation

Remove `BaseTransaction.create_from_struct()` in favor of the `vertex_deserializer` module, which provides a cleaner separation between transaction model classes and their binary serialization logic.

### Acceptance Criteria

- `BaseTransaction.create_from_struct()` is removed
- All call sites migrated to `vertex_deserializer.deserialize()` or type-specific functions (`deserialize_block()`, `deserialize_transaction()`)
- Type-specific deserialization functions used where the expected type is known, providing compile-time type safety
- `settings` parameter made optional in all type-specific functions (defaults to `get_global_settings()`)
- Type assertion added in `VertexParser.deserialize()` to validate the result matches `tx_version.get_cls()`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged