### PR TITLE
fix(nano): handle voided blocks in state API

### DIFF
--- a/hathor/nanocontracts/resources/state.py
+++ b/hathor/nanocontracts/resources/state.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     from hathor.nanocontracts.storage import NCContractStorage
     from hathor.transaction import Block
 
+MAX_TIMESTAMP_BLOCKS: int = 100
+
 
 @register_resource
 class NanoContractStateResource(Resource):
@@ -72,10 +74,10 @@ class NanoContractStateResource(Resource):
             return error_response.json_dumpb()
 
         nc_storage: NCContractStorage
-        block: Block
-        block_hash: Optional[bytes]
+        block: Block | None = None
+        block_hashes: list[bytes] | bytes | None
         try:
-            block_hash = bytes.fromhex(params.block_hash) if params.block_hash else None
+            block_hashes = bytes.fromhex(params.block_hash) if params.block_hash else None
         except ValueError:
             # This error will be raised in case the block_hash parameter is an invalid hex
             request.setResponseCode(400)
@@ -84,8 +86,8 @@ class NanoContractStateResource(Resource):
 
         if params.block_height is not None:
             # Get hash of the block with the height
-            block_hash = self.manager.tx_storage.indexes.height.get(params.block_height)
-            if block_hash is None:
+            block_hashes = self.manager.tx_storage.indexes.height.get(params.block_height)
+            if block_hashes is None:
                 # No block hash was found with this height
                 request.setResponseCode(400)
                 error_response = ErrorResponse(
@@ -94,29 +96,41 @@ class NanoContractStateResource(Resource):
                                 )
                 return error_response.json_dumpb()
         elif params.timestamp is not None:
-            block_hashes, has_more = self.manager.tx_storage.indexes.sorted_blocks.get_older(
+            ts_hashes, has_more = self.manager.tx_storage.indexes.sorted_blocks.get_older(
                 timestamp=params.timestamp,
                 hash_bytes=None,
-                count=1,
+                count=MAX_TIMESTAMP_BLOCKS,
             )
-            if not block_hashes:
-                # No block hash was found before this timestamp
+            if not ts_hashes:
                 request.setResponseCode(400)
                 error_response = ErrorResponse(
                     success=False,
                     error=f'No block hash was found before timestamp {params.timestamp}.'
                 )
                 return error_response.json_dumpb()
-            assert len(block_hashes) == 1
-            block_hash = block_hashes[0]
+            assert len(ts_hashes) <= MAX_TIMESTAMP_BLOCKS
+            block_hashes = ts_hashes
 
-        if block_hash:
-            try:
-                block = self.manager.tx_storage.get_block(block_hash)
-            except AssertionError:
-                # This block hash is not from a block
-                request.setResponseCode(400)
-                error_response = ErrorResponse(success=False, error=f'Invalid block_hash {params.block_hash}.')
+        if block_hashes:
+            if isinstance(block_hashes, bytes):
+                block_hashes = [block_hashes]
+            assert isinstance(block_hashes, list)
+            for block_hash in block_hashes:
+                try:
+                    current_block = self.manager.tx_storage.get_block(block_hash)
+                except AssertionError:
+                    # This block hash is not from a block
+                    request.setResponseCode(400)
+                    error_response = ErrorResponse(success=False, error=f'Invalid block_hash {params.block_hash}.')
+                    return error_response.json_dumpb()
+                meta = current_block.get_metadata()
+                if not meta.voided_by:
+                    block = current_block
+                    assert meta.nc_block_root_id is not None, f'expected root id to be set on block {block.hash_hex}'
+                    break
+            if block is None:
+                request.setResponseCode(404)
+                error_response = ErrorResponse(success=False, error='Couldn\'t find non-voided block')
                 return error_response.json_dumpb()
         else:
             block = self.manager.tx_storage.get_best_block()

--- a/hathor_tests/resources/nanocontracts/test_state.py
+++ b/hathor_tests/resources/nanocontracts/test_state.py
@@ -23,10 +23,11 @@ from hathor.nanocontracts.types import (
 )
 from hathor.nanocontracts.utils import sign_openssl
 from hathor.simulator.utils import add_new_block
-from hathor.transaction import Transaction, TxInput
+from hathor.transaction import Block, Transaction, TxInput
 from hathor.transaction.headers import NanoHeader
 from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.transaction.scripts import P2PKH
+from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
 from hathor_tests.utils import add_blocks_unlock_reward, get_genesis_key
 
@@ -609,3 +610,42 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         assert response12.json_value()['calls']['get_return_tuple()'] == {
             'value': ['bar', '1' * 64]
         }
+
+    async def test_state_by_timestamp_with_voided_block(self) -> None:
+        """Test that querying nano contract state by timestamp correctly skips voided blocks."""
+        dag_builder = TestDAGBuilder.from_manager(self.manager)
+        date_last_bet = 1699579721
+
+        artifacts = dag_builder.build_from_str(f"""
+            blockchain genesis b[1..11]
+            blockchain b10 a[11..12]
+            b10 < dummy
+            a12.weight = 3
+
+            nc1.nc_id = "{self.bet_id.hex()}"
+            nc1.nc_method = initialize("00", {date_last_bet})
+            nc1 <-- b11
+
+            b11 < a11
+        """)
+
+        artifacts.propagate_with(self.manager)
+
+        b11, a11 = artifacts.get_typed_vertices(('b11', 'a11'), Block)
+        nc1 = artifacts.get_typed_vertex('nc1', Transaction)
+
+        # After the reorg, b11 is voided and a11 is the best chain
+        assert b11.get_metadata().voided_by
+        assert not a11.get_metadata().voided_by
+        assert b11.timestamp < a11.timestamp
+
+        # Query state by b11's timestamp (voided block).
+        response = await self.web.get(
+            'state', [
+                (b'id', nc1.hash.hex().encode('ascii')),
+                (b'timestamp', str(b11.timestamp).encode('ascii')),
+            ]
+        )
+        # The NC was confirmed by b11 which is now voided, so the contract
+        # should not exist at this point (b10). The API must return 404, not crash.
+        assert response.responseCode == 404


### PR DESCRIPTION
### Motivation

There's a bug in the `/nano_contracts/state` API. It supports retrieving nano state by timestamp, which gets the newest block before the requested timestamp. It uses the timestamp index to do that, however that index may return voided blocks, in which case it triggers an assertion downstream. This PRs fixes this by retrieving up to 100 sequential blocks from this index, and iterating them until finding a non-voided block to fetch the nano state from.

### Acceptance Criteria

- Update the `/nano_contracts/state` API so it fetches up to 100 blocks from the timestamp index, until it finds a non-voided block.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 