### PR TITLE
feat(p2p): Check Entrypoints Slot for entrypoint verification

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -716,14 +716,16 @@ class Builder:
         if self._slots_manager:
             return self._slots_manager
 
-        # Instances of Connection Slots
         settings = self._get_or_create_settings()
 
+        # Instances of Connection Slots
         max_outgoing: int = settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
         max_incoming: int = settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
-        max_bootstrap: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+        max_boot: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+        max_check_ep: int = settings.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
+        max_queue: int = settings.P2P_QUEUE_SIZE
 
-        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap)
+        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_boot, max_check_ep, max_queue)
 
         # Connection slots manager -> Kickstarts connection slots
         slots_manager = SlotsManager(slots_manager_settings)

--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -39,6 +39,7 @@ from hathor.nanocontracts.blueprint_service import BlueprintService
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig, NCLogStorage
 from hathor.nanocontracts.runner.runner import RunnerFactory
 from hathor.nanocontracts.sorter.types import NCSorterCallable
+from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.pubsub import PubSubManager
@@ -188,6 +189,7 @@ class Builder:
         self._vertex_parser: VertexParser | None = None
         self._consensus: ConsensusAlgorithm | None = None
         self._p2p_manager: ConnectionsManager | None = None
+        self._slots_manager: SlotsManager | None = None
         self._poa_signer: PoaSigner | None = None
         self._poa_block_producer: PoaBlockProducer | None = None
 
@@ -469,6 +471,7 @@ class Builder:
         enable_ssl = True
         reactor = self._get_reactor()
         my_peer = self._get_peer()
+        slots_manager = self._get_or_create_slots_manager()
 
         self._p2p_manager = ConnectionsManager(
             settings=self._get_or_create_settings(),
@@ -480,6 +483,7 @@ class Builder:
             rng=self._rng,
             enable_ipv6=self._enable_ipv6,
             disable_ipv4=self._disable_ipv4,
+            slots_manager=slots_manager
         )
         SyncSupportLevel.add_factories(
             self._get_or_create_settings(),
@@ -707,6 +711,24 @@ class Builder:
             )
 
         return self._blueprint_service
+
+    def _get_or_create_slots_manager(self) -> SlotsManager:
+        if self._slots_manager:
+            return self._slots_manager
+
+        # Instances of Connection Slots
+        settings = self._get_or_create_settings()
+
+        max_outgoing: int = settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_incoming: int = settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
+        max_bootstrap: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+
+        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap)
+
+        # Connection slots manager -> Kickstarts connection slots
+        slots_manager = SlotsManager(slots_manager_settings)
+
+        return slots_manager
 
     def set_rocksdb_path(self, path: str | tempfile.TemporaryDirectory) -> 'Builder':
         if self._tx_storage:

--- a/hathor/feature_activation/utils.py
+++ b/hathor/feature_activation/utils.py
@@ -62,12 +62,6 @@ class Features:
         feature_states = feature_service.get_feature_states(vertex=vertex)
         feature_settings = Features.get_settings(settings)
 
-    @staticmethod
-    def from_vertex(*, settings: HathorSettings, feature_service: FeatureService, vertex: Vertex) -> Features:
-        """Return information about each feature according to the state in the provided vertex."""
-        feature_states = feature_service.get_feature_states(vertex=vertex)
-        feature_settings = Features.get_settings(settings)
-
         feature_is_active: dict[Feature, bool] = {
             feature: _is_feature_active(setting, feature_states.get(feature, FeatureState.DEFINED))
             for feature, setting in feature_settings.items()

--- a/hathor/feature_activation/utils.py
+++ b/hathor/feature_activation/utils.py
@@ -62,6 +62,12 @@ class Features:
         feature_states = feature_service.get_feature_states(vertex=vertex)
         feature_settings = Features.get_settings(settings)
 
+    @staticmethod
+    def from_vertex(*, settings: HathorSettings, feature_service: FeatureService, vertex: Vertex) -> Features:
+        """Return information about each feature according to the state in the provided vertex."""
+        feature_states = feature_service.get_feature_states(vertex=vertex)
+        feature_settings = Features.get_settings(settings)
+
         feature_is_active: dict[Feature, bool] = {
             feature: _is_feature_active(setting, feature_states.get(feature, FeatureState.DEFINED))
             for feature, setting in feature_settings.items()

--- a/hathor/p2p/connect_classes.py
+++ b/hathor/p2p/connect_classes.py
@@ -16,16 +16,23 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from hathor.p2p.peer_endpoint import PeerEndpoint
+
 
 class ConnectionType(Enum):
     """ Types of Connection as inputs for an instance of the Hathor Protocol. """
     OUTGOING = 0
     INCOMING = 1
     BOOTSTRAP = 2
+    CHECK_ENTRYPOINTS = 3
+
+    # If a connection comes from an entrypoint queue, if its assigned the
+    # 'REBOUNDED' state. It is not a slot.
+    REBOUNDED = 4
 
     def is_outbound(self) -> bool:
-        """ If value is 1, then the connection is inbound. If not, outbound."""
-        return self in (ConnectionType.OUTGOING, ConnectionType.BOOTSTRAP)
+        return self in (ConnectionType.OUTGOING, ConnectionType.BOOTSTRAP,
+                        ConnectionType.CHECK_ENTRYPOINTS, ConnectionType.CHECK_ENTRYPOINTS)
 
 
 class ConnectionState(Enum):
@@ -48,6 +55,7 @@ class ConnectionRejected:
 @dataclass(slots=True, frozen=True)
 class ConnectionRemoved:
     reason: str
+    entrypoint: PeerEndpoint | None
 
 
 @dataclass(slots=True, frozen=True)

--- a/hathor/p2p/connect_classes.py
+++ b/hathor/p2p/connect_classes.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ConnectionType(Enum):
+    """ Types of Connection as inputs for an instance of the Hathor Protocol. """
+    OUTGOING = 0
+    INCOMING = 1
+    BOOTSTRAP = 2
+
+    def is_outbound(self) -> bool:
+        """ If value is 1, then the connection is inbound. If not, outbound."""
+        return self in (ConnectionType.OUTGOING, ConnectionType.BOOTSTRAP)
+
+
+class ConnectionState(Enum):
+    """ State of connection of two peers - either in a slot queue or active. """
+    CREATED = 0
+    CONNECTING = 1
+    READY = 2
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionAllowed:
+    confirmation: str
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionRejected:
+    reason: str
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionRemoved:
+    reason: str
+
+
+@dataclass(slots=True, frozen=True)
+class ConnectionNotRemoved:
+    reason: str

--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -1,0 +1,138 @@
+# Copyright 2021 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from typing_extensions import assert_never
+
+from hathor.p2p.connect_classes import (
+    ConnectionAllowed,
+    ConnectionNotRemoved,
+    ConnectionRejected,
+    ConnectionRemoved,
+    ConnectionType,
+)
+from hathor.p2p.protocol import HathorProtocol
+
+AddToSlotResult = ConnectionAllowed | ConnectionRejected
+RemoveFromSlotResult = ConnectionRemoved | ConnectionNotRemoved
+
+
+class ConnectionSlots:
+    """ Class of a connection pool slot - outgoing, incoming, bootstrap connections. """
+    connection_slot: set[HathorProtocol]
+    type: ConnectionType
+    max_slot_connections: int
+
+    def __init__(self, type: ConnectionType, max_connections: int) -> None:
+
+        assert max_connections > 0, 'Slot max number must allow at least one connection'
+
+        self.type = type
+        self.connection_slot = set()
+        self.max_slot_connections = max_connections
+
+    def __in__(self, protocol: HathorProtocol) -> bool:
+        return protocol in self.connection_slot
+
+    def add_connection(self, protocol: HathorProtocol) -> AddToSlotResult:
+        """ Adds connection protocol to the slot. Checks whether the slot is full or not. If full,
+            disconnects the protocol. If the type is 'check_entrypoints', the returns peers of it
+            may go to a queue."""
+
+        assert self.type == protocol.connection_type
+
+        if protocol in self.connection_slot:
+            return ConnectionRejected("Protocol already in Slot.")
+
+        if self.is_full():
+            return ConnectionRejected(f"Slot {self.type} is full")
+
+        self.connection_slot.add(protocol)
+
+        return ConnectionAllowed(f"Added to slot {self.type}.")
+
+    def remove_connection(self, protocol: HathorProtocol) -> ConnectionRemoved:
+        """ Removes from given instance the protocol passed. Returns protocol from queue
+            when disconnection leads to free space in slot."""
+
+        assert self.type == protocol.connection_type
+
+        # Discard does nothing if protocol not in connection_slot.
+        self.connection_slot.discard(protocol)
+        return ConnectionRemoved('Connection successfully removed from slot.')
+
+    def is_full(self) -> bool:
+        """ Checks if connection slot has reached the limit of allowed connections."""
+        return len(self.connection_slot) >= self.max_slot_connections
+
+
+@dataclass(frozen=True, slots=True)
+class SlotsManagerSettings:
+    max_outgoing: int
+    max_incoming: int
+    max_bootstrap: int
+
+
+class SlotsManager:
+    """Manager of slot connections - selects the slot to which must we send the
+     arriving protocol. Three protocol slots: OUTGOING, INCOMING, BOOTSTRAP.
+    """
+    outgoing_slot: ConnectionSlots
+    incoming_slot: ConnectionSlots
+    bootstrap_slot: ConnectionSlots
+
+    def __init__(self, settings: SlotsManagerSettings) -> None:
+        self.outgoing_slot = ConnectionSlots(ConnectionType.OUTGOING, settings.max_outgoing)
+        self.incoming_slot = ConnectionSlots(ConnectionType.INCOMING, settings.max_incoming)
+        self.bootstrap_slot = ConnectionSlots(ConnectionType.BOOTSTRAP, settings.max_bootstrap)
+
+    def add_to_slot(self, protocol: HathorProtocol) -> AddToSlotResult:
+        """Add received protocol to one of the slots.
+        If slot is full, protocol is not added. """
+
+        conn_type = protocol.connection_type
+        slot: ConnectionSlots
+        match conn_type:
+            case ConnectionType.OUTGOING:
+                slot = self.outgoing_slot
+            case ConnectionType.INCOMING:
+                slot = self.incoming_slot
+            case ConnectionType.BOOTSTRAP:
+                slot = self.bootstrap_slot
+            case _:
+                assert_never(conn_type)
+
+        status = slot.add_connection(protocol)
+
+        return status
+
+    def remove_from_slot(self, protocol: HathorProtocol) -> RemoveFromSlotResult:
+        """ Removes protocol from slot of same type.
+            If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
+            Should be called by manager when disconnecting a protocol."""
+
+        conn_type = protocol.connection_type
+        slot: ConnectionSlots
+        match conn_type:
+            case ConnectionType.OUTGOING:
+                slot = self.outgoing_slot
+            case ConnectionType.INCOMING:
+                slot = self.incoming_slot
+            case ConnectionType.BOOTSTRAP:
+                slot = self.bootstrap_slot
+            case _:
+                assert_never(conn_type)
+
+        return slot.remove_connection(protocol)

--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -110,7 +110,7 @@ class ConnectionSlots:
         self.connection_slot = set()
         self.max_slot_connections = max_connections
 
-    def __in__(self, connection: HathorProtocol) -> bool:
+    def __contains__(self, connection: HathorProtocol) -> bool:
         return connection in self.connection_slot
 
     def __len__(self) -> int:
@@ -137,7 +137,7 @@ class ConnectionSlots:
         """ Removes from given instance the protocol passed. Returns protocol from queue
             when disconnection leads to free space in slot."""
 
-        if not self.is_in_slot(protocol):
+        if protocol not in self:
             return ConnectionNotRemoved('Connection not in slot for removal.')
 
         # Discard does nothing if protocol not in connection_slot.
@@ -146,9 +146,6 @@ class ConnectionSlots:
 
     def is_slot_full(self) -> bool:
         return len(self.connection_slot) >= self.max_slot_connections
-
-    def is_in_slot(self, protocol: HathorProtocol) -> bool:
-        return protocol in self
 
 
 class CheckEntrypoints(ConnectionSlots):
@@ -277,7 +274,7 @@ class CheckEntrypoints(ConnectionSlots):
          queue all provided entrypoints by the peer for later analysis. If it is not ready
          due to a timeout, we blacklist the entrypoint."""
 
-        if not self.is_in_slot(protocol):
+        if protocol not in self:
             return ConnectionNotRemoved('Connection not in slot for removal.')
 
         # Check if needs to blacklist protocol.

--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import deque
 from dataclasses import dataclass
 
 from typing_extensions import assert_never
@@ -21,62 +22,412 @@ from hathor.p2p.connect_classes import (
     ConnectionNotRemoved,
     ConnectionRejected,
     ConnectionRemoved,
+    ConnectionState,
     ConnectionType,
 )
+from hathor.p2p.peer_endpoint import PeerAddress, PeerEndpoint
 from hathor.p2p.protocol import HathorProtocol
 
 AddToSlotResult = ConnectionAllowed | ConnectionRejected
-RemoveFromSlotResult = ConnectionRemoved | ConnectionNotRemoved
+
+TIME_PENALTY = 10*60  # 10 minutes penalty for blacklisted entrypoints.
+
+
+class BlacklistedSet:
+    """ Set of blacklisted entrypoints, with the timestamp of blacklisting.
+        If a connection is opened with an entrypoint in blacklist, it is terminated.
+
+        After TIME_INTERVAL seconds have passed since the blacklisting timestamp, a
+        new connection can be opened with this entrypoint.
+
+        entrypoint_set: set of peer entrypoints.
+        time_map: Dictionary which maps the entrypoint to its blacklisting timestamp. """
+
+    entrypoint_set: set[PeerAddress]
+    time_map: dict[PeerAddress, float]
+
+    def __init__(self) -> None:
+        self.entrypoint_set = set()
+        self.time_map = dict()
+
+    def __contains__(self, entrypoint: PeerEndpoint) -> bool:
+        return entrypoint.addr in self.entrypoint_set
+
+    def add_to_blacklist(self, protocol: HathorProtocol) -> None:
+
+        if protocol.entrypoint is None:
+            return
+
+        entrypoint = protocol.entrypoint.addr
+        timestamp = protocol.reactor.seconds()
+
+        assert timestamp > 0, ValueError
+        assert entrypoint is not None, AssertionError
+
+        # Add to sets
+        self.entrypoint_set.add(entrypoint)
+        self.time_map[entrypoint] = timestamp
+
+    def remove_from_blacklist(self, entrypoint: PeerAddress | None) -> None:
+        if entrypoint is None:
+            return
+        self.entrypoint_set.discard(entrypoint)
+        self.time_map.pop(entrypoint, None)
+
+    def may_unblacklist(self, protocol: HathorProtocol) -> bool:
+
+        if protocol.entrypoint is None:
+            return False
+
+        entrypoint = protocol.entrypoint.addr
+        timestamp = self.time_map.get(entrypoint, None)
+
+        if entrypoint is None:
+            return False
+
+        if timestamp is None:
+            return False
+
+        current_time = protocol.reactor.seconds()
+        dt = current_time - timestamp
+
+        if dt > TIME_PENALTY:
+            return True
+        return False
 
 
 class ConnectionSlots:
     """ Class of a connection pool slot - outgoing, incoming, bootstrap connections. """
     connection_slot: set[HathorProtocol]
+    type: ConnectionType
     max_slot_connections: int
 
     def __init__(self, type: ConnectionType, max_connections: int) -> None:
 
         assert max_connections > 0, 'Slot max number must allow at least one connection'
 
+        self.type = type
         self.connection_slot = set()
         self.max_slot_connections = max_connections
 
-    def __in__(self, protocol: HathorProtocol) -> bool:
-        return protocol in self.connection_slot
+    def __in__(self, connection: HathorProtocol) -> bool:
+        return connection in self.connection_slot
+
+    def __len__(self) -> int:
+        return len(self.connection_slot)
 
     def add_connection(self, protocol: HathorProtocol) -> AddToSlotResult:
         """ Adds connection protocol to the slot. Checks whether the slot is full or not. If full,
             disconnects the protocol. If the type is 'check_entrypoints', the returns peers of it
             may go to a queue."""
 
+        assert self.type == protocol.connection_type
+
         if protocol in self.connection_slot:
             return ConnectionRejected("Protocol already in Slot.")
 
-        if self.is_full():
-            return ConnectionRejected(f"Slot {protocol.connection_type} is full")
+        if self.is_slot_full():
+            return ConnectionRejected(f"Slot {self.type} is full")
 
         self.connection_slot.add(protocol)
 
-        return ConnectionAllowed(f"Added to slot {protocol.connection_type}.")
+        return ConnectionAllowed(f"Added to slot {self.type}.")
 
-    def remove_connection(self, protocol: HathorProtocol) -> ConnectionRemoved:
+    def remove_connection(self, protocol: HathorProtocol) -> ConnectionRemoved | ConnectionNotRemoved:
         """ Removes from given instance the protocol passed. Returns protocol from queue
             when disconnection leads to free space in slot."""
 
+        if not self.is_in_slot(protocol):
+            return ConnectionNotRemoved('Connection not in slot for removal.')
+
         # Discard does nothing if protocol not in connection_slot.
         self.connection_slot.discard(protocol)
-        return ConnectionRemoved('Connection successfully removed from slot.')
+        return ConnectionRemoved('Connection successfully removed.', None)
 
-    def is_full(self) -> bool:
-        """ Checks if connection slot has reached the limit of allowed connections."""
+    def is_slot_full(self) -> bool:
         return len(self.connection_slot) >= self.max_slot_connections
 
+    def is_in_slot(self, protocol: HathorProtocol) -> bool:
+        return protocol in self
 
-@dataclass(frozen=True, slots=True)
+
+class CheckEntrypoints(ConnectionSlots):
+    """ Checks the entrypoints of protocols and the ones provided by the peer.
+
+
+     Outflown connections from the outgoing slot arrive to the CheckEntrypoints class.
+     They are added to the connection_slot set.
+
+     If the slot is full, the entrypoint is appended to the queue. If the queue is full,
+     the entrypoint is discarded.
+
+     Whenever a connection is removed, we pop an entrypoint from the queue and connect
+     to it, in the rebound_slot.
+
+     If they do, then the entrypoints provided by the peer are appended to the
+     entrypoint queue, for later connection attempt.
+
+     CONNECTION_SLOT: When a protocol comes to an OUTGOING slot, and it is full, we
+            redirect it to the CONNECTION_SLOT of CheckEntrypoints class, adding it here.
+            This is done for analysis, since the OUTGOING slot being full is anomalous.
+            We use the slot to check the entrypoint of the protocol. If it passes the check
+            (should NOT be blacklisted), we grab the other entrypoints provided by the peer,
+            queue them, and we'll check them later one by one.
+
+     UNTRUSTWORTHY_PEERS: If the connection is called to be removed, and it is NOT ready by a TIMEOUT,
+            we consider it not to be trustworthy. If so, we add it to this set.
+
+     DEQUEUED_ENTRYPOINTS: The set of entrypoints which have been taken out of the entrypoint queue.
+            When a protocol is to be added to the slot, if its core entrypoint is in this set, thence
+            it has been dequeued, hence needs to be analyzed in the rebound_slot.
+
+     SEEN_ENTRYPOINTS: All protocols which have been removed (ready or not) are added to this set. If
+            a protocol arrives to the add_slot method and its entrypoint has not been seen yet, when
+            at removal (and if ready) we queue all the entrypoints provided by this protocol, as we
+            are unaware of the other entrypoints of such peer.
+
+     REBOUND_SLOT: The rebound_slot is a separate space, of size 1, meant to only analyze protocols
+            instantiated from a previosly dequeued entrypoint. When the analysis is done (and we must remove it),
+            we pull another entrypoint from the queue, wrap it into a protocol via connect_to_endpoint
+            (in the p2p_manager) and later it will be added to the slot via SlotsManager.
+            When it's over, we remove it, pull another entrypoint, and keep the chain flowing.
+
+            At kickstart, when there is no protocol in rebound_slot to begin, we use the removal of a
+            connection_slot to kickstart the process, calling to dequeue an entrypoint and wrapping it
+            into a rebound protocol.
+
+            When a protocol meant to arrive at rebound can't (if it is full), we put it back into the queue
+            for a later attempt.
+
+            We establish a one-by-one analysis chain.
+
+            The rebound slot also analyzes entrypoints of connections which have tried to be checked earlier,
+            yet the slot was full so the entrypoint has been queued, for a later attempt. In this case, regardless
+            of having been seen or not, we do not fetch the other provided entrypoints by the peer into the queue.
+
+     """
+
+    entrypoint_queue: deque[PeerEndpoint]
+    dequeued_entrypoints: set[PeerAddress]
+    seen_entrypoints: set[PeerAddress]
+    verified_entrypoints: set[PeerAddress]
+    rebound_slot: HathorProtocol | None
+    blacklisted_entrypoints: BlacklistedSet
+
+    def __init__(self, slot_type: ConnectionType, max_connections: int, max_queue_size: int) -> None:
+
+        assert slot_type == ConnectionType.CHECK_ENTRYPOINTS
+
+        if max_queue_size <= 0:
+            raise ValueError('Entrypoint queue has no valid size.')
+
+        super().__init__(slot_type, max_connections)
+
+        # Shared data structures with the Slots Manager.
+        self.entrypoint_queue = deque()
+        self.dequeued_entrypoints = set()
+        self.seen_entrypoints = set()
+        self.verified_entrypoints = set()
+        self.blacklisted_entrypoints = BlacklistedSet()
+
+        # Slots parameters
+        self.max_queue_size = max_queue_size
+        self.rebound_slot = None
+
+    def __contains__(self, protocol: HathorProtocol) -> bool:
+        return protocol in self.connection_slot or protocol == self.rebound_slot
+
+    def add_connection(self, protocol: HathorProtocol) -> AddToSlotResult:
+
+        assert protocol.connection_type in [ConnectionType.CHECK_ENTRYPOINTS, ConnectionType.REBOUNDED]
+
+        entrypoint = protocol.entrypoint
+        if protocol.connection_type == ConnectionType.REBOUNDED:
+            assert self.has_been_dequeued(entrypoint), "Entrypoint should've been dequeued."
+
+            if not self.rebound_slot:
+                self.rebound_slot = protocol
+                return ConnectionAllowed('Connection added to rebound slot.')
+
+            # If rebound_slot occupied, queue the entrypoint back and try later.
+            self.put_on_queue(entrypoint)
+
+            return ConnectionRejected('Rebound slot occupied. Trying later... ')
+
+        # Now, connection is only check_entrypoints type, so can be added to connection_slot.
+        connection_status = super().add_connection(protocol)
+
+        if isinstance(connection_status, ConnectionRejected):
+
+            if not self.is_slot_full():
+                return connection_status
+
+            self.put_on_queue(protocol.entrypoint)
+        return connection_status
+
+    def remove_connection(self, protocol: HathorProtocol) -> ConnectionRemoved | ConnectionNotRemoved:
+        """ Removes protocol from the class.
+
+         The protocol can be either in the connection_slot or in the rebound_slot.
+
+         If in rebound, pull entrypoint from the queue.
+
+         If in slot, and there is no protocol in rebound, pull entrypoint from queue.
+         If the connection removed in slot is ready and the entrypoint has not been seen,
+         queue all provided entrypoints by the peer for later analysis. If it is not ready
+         due to a timeout, we blacklist the entrypoint."""
+
+        if not self.is_in_slot(protocol):
+            return ConnectionNotRemoved('Connection not in slot for removal.')
+
+        # Check if needs to blacklist protocol.
+        self.try_to_blacklist(protocol)
+
+        entrypoint = protocol.entrypoint
+        ready = ConnectionState.READY
+        connection_state = protocol.connection_state
+
+        if not self.has_been_verified(entrypoint) and connection_state == ready:
+            peer_entrypoints = protocol.peer.info.entrypoints
+
+            for peer_addr in peer_entrypoints:
+                if peer_addr not in self.seen_entrypoints:
+                    # Connect to Endpoint needs full PeerEndpoint
+                    self.put_on_queue(peer_addr.with_id(protocol.my_peer.id))
+
+            # Peer verified (READY) and ep's fetched. Verify the entrypoint.
+            if entrypoint is not None:
+                self.verified_entrypoints.add(entrypoint.addr)
+
+        new_entrypoint: PeerEndpoint | None
+        if self.should_dequeue_entrypoint(protocol):
+            new_entrypoint = self.pop_from_queue()
+
+        if protocol in self.connection_slot:
+            self.connection_slot.discard(protocol)
+        elif protocol == self.rebound_slot:
+            self.rebound_slot = None
+        else:
+            raise AttributeError
+
+        # Removal message:
+        msg = 'CheckEp connection removed from'
+        msg += 'Rebound Slot' if protocol.connection_type == ConnectionType.REBOUNDED else 'Slot'
+
+        return ConnectionRemoved(msg, new_entrypoint)
+
+    def has_been_dequeued(self, entrypoint: PeerEndpoint | None) -> bool:
+
+        if entrypoint is None:
+            return False
+
+        return entrypoint.addr in self.dequeued_entrypoints
+
+    def has_been_seen(self, entrypoint: PeerEndpoint | None) -> bool:
+        if entrypoint is None:
+            return False
+
+        if entrypoint.addr is None:
+            return False
+
+        return entrypoint.addr in self.seen_entrypoints
+
+    def is_queue_full(self) -> bool:
+        return len(self.entrypoint_queue) == self.max_queue_size
+
+    def is_queue_empty(self) -> bool:
+        return len(self.entrypoint_queue) == 0
+
+    def put_on_queue(self, entrypoint: PeerEndpoint | None) -> bool:
+
+        full = self.is_queue_full()
+        if entrypoint is None:
+            return False
+
+        if not full:
+            self.entrypoint_queue.appendleft(entrypoint)
+            self.seen_entrypoints.add(entrypoint.addr)
+
+        return full
+
+    def pop_from_queue(self) -> PeerEndpoint | None:
+        """Pops entrypoint from queue, if not empty. Adds entrypoint to the
+        'dequeued entrypoints' set. """
+
+        empty_queue = self.is_queue_empty()
+        entrypoint_queue = self.entrypoint_queue
+        dequeued_entrypoints = self.dequeued_entrypoints
+
+        if not empty_queue:
+            entrypoint = entrypoint_queue.pop()
+            dequeued_entrypoints.add(entrypoint.addr)
+            return entrypoint
+        return None
+
+    def try_to_blacklist(self, protocol: HathorProtocol) -> bool:
+        """ Decides if peer is not trustworthy.
+
+            Criteria: If time taken is timeout time and it is not ready.
+
+            If blacklisted, we reject connection attempts"""
+
+        if protocol.connection_state == ConnectionState.READY:
+            return False
+
+        # Check if exceeded time matches time-out limit.
+        dt = protocol.diff_timestamp
+        dt_max = protocol.idle_timeout
+
+        if dt is None or dt_max is None:
+            return False
+
+        if dt < dt_max:
+            # Does not exceed timeout, it was only disconnected, so valid protocol.
+            return False
+
+        # If not ready and exceeded time-out, we consider it not trustworthy - blacklist.
+        self.blacklist_entrypoint(protocol)
+
+        return True
+
+    def blacklist_entrypoint(self, protocol: HathorProtocol) -> None:
+        self.blacklisted_entrypoints.add_to_blacklist(protocol)
+
+    def should_dequeue_entrypoint(self, protocol: HathorProtocol) -> bool:
+        """There are two scenarios where should dequeue:
+        1. We are disconnecting a protocol in the rebound slot, and it will pull an entrypoint
+        from the queue by doing so (usual situation: one removal pulls one entrypoint).
+
+        This first scenario we call 'usual_flow'.
+
+        2. We disconnect a protocol in the slot, but there is no other connection in the rebound slot.
+        In this exception scenario, we also pull from the queue to engage into a new connection down the line.
+
+        This second scenario is called 'kickstart', as it is meant to kickstart the usual_flow, as there is no
+        protocol in the rebound slot still.
+
+        This method should only be called when a protocol is disconnected.
+        """
+        kickstart = protocol in self.connection_slot and not self.rebound_slot
+        usual_flow = protocol == self.rebound_slot
+
+        return kickstart or usual_flow
+
+    def has_been_verified(self, entrypoint: PeerEndpoint | None) -> bool:
+        if entrypoint is None:
+            return False
+
+        return entrypoint.addr in self.verified_entrypoints
+
+
+# To-Do: kw_only and update all dataclasses.
+@dataclass(slots=True, frozen=True)
 class SlotsManagerSettings:
     max_outgoing: int
     max_incoming: int
     max_bootstrap: int
+    max_check_ep: int
+    max_queue_ep: int
 
 
 class SlotsManager:
@@ -86,18 +437,106 @@ class SlotsManager:
     outgoing_slot: ConnectionSlots
     incoming_slot: ConnectionSlots
     bootstrap_slot: ConnectionSlots
+    check_ep_slot: CheckEntrypoints
+
+    types_allowed: set[ConnectionType] = {
+        ConnectionType.OUTGOING,
+        ConnectionType.INCOMING,
+        ConnectionType.BOOTSTRAP,
+        ConnectionType.CHECK_ENTRYPOINTS,
+        ConnectionType.REBOUNDED
+    }
+
+    states_allowed: set[ConnectionState] = {
+        ConnectionState.CREATED,
+        ConnectionState.CONNECTING,
+        ConnectionState.READY,
+    }
 
     def __init__(self, settings: SlotsManagerSettings) -> None:
         self.outgoing_slot = ConnectionSlots(ConnectionType.OUTGOING, settings.max_outgoing)
         self.incoming_slot = ConnectionSlots(ConnectionType.INCOMING, settings.max_incoming)
         self.bootstrap_slot = ConnectionSlots(ConnectionType.BOOTSTRAP, settings.max_bootstrap)
 
+        # Setting up Check Entrypoints Slot Class
+        type_check = ConnectionType.CHECK_ENTRYPOINTS
+        max_check = settings.max_check_ep
+        max_queue = settings.max_queue_ep
+
+        self.check_ep_slot = CheckEntrypoints(type_check, max_check, max_queue)
+
     def add_to_slot(self, protocol: HathorProtocol) -> AddToSlotResult:
         """Add received protocol to one of the slots.
-        If slot is full, protocol is not added. """
+
+         If protocol is INCOMING or BOOTSTRAP, if slot full protocol is voided.
+         If OUTGOING and slot full, type shifts to CHECK ENTRYPOINTS.
+         If the entrypoint of the protocol is in 'dequeued_entrypoints' set,
+         the protocol was constructed in a remove_connection execution. This
+         protocol must go to the REBOUND slot, so the type shifts to REBOUNDED.
+         It will go to the rebound slot, within the CHECK ENTRYPOINTS class.
+
+         There must not have any CHECK ENTRYPOINTS or REBOUNDED protocol being directly added
+         to the slot.
+         """
+
+        assert protocol.connection_type != ConnectionType.CHECK_ENTRYPOINTS
+        assert protocol.connection_type != ConnectionType.REBOUNDED
+
+        entrypoint = protocol.entrypoint
+        dequeued_eps = self.check_ep_slot.dequeued_entrypoints
+
+        # If entrypoint in dequeued, it is a rebound connection.
+        if entrypoint is not None and entrypoint.addr in dequeued_eps:
+            protocol.connection_type = ConnectionType.REBOUNDED
 
         conn_type = protocol.connection_type
         slot: ConnectionSlots
+
+        assert conn_type in self.types_allowed
+
+        match conn_type:
+
+            case ConnectionType.OUTGOING:
+                slot = self.outgoing_slot
+
+                if slot.is_slot_full():
+                    protocol.connection_type = ConnectionType.CHECK_ENTRYPOINTS
+                    slot = self.check_ep_slot
+
+            case ConnectionType.INCOMING:
+                slot = self.incoming_slot
+
+            case ConnectionType.BOOTSTRAP:
+                slot = self.bootstrap_slot
+
+            case ConnectionType.REBOUNDED:
+                slot = self.check_ep_slot
+
+            case ConnectionType.CHECK_ENTRYPOINTS:
+                raise TypeError('Check Entrypoints cannot be added directly to slot.')
+
+            case _:
+                assert_never(conn_type)
+
+        # If connection is rejected, p2p_manager needs to disconnect protocol.
+        return slot.add_connection(protocol)
+
+    def remove_from_slot(self, protocol: HathorProtocol) -> ConnectionRemoved | ConnectionNotRemoved:
+        """ Removes protocol from slot of same type.
+            If OUTGOING, INCOMING, BOOTSTRAP, its remove_connection method will simply discard
+            the protocol from the set.
+
+            If CHECK ENTRYPOINTS or REBOUNDED, it will call its remove_connection method, but it
+            will also manage the flow of entrypoints - queueing, dequeueing, blacklisting -
+            depending on the conditions of the received protocol.
+            Both refer to the same slot object - check_ep_slot.
+
+            This method should be called by p2p_manager when disconnecting a protocol."""
+
+        conn_type = protocol.connection_type
+        assert conn_type in self.types_allowed
+
+        slot: ConnectionSlots | CheckEntrypoints | None = None
         match conn_type:
             case ConnectionType.OUTGOING:
                 slot = self.outgoing_slot
@@ -105,36 +544,36 @@ class SlotsManager:
                 slot = self.incoming_slot
             case ConnectionType.BOOTSTRAP:
                 slot = self.bootstrap_slot
+            case ConnectionType.CHECK_ENTRYPOINTS:
+                slot = self.check_ep_slot
+            case ConnectionType.REBOUNDED:
+                slot = self.check_ep_slot
             case _:
                 assert_never(conn_type)
 
-        status = slot.add_connection(protocol)
-
-        return status
-
-    def remove_from_slot(self, protocol: HathorProtocol) -> None:
-        """ Removes protocol from slot of same type.
-            If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
-            Should be called by manager when disconnecting a protocol.
-            Wraps _remove_from_slot_result and reduces API exposure."""
-
-        self._remove_from_slot_result(protocol)
-
-    def _remove_from_slot_result(self, protocol: HathorProtocol) -> RemoveFromSlotResult:
-        """ Removes protocol from slot of same type.
-            If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
-            Returns type for result, used in tests."""
-
-        conn_type = protocol.connection_type
-        slot: ConnectionSlots
-        match conn_type:
-            case ConnectionType.OUTGOING:
-                slot = self.outgoing_slot
-            case ConnectionType.INCOMING:
-                slot = self.incoming_slot
-            case ConnectionType.BOOTSTRAP:
-                slot = self.bootstrap_slot
-            case _:
-                assert_never(conn_type)
+        assert slot.type in self.types_allowed
+        assert protocol.connection_state in self.states_allowed
 
         return slot.remove_connection(protocol)
+
+    def has_been_seen(self, entrypoint: PeerEndpoint | None) -> bool:
+        """If an entrypoint has been seen before, regardless of being considered trustworthy."""
+        return self.check_ep_slot.has_been_seen(entrypoint)
+
+    def has_been_verified(self, entrypoint: PeerEndpoint | None) -> bool:
+        """If an entrypoint has been verified (protocol has achieved READY state.)"""
+        return self.check_ep_slot.has_been_verified(entrypoint)
+
+    def is_blacklisted(self, entrypoint: PeerEndpoint) -> bool:
+        """If the entrypoint is in the blacklist and the penalty has not expired."""
+        return entrypoint in self.check_ep_slot.blacklisted_entrypoints
+
+    def may_unblacklist(self, protocol: HathorProtocol) -> bool:
+        """If the entrypoint is blacklisted and penalty has expired."""
+        return self.check_ep_slot.blacklisted_entrypoints.may_unblacklist(protocol)
+
+    def remove_from_blacklist(self, protocol: HathorProtocol) -> None:
+        if protocol.entrypoint is None:
+            return
+        ep_addr = protocol.entrypoint.addr
+        self.check_ep_slot.blacklisted_entrypoints.remove_from_blacklist(ep_addr)

--- a/hathor/p2p/connection_slot.py
+++ b/hathor/p2p/connection_slot.py
@@ -32,14 +32,12 @@ RemoveFromSlotResult = ConnectionRemoved | ConnectionNotRemoved
 class ConnectionSlots:
     """ Class of a connection pool slot - outgoing, incoming, bootstrap connections. """
     connection_slot: set[HathorProtocol]
-    type: ConnectionType
     max_slot_connections: int
 
     def __init__(self, type: ConnectionType, max_connections: int) -> None:
 
         assert max_connections > 0, 'Slot max number must allow at least one connection'
 
-        self.type = type
         self.connection_slot = set()
         self.max_slot_connections = max_connections
 
@@ -51,23 +49,19 @@ class ConnectionSlots:
             disconnects the protocol. If the type is 'check_entrypoints', the returns peers of it
             may go to a queue."""
 
-        assert self.type == protocol.connection_type
-
         if protocol in self.connection_slot:
             return ConnectionRejected("Protocol already in Slot.")
 
         if self.is_full():
-            return ConnectionRejected(f"Slot {self.type} is full")
+            return ConnectionRejected(f"Slot {protocol.connection_type} is full")
 
         self.connection_slot.add(protocol)
 
-        return ConnectionAllowed(f"Added to slot {self.type}.")
+        return ConnectionAllowed(f"Added to slot {protocol.connection_type}.")
 
     def remove_connection(self, protocol: HathorProtocol) -> ConnectionRemoved:
         """ Removes from given instance the protocol passed. Returns protocol from queue
             when disconnection leads to free space in slot."""
-
-        assert self.type == protocol.connection_type
 
         # Discard does nothing if protocol not in connection_slot.
         self.connection_slot.discard(protocol)
@@ -118,10 +112,18 @@ class SlotsManager:
 
         return status
 
-    def remove_from_slot(self, protocol: HathorProtocol) -> RemoveFromSlotResult:
+    def remove_from_slot(self, protocol: HathorProtocol) -> None:
         """ Removes protocol from slot of same type.
             If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
-            Should be called by manager when disconnecting a protocol."""
+            Should be called by manager when disconnecting a protocol.
+            Wraps _remove_from_slot_result and reduces API exposure."""
+
+        self._remove_from_slot_result(protocol)
+
+    def _remove_from_slot_result(self, protocol: HathorProtocol) -> RemoveFromSlotResult:
+        """ Removes protocol from slot of same type.
+            If OUTGOING, INCOMING or BOOTSTRAP, simply remove from slot and disconnect.
+            Returns type for result, used in tests."""
 
         conn_type = protocol.connection_type
         slot: ConnectionSlots

--- a/hathor/p2p/factory.py
+++ b/hathor/p2p/factory.py
@@ -18,13 +18,14 @@ from twisted.internet import protocol
 from twisted.internet.interfaces import IAddress
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connect_classes import ConnectionType
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.protocol import HathorLineReceiver
 
 
 class _HathorLineReceiverFactory(ABC, protocol.Factory):
-    inbound: bool
+    connection_type: ConnectionType
 
     def __init__(
         self,
@@ -45,7 +46,7 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
             my_peer=self.my_peer,
             p2p_manager=self.p2p_manager,
             use_ssl=self.use_ssl,
-            inbound=self.inbound,
+            connection_type=self.connection_type,
             settings=self._settings
         )
         p.factory = self
@@ -55,10 +56,18 @@ class _HathorLineReceiverFactory(ABC, protocol.Factory):
 class HathorServerFactory(_HathorLineReceiverFactory, protocol.ServerFactory):
     """ HathorServerFactory is used to generate HathorProtocol objects when a new connection arrives.
     """
-    inbound = True
+    connection_type = ConnectionType.INCOMING
 
 
 class HathorClientFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
     """ HathorClientFactory is used to generate HathorProtocol objects when we connected to another peer.
     """
-    inbound = False
+    connection_type = ConnectionType.OUTGOING
+
+
+class HathorBootstrapFactory(_HathorLineReceiverFactory, protocol.ClientFactory):
+    """
+        HathorBootstrapFactory is the same as a HathorClientFactory, but the type of connection is set to
+        bootstrap, for connection pool slotting.
+    """
+    connection_type = ConnectionType.BOOTSTRAP

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -26,7 +26,7 @@ from twisted.python.failure import Failure
 from twisted.web.client import Agent
 
 from hathor.conf.settings import HathorSettings
-from hathor.p2p.connect_classes import ConnectionRejected, ConnectionState
+from hathor.p2p.connect_classes import ConnectionRejected, ConnectionRemoved, ConnectionState
 from hathor.p2p.connection_slot import SlotsManager
 from hathor.p2p.netfilter.factory import NetfilterFactory
 from hathor.p2p.peer import PrivatePeer, PublicPeer, UnverifiedPeer
@@ -283,6 +283,9 @@ class ConnectionsManager:
         """
         Do a discovery and connect on all discovery strategies.
         """
+        def connect_to_bootstrap(entrypoint: PeerEndpoint) -> None:
+            self.connect_to_endpoint(entrypoint, discovery_call=True)
+
         for peer_discovery in self.peer_discoveries:
             coro = peer_discovery.discover_and_connect(self.connect_to_bootstrap)
             Deferred.fromCoroutine(coro)
@@ -430,8 +433,20 @@ class ConnectionsManager:
             protocol.disconnect(force=True)
             return
 
+        # Checks if entrypoint has been blacklisted. If so, then if it can be delisted.
+        if protocol.entrypoint is not None and self.slots_manager.is_blacklisted(protocol.entrypoint):
+
+            # Check if can be delisted:
+            if not self.slots_manager.may_unblacklist(protocol):
+                self.log.warn('entrypoint blacklisted, disconnecting...')
+                protocol.disconnect(force=True)
+                return
+
+            self.slots_manager.remove_from_blacklist(protocol)
+
         connection_status = self.slots_manager.add_to_slot(protocol)
 
+        # Adding rejected, disconnect protocol.
         if isinstance(connection_status, ConnectionRejected):
             self.log.warn('Connection Rejected')
             protocol.disconnect(force=True)
@@ -467,6 +482,10 @@ class ConnectionsManager:
             protocol=protocol,
             peers_count=self._get_peers_count()
         )
+
+        # If in check_ep, getting ready we may disconnect.
+        if protocol in self.slots_manager.check_ep_slot:
+            protocol.disconnect('Entrypoint checked - READY', force=True)
 
         peer_id = protocol.peer.id
         if peer_id in self.connected_peers:
@@ -511,7 +530,11 @@ class ConnectionsManager:
         self.connections.discard(protocol)
 
         # Each conn is from a slot - discard from it as well.
-        self.slots_manager.remove_from_slot(protocol)
+        status = self.slots_manager.remove_from_slot(protocol)
+
+        # If there is some entrypoint popped from queue, we attempt to connect.
+        if isinstance(status, ConnectionRemoved) and status.entrypoint:
+            self.connect_to_endpoint(status.entrypoint)
 
         if protocol in self.handshaking_peers:
             self.handshaking_peers.remove(protocol)

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -275,15 +275,16 @@ class ConnectionsManager:
         """Add a peer discovery method."""
         self.peer_discoveries.append(peer_discovery)
 
+    def connect_to_bootstrap(self, entrypoint: PeerEndpoint) -> None:
+        """Connect to a bootstrap entrypoint discovered via a PeerDiscovery strategy."""
+        self.connect_to_endpoint(entrypoint, discovery_call=True)
+
     def do_discovery(self) -> None:
         """
         Do a discovery and connect on all discovery strategies.
         """
-        def connect_to_bootstrap(entrypoint: PeerEndpoint) -> None:
-            self.connect_to_endpoint(entrypoint, discovery_call=True)
-
         for peer_discovery in self.peer_discoveries:
-            coro = peer_discovery.discover_and_connect(connect_to_bootstrap)
+            coro = peer_discovery.discover_and_connect(self.connect_to_bootstrap)
             Deferred.fromCoroutine(coro)
 
     def disable_rate_limiter(self) -> None:

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -26,6 +26,8 @@ from twisted.python.failure import Failure
 from twisted.web.client import Agent
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connect_classes import ConnectionRejected, ConnectionState
+from hathor.p2p.connection_slot import SlotsManager
 from hathor.p2p.netfilter.factory import NetfilterFactory
 from hathor.p2p.peer import PrivatePeer, PublicPeer, UnverifiedPeer
 from hathor.p2p.peer_discovery import PeerDiscovery
@@ -103,6 +105,7 @@ class ConnectionsManager:
         whitelist_only: bool,
         enable_ipv6: bool,
         disable_ipv4: bool,
+        slots_manager: SlotsManager
     ) -> None:
         self.log = logger.new()
         self._settings = settings
@@ -115,7 +118,6 @@ class ConnectionsManager:
 
         self.reactor = reactor
         self.my_peer = my_peer
-
         # List of address descriptions to listen for new connections (eg: [tcp:8000])
         self.listen_address_descriptions: list[str] = []
 
@@ -129,12 +131,15 @@ class ConnectionsManager:
         self.localhost_only = False
 
         # Factories.
-        from hathor.p2p.factory import HathorClientFactory, HathorServerFactory
+        from hathor.p2p.factory import HathorBootstrapFactory, HathorClientFactory, HathorServerFactory
         self.use_ssl = ssl
         self.server_factory = HathorServerFactory(
             self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
         self.client_factory = HathorClientFactory(
+            self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
+        )
+        self.bootstrap_factory = HathorBootstrapFactory(
             self.my_peer, p2p_manager=self, use_ssl=self.use_ssl, settings=self._settings
         )
 
@@ -156,6 +161,8 @@ class ConnectionsManager:
 
         # List of peers connected and ready to communicate.
         self.connected_peers = {}
+
+        self.slots_manager = slots_manager
 
         # Queue of ready peer-id's used by connect_to_peer_from_connection_queue to choose the next peer to pull a
         # random new connection from
@@ -272,8 +279,11 @@ class ConnectionsManager:
         """
         Do a discovery and connect on all discovery strategies.
         """
+        def connect_to_bootstrap(entrypoint: PeerEndpoint) -> None:
+            self.connect_to_endpoint(entrypoint, discovery_call=True)
+
         for peer_discovery in self.peer_discoveries:
-            coro = peer_discovery.discover_and_connect(self.connect_to_endpoint)
+            coro = peer_discovery.discover_and_connect(connect_to_bootstrap)
             Deferred.fromCoroutine(coro)
 
     def disable_rate_limiter(self) -> None:
@@ -356,7 +366,7 @@ class ConnectionsManager:
             len(self.connecting_peers),
             len(self.handshaking_peers),
             len(self.connected_peers),
-            len(self.verified_peer_storage)
+            len(self.verified_peer_storage),
         )
 
     def get_sync_factory(self, sync_version: SyncVersion) -> SyncAgentFactory:
@@ -412,12 +422,25 @@ class ConnectionsManager:
 
     def on_peer_connect(self, protocol: HathorProtocol) -> None:
         """Called when a new connection is established."""
+
+        # Checks whether connections in the network are at limit.
         if len(self.connections) >= self.max_connections:
             self.log.warn('reached maximum number of connections', max_connections=self.max_connections)
             protocol.disconnect(force=True)
             return
+
+        connection_status = self.slots_manager.add_to_slot(protocol)
+
+        if isinstance(connection_status, ConnectionRejected):
+            self.log.warn('Connection Rejected')
+            protocol.disconnect(force=True)
+            return
+
         self.connections.add(protocol)
         self.handshaking_peers.add(protocol)
+
+        # If not queued, connection state is "CONNECTING", as it is not ready yet, added to handshaking.
+        protocol.connection_state = ConnectionState.CONNECTING
 
         self.pubsub.publish(
             HathorEvents.NETWORK_PEER_CONNECTED,
@@ -429,10 +452,12 @@ class ConnectionsManager:
         """Called when a peer is ready."""
         assert protocol.peer is not None
         self.verified_peer_storage.add_or_replace(protocol.peer)
-
         self.handshaking_peers.remove(protocol)
+
         for conn in self.iter_all_connections():
             conn.unverified_peer_storage.remove(protocol.peer)
+        # In 1614 - should we disconnect to checkep-?
+        protocol.connection_state = ConnectionState.READY
 
         # we emit the event even if it's a duplicate peer as a matching
         # NETWORK_PEER_DISCONNECTED will be emitted regardless
@@ -480,9 +505,16 @@ class ConnectionsManager:
 
     def on_peer_disconnect(self, protocol: HathorProtocol) -> None:
         """Called when a peer disconnect."""
+
+        # Discard handles case when not in connections.
         self.connections.discard(protocol)
+
+        # Each conn is from a slot - discard from it as well.
+        self.slots_manager.remove_from_slot(protocol)
+
         if protocol in self.handshaking_peers:
             self.handshaking_peers.remove(protocol)
+
         if protocol._peer is not None:
             peer_id = protocol.peer.id
             existing_protocol = self.connected_peers.pop(peer_id, None)
@@ -499,6 +531,7 @@ class ConnectionsManager:
             elif peer_id in self.new_connection_from_queue:
                 # now we're sure it can be removed from new_connection_from_queue
                 self.new_connection_from_queue.remove(peer_id)
+
         self.pubsub.publish(
             HathorEvents.NETWORK_PEER_DISCONNECTED,
             protocol=protocol,
@@ -507,13 +540,11 @@ class ConnectionsManager:
 
     def iter_all_connections(self) -> Iterable[HathorProtocol]:
         """Iterate over all connections."""
-        for conn in self.connections:
-            yield conn
+        yield from self.connections
 
     def iter_ready_connections(self) -> Iterable[HathorProtocol]:
         """Iterate over ready connections."""
-        for conn in self.connected_peers.values():
-            yield conn
+        yield from self.connected_peers.values()
 
     def iter_not_ready_endpoints(self) -> Iterable[PeerEndpoint]:
         """Iterate over not-ready connections."""
@@ -675,6 +706,7 @@ class ConnectionsManager:
         peer: UnverifiedPeer | PublicPeer | None,
         endpoint: IStreamClientEndpoint,
         entrypoint: PeerEndpoint,
+        discovery_call: bool = False
     ) -> None:
         """Called when we successfully connect to a peer."""
         if isinstance(protocol, HathorProtocol):
@@ -690,6 +722,7 @@ class ConnectionsManager:
         entrypoint: PeerEndpoint,
         peer: UnverifiedPeer | PublicPeer | None = None,
         use_ssl: bool | None = None,
+        discovery_call: bool = False
     ) -> None:
         """ Attempt to connect directly to an endpoint, prefer calling `connect_to_peer` when possible.
 
@@ -699,6 +732,7 @@ class ConnectionsManager:
 
         If `use_ssl` is True, then the connection will be wraped by a TLS.
         """
+
         if entrypoint.peer_id is not None and peer is not None and entrypoint.peer_id != peer.id:
             self.log.debug('skipping because the entrypoint peer_id does not match the actual peer_id',
                            entrypoint=str(entrypoint))
@@ -729,11 +763,10 @@ class ConnectionsManager:
 
         endpoint = entrypoint.addr.to_client_endpoint(self.reactor)
 
-        factory: IProtocolFactory
+        factory: IProtocolFactory = self.bootstrap_factory if discovery_call else self.client_factory
+
         if use_ssl:
-            factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, self.client_factory)
-        else:
-            factory = self.client_factory
+            factory = TLSMemoryBIOFactory(self.my_peer.certificate_options, True, factory)
 
         if peer is not None:
             now = int(self.reactor.seconds())
@@ -819,9 +852,10 @@ class ConnectionsManager:
         assert protocol.peer.id is not None
         assert protocol.my_peer.id is not None
         other_connection = self.connected_peers[protocol.peer.id]
+        is_outbound = protocol.connection_type.is_outbound()
         if bytes(protocol.my_peer.id) > bytes(protocol.peer.id):
             # connection started by me is kept
-            if not protocol.inbound:
+            if is_outbound:
                 # other connection is dropped
                 return other_connection
             else:
@@ -829,7 +863,7 @@ class ConnectionsManager:
                 return protocol
         else:
             # connection started by peer is kept
-            if not protocol.inbound:
+            if is_outbound:
                 return protocol
             else:
                 return other_connection

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -25,6 +25,7 @@ from twisted.protocols.basic import LineReceiver
 from twisted.python.failure import Failure
 
 from hathor.conf.settings import HathorSettings
+from hathor.p2p.connect_classes import ConnectionState, ConnectionType
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer import PrivatePeer, PublicPeer, UnverifiedPeer
 from hathor.p2p.peer_endpoint import PeerEndpoint
@@ -95,6 +96,7 @@ class HathorProtocol:
     idle_timeout: int
     sync_version: Optional[SyncVersion]  # version chosen to be used on this connection
     capabilities: set[str]  # capabilities received from the peer in HelloState
+    connection_state: ConnectionState  # in slot queue, connecting or ready/in-slot.
 
     @property
     def peer(self) -> PublicPeer:
@@ -108,7 +110,7 @@ class HathorProtocol:
         *,
         settings: HathorSettings,
         use_ssl: bool,
-        inbound: bool,
+        connection_type: ConnectionType,
     ) -> None:
         self._settings = settings
         self.my_peer = my_peer
@@ -120,8 +122,12 @@ class HathorProtocol:
         assert self.connections.reactor is not None
         self.reactor = self.connections.reactor
 
-        # Indicate whether it is an inbound connection (true) or an outbound connection (false).
-        self.inbound = inbound
+        # Type of Connection
+        # 0 == Outgoing, 1 == Incoming, 2 == Bootstrap
+        self.connection_type = connection_type
+
+        # Connection State
+        self.connection_state = ConnectionState.CREATED
 
         # Maximum period without receiving any messages.
         self.idle_timeout = self._settings.PEER_IDLE_TIMEOUT

--- a/hathor/p2p/protocol.py
+++ b/hathor/p2p/protocol.py
@@ -123,7 +123,6 @@ class HathorProtocol:
         self.reactor = self.connections.reactor
 
         # Type of Connection
-        # 0 == Outgoing, 1 == Incoming, 2 == Bootstrap
         self.connection_type = connection_type
 
         # Connection State

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -61,11 +61,13 @@ class FakeConnection:
         addr1: IPv4Address | IPv6Address | None = None,
         addr2: IPv4Address | IPv6Address | None = None,
         fake_bootstrap_id: PeerId | None | Literal[False] = False,
+        fresh_entrypoints: bool = False
     ):
         """
         :param: latency: Latency between nodes in seconds
         :fake_bootstrap_id: when False, bootstrap mode is disabled. When a PeerId or None are passed, bootstrap mode is
             enabled and the value is used as the connection's entrypoint.peer_id
+        :fresh_entrypoints: When True, force protocols to have entrypoint from the get-go.
         """
         self.log = logger.new()
         self._fake_bootstrap_id = fake_bootstrap_id
@@ -85,6 +87,8 @@ class FakeConnection:
         self.addr1 = addr1 or IPv4Address('TCP', '127.0.0.1', self._get_port(manager1))
         # manager2's address, the client, where manager2 will connect from
         self.addr2 = addr2 or IPv4Address('TCP', '127.0.0.1', self._get_port(manager2))
+
+        self.fresh_entrypoints = fresh_entrypoints
 
         self.reconnect()
 
@@ -273,14 +277,19 @@ class FakeConnection:
         self._buf2.clear()
 
         self._proto1 = self.manager1.connections.server_factory.buildProtocol(self.addr2)
+        if self.fresh_entrypoints:
+            self._proto1.entrypoint = PeerAddress.from_address(self.addr2).with_id(self.manager1.my_peer.id)
 
-        # If in bootstrap mode, now we instantiate the Bootstrap Factory.
+        # If in bootstrap mode, now we instantiate the Discovery Factory.
         if self._fake_bootstrap_id is False:
             self._proto2 = self.manager2.connections.client_factory.buildProtocol(self.addr1)
         elif self._fake_bootstrap_id or self._fake_bootstrap_id is None:
             self._proto2 = self.manager2.connections.bootstrap_factory.buildProtocol(self.addr1)
         else:
             raise ValueError("Fake bootstrap id not valid.")
+
+        if self.fresh_entrypoints:
+            self._proto2.entrypoint = self.entrypoint
 
         # When _fake_bootstrap_id is set we don't pass the peer because that's how bootstrap calls
         # connect_to_endpoint()

--- a/hathor/simulator/fake_connection.py
+++ b/hathor/simulator/fake_connection.py
@@ -273,7 +273,14 @@ class FakeConnection:
         self._buf2.clear()
 
         self._proto1 = self.manager1.connections.server_factory.buildProtocol(self.addr2)
-        self._proto2 = self.manager2.connections.client_factory.buildProtocol(self.addr1)
+
+        # If in bootstrap mode, now we instantiate the Bootstrap Factory.
+        if self._fake_bootstrap_id is False:
+            self._proto2 = self.manager2.connections.client_factory.buildProtocol(self.addr1)
+        elif self._fake_bootstrap_id or self._fake_bootstrap_id is None:
+            self._proto2 = self.manager2.connections.bootstrap_factory.buildProtocol(self.addr1)
+        else:
+            raise ValueError("Fake bootstrap id not valid.")
 
         # When _fake_bootstrap_id is set we don't pass the peer because that's how bootstrap calls
         # connect_to_endpoint()

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -35,6 +35,7 @@ from hathor.nanocontracts.blueprint_service import BlueprintService
 from hathor.nanocontracts.execution import NCBlockExecutor
 from hathor.nanocontracts.nc_exec_logs import NCLogStorage
 from hathor.nanocontracts.runner.runner import RunnerFactory
+from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_endpoint import PeerEndpoint
@@ -310,6 +311,16 @@ class CliBuilder:
 
         cpu_mining_service = CpuMiningService()
 
+        # Instances of Connection Slots
+        max_outgoing: int = settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+        max_incoming: int = settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
+        max_bootstrap: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+
+        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap)
+
+        # Connection slots manager -> Kickstarts connection slots
+        slots_manager = SlotsManager(slots_manager_settings)
+
         p2p_manager = ConnectionsManager(
             settings=settings,
             reactor=reactor,
@@ -320,6 +331,7 @@ class CliBuilder:
             rng=Random(),
             enable_ipv6=self._args.x_enable_ipv6,
             disable_ipv4=self._args.x_disable_ipv4,
+            slots_manager= slots_manager
         )
 
         vertex_handler = VertexHandler(

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -315,8 +315,10 @@ class CliBuilder:
         max_outgoing: int = settings.P2P_PEER_MAX_OUTGOING_CONNECTIONS
         max_incoming: int = settings.P2P_PEER_MAX_INCOMING_CONNECTIONS
         max_bootstrap: int = settings.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+        max_check_ep: int = settings.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
+        max_ep_queue: int = settings.P2P_QUEUE_SIZE
 
-        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap)
+        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_ep_queue)
 
         # Connection slots manager -> Kickstarts connection slots
         slots_manager = SlotsManager(slots_manager_settings)

--- a/hathor_tests/others/test_metrics.py
+++ b/hathor_tests/others/test_metrics.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 from hathor.indexes import RocksDBIndexesManager
 from hathor.manager import HathorManager
+from hathor.p2p.connect_classes import ConnectionType
 from hathor.p2p.manager import PeerConnectionsMetrics
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.peer_endpoint import PeerEndpoint
@@ -209,7 +210,7 @@ class MetricsTest(unittest.TestCase):
                 my_peer=my_peer,
                 p2p_manager=manager.connections,
                 use_ssl=False,
-                inbound=False,
+                connection_type=ConnectionType.OUTGOING,
                 settings=self._settings
             )
             protocol._peer = PrivatePeer.auto_generated().to_public_peer()

--- a/hathor_tests/p2p/test_bootstrap.py
+++ b/hathor_tests/p2p/test_bootstrap.py
@@ -59,7 +59,8 @@ class BootstrapTestCase(unittest.TestCase):
             self.rng,
             True,
             enable_ipv6=False,
-            disable_ipv4=False
+            disable_ipv4=False,
+            slots_manager=None  # type: ignore
         )
 
         host_ports1 = [
@@ -94,7 +95,8 @@ class BootstrapTestCase(unittest.TestCase):
             self.rng,
             True,
             enable_ipv6=False,
-            disable_ipv4=False
+            disable_ipv4=False,
+            slots_manager=None  # type: ignore
         )
 
         bootstrap_a = [

--- a/hathor_tests/p2p/test_connection_slots.py
+++ b/hathor_tests/p2p/test_connection_slots.py
@@ -1,7 +1,8 @@
 from twisted.python.failure import Failure
 
-from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
+from hathor.p2p.connection_slot import ConnectionState, ConnectionType, SlotsManager, SlotsManagerSettings
 from hathor.simulator import FakeConnection
+from hathor.simulator.fake_connection import IPv4Address
 from hathor_tests.simulation.base import SimulatorTestCase
 
 
@@ -22,13 +23,15 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         max_outgoing = 20
         max_incoming = 15
         max_bootstrap = 10
-        max_connections = max_bootstrap + max_incoming + max_outgoing
+        max_check_ep = 5
+        max_queue_ep = 100
+        max_connections = max_bootstrap + max_incoming + max_outgoing + max_check_ep
 
         # Set SlotsManager Settings:
-        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap)
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
 
         # Set SlotsManager:
-        slots_manager = SlotsManager(slots_manager_settings)
+        slots_manager = SlotsManager(sm_settings)
 
         # Attribute it to the peer
         full_node.connections.slots_manager = slots_manager
@@ -59,7 +62,7 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
 
         out_connList = []
         out_peerList = []
-        for i in range(0, max_outgoing + 1):
+        for i in range(0, max_outgoing + max_check_ep):
 
             out_peerList.append(self.create_peer())
             out_connList.append(FakeConnection(out_peerList[i], full_node))
@@ -83,9 +86,11 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         number_bootstrap_slot = len(bootstrap_slot.connection_slot)
 
         self.assertTrue(number_bootstrap_slot == max_bootstrap)
+
         # Finally, assure the number of connected peers is the same as the sum of all (no bootstrap connections).
         connection_pool = full_node.connections.connections
-        self.assertTrue(number_outgoing_slot + number_incoming_slot + number_bootstrap_slot == len(connection_pool))
+        total_amount = max_check_ep + number_outgoing_slot + number_incoming_slot + number_bootstrap_slot
+        self.assertTrue(total_amount == len(connection_pool))
         self.assertTrue(len(connection_pool) <= max_connections)
 
     def test_wrong_conn_outgoing(self) -> None:
@@ -104,9 +109,14 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         self.simulator.add_connection(boot_conn)
         self.simulator.run(5)
 
-        # Outgoing slot must not update
+        # Outgoing slot must not update, others must.
         outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+
         self.assertTrue(len(outgoing_slot.connection_slot) == 0)
+        self.assertTrue(len(bootstrap_slot.connection_slot) == 1)
+        self.assertTrue(len(incoming_slot.connection_slot) == 1)
 
     def test_wrong_conn_incoming(self) -> None:
 
@@ -123,7 +133,13 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         self.simulator.add_connection(boot_conn)
         self.simulator.run(5)
 
+        # Incoming slot must not update, others must.
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
         incoming_slot = full_node.connections.slots_manager.incoming_slot
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+
+        self.assertTrue(len(outgoing_slot.connection_slot) == 1)
+        self.assertTrue(len(bootstrap_slot.connection_slot) == 1)
         self.assertTrue(len(incoming_slot.connection_slot) == 0)
 
     def test_wrong_conn_bootstrap(self) -> None:
@@ -141,8 +157,14 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         self.simulator.add_connection(in_conn)
         self.simulator.run(5)
 
+        # Bootstrap slot must not update, others must.
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
         bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+
+        self.assertTrue(len(outgoing_slot.connection_slot) == 1)
         self.assertTrue(len(bootstrap_slot.connection_slot) == 0)
+        self.assertTrue(len(incoming_slot.connection_slot) == 1)
 
     def test_connections_equal_slots(self) -> None:
         """ Test if connections keep equal to the sum of connections in each slot."""
@@ -186,7 +208,9 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         outgoing_slot = full_node.connections.slots_manager.outgoing_slot.connection_slot
         incoming_slot = full_node.connections.slots_manager.incoming_slot.connection_slot
         bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot.connection_slot
+
         sum_of_slots = len(bootstrap_slot) + len(incoming_slot) + len(outgoing_slot)
+
         self.assertTrue(len(connections) == sum_of_slots)
 
     def test_remove_connection(self) -> None:
@@ -237,3 +261,1012 @@ class ConnectionSlotsTestCase(SimulatorTestCase):
         bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
         self.assertTrue(len(bootstrap_slot.connection_slot) == 0)
         self.assertTrue(len(full_node.connections.connections) == 0)
+
+
+class CheckEntrypointsTestCase(SimulatorTestCase):
+    def test_add_connection(self) -> None:
+
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 100
+
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+
+        # We'll add two connections to outgoing slot.
+
+        out_peer_1 = self.create_peer()
+        out_peer_2 = self.create_peer()
+
+        out_conn_1 = FakeConnection(out_peer_1, full_node)
+        out_conn_2 = FakeConnection(out_peer_2, full_node)
+        self.simulator.add_connection(out_conn_1)
+        self.simulator.add_connection(out_conn_2)
+        self.simulator.run(1)
+
+        # Make sure the outgoing slot is still at ONE connection
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        assert len(outgoing_slot) == max_outgoing
+
+        # Make sure there is still ONE connection in the check ep Slot
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+        assert len(check_ep_slot) == 1
+
+    def test_type_change(self) -> None:
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 100
+
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+
+        # We'll add two connections to outgoing slot.
+
+        out_peer_1 = self.create_peer()
+        out_peer_2 = self.create_peer()
+
+        out_conn_1 = FakeConnection(out_peer_1, full_node)
+        out_conn_2 = FakeConnection(out_peer_2, full_node)
+        self.simulator.add_connection(out_conn_1)
+        self.simulator.add_connection(out_conn_2)
+        self.simulator.run(1)
+
+        # Assure the typing of connections. We use proto2 as full node is in the 2nd position.
+        assert out_conn_1.proto2.connection_type == ConnectionType.OUTGOING
+        assert out_conn_2.proto2.connection_type == ConnectionType.CHECK_ENTRYPOINTS
+
+    def test_remove_connection_checkEp_slot(self) -> None:
+
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 100
+
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+
+        # Add two connections to outgoing, one will be at check_entrypoints.
+        out_peer_1 = self.create_peer()
+        out_peer_2 = self.create_peer()
+
+        out_conn_1 = FakeConnection(out_peer_1, full_node)
+        out_conn_2 = FakeConnection(out_peer_2, full_node)
+        self.simulator.add_connection(out_conn_1)
+        self.simulator.add_connection(out_conn_2)
+        self.simulator.run(1)
+
+        # Make sure there is still ONE connection in the check ep Slot
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # out_conn_2 should be the connection in check_ep_slot.
+        out_conn_2.disconnect(Failure(Exception('forced reconnection')))
+        self.simulator.remove_connection(out_conn_2)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 0
+
+    def test_multiple_check_ep_connections(self) -> None:
+        """Attempt lots of connections towards check_entrypoints, see if it caps."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 100
+
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # Now, we add multiple connections to check_ep_slot and see if it caps.
+        for _ in range(max_check_ep + 5):
+            out_peer = self.create_peer()
+            out_conn = FakeConnection(out_peer, full_node)
+            self.simulator.add_connection(out_conn)
+
+        self.simulator.run(1)
+
+        assert check_ep_slot.is_slot_full()
+        assert len(check_ep_slot) == max_check_ep
+
+    def test_queue_after_slot_filling(self) -> None:
+        """We'll keep track of the number of entrypoints in the queue and make sure none is lost."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 10000
+
+        n_in_queue = 5  # Number of entrypoints we wish to see in queue.
+
+        full_node = self.create_peer()
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # Now, we add multiple connections to check_ep_slot and see if it caps.
+        for _ in range(max_check_ep + max_outgoing + n_in_queue):
+            out_peer = self.create_peer()
+            out_conn = FakeConnection(out_peer, full_node)
+            self.simulator.add_connection(out_conn)
+
+        self.simulator.run(1)
+
+        # Make sure slot caps at the expected size
+        assert len(check_ep_slot) == max_check_ep
+
+        # Now, let us see if the queue stores the correct number of entrypoints in the queue
+        if n_in_queue > max_queue_ep:
+            n_in_queue = max_queue_ep
+
+        assert len(check_ep_slot.entrypoint_queue) == n_in_queue
+
+    def test_queue_cap(self) -> None:
+        """Test if the queue does limit the amount of allowed entrypoints. """
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 10
+
+        n_ep_voided = 5  # Number of entrypoints we wish to see out of queue
+
+        # Code n to be out of the queue's limit
+        n_to_queue = max_queue_ep + n_ep_voided
+
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # Now, we add multiple connections to check_ep_slot and see if it caps.
+        for _ in range(max_outgoing + n_to_queue):
+            out_peer = self.create_peer()
+            out_conn = FakeConnection(out_peer, full_node)
+            self.simulator.add_connection(out_conn)
+
+        self.simulator.run(1)
+
+        # Now, let us see if the queue stores the correct number of entrypoints in the queue
+        assert len(check_ep_slot.entrypoint_queue) == max_queue_ep
+
+    def test_entrypoint_queue_removal(self) -> None:
+        """Test the """
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 10
+        extra_eps = 3
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        out_conn_list: list[FakeConnection] = []
+        check_conn_list: list[FakeConnection] = []
+
+        # We'll add some connections but we'll leave space in the queue.
+        for _ in range(max_outgoing):
+            out_peer = self.create_peer()
+            out_conn = FakeConnection(out_peer, full_node)
+            out_conn_list.append(out_conn)
+            self.simulator.add_connection(out_conn)
+
+        for _ in range(max_check_ep):
+            check_peer = self.create_peer()
+            check_conn = FakeConnection(check_peer, full_node)
+            check_conn_list.append(check_conn)
+            self.simulator.add_connection(check_conn)
+
+        # We'll manually add the entrypoints, since proto2 does not set up correctly entrypoints.
+        from hathor.p2p.peer_endpoint import PeerAddress
+        known_entrypoints = []
+        for _ in range(extra_eps):
+            peer = self.create_peer()
+            ep = PeerAddress.from_address(
+                IPv4Address('TCP', '127.0.0.1', FakeConnection._get_port(peer))
+            ).with_id(peer.my_peer.id)
+            known_entrypoints.append(ep.addr)
+            check_ep_slot.put_on_queue(ep)
+
+        self.simulator.run(1)
+
+        # Let us see if the queue stores the correct number of entrypoints in the queue
+        assert len(check_ep_slot.entrypoint_queue) == extra_eps
+        assert len(check_ep_slot.dequeued_entrypoints) == 0
+
+        # Now, we'll remove a connection, and see if the entrypoint is appended.
+        check_conn = check_conn_list[-1]
+
+        # Mocking parameters for should_blacklist
+        check_conn.proto2.diff_timestamp = 10
+        check_conn.proto2.idle_timeout = 100
+
+        check_conn.disconnect(Failure(Exception('forced reconnection')))
+        self.simulator.remove_connection(check_conn)
+
+        # Run the simulator and see if the entrypoint has been updated.
+        self.simulator.run(1)
+
+        # Check if the entrypoint has been dequeued.
+        assert len(check_ep_slot) == max_check_ep - 1
+        assert len(check_ep_slot.entrypoint_queue) == extra_eps - 1
+        assert len(check_ep_slot.dequeued_entrypoints) == 1
+
+        # We'll now MOCK the connect_to_endpoint by reconnecting the call manually.
+        # The queue is FIFO:
+        dequeued_addr = next(iter(check_ep_slot.dequeued_entrypoints))
+        assert dequeued_addr == known_entrypoints[0]
+
+        # Build a protocol manually with the dequeued entrypoint pre-set,
+        # then call add_to_slot. This bypasses connect_to_endpoint (which
+        # doesn't work in the simulator) but exercises the real slot logic.
+        rebound_addr = IPv4Address('TCP', '127.0.0.1', 59999)
+        proto_rebound = full_node.connections.client_factory.buildProtocol(rebound_addr)
+        proto_rebound.entrypoint = dequeued_addr.with_id(None)
+
+        # add_to_slot sees entrypoint in dequeued_entrypoints and reclassifies to REBOUNDED
+        full_node.connections.slots_manager.add_to_slot(proto_rebound)
+        self.simulator.run(5)
+
+        # Therefore:
+        # 1. The slots manager put it to CheckEntrypoints Slot
+        # 2. In the slot, ep is in dequeued, so type changes to REBOUNDED
+        # 3. The protocol is stored in the rebounded slot, with the ep from dequeue.
+
+        # Hence, dequeueing mechanism seems to be working.
+        assert proto_rebound.connection_type == ConnectionType.REBOUNDED
+        assert check_ep_slot.rebound_slot == proto_rebound
+        assert proto_rebound.entrypoint.addr == dequeued_addr
+
+    def test_remove_when_queue_full(self) -> None:
+        """When a READY check_ep protocol is removed and its peer's entrypoints should be
+        queued, but the queue is already full, the overflow entrypoints are silently dropped."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 2  # Small queue so we can fill it easily.
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # Fill outgoing slot.
+        out_peer = self.create_peer()
+        out_conn = FakeConnection(out_peer, full_node)
+        self.simulator.add_connection(out_conn)
+
+        # Overflow to check_ep_slot.
+        check_peer = self.create_peer()
+        check_conn = FakeConnection(check_peer, full_node, fresh_entrypoints=True)
+        self.simulator.add_connection(check_conn)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 1
+
+        # Fill the queue to max before removing the protocol.
+        from hathor.p2p.peer_endpoint import PeerAddress
+        for i in range(max_queue_ep):
+            filler_ep = PeerAddress.from_address(
+                IPv4Address('TCP', '127.0.0.1', 61000 + i)
+            ).with_id(full_node.my_peer.id)
+            check_ep_slot.put_on_queue(filler_ep)
+
+        assert check_ep_slot.is_queue_full()
+
+        # Inject extra entrypoints into the peer's info.
+        extra_ep_1 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60001)
+        ).with_id(check_peer.my_peer.id)
+        extra_ep_2 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60002)
+        ).with_id(check_peer.my_peer.id)
+
+        check_conn.proto2.peer.info.entrypoints.add(extra_ep_1.addr)
+        check_conn.proto2.peer.info.entrypoints.add(extra_ep_2.addr)
+
+        # Force READY so removal triggers the entrypoint-fetching path.
+        check_conn.proto2.connection_state = ConnectionState.READY
+        check_conn.proto2.diff_timestamp = 10
+        check_conn.proto2.idle_timeout = 100
+
+        # Disconnect — unseen + READY, so it tries to queue peer entrypoints, but queue is full.
+        # Note: remove_connection also triggers kickstart (pops one filler from the queue).
+        check_conn.disconnect(Failure(Exception('done checking')))
+        self.simulator.remove_connection(check_conn)
+        self.simulator.run(1)
+
+        # Kickstart popped one filler, so queue is max_queue_ep - 1.
+        # The extra entrypoints were NOT added because the queue was full at the time of the attempt.
+        assert len(check_ep_slot.entrypoint_queue) == max_queue_ep - 1
+        assert len(check_ep_slot.dequeued_entrypoints) == 1
+
+        # The extra entrypoints must NOT have made it into the queue.
+        queued_addrs = set(ep.addr for ep in check_ep_slot.entrypoint_queue)
+        assert extra_ep_1.addr not in queued_addrs
+        assert extra_ep_2.addr not in queued_addrs
+
+    def test_fetch_entrypoints_from_ready_protocol(self) -> None:
+        """Test that when a check_ep protocol becomes READY and is removed,
+      its peer's other entrypoints get queued."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 100
+
+        full_node = self.create_peer()
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # First connection fills outgoing
+        out_peer = self.create_peer()
+        out_conn = FakeConnection(out_peer, full_node)
+        self.simulator.add_connection(out_conn)
+
+        # Second connection overflows to check_ep, with fresh_entrypoints so it gets one
+        check_peer = self.create_peer()
+        check_conn = FakeConnection(check_peer, full_node, fresh_entrypoints=True)
+        self.simulator.add_connection(check_conn)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 1
+        assert check_conn.proto2.connection_type == ConnectionType.CHECK_ENTRYPOINTS
+
+        # Manually inject additional entrypoints into the peer's info, simulating
+        # entrypoints that the peer advertised.
+        from hathor.p2p.peer_endpoint import PeerAddress
+        extra_ep_1 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60001)
+        ).with_id(check_peer.my_peer.id)
+        extra_ep_2 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60002)
+        ).with_id(check_peer.my_peer.id)
+
+        # Add entrypoints to the peer info so remove_connection can read them
+        check_conn.proto2.peer.info.entrypoints.add(extra_ep_1.addr)
+        check_conn.proto2.peer.info.entrypoints.add(extra_ep_2.addr)
+
+        # Force the protocol to READY state so the removal path fetches entrypoints
+        check_conn.proto2.connection_state = ConnectionState.READY
+
+        # Now remove it — since entrypoint was unseen, peer's entrypoints should be queued
+        check_conn.proto2.diff_timestamp = 10
+        check_conn.proto2.idle_timeout = 100
+
+        check_conn.disconnect(Failure(Exception('done checking')))
+        self.simulator.remove_connection(check_conn)
+        self.simulator.run(1)
+
+        # The two extra entrypoints should be in the queue (the main one was already seen)
+
+        # EVENTUALLY: CHANGE ENTRYPOINT QUEUE TO BE PEER ADDRESS ALSO, LIKE THE REST.
+        # Change everything.
+        assert len(check_ep_slot.entrypoint_queue) + len(check_ep_slot.dequeued_entrypoints) >= 2
+        queued_addrs = set(ep.addr for ep in check_ep_slot.entrypoint_queue)
+        dequeued_addrs = set(ep_addr for ep_addr in check_ep_slot.dequeued_entrypoints)
+        assert extra_ep_1.addr in dequeued_addrs or extra_ep_1.addr in queued_addrs
+        assert extra_ep_2.addr in queued_addrs or extra_ep_2.addr in dequeued_addrs
+
+    def test_ep_requeue_for_busy_rebound_slot(self) -> None:
+        """When a REBOUNDED protocol arrives but the rebound_slot is already occupied,
+        its entrypoint must be put back on the queue and the connection rejected."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 100
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # Fill the outgoing slot.
+        out_peer = self.create_peer()
+        out_conn = FakeConnection(out_peer, full_node)
+        self.simulator.add_connection(out_conn)
+
+        # Fill check_ep_slot with max_check_ep connections so the queue gets entries.
+        check_conn_list: list[FakeConnection] = []
+        for _ in range(max_check_ep):
+            peer = self.create_peer()
+            conn = FakeConnection(peer, full_node)
+            check_conn_list.append(conn)
+            self.simulator.add_connection(conn)
+
+        self.simulator.run(1)
+        assert len(check_ep_slot) == max_check_ep
+
+        # Manually queue two entrypoints so we can dequeue them later.
+        from hathor.p2p.peer_endpoint import PeerAddress
+        ep_a = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60101)
+        ).with_id(full_node.my_peer.id)
+        ep_b = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60102)
+        ).with_id(full_node.my_peer.id)
+
+        check_ep_slot.put_on_queue(ep_a)
+        check_ep_slot.put_on_queue(ep_b)
+        assert len(check_ep_slot.entrypoint_queue) == 2
+
+        # Pop ep_a from queue (FIFO: ep_a was pushed first via appendleft, but ep_b was pushed
+        # after, so ep_a is on the right). This marks ep_a.addr in dequeued_entrypoints.
+        popped = check_ep_slot.pop_from_queue()
+        assert popped is not None
+        assert popped.addr in check_ep_slot.dequeued_entrypoints
+        # Place a protocol in rebound_slot to occupy it.
+        rebound_addr_1 = IPv4Address('TCP', '127.0.0.1', 59801)
+        proto_rebound_1 = full_node.connections.client_factory.buildProtocol(rebound_addr_1)
+        proto_rebound_1.entrypoint = popped
+        proto_rebound_1.connection_type = ConnectionType.REBOUNDED
+        # Directly place in rebound_slot (bypassing add_connection for setup).
+        check_ep_slot.rebound_slot = proto_rebound_1
+
+        assert check_ep_slot.rebound_slot is not None
+
+        # Pop ep_b from queue and mark it as dequeued.
+        popped_b = check_ep_slot.pop_from_queue()
+        assert popped_b is not None
+        assert popped_b.addr in check_ep_slot.dequeued_entrypoints
+        popped_b_addr = popped_b.addr
+
+        # Queue should now be empty.
+        assert len(check_ep_slot.entrypoint_queue) == 0
+
+        # Build a second REBOUNDED protocol for ep_b — rebound_slot is busy.
+        rebound_addr_2 = IPv4Address('TCP', '127.0.0.1', 59802)
+        proto_rebound_2 = full_node.connections.client_factory.buildProtocol(rebound_addr_2)
+        proto_rebound_2.entrypoint = popped_b
+        proto_rebound_2.connection_type = ConnectionType.REBOUNDED
+
+        # Attempt to add — should be rejected because rebound_slot is occupied.
+        result = check_ep_slot.add_connection(proto_rebound_2)
+
+        from hathor.p2p.connection_slot import ConnectionRejected
+        assert isinstance(result, ConnectionRejected)
+
+        # The entrypoint must have been put back on the queue.
+        assert len(check_ep_slot.entrypoint_queue) == 1
+        requeued_ep = check_ep_slot.entrypoint_queue[0]
+        assert requeued_ep.addr == popped_b_addr
+
+        # rebound_slot must still hold the first protocol.
+        assert check_ep_slot.rebound_slot is proto_rebound_1
+
+    def test_blacklist_blocking(self) -> None:
+        "We'll test if, when attempting to connect to a blacklisted peer, protocol is blocked. "
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 10
+        node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        node.connections.slots_manager = SlotsManager(sm_settings)
+        ch_slot = node.connections.slots_manager.check_ep_slot
+
+        # We'll make a connection timeout, without being ready.
+
+        # First connection (outgoing slot)
+        out_peer_1 = self.create_peer()
+        out_conn_1 = FakeConnection(out_peer_1, node)
+        self.simulator.add_connection(out_conn_1)
+
+        # Second connection (check_ep_slot) - we'll set entrypoints to be avaiable from the beginning.
+        out_peer_2 = self.create_peer()
+        out_conn_2 = FakeConnection(out_peer_2, node, fresh_entrypoints=True)
+        self.simulator.add_connection(out_conn_2)
+
+        # Run the simulator
+        self.simulator.run(1)
+
+        # Assert the shift
+        assert len(ch_slot) == 1
+
+        # We'll force the connection to be blacklisted.
+        # For this, we'll:
+        # 1. Force the connection to revert back to CONNECTING... State.
+        # 2. Give timeout burst parameters.
+
+        # The entrypoint which we'll ban.
+        banned_entrypoint = out_conn_2.entrypoint
+        assert banned_entrypoint is not None
+
+        # We'll alter the params on the fly before disconnection to trigger blacklisting.
+        out_conn_2.proto1.entrypoint = banned_entrypoint
+        out_conn_2.proto1.idle_timeout = 1
+        out_conn_2.proto1.diff_timestamp = 1
+        out_conn_2.proto1.connection_state = ConnectionState.CONNECTING
+        out_conn_2.proto2.entrypoint = banned_entrypoint
+        out_conn_2.proto2.idle_timeout = 1
+        out_conn_2.proto2.diff_timestamp = 1
+        out_conn_2.proto2.connection_state = ConnectionState.CONNECTING
+
+        # Remove connection - at this point, blacklist must be triggered.
+        out_conn_2.disconnect(Failure(Exception('Forced disconnection')))
+        self.simulator.remove_connection(out_conn_2)
+
+        # Run the simulator
+        self.simulator.run(1)
+
+        # Assert that the connection is gone from slot.
+        assert len(ch_slot) == 0
+
+        # Assert that the entrypoint has been banned:
+        assert node.connections.slots_manager.is_blacklisted(banned_entrypoint)
+
+        # Build a new connection, then disconnect it, blacklist its entrypoint, and reconnect.
+        new_peer = self.create_peer()
+        new_conn = FakeConnection(new_peer, node, fresh_entrypoints=True)
+        self.simulator.add_connection(new_conn)
+        self.simulator.run(1)
+
+        # The new connection entered check_ep_slot (outgoing was full).
+        assert len(ch_slot) == 1
+
+        # Now blacklist the actual entrypoint address and disconnect.
+        ban_ep = new_conn.proto2.entrypoint.addr
+        new_conn.disconnect(Failure(Exception('forced disconnection')))
+        self.simulator.remove_connection(new_conn)
+        self.simulator.run(1)
+        assert len(ch_slot) == 0
+
+        node_sm = node.connections.slots_manager
+        node_sm.check_ep_slot.blacklisted_entrypoints.entrypoint_set.add(ban_ep)
+
+        # Reconnect — the blacklist gate in on_peer_connect should now block it.
+        new_conn.reconnect()
+        self.simulator.add_connection(new_conn)
+        self.simulator.run(1)
+
+        # The connection should have been rejected by the blacklist check.
+        assert len(ch_slot) == 0
+
+    def test_attempt_delisting_before_expiration(self) -> None:
+        """Attempt to delist an entrypoint before time penalty.
+        Blacklist an entrypoint, advance the clock by less than TIME_PENALTY,
+        then try to reconnect with the same entrypoint. The connection must be rejected."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 10
+        node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        node.connections.slots_manager = SlotsManager(sm_settings)
+        node_sm = node.connections.slots_manager
+        check_ep_slot = node_sm.check_ep_slot
+        blacklisted_set = check_ep_slot.blacklisted_entrypoints
+
+        # First connection fills outgoing slot.
+        out_peer = self.create_peer()
+        out_conn = FakeConnection(out_peer, node)
+        self.simulator.add_connection(out_conn)
+
+        # Second connection overflows to check_ep_slot.
+        check_peer = self.create_peer()
+        check_conn = FakeConnection(check_peer, node, fresh_entrypoints=True)
+        self.simulator.add_connection(check_conn)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 1
+
+        # Record the entrypoint we'll blacklist.
+        banned_entrypoint = check_conn.entrypoint
+        assert banned_entrypoint is not None
+        banned_addr = banned_entrypoint.addr
+
+        # Force blacklist conditions: not READY, timed out.
+        check_conn.proto2.entrypoint = banned_entrypoint
+        check_conn.proto2.idle_timeout = 1
+        check_conn.proto2.diff_timestamp = 1
+        check_conn.proto2.connection_state = ConnectionState.CONNECTING
+
+        # Disconnect — triggers blacklisting.
+        check_conn.disconnect(Failure(Exception('forced timeout')))
+        self.simulator.remove_connection(check_conn)
+        self.simulator.run(1)
+
+        # Confirm blacklisted.
+        assert node_sm.is_blacklisted(banned_entrypoint)
+        assert banned_addr in blacklisted_set.entrypoint_set
+        assert banned_addr in blacklisted_set.time_map
+
+        # Advance clock by LESS than TIME_PENALTY (600s). Use 300s (half).
+        self.simulator._clock.advance(300)
+
+        # Reconnect the same FakeConnection — it carries the same (banned) entrypoint.
+        check_conn.reconnect()
+        self.simulator.add_connection(check_conn)
+        self.simulator.run(1)
+
+        # The connection must have been rejected — blacklist not expired.
+        assert len(check_ep_slot) == 0
+
+        # Entrypoint must still be blacklisted.
+        assert banned_addr in blacklisted_set.entrypoint_set
+        assert banned_addr in blacklisted_set.time_map
+
+    def test_attempt_delisting_after_expiration(self) -> None:
+        """Attempt to delist after penalty, and attempt new connection to see its
+        protocol not being blocked."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 10
+        node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        node.connections.slots_manager = SlotsManager(sm_settings)
+        node_sm = node.connections.slots_manager
+        check_ep_slot = node_sm.check_ep_slot
+        blacklisted_set = check_ep_slot.blacklisted_entrypoints
+
+        # First connection fills outgoing slot.
+        out_peer = self.create_peer()
+        out_conn = FakeConnection(out_peer, node)
+        self.simulator.add_connection(out_conn)
+
+        # Second connection overflows to check_ep_slot.
+        check_peer = self.create_peer()
+        check_conn = FakeConnection(check_peer, node, fresh_entrypoints=True)
+        self.simulator.add_connection(check_conn)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 1
+
+        # Record the entrypoint we'll blacklist.
+        banned_entrypoint = check_conn.entrypoint
+        assert banned_entrypoint is not None
+        banned_addr = banned_entrypoint.addr
+
+        # Force blacklist conditions: not READY, timed out.
+        check_conn.proto2.entrypoint = banned_entrypoint
+        check_conn.proto2.idle_timeout = 1
+        check_conn.proto2.diff_timestamp = 1
+        check_conn.proto2.connection_state = ConnectionState.CONNECTING
+
+        # Disconnect — triggers blacklisting.
+        check_conn.disconnect(Failure(Exception('forced timeout')))
+        self.simulator.remove_connection(check_conn)
+        self.simulator.run(1)
+
+        # Confirm blacklisted.
+        assert node_sm.is_blacklisted(banned_entrypoint)
+        assert banned_addr in blacklisted_set.entrypoint_set
+        assert banned_addr in blacklisted_set.time_map
+
+        # Advance clock PAST TIME_PENALTY (600s). Use 601s.
+        self.simulator._clock.advance(601)
+
+        # Reconnect the same FakeConnection — it carries the same (banned) entrypoint.
+        check_conn.reconnect()
+        self.simulator.add_connection(check_conn)
+        self.simulator.run(1)
+
+        # The connection must have been accepted — blacklist expired.
+        # on_peer_connect calls may_unblacklist -> True, then remove_from_blacklist.
+        assert len(check_ep_slot) == 1
+
+        # Entrypoint must have been removed from the blacklist.
+        assert banned_addr not in blacklisted_set.entrypoint_set
+        assert banned_addr not in blacklisted_set.time_map
+
+    def test_rebound_full_queue(self) -> None:
+        """Test the rebound mechanism, and see if it voids the entrypoint
+        when the queue, where it is supposed to go, is full."""
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 5
+        max_queue_ep = 3  # Small queue so we can fill it easily.
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        check_ep_slot = full_node.connections.slots_manager.check_ep_slot
+
+        # Fill the outgoing slot.
+        out_peer = self.create_peer()
+        out_conn = FakeConnection(out_peer, full_node)
+        self.simulator.add_connection(out_conn)
+
+        # Fill check_ep_slot so we can work with the queue directly.
+        check_conn_list: list[FakeConnection] = []
+        for _ in range(max_check_ep):
+            peer = self.create_peer()
+            conn = FakeConnection(peer, full_node)
+            check_conn_list.append(conn)
+            self.simulator.add_connection(conn)
+
+        self.simulator.run(1)
+        assert len(check_ep_slot) == max_check_ep
+
+        # Manually queue entrypoints to fill the queue completely.
+        from hathor.p2p.peer_endpoint import PeerAddress
+        for i in range(max_queue_ep):
+            ep = PeerAddress.from_address(
+                IPv4Address('TCP', '127.0.0.1', 61000 + i)
+            ).with_id(full_node.my_peer.id)
+            check_ep_slot.put_on_queue(ep)
+
+        assert check_ep_slot.is_queue_full()
+
+        # Pop one entrypoint to create a REBOUNDED protocol for it.
+        popped_a = check_ep_slot.pop_from_queue()
+        assert popped_a is not None
+
+        # Re-fill the queue back to max.
+        refill_ep = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 62000)
+        ).with_id(full_node.my_peer.id)
+        check_ep_slot.put_on_queue(refill_ep)
+        assert check_ep_slot.is_queue_full()
+
+        # Occupy rebound_slot with a protocol for popped_a.
+        occupy_addr = IPv4Address('TCP', '127.0.0.1', 59701)
+        proto_occupy = full_node.connections.client_factory.buildProtocol(occupy_addr)
+        proto_occupy.entrypoint = popped_a
+        proto_occupy.connection_type = ConnectionType.REBOUNDED
+        check_ep_slot.rebound_slot = proto_occupy
+
+        # Pop another entrypoint — this one will be the dropped victim.
+        popped_b = check_ep_slot.pop_from_queue()
+        assert popped_b is not None
+
+        # Re-fill the queue again so the put_on_queue inside add_connection will fail.
+        refill_ep_2 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 62001)
+        ).with_id(full_node.my_peer.id)
+        check_ep_slot.put_on_queue(refill_ep_2)
+        assert check_ep_slot.is_queue_full()
+        queue_snapshot = list(check_ep_slot.entrypoint_queue)
+
+        # Build a REBOUNDED protocol for popped_b — rebound occupied AND queue full.
+        reject_addr = IPv4Address('TCP', '127.0.0.1', 59702)
+        proto_rejected = full_node.connections.client_factory.buildProtocol(reject_addr)
+        proto_rejected.entrypoint = popped_b
+        proto_rejected.connection_type = ConnectionType.REBOUNDED
+
+        result = check_ep_slot.add_connection(proto_rejected)
+
+        from hathor.p2p.connection_slot import ConnectionRejected
+        assert isinstance(result, ConnectionRejected)
+
+        # Queue must still be full — the entrypoint was dropped, not re-added.
+        assert check_ep_slot.is_queue_full()
+        assert len(check_ep_slot.entrypoint_queue) == max_queue_ep
+
+        # Queue contents unchanged — dropped entrypoint did not squeeze in.
+        assert list(check_ep_slot.entrypoint_queue) == queue_snapshot
+
+        # rebound_slot still holds the first protocol.
+        assert check_ep_slot.rebound_slot is proto_occupy
+
+    def test_E2E_full_life_cycle(self) -> None:
+        """End-to-end test of the CheckEntrypoints mechanism.
+
+        Three protocols:
+        - peer_A: times out → blacklisted → unblacklisted after TIME_PENALTY → reconnects → READY
+        - peer_B: reaches READY → disconnected → extra entrypoints queued → rebound chain drains them
+        - peer_C: has an already-seen entrypoint → reaches READY → peer entrypoints NOT re-fetched
+        """
+        from hathor.p2p.peer_endpoint import PeerAddress
+
+        max_outgoing = 1
+        max_incoming = 1
+        max_bootstrap = 1
+        max_check_ep = 2
+        max_queue_ep = 100
+        full_node = self.create_peer()
+
+        sm_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap, max_check_ep, max_queue_ep)
+        full_node.connections.slots_manager = SlotsManager(sm_settings)
+        node_sm = full_node.connections.slots_manager
+        check_ep_slot = node_sm.check_ep_slot
+        blacklisted_set = check_ep_slot.blacklisted_entrypoints
+
+        # --- Phase 1: Fill outgoing slot ---
+        peer_out = self.create_peer()
+        out_conn = FakeConnection(peer_out, full_node)
+        self.simulator.add_connection(out_conn)
+        self.simulator.run(1)
+
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        assert len(outgoing_slot) == 1
+        assert len(check_ep_slot) == 0
+
+        # --- Phase 2: peer_A overflows to check_ep, times out, gets blacklisted ---
+        peer_A = self.create_peer()
+        conn_A = FakeConnection(peer_A, full_node, fresh_entrypoints=True)
+        self.simulator.add_connection(conn_A)
+        self.simulator.run(1)
+
+        assert conn_A.proto2.connection_type == ConnectionType.CHECK_ENTRYPOINTS
+        assert len(check_ep_slot) == 1
+
+        # Record entrypoint before forcing timeout.
+        ep_A = conn_A.entrypoint
+        assert ep_A is not None
+        addr_A = ep_A.addr
+
+        # Force timeout conditions: not READY, diff_timestamp >= idle_timeout.
+        conn_A.proto2.entrypoint = ep_A
+        conn_A.proto2.idle_timeout = 1
+        conn_A.proto2.diff_timestamp = 1
+        conn_A.proto2.connection_state = ConnectionState.CONNECTING
+
+        # Disconnect — triggers blacklisting.
+        conn_A.disconnect(Failure(Exception('peer_A timeout')))
+        self.simulator.remove_connection(conn_A)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 0
+        assert node_sm.is_blacklisted(ep_A)
+        assert addr_A in blacklisted_set.entrypoint_set
+        assert addr_A in blacklisted_set.time_map
+
+        # --- Phase 3: peer_B reaches READY, extra entrypoints queued ---
+        peer_B = self.create_peer()
+        conn_B = FakeConnection(peer_B, full_node, fresh_entrypoints=True)
+        self.simulator.add_connection(conn_B)
+        self.simulator.run(1)
+
+        assert conn_B.proto2.connection_type == ConnectionType.CHECK_ENTRYPOINTS
+        assert len(check_ep_slot) == 1
+
+        # Inject extra entrypoints into peer_B's info, simulating advertised entrypoints.
+        extra_ep_1 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60001)
+        ).with_id(peer_B.my_peer.id)
+        extra_ep_2 = PeerAddress.from_address(
+            IPv4Address('TCP', '127.0.0.1', 60002)
+        ).with_id(peer_B.my_peer.id)
+
+        conn_B.proto2.peer.info.entrypoints.add(extra_ep_1.addr)
+        conn_B.proto2.peer.info.entrypoints.add(extra_ep_2.addr)
+
+        # Force READY state so removal fetches peer entrypoints.
+        conn_B.proto2.connection_state = ConnectionState.READY
+        conn_B.proto2.diff_timestamp = 10
+        conn_B.proto2.idle_timeout = 100
+
+        # Disconnect — since entrypoint was unseen and READY, peer's extra entrypoints get queued.
+        conn_B.disconnect(Failure(Exception('peer_B checked')))
+        self.simulator.remove_connection(conn_B)
+        self.simulator.run(1)
+
+        assert len(check_ep_slot) == 0
+
+        # extra_ep_1 and extra_ep_2 should be queued or dequeued (kickstart pops one immediately).
+        queued_addrs = set(ep.addr for ep in check_ep_slot.entrypoint_queue)
+        dequeued_addrs = check_ep_slot.dequeued_entrypoints
+        assert extra_ep_1.addr in queued_addrs or extra_ep_1.addr in dequeued_addrs
+        assert extra_ep_2.addr in queued_addrs or extra_ep_2.addr in dequeued_addrs
+
+        # Both should now be in seen_entrypoints.
+        assert extra_ep_1.addr in check_ep_slot.seen_entrypoints
+        assert extra_ep_2.addr in check_ep_slot.seen_entrypoints
+
+        # --- Phase 4: Rebound chain drains dequeued entrypoints ---
+        # Kickstart should have popped one entrypoint already. Identify it.
+        assert len(check_ep_slot.dequeued_entrypoints) == 1
+        dequeued_addr_1 = next(iter(check_ep_slot.dequeued_entrypoints))
+
+        # Build a protocol for the dequeued entrypoint, simulating connect_to_endpoint callback.
+        rebound_addr_1 = IPv4Address('TCP', '127.0.0.1', 59801)
+        proto_rebound_1 = full_node.connections.client_factory.buildProtocol(rebound_addr_1)
+        proto_rebound_1.entrypoint = dequeued_addr_1.with_id(peer_B.my_peer.id)
+
+        # add_to_slot sees entrypoint in dequeued_entrypoints → reclassifies to REBOUNDED.
+        full_node.connections.slots_manager.add_to_slot(proto_rebound_1)
+
+        assert proto_rebound_1.connection_type == ConnectionType.REBOUNDED
+        assert check_ep_slot.rebound_slot is proto_rebound_1
+
+        # Safe timeout so it won't blacklist (diff_timestamp < idle_timeout).
+        # Not READY: manually-built protocols have no peer, so we avoid the fetch-entrypoints path.
+        proto_rebound_1.diff_timestamp = 10
+        proto_rebound_1.idle_timeout = 100
+
+        # Remove from slot — triggers usual_flow dequeue of the second entrypoint.
+        removal_result = check_ep_slot.remove_connection(proto_rebound_1)
+
+        assert check_ep_slot.rebound_slot is None
+        assert removal_result.entrypoint is not None
+
+        # The second extra_ep should now be dequeued.
+        assert len(check_ep_slot.dequeued_entrypoints) == 2
+        assert len(check_ep_slot.entrypoint_queue) == 0
+
+        # --- Phase 5: peer_C has an already-seen entrypoint, entrypoints NOT re-fetched ---
+        # The second dequeued entrypoint is already in seen_entrypoints from Phase 3.
+        dequeued_addr_2 = removal_result.entrypoint.addr
+        assert dequeued_addr_2 in check_ep_slot.seen_entrypoints
+
+        # Build a protocol for it, simulating connect_to_endpoint callback.
+        rebound_addr_2 = IPv4Address('TCP', '127.0.0.1', 59802)
+        proto_C = full_node.connections.client_factory.buildProtocol(rebound_addr_2)
+        proto_C.entrypoint = dequeued_addr_2.with_id(peer_B.my_peer.id)
+
+        full_node.connections.slots_manager.add_to_slot(proto_C)
+
+        assert proto_C.connection_type == ConnectionType.REBOUNDED
+        assert check_ep_slot.rebound_slot is proto_C
+
+        # Safe timeout so it won't blacklist (diff_timestamp < idle_timeout).
+        # Not READY: manually-built protocols have no peer.
+        proto_C.diff_timestamp = 10
+        proto_C.idle_timeout = 100
+
+        # Snapshot queue before removal.
+        queue_before = len(check_ep_slot.entrypoint_queue)
+
+        # Remove — not READY, so the entrypoint-fetching branch is skipped entirely.
+        check_ep_slot.remove_connection(proto_C)
+
+        assert check_ep_slot.rebound_slot is None
+        assert len(check_ep_slot.entrypoint_queue) == queue_before
+
+        # --- Phase 6: peer_A unblacklisted after TIME_PENALTY, reconnects, reaches READY ---
+        # Advance clock past TIME_PENALTY (600s).
+        self.simulator._clock.advance(601)
+
+        # Reconnect peer_A — same FakeConnection, same entrypoint.
+        conn_A.reconnect()
+        self.simulator.add_connection(conn_A)
+        self.simulator.run(1)
+
+        # Blacklist expired — connection accepted into check_ep_slot.
+        assert len(check_ep_slot) == 1
+        assert addr_A not in blacklisted_set.entrypoint_set
+        assert addr_A not in blacklisted_set.time_map
+
+        # peer_A's entrypoint was never queued, so it is NOT in seen_entrypoints.
+        # When removed as READY, the unseen path will try to fetch peer_A's advertised
+        # entrypoints — but peer_A has no extra entrypoints, so nothing gets queued.
+        assert addr_A not in check_ep_slot.seen_entrypoints
+
+        # Force READY and safe timeout.
+        conn_A.proto2.connection_state = ConnectionState.READY
+        conn_A.proto2.diff_timestamp = 10
+        conn_A.proto2.idle_timeout = 100
+
+        # Disconnect — removed as READY + unseen, but peer has no extra entrypoints to queue.
+        conn_A.disconnect(Failure(Exception('peer_A finally checked')))
+        self.simulator.remove_connection(conn_A)
+        self.simulator.run(1)
+
+        # --- Final assertions: everything drained ---
+        assert len(check_ep_slot.connection_slot) == 0
+        assert check_ep_slot.rebound_slot is None
+        assert len(check_ep_slot.entrypoint_queue) == 0
+        assert len(blacklisted_set.entrypoint_set) == 0
+        assert len(blacklisted_set.time_map) == 0
+
+        # The extra entrypoints from peer_B were seen (via put_on_queue).
+        assert extra_ep_1.addr in check_ep_slot.seen_entrypoints
+        assert extra_ep_2.addr in check_ep_slot.seen_entrypoints

--- a/hathor_tests/p2p/test_connection_slots.py
+++ b/hathor_tests/p2p/test_connection_slots.py
@@ -1,0 +1,239 @@
+from twisted.python.failure import Failure
+
+from hathor.p2p.connection_slot import SlotsManager, SlotsManagerSettings
+from hathor.simulator import FakeConnection
+from hathor_tests.simulation.base import SimulatorTestCase
+
+
+class ConnectionSlotsTestCase(SimulatorTestCase):
+    def test_slot_limit(self) -> None:
+        """ Tests whether the slots and the pool stop increasing connections after cap is reached.
+
+            Important note: create_peer caps the peer pool at 100. Hence, if more than 100 connections
+            are opened (if settings.P2P_..._OUTGOING + settings.P2P_...INCOMING _+ ... exceed 100)
+            then the tests will fail."""
+
+        # Full-Node: May receive incoming connections, deliver outgoing connections, etc.
+        # If the total amount of connections exceeds 100, create_peer will not yield more than 100 peers as well.
+        full_node = self.create_peer()
+
+        # Set the limits for each slot (sum MUST NOT exceed 100).
+        # We set the limits here since grabbing the values from the settings exceeds limits in simulator.
+        max_outgoing = 20
+        max_incoming = 15
+        max_bootstrap = 10
+        max_connections = max_bootstrap + max_incoming + max_outgoing
+
+        # Set SlotsManager Settings:
+        slots_manager_settings = SlotsManagerSettings(max_outgoing, max_incoming, max_bootstrap)
+
+        # Set SlotsManager:
+        slots_manager = SlotsManager(slots_manager_settings)
+
+        # Attribute it to the peer
+        full_node.connections.slots_manager = slots_manager
+
+        # For each connection type we add more peers than necessary to see if the slot limits it.
+        # Create peer list for incoming connections
+        in_connList = []
+        in_peerList = []
+        for i in range(0, max_incoming + 1):
+            in_peerList.append(self.create_peer())
+
+            # Generate incoming connections - full_node is the target.
+            in_connList.append(FakeConnection(full_node, in_peerList[i]))
+
+            # Add connections to simulator.
+            self.simulator.add_connection(in_connList[i])
+
+        self.simulator.run(10)
+
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        number_incoming_slot = len(incoming_slot.connection_slot)
+        # Checks whether the connection has capped on its limit size.
+        self.assertTrue(number_incoming_slot == max_incoming)
+
+        # We repeat the analysis for all other slots.
+
+        # --- outgoing slot ---
+
+        out_connList = []
+        out_peerList = []
+        for i in range(0, max_outgoing + 1):
+
+            out_peerList.append(self.create_peer())
+            out_connList.append(FakeConnection(out_peerList[i], full_node))
+            self.simulator.add_connection(out_connList[i])
+
+        self.simulator.run(10)
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        number_outgoing_slot = len(outgoing_slot.connection_slot)
+        self.assertTrue(number_outgoing_slot == max_outgoing)
+
+        # --- bootstrap slot ---
+        bootstrap_connList = []
+        bootstrap_peerList = []
+
+        for i in range(0, max_bootstrap + 1):
+            bootstrap_peerList.append(self.create_peer())
+            bootstrap_connList.append(FakeConnection(bootstrap_peerList[i], full_node, fake_bootstrap_id=None))
+            self.simulator.add_connection(bootstrap_connList[i])
+
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+        number_bootstrap_slot = len(bootstrap_slot.connection_slot)
+
+        self.assertTrue(number_bootstrap_slot == max_bootstrap)
+        # Finally, assure the number of connected peers is the same as the sum of all (no bootstrap connections).
+        connection_pool = full_node.connections.connections
+        self.assertTrue(number_outgoing_slot + number_incoming_slot + number_bootstrap_slot == len(connection_pool))
+        self.assertTrue(len(connection_pool) <= max_connections)
+
+    def test_wrong_conn_outgoing(self) -> None:
+        """ Test if, by sending a connection to the wrong slot, it is blocked.
+                Note: Connections stop being updated after removed from simulator."""
+
+        full_node = self.create_peer()
+        peer_in = self.create_peer()
+        peer_boot = self.create_peer()
+
+        # -> Test outgoing slot - make incoming and bootstrap connections.
+        in_conn = FakeConnection(full_node, peer_in)
+        boot_conn = FakeConnection(peer_boot, full_node, fake_bootstrap_id=None)
+
+        self.simulator.add_connection(in_conn)
+        self.simulator.add_connection(boot_conn)
+        self.simulator.run(5)
+
+        # Outgoing slot must not update
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        self.assertTrue(len(outgoing_slot.connection_slot) == 0)
+
+    def test_wrong_conn_incoming(self) -> None:
+
+        full_node = self.create_peer()
+        peer_out = self.create_peer()
+        peer_boot = self.create_peer()
+
+        # <- Test incoming slot - make incoming and bootstrap connections.
+
+        out_conn = FakeConnection(peer_out, full_node)
+        boot_conn = FakeConnection(peer_boot, full_node, fake_bootstrap_id=None)
+
+        self.simulator.add_connection(out_conn)
+        self.simulator.add_connection(boot_conn)
+        self.simulator.run(5)
+
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        self.assertTrue(len(incoming_slot.connection_slot) == 0)
+
+    def test_wrong_conn_bootstrap(self) -> None:
+
+        full_node = self.create_peer()
+        peer_out = self.create_peer()
+        peer_in = self.create_peer()
+
+        # <- Test incoming slot - make incoming and bootstrap connections.
+
+        out_conn = FakeConnection(peer_out, full_node)
+        in_conn = FakeConnection(full_node, peer_in)
+
+        self.simulator.add_connection(out_conn)
+        self.simulator.add_connection(in_conn)
+        self.simulator.run(5)
+
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+        self.assertTrue(len(bootstrap_slot.connection_slot) == 0)
+
+    def test_connections_equal_slots(self) -> None:
+        """ Test if connections keep equal to the sum of connections in each slot."""
+        full_node = self.create_peer()
+        number_out = 8  # Random numbers
+        number_in = 11
+        number_boot = 9
+        out_peer_list = []
+        in_peer_list = []
+        boot_peer_list = []
+
+        # Create peer lists:
+        for _ in range(number_out):
+            out_peer_list.append(self.create_peer())
+        for _ in range(number_in):
+            in_peer_list.append(self.create_peer())
+        for _ in range(number_boot):
+            boot_peer_list.append(self.create_peer())
+
+        # Create connections to the peers in the list:
+
+        # Outgoing:
+        out_conn_list = []
+        for _, peer in enumerate(out_peer_list):
+            out_conn_list.append(FakeConnection(peer, full_node))
+            self.simulator.add_connection(out_conn_list[-1])
+        # Incoming:
+        in_conn_list = []
+        for _, peer in enumerate(in_peer_list):
+            in_conn_list.append(FakeConnection(full_node, peer))
+            self.simulator.add_connection(in_conn_list[-1])
+
+        # Bootstrap:
+        boot_conn_list = []
+        for _, peer in enumerate(boot_peer_list):
+            boot_conn_list.append(FakeConnection(peer, full_node, fake_bootstrap_id=None))
+            self.simulator.add_connection(boot_conn_list[-1])
+
+        self.simulator.run(1)
+        connections = full_node.connections.connections
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot.connection_slot
+        incoming_slot = full_node.connections.slots_manager.incoming_slot.connection_slot
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot.connection_slot
+        sum_of_slots = len(bootstrap_slot) + len(incoming_slot) + len(outgoing_slot)
+        self.assertTrue(len(connections) == sum_of_slots)
+
+    def test_remove_connection(self) -> None:
+        """Test if removing connections from each slot properly decreases slot and pool sizes."""
+
+        full_node = self.create_peer()
+
+        # Create one connection per slot type
+        out_peer = self.create_peer()
+        in_peer = self.create_peer()
+        boot_peer = self.create_peer()
+
+        out_conn = FakeConnection(out_peer, full_node)
+        in_conn = FakeConnection(full_node, in_peer)
+        boot_conn = FakeConnection(boot_peer, full_node, fake_bootstrap_id=None)
+
+        self.simulator.add_connection(out_conn)
+        self.simulator.add_connection(in_conn)
+        self.simulator.add_connection(boot_conn)
+        self.simulator.run(5)
+
+        # Make sure three connections we appended to the whole pool
+        self.assertTrue(len(full_node.connections.connections) == 3)
+
+        # Remove outgoing
+        out_conn.disconnect(Failure(Exception('test disconnect')))
+        self.simulator.remove_connection(out_conn)
+        self.simulator.run(1)
+
+        outgoing_slot = full_node.connections.slots_manager.outgoing_slot
+        self.assertTrue(len(outgoing_slot.connection_slot) == 0)
+        self.assertTrue(len(full_node.connections.connections) == 2)
+
+        # Remove incoming
+        in_conn.disconnect(Failure(Exception('test disconnect')))
+        self.simulator.remove_connection(in_conn)
+        self.simulator.run(1)
+
+        incoming_slot = full_node.connections.slots_manager.incoming_slot
+        self.assertTrue(len(incoming_slot.connection_slot) == 0)
+        self.assertTrue(len(full_node.connections.connections) == 1)
+
+        # Remove bootstrap
+        boot_conn.disconnect(Failure(Exception('test disconnect')))
+        self.simulator.remove_connection(boot_conn)
+        self.simulator.run(1)
+
+        bootstrap_slot = full_node.connections.slots_manager.bootstrap_slot
+        self.assertTrue(len(bootstrap_slot.connection_slot) == 0)
+        self.assertTrue(len(full_node.connections.connections) == 0)

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -381,9 +381,19 @@ class HathorSettings(BaseModel):
     PEER_MAX_CONNECTIONS: int = 125
 
     # Max Number of each connection slot (int):
+    # Note that the sum is 124 < 125.
+    # Reason: We must leave always ONE protocol space for
+    # the rebound slot. Otherwise, if the whole net is flooded
+    # (Incoming, Outgoing, Bootstrap, Check), we'll not be
+    # able to analyze queued entrypoints.
+
     P2P_PEER_MAX_INCOMING_CONNECTIONS: int = 50
-    P2P_PEER_MAX_OUTGOING_CONNECTIONS: int = 60
-    P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS: int = 15
+    P2P_PEER_MAX_OUTGOING_CONNECTIONS: int = 59  # Leave ONE for REBOUND.
+    P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS: int = 10
+    P2P_PEER_MAX_CHECK_PEER_CONNECTIONS: int = 5
+
+    # Maximum number of entrypoints in check_entrypoints queue.
+    P2P_QUEUE_SIZE: int = 100
 
     # Maximum period without receiving any messages from ther peer (in seconds).
     PEER_IDLE_TIMEOUT: int = 60
@@ -581,13 +591,16 @@ class HathorSettings(BaseModel):
             self.P2P_PEER_MAX_INCOMING_CONNECTIONS
             + self.P2P_PEER_MAX_OUTGOING_CONNECTIONS
             + self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+            + self.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS
+            + 1  # REBOUND SLOT CONNECTION
         )
         if self.PEER_MAX_CONNECTIONS != slot_total:
             raise ValueError(
                 f'PEER_MAX_CONNECTIONS ({self.PEER_MAX_CONNECTIONS}) must equal '
                 f'P2P_PEER_MAX_INCOMING_CONNECTIONS ({self.P2P_PEER_MAX_INCOMING_CONNECTIONS}) + '
                 f'P2P_PEER_MAX_OUTGOING_CONNECTIONS ({self.P2P_PEER_MAX_OUTGOING_CONNECTIONS}) + '
-                f'P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS '
-                f'({self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS}) = {slot_total}'
+                f'P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS ({self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS}) + '
+                f'P2P_PEER_MAX_CHECK_PEER_CONNECTIONS ({self.P2P_PEER_MAX_CHECK_PEER_CONNECTIONS}) + '
+                f'REBOUND SLOT VACANCY (1 extra slot ) = {slot_total}'
             )
         return self

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -380,6 +380,11 @@ class HathorSettings(BaseModel):
     # Number max of connections in the p2p network
     PEER_MAX_CONNECTIONS: int = 125
 
+    # Max Number of each connection slot (int):
+    P2P_PEER_MAX_INCOMING_CONNECTIONS: int = 50
+    P2P_PEER_MAX_OUTGOING_CONNECTIONS: int = 60
+    P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS: int = 15
+
     # Maximum period without receiving any messages from ther peer (in seconds).
     PEER_IDLE_TIMEOUT: int = 60
 
@@ -567,5 +572,22 @@ class HathorSettings(BaseModel):
             raise ValueError(
                 f'invalid tokens: GENESIS_TOKENS={genesis_tokens}, '
                 f'GENESIS_TOKEN_UNITS={genesis_token_units}, DECIMAL_PLACES={decimal_places}'
+            )
+        return self
+
+    @model_validator(mode='after')
+    def _validate_peer_connection_slots(self) -> Self:
+        slot_total = (
+            self.P2P_PEER_MAX_INCOMING_CONNECTIONS
+            + self.P2P_PEER_MAX_OUTGOING_CONNECTIONS
+            + self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS
+        )
+        if self.PEER_MAX_CONNECTIONS != slot_total:
+            raise ValueError(
+                f'PEER_MAX_CONNECTIONS ({self.PEER_MAX_CONNECTIONS}) must equal '
+                f'P2P_PEER_MAX_INCOMING_CONNECTIONS ({self.P2P_PEER_MAX_INCOMING_CONNECTIONS}) + '
+                f'P2P_PEER_MAX_OUTGOING_CONNECTIONS ({self.P2P_PEER_MAX_OUTGOING_CONNECTIONS}) + '
+                f'P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS '
+                f'({self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS}) = {slot_total}'
             )
         return self


### PR DESCRIPTION
### Motivation
RFCs avaiable: https://github.com/HathorNetwork/internal-rfcs/tree/design/connection-pool-slots/projects/p2p-projects/connection-pool-slots/

The original Pull Request for slotting the connection pool (https://github.com/HathorNetwork/hathor-core/pull/1266 ) was proposed for subdividing the connections into four main groups, allowing for a more solid infrastructure against attacks onto hathor-core.

The original PR has been subdivided into two smaller ones - the first one (#1613  ) focusing on the development of a SlotsManager class to handle the distribution and coordination of protocols between the ConnectionsSlot classes (OUTGOING, INCOMING, BOOTSTRAP) - and the current one focusing on adding a fourth class to the system, which necessitates its own PR due to the inner complexities of the necessary infrastructure. 

The fourth class - CheckEntrypoints - is meant to be a simple security measure for the full node. When the amount of non-bootstrap outbound type of connections becomes too high (outgoing slot), to the point of making it too full, we shift these to a special slot, called "Check Entrypoints". This is done so to check which are these entrypoints that we are connecting ourselves too, so to see if they present some malicious behaviour or intent.

If the connection reaches the "READY" state, we consider it enough proof for lack of malicious intent. Afterwards, we grab the entrypoints the other peer displays as the ones it is connected to as well, putting then in a queue of entrypoints.

This queue must be routinely popped, and the entrypoint wrapped to a HathorProtocol instance, establishing a connection with it and repeating the cycle.

When the queue becomes empty and all connections are cleared, the check entrypoints slots becomes empty once more, and the analysis is complete. The verified entrypoints will be marked in a set within the slot. The protocols whose connection did not reach the READY state will be terminated, and their entrypoints will not be appended to the set of verified entrypoints, after the analysis. (Perhaps a set of the entrypoints whose connection could not be established makes more sense?

Notes

1. This PR has flaking issues and may have compatibility constraints, as the idea for now is to discuss the ideas and implementations described within its code body;
2. SlotsManager is not fully developed here, as we left the previous state of functioning to discuss better the check entrypoints bit.
3. Many core tests need to be re-worked.
4. Check entrypoints needs still to be reworked significantly.


### Acceptance Criteria
- When OUTGOING slot full, we need to change the connection's type and add it to the checkEp slot.
- Add fully functioning Check EP slot
- Add entrypoint queue
- Add verified entrypoints (or unverified entrypoints counterpart)
- Dequeued entrypoints need to be wrapped into a protocol and should connect later, being added preferably back to the check_entrypoints slot without being lost due to latency (say, while a new connection from the queue is still being created, we should reserve a spot within the slot for when it arrives later, not letting any other connection take its place).
- When READY, protocol must be finished.
- Check Entrypoints needs to be empty as a slot eventually, as it exists solely to solve the surgent overflow of the outgoing slot. Whenever the surge stops, so must the slot flow back to being empty (as well as its queue), leaving the entrypoint set of verification as a result of the research.

### Checklist
Not production ready