### PR TITLE
feat(p2p): SlotsManager class for managing connection pool slots

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -39,6 +39,7 @@ from hathor.nanocontracts.blueprint_service import BlueprintService
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig, NCLogStorage
 from hathor.nanocontracts.runner.runner import RunnerFactory
 from hathor.nanocontracts.sorter.types import NCSorterCallable
+from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.pubsub import PubSubManager
@@ -188,6 +189,7 @@ class Builder:
         self._vertex_parser: VertexParser | None = None
         self._consensus: ConsensusAlgorithm | None = None
         self._p2p_manager: ConnectionsManager | None = None
+        self._slots_manager: SlotsManager | None = None
         self._poa_signer: PoaSigner | None = None
         self._poa_block_producer: PoaBlockProducer | None = None
 
@@ -469,6 +471,7 @@ class Builder:
         enable_ssl = True
         reactor = self._get_reactor()
         my_peer = self._get_peer()
+        slots_manager = self._get_or_create_slots_manager()
 
         self._p2p_manager = ConnectionsManager(
             settings=self._get_or_create_settings(),
@@ -479,6 +482,7 @@ class Builder:
             rng=self._rng,
             enable_ipv6=self._enable_ipv6,
             disable_ipv4=self._disable_ipv4,
+            slots_manager=slots_manager
         )
         SyncSupportLevel.add_factories(
             self._get_or_create_settings(),
@@ -710,6 +714,28 @@ class Builder:
             )
 
         return self._blueprint_service
+
+    def _get_or_create_slots_manager(self) -> SlotsManager:
+        if self._slots_manager:
+            return self._slots_manager
+
+        # Instances of Connection Slots
+        settings = self._get_or_create_settings()
+
+        max_outgoing: int = settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_incoming: int = settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
+        max_bootstrap: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+
+        slots_manager_settings = SlotsManagerSettings(
+            max_outgoing=max_outgoing,
+            max_incoming=max_incoming,
+            max_bootstrap=max_bootstrap,
+        )
+
+        # Connection slots manager -> Kickstarts connection slots
+        slots_manager = SlotsManager(slots_manager_settings)
+
+        return slots_manager
 
     def set_rocksdb_path(self, path: str | tempfile.TemporaryDirectory) -> 'Builder':
         if self._tx_storage:

--- a/hathor/p2p/connect_classes.py
+++ b/hathor/p2p/connect_classes.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ConnectionType(Enum):
+    """ Types of Connection as inputs for an instance of the Hathor Protocol. """
+    OUTGOING = 0
+    INCOMING = 1
+    BOOTSTRAP = 2
+
+    def is_outbound(self) -> bool:
+        """ If value is 1, then the connection is inbound. If not, outbound."""
+        return self in (ConnectionType.OUTGOING, ConnectionType.BOOTSTRAP)
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionAllowed:
+    confirmation: str
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionRejected:
+    reason: str
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionRemoved:
+    reason: str
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionNotRemoved:
+    reason: str

--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -1,0 +1,140 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from typing_extensions import assert_never
+
+from hathor.p2p.connect_classes import (
+    ConnectionAllowed,
+    ConnectionNotRemoved,
+    ConnectionRejected,
+    ConnectionRemoved,
+    ConnectionType,
+)
+from hathor.p2p.protocol import HathorProtocol
+
+AddToSlotResult = ConnectionAllowed | ConnectionRejected
+RemoveFromSlotResult = ConnectionRemoved | ConnectionNotRemoved
+
+
+class ConnectionSlots:
+    """ Class of a connection pool slot - outgoing, incoming, bootstrap connections. """
+    connection_slot: set[HathorProtocol]
+    max_slot_connections: int
+
+    def __init__(self, type: ConnectionType, max_connections: int) -> None:
+
+        assert max_connections > 0, 'Slot max number must allow at least one connection'
+
+        self.connection_slot = set()
+        self.max_slot_connections = max_connections
+
+    def __contains__(self, protocol: HathorProtocol) -> bool:
+        return protocol in self.connection_slot
+
+    def add_connection(self, protocol: HathorProtocol) -> AddToSlotResult:
+        """ Adds connection protocol to the slot. Checks whether the slot is full or not. If full,
+            disconnects the protocol. If the type is 'check_entrypoints', the returns peers of it
+            may go to a queue."""
+
+        if protocol in self.connection_slot:
+            return ConnectionRejected("Protocol already in Slot.")
+
+        if self.is_full():
+            return ConnectionRejected(f"Slot {protocol.connection_type} is full")
+
+        self.connection_slot.add(protocol)
+
+        return ConnectionAllowed(f"Added to slot {protocol.connection_type}.")
+
+    def remove_connection(self, protocol: HathorProtocol) -> ConnectionRemoved:
+        """ Removes from given instance the protocol passed. Returns protocol from queue
+            when disconnection leads to free space in slot."""
+
+        # Discard does nothing if protocol not in connection_slot.
+        self.connection_slot.discard(protocol)
+        return ConnectionRemoved('Connection successfully removed from slot.')
+
+    def is_full(self) -> bool:
+        """ Checks if connection slot has reached the limit of allowed connections."""
+        return len(self.connection_slot) >= self.max_slot_connections
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SlotsManagerSettings:
+    max_outgoing: int
+    max_incoming: int
+    max_bootstrap: int
+
+
+class SlotsManager:
+    """Manager of slot connections - selects the slot to which must we send the
+     arriving protocol. Three protocol slots: OUTGOING, INCOMING, BOOTSTRAP.
+    """
+    outgoing_slot: ConnectionSlots
+    incoming_slot: ConnectionSlots
+    bootstrap_slot: ConnectionSlots
+
+    def __init__(self, settings: SlotsManagerSettings) -> None:
+        self.outgoing_slot = ConnectionSlots(ConnectionType.OUTGOING, settings.max_outgoing)
+        self.incoming_slot = ConnectionSlots(ConnectionType.INCOMING, settings.max_incoming)
+        self.bootstrap_slot = ConnectionSlots(ConnectionType.BOOTSTRAP, settings.max_bootstrap)
+
+    def add_to_slot(self, protocol: HathorProtocol) -> AddToSlotResult:
+        """Add received protocol to one of the slots.
+        If slot is full, protocol is not added. """
+
+        conn_type = protocol.connection_type
+        slot: ConnectionSlots
+        match conn_type:
+            case ConnectionType.OUTGOING:
+                slot = self.outgoing_slot
+            case ConnectionType.INCOMING:
+                slot = self.incoming_slot
+            case ConnectionType.BOOTSTRAP:
+                slot = self.bootstrap_slot
+            case _:
+                assert_never(conn_type)
+
+        status = slot.add_connection(protocol)
+
+        return status
+
+    def remove_from_slot(self, protocol: HathorProtocol) -> None:
+        """ Removes protocol from slot of same type.
+            If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
+            Should be called by manager when disconnecting a protocol.
+            Wraps _remove_from_slot_result and reduces API exposure."""
+
+        self._remove_from_slot_result(protocol)
+
+    def _remove_from_slot_result(self, protocol: HathorProtocol) -> RemoveFromSlotResult:
+        """ Removes protocol from slot of same type.
+            If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
+            Returns type for result, used in tests."""
+
+        conn_type = protocol.connection_type
+        slot: ConnectionSlots
+        match conn_type:
+            case ConnectionType.OUTGOING:
+                slot = self.outgoing_slot
+            case ConnectionType.INCOMING:
+                slot = self.incoming_slot
+            case ConnectionType.BOOTSTRAP:
+                slot = self.bootstrap_slot
+            case _:
+                assert_never(conn_type)
+
+        return slot.remove_connection(protocol)

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -18,13 +18,14 @@ from twisted.internet import protocol
 from twisted.internet.interfaces import IAddress
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connect_classes import ConnectionType
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.protocol import HathorLineReceiver
 
 
 class _HathorLineReceiverFactory(ABC, protocol.Factory):
-    inbound: bool
+    connection_type: ConnectionType
 
     def __init__(
         self,
@@ -45,7 +46,7 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
             my_peer=self.my_peer,
             p2p_manager=self.p2p_manager,
             use_ssl=self.use_ssl,
-            inbound=self.inbound,
+            connection_type=self.connection_type,
             settings=self._settings
         )
         p.factory = self
@@ -55,10 +56,18 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
 class HathorServerFactory(_HathorLineReceiverFactory, protocol.ServerFactory):
     """ HathorServerFactory is used to generate HathorProtocol objects when a new connection arrives.
     """
-    inbound = True
+    connection_type = ConnectionType.INCOMING
 
 
 class HathorClientFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
     """ HathorClientFactory is used to generate HathorProtocol objects when we connected to another peer.
     """
-    inbound = False
+    connection_type = ConnectionType.OUTGOING
+
+
+class HathorBootstrapFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
+    """
+        HathorBootstrapFactory is the same as a HathorClientFactory, but the type of connection is set to
+        bootstrap, for connection pool slotting.
+    """
+    connection_type = ConnectionType.BOOTSTRAP

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -23,8 +23,11 @@ from twisted.internet.interfaces import IListeningPort, IProtocol, IProtocolFact
 from twisted.internet.task import LoopingCall
 from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
 from twisted.python.failure import Failure
+from typing_extensions import assert_never
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connect_classes import ConnectionAllowed, ConnectionRejected
+from hathor.p2p.connection_slot import SlotsManager
 from hathor.p2p.netfilter.factory import NetfilterFactory
 from hathor.p2p.peer import PrivatePeer, PublicPeer, UnverifiedPeer
 from hathor.p2p.peer_discovery import PeerDiscovery
@@ -98,6 +101,7 @@ class ConnectionsManager:
         rng: Random,
         enable_ipv6: bool,
         disable_ipv4: bool,
+        slots_manager: SlotsManager
     ) -> None:
         self.log = logger.new()
         self._settings = settings
@@ -110,7 +114,6 @@ class ConnectionsManager:
 
         self.reactor = reactor
         self.my_peer = my_peer
-
         # List of address descriptions to listen for new connections (eg: [tcp:8000])
         self.listen_address_descriptions: list[str] = []
 
@@ -124,12 +127,15 @@ class ConnectionsManager:
         self.localhost_only = False
 
         # Factories.
-        from hathor.p2p.factory import HathorClientFactory, HathorServerFactory
+        from hathor.p2p.factory import HathorBootstrapFactory, HathorClientFactory, HathorServerFactory
         self.use_ssl = ssl
         self.server_factory = HathorServerFactory(
             self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
         self.client_factory = HathorClientFactory(
+            self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
+        )
+        self.bootstrap_factory = HathorBootstrapFactory(
             self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
 
@@ -151,6 +157,8 @@ class ConnectionsManager:
 
         # List of peers connected and ready to communicate.
         self.connected_peers = {}
+
+        self.slots_manager = slots_manager
 
         # Queue of ready peer-id's used by connect_to_peer_from_connection_queue to choose the next peer to pull a
         # random new connection from
@@ -259,12 +267,16 @@ class ConnectionsManager:
         """Add a peer discovery method."""
         self.peer_discoveries.append(peer_discovery)
 
+    def connect_to_bootstrap(self, entrypoint: PeerEndpoint) -> None:
+        """Connect to a bootstrap entrypoint discovered via a PeerDiscovery strategy."""
+        self.connect_to_endpoint(entrypoint, discovery_call=True)
+
     def do_discovery(self) -> None:
         """
         Do a discovery and connect on all discovery strategies.
         """
         for peer_discovery in self.peer_discoveries:
-            coro = peer_discovery.discover_and_connect(self.connect_to_endpoint)
+            coro = peer_discovery.discover_and_connect(self.connect_to_bootstrap)
             Deferred.fromCoroutine(coro)
 
     def disable_rate_limiter(self) -> None:
@@ -331,7 +343,7 @@ class ConnectionsManager:
             len(self.connecting_peers),
             len(self.handshaking_peers),
             len(self.connected_peers),
-            len(self.verified_peer_storage)
+            len(self.verified_peer_storage),
         )
 
     def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:
@@ -387,10 +399,26 @@ class ConnectionsManager:
 
     def on_peer_connect(self, protocol: HathorProtocol) -> None:
         """Called when a new connection is established."""
+
+        # Checks whether connections in the network are at limit.
         if len(self.connections) >= self.max_connections:
             self.log.warn('reached maximum number of connections', max_connections=self.max_connections)
             protocol.disconnect(force=True)
             return
+
+        connection_status = self.slots_manager.add_to_slot(protocol)
+
+        match connection_status:
+            case ConnectionRejected():
+                self.log.warn('Connection Rejected')
+                protocol.disconnect(force=True)
+                return
+            case ConnectionAllowed():
+                pass
+            case _:
+                assert_never(connection_status)
+
+
         self.connections.add(protocol)
         self.handshaking_peers.add(protocol)
 
@@ -404,8 +432,8 @@ class ConnectionsManager:
         """Called when a peer is ready."""
         assert protocol.peer is not None
         self.verified_peer_storage.add_or_replace(protocol.peer)
-
         self.handshaking_peers.remove(protocol)
+
         for conn in self.iter_all_connections():
             conn.unverified_peer_storage.remove(protocol.peer)
 
@@ -455,9 +483,16 @@ class ConnectionsManager:
 
     def on_peer_disconnect(self, protocol: HathorProtocol) -> None:
         """Called when a peer disconnect."""
+
+        # Discard handles case when not in connections.
         self.connections.discard(protocol)
+
+        # Each conn is from a slot - discard from it as well.
+        self.slots_manager.remove_from_slot(protocol)
+
         if protocol in self.handshaking_peers:
             self.handshaking_peers.remove(protocol)
+
         if protocol._peer is not None:
             peer_id = protocol.peer.id
             existing_protocol = self.connected_peers.pop(peer_id, None)
@@ -474,6 +509,7 @@ class ConnectionsManager:
             elif peer_id in self.new_connection_from_queue:
                 # now we're sure it can be removed from new_connection_from_queue
                 self.new_connection_from_queue.remove(peer_id)
+
         self.pubsub.publish(
             HathorEvents.NETWORK_PEER_DISCONNECTED,
             protocol=protocol,
@@ -482,13 +518,11 @@ class ConnectionsManager:
 
     def iter_all_connections(self) -> Iterable[HathorProtocol]:
         """Iterate over all connections."""
-        for conn in self.connections:
-            yield conn
+        yield from self.connections
 
     def iter_ready_connections(self) -> Iterable[HathorProtocol]:
         """Iterate over ready connections."""
-        for conn in self.connected_peers.values():
-            yield conn
+        yield from self.connected_peers.values()
 
     def iter_not_ready_endpoints(self) -> Iterable[PeerEndpoint]:
         """Iterate over not-ready connections."""
@@ -624,6 +658,7 @@ class ConnectionsManager:
         entrypoint: PeerEndpoint,
         peer: UnverifiedPeer | PublicPeer | None = None,
         use_ssl: bool | None = None,
+        discovery_call: bool = False
     ) -> None:
         """ Attempt to connect directly to an endpoint, prefer calling `connect_to_peer` when possible.
 
@@ -633,6 +668,7 @@ class ConnectionsManager:
 
         If `use_ssl` is True, then the connection will be wraped by a TLS.
         """
+
         if entrypoint.peer_id is not None and peer is not None and entrypoint.peer_id != peer.id:
             self.log.debug('skipping because the entrypoint peer_id does not match the actual peer_id',
                            entrypoint=str(entrypoint))
@@ -663,11 +699,10 @@ class ConnectionsManager:
 
         endpoint = entrypoint.addr.to_client_endpoint(self.reactor)
 
-        factory: IProtocolFactory
+        factory: IProtocolFactory = self.bootstrap_factory if discovery_call else self.client_factory
+
         if use_ssl:
-            factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, self.client_factory)
-        else:
-            factory = self.client_factory
+            factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, factory)
 
         if peer is not None:
             now = int(self.reactor.seconds())
@@ -753,9 +788,10 @@ class ConnectionsManager:
         assert protocol.peer.id is not None
         assert protocol.my_peer.id is not None
         other_connection = self.connected_peers[protocol.peer.id]
+        is_outbound = protocol.connection_type.is_outbound()
         if bytes(protocol.my_peer.id) > bytes(protocol.peer.id):
             # connection started by me is kept
-            if not protocol.inbound:
+            if is_outbound:
                 # other connection is dropped
                 return other_connection
             else:
@@ -763,7 +799,7 @@ class ConnectionsManager:
                 return protocol
         else:
             # connection started by peer is kept
-            if not protocol.inbound:
+            if is_outbound:
                 return protocol
             else:
                 return other_connection

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -25,6 +25,7 @@ from twisted.protocols.basic import LineReceiver
 from twisted.python.failure import Failure
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connect_classes import ConnectionType
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer import PrivatePeer, PublicPeer, UnverifiedPeer
 from hathor.p2p.peer_endpoint import PeerEndpoint
@@ -108,7 +109,7 @@ class HathorProtocol:
         *,
         settings: HathorSettings,
         use_ssl: bool,
-        inbound: bool,
+        connection_type: ConnectionType,
     ) -> None:
         self._settings = settings
         self.my_peer = my_peer
@@ -120,8 +121,9 @@ class HathorProtocol:
         assert self.connections.reactor is not None
         self.reactor = self.connections.reactor
 
-        # Indicate whether it is an inbound connection (true) or an outbound connection (false).
-        self.inbound = inbound
+        # Type of Connection
+        # 0 == Outgoing, 1 == Incoming, 2 == Bootstrap
+        self.connection_type = connection_type
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -21,6 +21,7 @@ from OpenSSL.crypto import X509
 from structlog import get_logger
 from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.testing import StringTransport
+from typing_extensions import assert_never
 
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_endpoint import PeerAddress, PeerEndpoint
@@ -273,7 +274,15 @@ class FakeConnection:
         self._buf2.clear()
 
         self._proto1 = self.manager1.connections.server_factory.buildProtocol(self.addr2)
-        self._proto2 = self.manager2.connections.client_factory.buildProtocol(self.addr1)
+
+        # If in bootstrap mode, now we instantiate the Bootstrap Factory.
+        match self._fake_bootstrap_id:
+            case False:
+                self._proto2 = self.manager2.connections.client_factory.buildProtocol(self.addr1)
+            case None | PeerId():
+                self._proto2 = self.manager2.connections.bootstrap_factory.buildProtocol(self.addr1)
+            case _:
+                assert_never(self._fake_bootstrap_id)
 
         # When _fake_bootstrap_id is set we don't pass the peer because that's how bootstrap calls
         # connect_to_endpoint()

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -35,6 +35,7 @@ from hathor.nanocontracts.blueprint_service import BlueprintService
 from hathor.nanocontracts.execution import NCBlockExecutor
 from hathor.nanocontracts.nc_exec_logs import NCLogStorage
 from hathor.nanocontracts.runner.runner import RunnerFactory
+from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_endpoint import PeerEndpoint
@@ -314,6 +315,20 @@ class CliBuilder:
 
         cpu_mining_service = CpuMiningService()
 
+        # Instances of Connection Slots
+        max_outgoing: int = settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_incoming: int = settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
+        max_bootstrap: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+
+        slots_manager_settings = SlotsManagerSettings(
+            max_outgoing=max_outgoing,
+            max_incoming=max_incoming,
+            max_bootstrap=max_bootstrap,
+        )
+
+        # Connection slots manager -> Kickstarts connection slots
+        slots_manager = SlotsManager(slots_manager_settings)
+
         p2p_manager = ConnectionsManager(
             settings=settings,
             reactor=reactor,
@@ -323,6 +338,7 @@ class CliBuilder:
             rng=Random(),
             enable_ipv6=self._args.x_enable_ipv6,
             disable_ipv4=self._args.x_disable_ipv4,
+            slots_manager= slots_manager
         )
 
         vertex_handler = VertexHandler(

--- a/hathor_tests/others/test_metrics.py
+++ b/hathor_tests/others/test_metrics.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 from hathor.indexes import RocksDBIndexesManager
 from hathor.manager import HathorManager
+from hathor.p2p.connect_classes import ConnectionType
 from hathor.p2p.manager import PeerConnectionsMetrics
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_endpoint import PeerEndpoint
@@ -209,7 +210,7 @@ class MetricsTest(unittest.TestCase):
                 my_peer=my_peer,
                 p2p_manager=manager.connections,
                 use_ssl=False,
-                inbound=False,
+                connection_type=ConnectionType.OUTGOING,
                 settings=self._settings
             )
             protocol._peer = PrivatePeer.auto_generated().to_public_peer()

--- a/hathor_tests/p2p/test_bootstrap.py
+++ b/hathor_tests/p2p/test_bootstrap.py
@@ -58,7 +58,8 @@ class BootstrapTestCase(unittest.TestCase):
             True,
             self.rng,
             enable_ipv6=False,
-            disable_ipv4=False
+            disable_ipv4=False,
+            slots_manager=None  # type: ignore
         )
 
         host_ports1 = [
@@ -92,7 +93,8 @@ class BootstrapTestCase(unittest.TestCase):
             True,
             self.rng,
             enable_ipv6=False,
-            disable_ipv4=False
+            disable_ipv4=False,
+            slots_manager=None  # type: ignore
         )
 
         bootstrap_a = [

--- a/hathor_tests/p2p/test_connection_slots.py
+++ b/hathor_tests/p2p/test_connection_slots.py
@@ -1,0 +1,243 @@
+from twisted.python.failure import Failure
+
+from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
+from hathor.simulator import FakeConnection
+from hathor_tests.simulation.base import SimulatorTestCase
+
+
+class ConnectionSlotsTestCase(SimulatorTestCase):
+    def test_slot_limit(self) -> None:
+        """ Tests whether the slots and the pool stop increasing connections after cap is reached.
+
+            Important note: create_peer caps the peer pool at 100. Hence, if more than 100 connections
+            are opened (if settings.P2P_..._OUTGOING + settings.P2P_...INCOMING _+ ... exceed 100)
+            then the tests will fail."""
+
+        # Full-Node: May receive incoming connections, deliver outgoing connections, etc.
+        # If the total amount of connections exceeds 100, create_peer will not yield more than 100 peers as well.
+        full_node = self.create_peer()
+
+        # Set the limits for each slot (sum MUST NOT exceed 100).
+        # We set the limits here since grabbing the values from the settings exceeds limits in simulator.
+        max_outgoing = 20
+        max_incoming = 15
+        max_bootstrap = 10
+        max_connections = max_bootstrap + max_incoming + max_outgoing
+
+        # Set SlotsManager Settings:
+        slots_manager_settings = SlotsManagerSettings(
+            max_outgoing=max_outgoing,
+            max_incoming=max_incoming,
+            max_bootstrap=max_bootstrap,
+        )
+
+        # Set SlotsManager:
+        slots_manager = SlotsManager(slots_manager_settings)
+
+        # Attribute it to the peer
+        full_node.connections.slots_manager = slots_manager
+
+        # For each connection type we add more peers than necessary to see if the slot limits it.
+        # Create peer list for incoming connections
+        in_connList = []
+        in_peerList = []
+        for i in range(0, max_incoming + 1):
+            in_peerList.append(self.create_peer())
+
+            # Generate incoming connections - full_node is the target.
+            in_connList.append(FakeConnection(full_node, in_peerList[i]))
+
+            # Add connections to simulator.
+            self.simulator.add_connection(in_connList[i])
+
+        self.simulator.run(10)
+
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        number_incoming_slot = len(incoming_slot.connection_slot)
+        # Checks whether the connection has capped on its limit size.
+        self.assertTrue(number_incoming_slot == max_incoming)
+
+        # We repeat the analysis for all other slots.
+
+        # --- outgoing slot ---
+
+        out_connList = []
+        out_peerList = []
+        for i in range(0, max_outgoing + 1):
+
+            out_peerList.append(self.create_peer())
+            out_connList.append(FakeConnection(out_peerList[i], full_node))
+            self.simulator.add_connection(out_connList[i])
+
+        self.simulator.run(10)
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        number_outgoing_slot = len(outgoing_slot.connection_slot)
+        self.assertTrue(number_outgoing_slot == max_outgoing)
+
+        # --- bootstrap slot ---
+        bootstrap_connList = []
+        bootstrap_peerList = []
+
+        for i in range(0, max_bootstrap + 1):
+            bootstrap_peerList.append(self.create_peer())
+            bootstrap_connList.append(FakeConnection(bootstrap_peerList[i], full_node, fake_bootstrap_id=None))
+            self.simulator.add_connection(bootstrap_connList[i])
+
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+        number_bootstrap_slot = len(bootstrap_slot.connection_slot)
+
+        self.assertTrue(number_bootstrap_slot == max_bootstrap)
+        # Finally, assure the number of connected peers is the same as the sum of all (no bootstrap connections).
+        connection_pool = full_node.connections.connections
+        self.assertTrue(number_outgoing_slot + number_incoming_slot + number_bootstrap_slot == len(connection_pool))
+        self.assertTrue(len(connection_pool) <= max_connections)
+
+    def test_wrong_conn_outgoing(self) -> None:
+        """ Test if, by sending a connection to the wrong slot, it is blocked.
+                Note: Connections stop being updated after removed from simulator."""
+
+        full_node = self.create_peer()
+        peer_in = self.create_peer()
+        peer_boot = self.create_peer()
+
+        # -> Test outgoing slot - make incoming and bootstrap connections.
+        in_conn = FakeConnection(full_node, peer_in)
+        boot_conn = FakeConnection(peer_boot, full_node, fake_bootstrap_id=None)
+
+        self.simulator.add_connection(in_conn)
+        self.simulator.add_connection(boot_conn)
+        self.simulator.run(5)
+
+        # Outgoing slot must not update
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        self.assertTrue(len(outgoing_slot.connection_slot) == 0)
+
+    def test_wrong_conn_incoming(self) -> None:
+
+        full_node = self.create_peer()
+        peer_out = self.create_peer()
+        peer_boot = self.create_peer()
+
+        # <- Test incoming slot - make incoming and bootstrap connections.
+
+        out_conn = FakeConnection(peer_out, full_node)
+        boot_conn = FakeConnection(peer_boot, full_node, fake_bootstrap_id=None)
+
+        self.simulator.add_connection(out_conn)
+        self.simulator.add_connection(boot_conn)
+        self.simulator.run(5)
+
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        self.assertTrue(len(incoming_slot.connection_slot) == 0)
+
+    def test_wrong_conn_bootstrap(self) -> None:
+
+        full_node = self.create_peer()
+        peer_out = self.create_peer()
+        peer_in = self.create_peer()
+
+        # <- Test incoming slot - make incoming and bootstrap connections.
+
+        out_conn = FakeConnection(peer_out, full_node)
+        in_conn = FakeConnection(full_node, peer_in)
+
+        self.simulator.add_connection(out_conn)
+        self.simulator.add_connection(in_conn)
+        self.simulator.run(5)
+
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+        self.assertTrue(len(bootstrap_slot.connection_slot) == 0)
+
+    def test_connections_equal_slots(self) -> None:
+        """ Test if connections keep equal to the sum of connections in each slot."""
+        full_node = self.create_peer()
+        number_out = 8  # Random numbers
+        number_in = 11
+        number_boot = 9
+        out_peer_list = []
+        in_peer_list = []
+        boot_peer_list = []
+
+        # Create peer lists:
+        for _ in range(number_out):
+            out_peer_list.append(self.create_peer())
+        for _ in range(number_in):
+            in_peer_list.append(self.create_peer())
+        for _ in range(number_boot):
+            boot_peer_list.append(self.create_peer())
+
+        # Create connections to the peers in the list:
+
+        # Outgoing:
+        out_conn_list = []
+        for _, peer in enumerate(out_peer_list):
+            out_conn_list.append(FakeConnection(peer, full_node))
+            self.simulator.add_connection(out_conn_list[-1])
+        # Incoming:
+        in_conn_list = []
+        for _, peer in enumerate(in_peer_list):
+            in_conn_list.append(FakeConnection(full_node, peer))
+            self.simulator.add_connection(in_conn_list[-1])
+
+        # Bootstrap:
+        boot_conn_list = []
+        for _, peer in enumerate(boot_peer_list):
+            boot_conn_list.append(FakeConnection(peer, full_node, fake_bootstrap_id=None))
+            self.simulator.add_connection(boot_conn_list[-1])
+
+        self.simulator.run(1)
+        connections = full_node.connections.connections
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot.connection_slot
+        incoming_slot = full_node.connections.slots_manager.incoming_slot.connection_slot
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot.connection_slot
+        sum_of_slots = len(bootstrap_slot) + len(incoming_slot) + len(outgoing_slot)
+        self.assertTrue(len(connections) == sum_of_slots)
+
+    def test_remove_connection(self) -> None:
+        """Test if removing connections from each slot properly decreases slot and pool sizes."""
+
+        full_node = self.create_peer()
+
+        # Create one connection per slot type
+        out_peer = self.create_peer()
+        in_peer = self.create_peer()
+        boot_peer = self.create_peer()
+
+        out_conn = FakeConnection(out_peer, full_node)
+        in_conn = FakeConnection(full_node, in_peer)
+        boot_conn = FakeConnection(boot_peer, full_node, fake_bootstrap_id=None)
+
+        self.simulator.add_connection(out_conn)
+        self.simulator.add_connection(in_conn)
+        self.simulator.add_connection(boot_conn)
+        self.simulator.run(5)
+
+        # Make sure three connections we appended to the whole pool
+        self.assertTrue(len(full_node.connections.connections) == 3)
+
+        # Remove outgoing
+        out_conn.disconnect(Failure(Exception('test disconnect')))
+        self.simulator.remove_connection(out_conn)
+        self.simulator.run(1)
+
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        self.assertTrue(len(outgoing_slot.connection_slot) == 0)
+        self.assertTrue(len(full_node.connections.connections) == 2)
+
+        # Remove incoming
+        in_conn.disconnect(Failure(Exception('test disconnect')))
+        self.simulator.remove_connection(in_conn)
+        self.simulator.run(1)
+
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        self.assertTrue(len(incoming_slot.connection_slot) == 0)
+        self.assertTrue(len(full_node.connections.connections) == 1)
+
+        # Remove bootstrap
+        boot_conn.disconnect(Failure(Exception('test disconnect')))
+        self.simulator.remove_connection(boot_conn)
+        self.simulator.run(1)
+
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+        self.assertTrue(len(bootstrap_slot.connection_slot) == 0)
+        self.assertTrue(len(full_node.connections.connections) == 0)

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -376,6 +376,11 @@ class HathorSettings(BaseModel):
     # Number max of connections in the p2p network
     PEER_MAX_CONNECTIONS: int = 125
 
+    # Max Number of each connection slot (int):
+    P2P_PEER_MAX_INCOMING_CONNECTIONS: int = 50
+    P2P_PEER_MAX_OUTGOING_CONNECTIONS: int = 60
+    P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS: int = 15
+
     # Maximum period without receiving any messages from ther peer (in seconds).
     PEER_IDLE_TIMEOUT: int = 60
 
@@ -563,5 +568,22 @@ class HathorSettings(BaseModel):
             raise ValueError(
                 f'invalid tokens: GENESIS_TOKENS={genesis_tokens}, '
                 f'GENESIS_TOKEN_UNITS={genesis_token_units}, DECIMAL_PLACES={decimal_places}'
+            )
+        return self
+
+    @model_validator(mode='after')
+    def _validate_peer_connection_slots(self) -> Self:
+        slot_total = (
+            self.P2P_PEER_MAX_INCOMING_CONNECTIONS
+            + self.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+            + self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+        )
+        if self.PEER_MAX_CONNECTIONS != slot_total:
+            raise ValueError(
+                f'PEER_MAX_CONNECTIONS ({self.PEER_MAX_CONNECTIONS}) must equal '
+                f'P2P_PEER_MAX_INCOMING_CONNECTIONS ({self.P2P_PEER_MAX_INCOMING_CONNECTIONS}) + '
+                f'P2P_PEER_MAX_OUTGOING_CONNECTIONS ({self.P2P_PEER_MAX_OUTGOING_CONNECTIONS}) + '
+                f'P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS '
+                f'({self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS}) = {slot_total}'
             )
         return self


### PR DESCRIPTION
### Motivation

RFCs available: https://github.com/HathorNetwork/internal-rfcs/tree/design/connection-pool-slots/projects/p2p-projects/connection-pool-slots/

The original Pull Request for slotting the connection pool (#1266 ) was proposed for subdividing the connections into four main groups, allowing for a more solid infrastructure against attacks onto hathor-core. 

The original PR has been subdivided into two smaller ones - this focusing on the development of a SlotsManager class to handle the distribution and coordination of protocols between the ConnectionsSlot classes, which for this pull request will be restricted to three:

- OUTGOING: Outbound connections started by the node to other peers, after all bootstrap set-ups have been finalized.
- INCOMING: Inbound connections, started by other peers towards our node. 
- BOOTSTRAP: Outbound connections right at the beginning of the full node boot up, trying to fetch hardcoded honest peers to connect to.

The second PR will deal with the fourth slot class - CHECK_ENTRYPOINTS - which deserves its separate pipeline due to the inner intrincacies of the checking mechanism.

When starting the ConnectionsManager class, the SlotsManager will be booted up, which will bring up by itself the slots.

The SlotsManager will be called whenever some manipulation of the protocol flux towards or outwards the slots needs to be performed, particularly when connecting/disconnecting a HathorProtocol instance.

**Notes**
1. This PR has flaking issues and may have compatibility constraints, as the idea for now is to discuss the ideas and implementations described within its code body;
2. Many of the new features regarding the SlotsManager still need to be properly tested, and the old tests need to be updated as well.
3. Check Entrypoints has been purposefully extracted out of the code, so to test and discuss specifically the slotting of the connection pool first, rather than both it and the check entrypoints mechanism in the same breath.


### Acceptance Criteria

- Connection establishment must be capped by the slot limitations
- Connections must be subdivided into the proper slots by their connection type
- When a protocol is disconnected, it must be removed from the slot
- When a protocol is connected, it must be added to the proper slot
- No protocol of type A should be appended to slot of type B !=A
- Total active connections == Connections(slotA) + Connections(slotB) + Connectioons(slotC): in other words, the slots must be able to limit the connection flow to their inner circles.

### Checklist

- Connection establishment must be capped by the slot limitations - OK
- Connections must be subdivided into the proper slots by their connection type - OK
- When a protocol is disconnected, it must be removed from the slot - OK
- When a protocol is connected, it must be added to the proper slot - OK
- No protocol of type A should be appended to slot of type B !=A - OK
- Total active connections == Connections(slotA) + Connections(slotB) + Connectioons(slotC): in other words, the slots must be able to limit the connection flow to their inner circles. - OK

