### PR TITLE
tests(nano): convert all tests to BlueprintVersion.V2

### DIFF
--- a/hathor/nanocontracts/blueprint_service.py
+++ b/hathor/nanocontracts/blueprint_service.py
@@ -137,7 +137,7 @@ class BlueprintService:
         blueprint: type[Blueprint],
         *,
         strict: bool = False,
-        blueprint_version: BlueprintVersion = BlueprintVersion.V1,  # TODO: Change to V2 after all tests are updated
+        blueprint_version: BlueprintVersion | None = None
     ) -> None:
         """Register a single blueprint in the catalog."""
         self.nc_catalog.register_blueprints(
@@ -148,5 +148,4 @@ class BlueprintService:
 
     def register_blueprints(self, blueprints: dict[bytes, type[Blueprint]], *, strict: bool = False) -> None:
         """Register multiple blueprints in the catalog."""
-        # TODO: Change to V2 after all tests are updated
-        self.nc_catalog.register_blueprints(blueprints, strict=strict, blueprint_version=BlueprintVersion.V1)
+        self.nc_catalog.register_blueprints(blueprints, strict=strict)

--- a/hathor_tests/dag_builder/test_dag_builder.py
+++ b/hathor_tests/dag_builder/test_dag_builder.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
+from hathor import HATHOR_TOKEN_UID
 from hathor.nanocontracts import Blueprint, Context, OnChainBlueprint, public
 from hathor.nanocontracts.types import NCDepositAction, NCWithdrawalAction, TokenUid
 from hathor.nanocontracts.utils import load_builtin_blueprint_for_ocb
@@ -21,6 +21,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context, initial: int) -> None:
+        action = ctx.get_single_action(HATHOR_TOKEN_UID)
+        ctx.authorize(action)
         self.counter = initial
 
     @public
@@ -286,14 +288,14 @@ class DAGBuilderTestCase(unittest.TestCase):
         tx2 = artifacts.by_name['tx2'].vertex
         tx3 = artifacts.by_name['tx3'].vertex
 
-        ctx2 = tx2.get_nano_header().get_context(blueprint_version=BlueprintVersion.V1)
-        self.assertEqual(dict(ctx2.actions), {
+        ctx2 = tx2.get_nano_header().get_context(BlueprintVersion.V2)
+        self.assertEqual(dict(ctx2.actions_by_token), {
             tka_id: (NCDepositAction(token_uid=tka_id, amount=5),),
             htr_id: (NCDepositAction(token_uid=htr_id, amount=10),),
         })
 
-        ctx3 = tx3.get_nano_header().get_context(blueprint_version=BlueprintVersion.V1)
-        self.assertEqual(dict(ctx3.actions), {
+        ctx3 = tx3.get_nano_header().get_context(BlueprintVersion.V2)
+        self.assertEqual(dict(ctx3.actions_by_token), {
             htr_id: (NCDepositAction(token_uid=htr_id, amount=3),),
             tka_id: (NCWithdrawalAction(token_uid=tka_id, amount=2),),
         })

--- a/hathor_tests/event/test_event_manager.py
+++ b/hathor_tests/event/test_event_manager.py
@@ -1,3 +1,4 @@
+from hathor import HATHOR_TOKEN_UID
 from hathor.event.model.event_data import TokenCreatedData
 from hathor.event.model.event_type import EventType
 from hathor.event.storage import EventRocksDBStorage
@@ -16,10 +17,13 @@ from hathor_tests.utils import create_tokens
 class _TokenFactoryBlueprint(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        action = ctx.get_single_action(HATHOR_TOKEN_UID)
+        ctx.authorize(action)
 
     @public(allow_deposit=True)
     def create_token(self, ctx: Context) -> None:
+        action = ctx.get_single_action(HATHOR_TOKEN_UID)
+        ctx.authorize(action)
         self.syscall.create_deposit_token(
             token_name='Deposit Token',
             token_symbol='DBT',

--- a/hathor_tests/nanocontracts/blueprints/test_bet.py
+++ b/hathor_tests/nanocontracts/blueprints/test_bet.py
@@ -188,7 +188,7 @@ class NCBetBlueprintTestCase(BlueprintTestCase):
         action = NCDepositAction(token_uid=token_uid, amount=1)
         context = self.create_context(caller_id=address_bytes, actions=[action])
         score = '1x1'
-        with self.assertNCFail('InvalidToken', 'token different from 00'):
+        with self.assertNCFail('NCFail', 'expected exactly 1 action for token 00'):
             self.runner.call_public_method(self.nc_id, 'bet', context, address_bytes, score)
 
     def test_withdraw_wrong_token(self) -> None:
@@ -198,5 +198,5 @@ class NCBetBlueprintTestCase(BlueprintTestCase):
         self.assertNotEqual(token_uid, self.token_uid)
         action = NCWithdrawalAction(token_uid=token_uid, amount=1)
         context = self.create_context(caller_id=bet1.address, actions=[action])
-        with self.assertNCFail('InvalidToken', 'token different from 00'):
+        with self.assertNCFail('NCFail', 'expected exactly 1 action for token 00'):
             self.runner.call_public_method(self.nc_id, 'withdraw', context)

--- a/hathor_tests/nanocontracts/blueprints/unittest.py
+++ b/hathor_tests/nanocontracts/blueprints/unittest.py
@@ -76,7 +76,7 @@ class BlueprintTestCase(unittest.TestCase):
         blueprint_class: type[Blueprint],
         blueprint_id: BlueprintId | None = None,
         *,
-        blueprint_version: BlueprintVersion = BlueprintVersion.V1,  # TODO: Change to V2 after all tests are updated
+        blueprint_version: BlueprintVersion | None = None,
     ) -> BlueprintId:
         """Register a blueprint class with an optional id, allowing contracts to be created from it."""
         if blueprint_id is None:

--- a/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
+++ b/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
@@ -2,7 +2,6 @@ import os
 import re
 from typing import Any, NamedTuple, Optional
 
-from hathor.conf import HathorSettings
 from hathor.crypto.util import decode_address, get_address_b58_from_public_key_bytes
 from hathor.nanocontracts import OnChainBlueprint
 from hathor.nanocontracts.nc_types import NCType, make_nc_type_for_arg_type as make_nc_type
@@ -25,13 +24,12 @@ from hathor.transaction import Transaction
 from hathor.transaction.scripts import P2PKH
 from hathor.util import initialize_hd_wallet, not_none
 from hathor.wallet import KeyPair
+from hathorlib.conf.settings import FeatureSetting
 
 from ...utils import DEFAULT_WORDS
 from .. import test_blueprints
 from ..blueprints.unittest import BlueprintTestCase
 from .utils import get_ocb_private_key
-
-settings = HathorSettings()
 
 ON_CHAIN_BET_NC_CODE: str = load_builtin_blueprint_for_ocb('bet.py', 'Bet', test_blueprints)
 TX_OUTPUT_SCRIPT_NC_TYPE = make_nc_type(TxOutputScript)
@@ -50,7 +48,8 @@ class BetInfo(NamedTuple):
 class OnChainBetBlueprintTestCase(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.manager = self.create_peer('unittests')
+        settings = self._settings.copy(update=dict(ENABLE_BLUEPRINT_V2=FeatureSetting.ENABLED))
+        self.manager = self.create_peer('unittests', settings=settings)
         self.wallet = initialize_hd_wallet(DEFAULT_WORDS)
         self.token_uid = TokenUid(settings.HATHOR_TOKEN_UID)
         self.initialize_contract()  # will set self.nc_id, self.runner, self.nc_storage
@@ -267,7 +266,7 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
         action = NCDepositAction(token_uid=token_uid, amount=1)
         context = self.create_context(caller_id=address_bytes, actions=[action])
         score = '1x1'
-        with self.assertNCFail('InvalidToken', 'token different from 00'):
+        with self.assertNCFail('NCFail', 'expected exactly 1 action for token 00'):
             self.runner.call_public_method(self.nc_id, 'bet', context, address_bytes, score)
 
     def test_withdraw_wrong_token(self) -> None:
@@ -277,5 +276,5 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
         self.assertNotEqual(token_uid, self.token_uid)
         action = NCWithdrawalAction(token_uid=token_uid, amount=1)
         context = self.create_context(caller_id=bet1.address, actions=[action])
-        with self.assertNCFail('InvalidToken', 'token different from 00'):
+        with self.assertNCFail('NCFail', 'expected exactly 1 action for token 00'):
             self.runner.call_public_method(self.nc_id, 'withdraw', context)

--- a/hathor_tests/nanocontracts/test_actions.py
+++ b/hathor_tests/nanocontracts/test_actions.py
@@ -40,7 +40,8 @@ from hathor_tests.nanocontracts.utils import assert_nc_failure_reason, set_nano_
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_actions=[
         NCActionType.DEPOSIT,
@@ -49,7 +50,8 @@ class MyBlueprint(Blueprint):
         NCActionType.ACQUIRE_AUTHORITY,
     ])
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def revoke(self, ctx: Context, token_uid: TokenUid, revoke_mint: bool, revoke_melt: bool) -> None:
@@ -57,10 +59,14 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_withdrawal=True, allow_grant_authority=True)
     def mint(self, ctx: Context, token_uid: TokenUid, amount: int) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.mint_tokens(token_uid, amount)
 
     @public(allow_deposit=True, allow_withdrawal=True)
     def melt(self, ctx: Context, token_uid: TokenUid, amount: int) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.melt_tokens(token_uid, amount)
 
 

--- a/hathor_tests/nanocontracts/test_actions_fee.py
+++ b/hathor_tests/nanocontracts/test_actions_fee.py
@@ -16,10 +16,13 @@ from hathor_tests.nanocontracts.test_reentrancy import HTR_TOKEN_UID
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True, allow_grant_authority=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_deposit=True, allow_grant_authority=True, allow_withdrawal=True,)
     def create_fee_token(self, ctx: Context, name: str, symbol: str, amount: int) -> TokenUid:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         return self.syscall.create_fee_token(
             token_name=name,
             token_symbol=symbol,
@@ -30,11 +33,14 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_withdrawal=True, allow_grant_authority=True)
     def create_deposit_token(self, ctx: Context, name: str, symbol: str, amount: int) -> TokenUid:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         return self.syscall.create_deposit_token(token_name=name, token_symbol=symbol, amount=amount)
 
     @public(allow_deposit=True, allow_withdrawal=True)
     def noop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_deposit=True, allow_withdrawal=True)
     def get_tokens_from_nc(
@@ -46,6 +52,8 @@ class MyBlueprint(Blueprint):
         fee_payment_token: TokenUid,
         fee_amount: int
     ) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         action = NCWithdrawalAction(token_uid=token_uid, amount=token_amount)
         fees = [NCFee(token_uid=TokenUid(fee_payment_token), amount=fee_amount)]
         self.syscall.get_contract(nc_id, blueprint_id=None).public(action, fees=fees).noop()
@@ -60,6 +68,8 @@ class MyBlueprint(Blueprint):
         fee_payment_token: TokenUid,
         fee_amount: int
     ) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         action = NCDepositAction(token_uid=token_uid, amount=token_amount)
         fees = [NCFee(token_uid=TokenUid(fee_payment_token), amount=fee_amount)]
         self.syscall.get_contract(nc_id, blueprint_id=None).public(action, fees=fees).noop()
@@ -72,6 +82,8 @@ class MyOtherBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_withdrawal=True, allow_grant_authority=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.fbt_uid = self.syscall.create_fee_token(
             token_name='FBT',
             token_symbol='FBT',
@@ -101,6 +113,8 @@ class MyOtherBlueprint(Blueprint):
         nc_id: ContractId,
         pay_with_dbt: bool,
     ) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         if pay_with_dbt:
             fees = [NCFee(token_uid=TokenUid(self.dbt_uid), amount=100)]
         else:
@@ -116,6 +130,8 @@ class MyOtherBlueprint(Blueprint):
         ctx: Context,
         nc_id: ContractId
     ) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.get_contract(nc_id, blueprint_id=None).public(
             NCDepositAction(token_uid=self.fbt_uid, amount=1000),
             NCDepositAction(token_uid=self.ftt_uid, amount=1000),

--- a/hathor_tests/nanocontracts/test_allowed_actions.py
+++ b/hathor_tests/nanocontracts/test_allowed_actions.py
@@ -42,19 +42,23 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def deposit(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_withdrawal=True)
     def withdrawal(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_grant_authority=True)
     def grant_authority(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_acquire_authority=True)
     def acquire_authority(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @fallback
     def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> None:

--- a/hathor_tests/nanocontracts/test_authorities_call_another.py
+++ b/hathor_tests/nanocontracts/test_authorities_call_another.py
@@ -29,7 +29,8 @@ class CalleeBlueprint(Blueprint):
 
     @public(allow_grant_authority=True, allow_acquire_authority=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def revoke_from_self(self, ctx: Context, token_uid: TokenUid, mint: bool, melt: bool) -> None:
@@ -50,11 +51,14 @@ class CallerBlueprint(Blueprint):
 
     @public(allow_grant_authority=True)
     def initialize(self, ctx: Context, other_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.other_id = other_id
 
     @public(allow_grant_authority=True, allow_reentrancy=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def grant_to_other(self, ctx: Context, token_uid: TokenUid, mint: bool, melt: bool) -> None:
@@ -63,6 +67,8 @@ class CallerBlueprint(Blueprint):
 
     @public(allow_grant_authority=True, allow_reentrancy=True)
     def revoke_from_self(self, ctx: Context, token_uid: TokenUid, mint: bool, melt: bool) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.revoke_authorities(token_uid, revoke_mint=mint, revoke_melt=melt)
 
     @public
@@ -91,6 +97,8 @@ class CallerBlueprint(Blueprint):
 
     @public(allow_grant_authority=True)
     def call_revoke_all_from_other(self, ctx: Context, token_uid: TokenUid) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         assert self.syscall.can_mint(token_uid)
         assert self.syscall.can_melt(token_uid)
         self.syscall.get_contract(self.other_id, blueprint_id=None).public().revoke_all_from_other(

--- a/hathor_tests/nanocontracts/test_authorities_index.py
+++ b/hathor_tests/nanocontracts/test_authorities_index.py
@@ -33,6 +33,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_grant_authority=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.token_uid = None
 
     @public
@@ -44,11 +46,14 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def create_token(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.token_uid = self.syscall.create_deposit_token(token_name='token a', token_symbol='TKA', amount=1000)
 
     @public(allow_acquire_authority=True)
     def allow_acquire_authority(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def acquire_authority(self, ctx: Context, other_id: ContractId) -> None:

--- a/hathor_tests/nanocontracts/test_blueprint.py
+++ b/hathor_tests/nanocontracts/test_blueprint.py
@@ -65,7 +65,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_withdrawal=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def fail(self, ctx: Context) -> None:

--- a/hathor_tests/nanocontracts/test_blueprints/bet.py
+++ b/hathor_tests/nanocontracts/test_blueprints/bet.py
@@ -18,7 +18,6 @@ from hathor import (
     Address,
     Blueprint,
     Context,
-    NCAction,
     NCDepositAction,
     NCFail,
     NCWithdrawalAction,
@@ -35,19 +34,11 @@ Result: TypeAlias = str
 Amount: TypeAlias = int
 
 
-class InvalidToken(NCFail):
-    pass
-
-
 class ResultAlreadySet(NCFail):
     pass
 
 
 class ResultNotAvailable(NCFail):
-    pass
-
-
-class TooManyActions(NCFail):
     pass
 
 
@@ -110,8 +101,6 @@ class Bet(Blueprint):
     @public
     def initialize(self, ctx: Context, oracle_script: TxOutputScript, token_uid: TokenUid,
                    date_last_bet: Timestamp) -> None:
-        if len(ctx.actions) != 0:
-            raise NCFail('must be a single call')
         self.bets_total = {}
         self.bets_address = {}
         self.address_details = {}
@@ -137,28 +126,13 @@ class Bet(Blueprint):
         if not self.has_result():
             raise ResultNotAvailable
 
-    def fail_if_invalid_token(self, action: NCAction) -> None:
-        """Fail the execution if the token is invalid."""
-        if action.token_uid != self.token_uid:
-            token1 = self.token_uid.hex() if self.token_uid else None
-            token2 = action.token_uid.hex() if action.token_uid else None
-            raise InvalidToken(f'invalid token ({token1} != {token2})')
-
-    def _get_action(self, ctx: Context) -> NCAction:
-        """Return the only action available; fails otherwise."""
-        if len(ctx.actions) != 1:
-            raise TooManyActions('only one token supported')
-        if self.token_uid not in ctx.actions:
-            raise InvalidToken(f'token different from {self.token_uid.hex()}')
-        return ctx.get_single_action(self.token_uid)
-
     @public(allow_deposit=True)
     def bet(self, ctx: Context, address: Address, score: str) -> None:
         """Make a bet."""
-        action = self._get_action(ctx)
+        action = ctx.get_single_action(self.token_uid)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         self.fail_if_result_is_available()
-        self.fail_if_invalid_token(action)
         if ctx.block.timestamp > self.date_last_bet:
             raise TooLate(f'cannot place bets after {self.date_last_bet}')
         amount = Amount(action.amount)
@@ -189,10 +163,10 @@ class Bet(Blueprint):
     @public(allow_withdrawal=True)
     def withdraw(self, ctx: Context) -> None:
         """Withdraw tokens after the final result is set."""
-        action = self._get_action(ctx)
+        action = ctx.get_single_action(self.token_uid)
+        ctx.authorize(action)
         assert isinstance(action, NCWithdrawalAction)
         self.fail_if_result_is_not_available()
-        self.fail_if_invalid_token(action)
         caller_address = ctx.get_caller_address()
         assert caller_address is not None
         address = Address(caller_address)

--- a/hathor_tests/nanocontracts/test_blueprints/contract_accessor_blueprint.py
+++ b/hathor_tests/nanocontracts/test_blueprints/contract_accessor_blueprint.py
@@ -35,6 +35,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.message = 'initialize called'
 
     @view
@@ -43,7 +45,9 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def simple_public_method(self, ctx: Context, name: str) -> str:
-        actions = ctx.actions.get(HATHOR_TOKEN_UID, ())
+        for action in ctx.all_actions:
+            ctx.authorize(action)
+        actions = ctx.actions_by_token.get(HATHOR_TOKEN_UID, ())
 
         # Setting the attribute makes it easier to test on OCBs with the DagBuilder,
         # as the returned value is not accessible.

--- a/hathor_tests/nanocontracts/test_blueprints/swap_demo.py
+++ b/hathor_tests/nanocontracts/test_blueprints/swap_demo.py
@@ -46,8 +46,11 @@ class SwapDemo(Blueprint):
         if token_a == token_b:
             raise NCFail
 
-        if set(ctx.actions.keys()) != {token_a, token_b}:
+        if set(ctx.actions_by_token.keys()) != {token_a, token_b}:
             raise InvalidTokens
+
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
         self.token_a = token_a
         self.token_b = token_b
@@ -59,11 +62,11 @@ class SwapDemo(Blueprint):
     def swap(self, ctx: Context) -> None:
         """Execute a token swap."""
 
-        if set(ctx.actions.keys()) != {self.token_a, self.token_b}:
+        if set(ctx.actions_by_token.keys()) != {self.token_a, self.token_b}:
             raise InvalidTokens
 
-        action_a = ctx.get_single_action(self.token_a)
-        action_b = ctx.get_single_action(self.token_b)
+        action_a = ctx.get_token_single_action(self.token_a)
+        action_b = ctx.get_token_single_action(self.token_b)
 
         if not (
             (isinstance(action_a, NCDepositAction) and isinstance(action_b, NCWithdrawalAction))
@@ -73,6 +76,9 @@ class SwapDemo(Blueprint):
 
         if not self.is_ratio_valid(action_a.amount, action_b.amount):
             raise InvalidRatio
+
+        ctx.authorize(action_a)
+        ctx.authorize(action_b)
 
         # All good! Let's accept the transaction.
         self.swaps_counter += 1

--- a/hathor_tests/nanocontracts/test_call_other_contract.py
+++ b/hathor_tests/nanocontracts/test_call_other_contract.py
@@ -41,6 +41,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context, initial: int) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter = initial
         self.contract = None
 
@@ -50,6 +52,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def split_balance(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         if self.contract is None:
             return
 
@@ -62,6 +66,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True)
     def get_tokens_from_another_contract(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         if self.contract is None:
             return
 

--- a/hathor_tests/nanocontracts/test_consensus.py
+++ b/hathor_tests/nanocontracts/test_consensus.py
@@ -8,7 +8,7 @@ from hathor.nanocontracts.exception import NCFail, NCInvalidSignature
 from hathor.nanocontracts.method import Method
 from hathor.nanocontracts.nc_types import make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage.contract_storage import Balance
-from hathor.nanocontracts.types import NCAction, NCActionType, NCDepositAction, NCWithdrawalAction, TokenUid
+from hathor.nanocontracts.types import NCActionType, NCDepositAction, NCWithdrawalAction, TokenUid
 from hathor.nanocontracts.utils import sign_pycoin
 from hathor.simulator.trigger import StopAfterMinimumBalance, StopAfterNMinedBlocks
 from hathor.simulator.utils import add_new_blocks
@@ -39,16 +39,6 @@ class MyBlueprint(Blueprint):
         self.counter = 0
         self.token_uid = token_uid
 
-    def _get_action(self, ctx: Context) -> NCAction:
-        if len(ctx.actions) != 1:
-            raise NCFail('only one token allowed')
-        if self.token_uid not in ctx.actions:
-            raise NCFail('invalid token')
-        action = ctx.get_single_action(self.token_uid)
-        if action.token_uid != self.token_uid:
-            raise NCFail('invalid token')
-        return action
-
     @public
     def nop(self, ctx: Context, a: int) -> None:
         self.counter += 1
@@ -56,14 +46,16 @@ class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def deposit(self, ctx: Context) -> None:
         self.counter += 1
-        action = self._get_action(ctx)
+        action = ctx.get_single_action(self.token_uid)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         self.total += action.amount
 
     @public(allow_withdrawal=True)
     def withdraw(self, ctx: Context) -> None:
         self.counter += 1
-        action = self._get_action(ctx)
+        action = ctx.get_single_action(self.token_uid)
+        ctx.authorize(action)
         assert isinstance(action, NCWithdrawalAction)
         self.total -= action.amount
 

--- a/hathor_tests/nanocontracts/test_contract_create_contract.py
+++ b/hathor_tests/nanocontracts/test_contract_create_contract.py
@@ -32,10 +32,12 @@ class MyBlueprint1(Blueprint):
 
     @public(allow_deposit=True, allow_grant_authority=True)
     def initialize(self, ctx: Context, blueprint_id: BlueprintId, initial: int, token_uid: Optional[TokenUid]) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.token_uid = token_uid
         if initial > 0:
             token_uid = TokenUid(HATHOR_TOKEN_UID)
-            action = ctx.get_single_action(token_uid)
+            action = ctx.get_token_single_action(token_uid)
             salt = b'x'
             assert isinstance(action, NCDepositAction)
             new_action = NCDepositAction(token_uid=token_uid, amount=action.amount - initial)
@@ -66,12 +68,15 @@ class MyBlueprint1(Blueprint):
 
     @public(allow_deposit=True)
     def mint(self, ctx: Context, amount: int) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         assert self.token_uid is not None
         self.syscall.mint_tokens(self.token_uid, amount)
 
     @public(allow_withdrawal=True)
     def withdraw(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
 
 class MyBlueprint2(Blueprint):
@@ -80,6 +85,8 @@ class MyBlueprint2(Blueprint):
 
     @public(allow_grant_authority=True)
     def initialize(self, ctx: Context, blueprint_id: BlueprintId, initial: int, token_uid: Optional[TokenUid]) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter = initial
         self.token_uid = token_uid
 

--- a/hathor_tests/nanocontracts/test_contract_upgrade.py
+++ b/hathor_tests/nanocontracts/test_contract_upgrade.py
@@ -42,7 +42,7 @@ class ProxyBlueprint(Blueprint):
     def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> None:
         blueprint_id = self.syscall.get_contract(self.contract, blueprint_id=None).get_blueprint_id()
         self.syscall.get_proxy(blueprint_id) \
-            .get_public_method(method_name, *ctx.actions_list) \
+            .get_public_method(method_name, *ctx.all_actions) \
             .call_with_nc_args(nc_args)
 
 

--- a/hathor_tests/nanocontracts/test_execution_order.py
+++ b/hathor_tests/nanocontracts/test_execution_order.py
@@ -30,6 +30,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context, token_uid: TokenUid) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.token_uid = token_uid
 
     def assert_balance(self, token_uid: TokenUid, *, before: int, current: int) -> None:
@@ -44,16 +46,22 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def deposit(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_htr_balance(before=10, current=10)
         self.assert_token_balance(before=0, current=10)
 
     @public(allow_withdrawal=True)
     def withdrawal(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_htr_balance(before=10, current=10)
         self.assert_token_balance(before=10, current=7)
 
     @public(allow_grant_authority=True)
     def mint(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_htr_balance(before=10, current=10)
         self.assert_token_balance(before=0, current=0)
         self.syscall.mint_tokens(self.token_uid, amount=300)
@@ -68,6 +76,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_grant_authority=True)
     def melt(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_htr_balance(before=7, current=7)
         self.assert_token_balance(before=300, current=300)
         self.syscall.melt_tokens(self.token_uid, amount=200)
@@ -82,6 +92,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def deposit_into_another(self, ctx: Context, contract_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_token_balance(before=0, current=10)
         action = NCDepositAction(token_uid=self.token_uid, amount=7)
         self.syscall \
@@ -92,6 +104,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def accept_deposit_from_another(self, ctx: Context, contract_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_token_balance(before=0, current=7)
         action = NCDepositAction(token_uid=self.token_uid, amount=3)
         self.syscall.get_contract(contract_id, blueprint_id=None).public(action).accept_deposit_from_another_callback()
@@ -99,10 +113,14 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_reentrancy=True)
     def accept_deposit_from_another_callback(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_token_balance(before=3, current=6)
 
     @public(allow_withdrawal=True)
     def withdraw_from_another(self, ctx: Context, contract_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_token_balance(before=6, current=5)
         action = NCWithdrawalAction(token_uid=self.token_uid, amount=2)
         self.syscall.get_contract(contract_id, blueprint_id=None).public(action).accept_withdrawal_from_another(
@@ -112,6 +130,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True)
     def accept_withdrawal_from_another(self, ctx: Context, contract_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_token_balance(before=4, current=2)
         action = NCWithdrawalAction(token_uid=self.token_uid, amount=1)
         self.syscall.get_contract(contract_id, blueprint_id=None) \
@@ -121,6 +141,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True, allow_reentrancy=True)
     def accept_withdrawal_from_another_callback(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.assert_token_balance(before=7, current=6)
 
 

--- a/hathor_tests/nanocontracts/test_exposed_properties.py
+++ b/hathor_tests/nanocontracts/test_exposed_properties.py
@@ -24,10 +24,11 @@ KNOWN_CASES = [
     'hathor.Blueprint.log',
     'hathor.Blueprint.some_new_attribute',
     'hathor.Blueprint.syscall',
-    'hathor.Context.actions',
-    'hathor.Context.actions_list',
+    'hathor.Context.actions_by_token',
+    'hathor.Context.all_actions',
     'hathor.Context.authorize',
     'hathor.Context.block',
+    'hathor.Context.blueprint_version',
     'hathor.Context.caller_id',
     'hathor.Context.get_caller_address',
     'hathor.Context.get_caller_contract_id',
@@ -160,10 +161,9 @@ if version_info[1] == 13:
 
 KNOWN_CASES.sort()
 
-BLUEPRINT_V2_ONLY = (
-    'blueprint_version',
-    'all_actions',
-    'actions_by_token',
+BLUEPRINT_V1_DEPRECATED = (
+    'actions',
+    'actions_list',
 )
 
 
@@ -229,8 +229,8 @@ def check_property_writeable(obj: object, prop_name: str) -> tuple[bool, object 
 
 def should_skip_attr(prop_name: str) -> bool:
     """Used to simulate AST restrictions and prevent loops."""
-    if prop_name in BLUEPRINT_V2_ONLY:
-        # Since the test harness uses Blueprint V1, calling V2 properties raises NCFail.
+    if prop_name in BLUEPRINT_V1_DEPRECATED:
+        # Since the test harness uses Blueprint V2, calling V1 properties raises NCFail.
         # We can simply skip them, for now.
         return True
     return '__' in prop_name

--- a/hathor_tests/nanocontracts/test_fallback_method.py
+++ b/hathor_tests/nanocontracts/test_fallback_method.py
@@ -34,10 +34,13 @@ from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @fallback(allow_deposit=True)
     def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> str:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         assert method_name == 'unknown'
         match nc_args:
             case NCRawArgs():
@@ -63,6 +66,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def call_another_fallback(self, ctx: Context, contract_id: ContractId) -> str:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         return self.syscall.get_contract(contract_id, blueprint_id=None).public().fallback()
 
     @public

--- a/hathor_tests/nanocontracts/test_fee_tokens.py
+++ b/hathor_tests/nanocontracts/test_fee_tokens.py
@@ -32,10 +32,13 @@ from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_withdrawal=True)
     def create_deposit_token(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.create_deposit_token(
             token_name='deposit-based token',
             token_symbol='DBT',
@@ -44,6 +47,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True)
     def create_fee_token(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.create_fee_token(
             token_name='fee-based token',
             token_symbol='FBT',
@@ -52,7 +57,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
 
 class FeeTokensTestCase(BlueprintTestCase):

--- a/hathor_tests/nanocontracts/test_get_contract.py
+++ b/hathor_tests/nanocontracts/test_get_contract.py
@@ -34,6 +34,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True)
     def address_subtract(self, ctx: Context, address: Address, amount: Amount) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter += 1
         if self.totals[address] < amount:
             raise NCFail('cannot subtract')

--- a/hathor_tests/nanocontracts/test_indexes.py
+++ b/hathor_tests/nanocontracts/test_indexes.py
@@ -23,6 +23,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter = 0
 
     @public

--- a/hathor_tests/nanocontracts/test_indexes2.py
+++ b/hathor_tests/nanocontracts/test_indexes2.py
@@ -25,6 +25,8 @@ from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context, amount: int) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.create_deposit_token(token_name='token a', token_symbol='TKA', amount=amount)
 
 

--- a/hathor_tests/nanocontracts/test_initialize_method_accessor.py
+++ b/hathor_tests/nanocontracts/test_initialize_method_accessor.py
@@ -24,7 +24,8 @@ from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 class MyBlueprint1(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def test_initialize_method(self, ctx: Context, blueprint_id: BlueprintId, name: str) -> str:
@@ -54,6 +55,8 @@ class MyBlueprint1(Blueprint):
 class MyBlueprint2(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context, name: str) -> str:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         return f'hello {name}'
 
 

--- a/hathor_tests/nanocontracts/test_nanocontract.py
+++ b/hathor_tests/nanocontracts/test_nanocontract.py
@@ -456,14 +456,14 @@ class NCNanoContractTestCase(unittest.TestCase):
         ))
         nc2.update_hash()
         nc2_nano_header = nc2.get_nano_header()
-        context = nc2_nano_header.get_context(BlueprintVersion.V1)
-        self.assertEqual(2, len(context.actions))
+        context = nc2_nano_header.get_context(BlueprintVersion.V2)
+        self.assertEqual(2, len(context.actions_by_token))
 
-        action1 = context.get_single_action(TokenUid(b'token-a'))
+        action1 = context.get_token_single_action(TokenUid(b'token-a'))
         assert isinstance(action1, NCWithdrawalAction)
         self.assertEqual(action1.amount, 50)
 
-        action2 = context.get_single_action(TokenUid(b'\0'))
+        action2 = context.get_token_single_action(TokenUid(b'\0'))
         assert isinstance(action2, NCDepositAction)
         self.assertEqual(action2.amount, 90)
 

--- a/hathor_tests/nanocontracts/test_nc_exec_logs.py
+++ b/hathor_tests/nanocontracts/test_nc_exec_logs.py
@@ -61,6 +61,8 @@ class MyBlueprint1(Blueprint):
 
     @public(allow_deposit=True)
     def call_another_public(self, ctx: Context, contract_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.log.debug('call_another_public() called on MyBlueprint1', contract_id=contract_id)
         action = NCDepositAction(token_uid=TokenUid(b'\x00'), amount=5)
         result1 = self.syscall.get_contract(contract_id, blueprint_id=None).public(action).sum(1, 2)
@@ -75,6 +77,8 @@ class MyBlueprint2(Blueprint):
 
     @public(allow_deposit=True)
     def sum(self, ctx: Context, a: int, b: int) -> int:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.log.debug('sum() called on MyBlueprint2', a=a, b=b)
         return a + b
 

--- a/hathor_tests/nanocontracts/test_negative_balance.py
+++ b/hathor_tests/nanocontracts/test_negative_balance.py
@@ -39,11 +39,13 @@ class FlashLoan(Blueprint):
 
     @public(allow_withdrawal=True)
     def withdrawal(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_deposit=True, allow_reentrancy=True)
     def deposit(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def call(self, ctx: Context, contract_id: ContractId, method_name: str, amount: Amount) -> None:
@@ -70,12 +72,14 @@ class UseFlashLoan(Blueprint):
     @public(allow_deposit=True)
     def nop(self, ctx: Context, loan_id: ContractId) -> None:
         action = ctx.get_single_action(HATHOR_TOKEN_UID)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         assert action.amount == self.syscall.get_current_balance(HATHOR_TOKEN_UID)
 
     @public(allow_deposit=True)
     def nop_payback(self, ctx: Context, loan_id: ContractId) -> None:
         action = ctx.get_single_action(HATHOR_TOKEN_UID)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         assert action.amount == self.syscall.get_current_balance(action.token_uid)
 

--- a/hathor_tests/nanocontracts/test_proxy_accessor.py
+++ b/hathor_tests/nanocontracts/test_proxy_accessor.py
@@ -38,6 +38,8 @@ class MyBlueprint1(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context, blueprint_id: BlueprintId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.other_blueprint_id = blueprint_id
 
     @public
@@ -140,7 +142,8 @@ class MyBlueprint1(Blueprint):
 
     @public(allow_deposit=True)
     def nop_public(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def call_itself_through_double_proxy_other(self, ctx: Context) -> None:
@@ -218,6 +221,8 @@ class MyBlueprint2(Blueprint):
 
     @public(allow_deposit=True)
     def hello(self, ctx: Context, name: str) -> str:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         return f'hello {name}'
 
     @fallback
@@ -234,7 +239,8 @@ class MyBlueprint2(Blueprint):
 
     @public(allow_deposit=True)
     def nop_public(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @view
     def nop_view(self) -> None:

--- a/hathor_tests/nanocontracts/test_reentrancy.py
+++ b/hathor_tests/nanocontracts/test_reentrancy.py
@@ -22,6 +22,7 @@ class MyBlueprint(Blueprint):
     def deposit(self, ctx: Context) -> None:
         address = ctx.caller_id
         action = ctx.get_single_action(HTR_TOKEN_UID)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         amount = action.amount
 
@@ -84,6 +85,7 @@ class AttackerBlueprint(Blueprint):
         self.counter = 0
 
         action = ctx.get_single_action(HTR_TOKEN_UID)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         self.amount = Amount(action.amount)
 
@@ -92,18 +94,25 @@ class AttackerBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_deposit=True, allow_reentrancy=True)
     def attack(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self._run_attack('transfer_to', 'attack')
 
     @public(allow_deposit=True, allow_reentrancy=True)
     def attack_fixed(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self._run_attack('fixed_transfer_to', 'attack_fixed')
 
     @public(allow_deposit=True, allow_reentrancy=True)
     def attack_protected(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self._run_attack('protected_transfer_to', 'attack_protected')
 
     def _run_attack(self, method: str, callback: str) -> None:

--- a/hathor_tests/nanocontracts/test_reset_counters.py
+++ b/hathor_tests/nanocontracts/test_reset_counters.py
@@ -23,7 +23,8 @@ from hathorlib.nanocontracts.types import ContractId, NCDepositAction
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def create_token(self, ctx: Context, fail: bool) -> None:

--- a/hathor_tests/nanocontracts/test_syscalls.py
+++ b/hathor_tests/nanocontracts/test_syscalls.py
@@ -47,11 +47,13 @@ class MyBlueprint(Blueprint):
 class OtherBlueprint(Blueprint):
     @public(allow_deposit=True, allow_grant_authority=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_grant_authority=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public
     def revoke(self, ctx: Context, token_uid: TokenUid, revoke_mint: bool, revoke_melt: bool) -> None:
@@ -70,11 +72,14 @@ class FeeTokenBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_grant_authority=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_deposit=True, allow_grant_authority=True)
     def create_fee_token(self, ctx: Context, name: str, symbol: str, amount: int,
                          fee_payment_token: TokenUid) -> TokenUid:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         token_uid = self.syscall.create_fee_token(
             token_name=name,
             token_symbol=symbol,
@@ -86,14 +91,20 @@ class FeeTokenBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_grant_authority=True)
     def create_deposit_token(self, ctx: Context, name: str, symbol: str, amount: int) -> TokenUid:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         return self.syscall.create_deposit_token(token_name=name, token_symbol=symbol, amount=amount)
 
     @public(allow_deposit=True)
     def mint(self, ctx: Context, token: TokenUid, amount: int, fee_payment_token: TokenUid) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.mint_tokens(token, amount=amount, fee_payment_token=fee_payment_token)
 
     @public(allow_deposit=True)
     def melt(self, ctx: Context, token: TokenUid, amount: int, fee_payment_token: TokenUid) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.melt_tokens(token, amount=amount, fee_payment_token=fee_payment_token)
 
 
@@ -102,10 +113,14 @@ class ProxyCallerBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter = 0
 
     @public(allow_deposit=True)
     def increment(self, ctx: Context, value: int) -> int:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter += value
         return self.counter
 
@@ -115,15 +130,21 @@ class TargetBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter = 0
 
     @public(allow_deposit=True)
     def increment(self, ctx: Context, value: int) -> int:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.counter += value
         return self.counter
 
     @public(allow_deposit=True)
     def proxy_increment(self, ctx: Context, blueprint_id: BlueprintId, value: int) -> int:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         """Call the increment method of another blueprint using proxy_call_public_method_nc_args."""
         args_parser = ArgsOnly.from_arg_types((int,))
         args_bytes = args_parser.serialize_args_bytes((value,))
@@ -131,7 +152,7 @@ class TargetBlueprint(Blueprint):
         # Pay 1 HTR as fee for the proxy call
         fees: list[NCFee] = [NCFee(token_uid=TokenUid(HATHOR_TOKEN_UID), amount=1)]
         result = self.syscall.get_proxy(blueprint_id) \
-            .public(*ctx.actions_list, fees=fees) \
+            .public(*ctx.all_actions, fees=fees) \
             .increment \
             .call_with_nc_args(nc_args)
         assert isinstance(result, int)

--- a/hathor_tests/nanocontracts/test_token_creation.py
+++ b/hathor_tests/nanocontracts/test_token_creation.py
@@ -25,12 +25,15 @@ class MyBlueprint(Blueprint):
 
     @public(allow_deposit=True)
     def initialize(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.a = ''
         self.b = 0
 
     @public(allow_withdrawal=True)
     def withdraw(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_deposit=True)
     def create_deposit_token(
@@ -43,6 +46,8 @@ class MyBlueprint(Blueprint):
         mint_authority: bool,
         melt_authority: bool,
     ) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.create_deposit_token(
             token_name=token_name,
             token_symbol=token_symbol,
@@ -150,9 +155,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         JKL._update_token_info_from_outputs(token_dict=jkl_token_info)
         assert jkl_token_info[settings.HATHOR_TOKEN_UID].amount == -2
 
-        jkl_context = JKL.get_nano_header().get_context(BlueprintVersion.V1)
+        jkl_context = JKL.get_nano_header().get_context(BlueprintVersion.V2)
         htr_token_uid = TokenUid(settings.HATHOR_TOKEN_UID)
-        assert jkl_context.actions[htr_token_uid] == (NCWithdrawalAction(token_uid=htr_token_uid, amount=3),)
+        assert jkl_context.actions_by_token[htr_token_uid] == (NCWithdrawalAction(token_uid=htr_token_uid, amount=3),)
 
         assert not tx2.is_nano_contract()
         assert tx2.get_metadata().voided_by is None

--- a/hathor_tests/nanocontracts/test_token_creation2.py
+++ b/hathor_tests/nanocontracts/test_token_creation2.py
@@ -24,10 +24,13 @@ from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 class MyBlueprint(Blueprint):
     @public(allow_deposit=True, allow_withdrawal=True)
     def initialize(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
     @public(allow_withdrawal=True)
     def create_deposit_token(self, ctx: Context) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.create_deposit_token(
             token_name='deposit-based token',
             token_symbol='DBT',
@@ -36,7 +39,8 @@ class MyBlueprint(Blueprint):
 
     @public(allow_withdrawal=True)
     def nop(self, ctx: Context) -> None:
-        pass
+        for action in ctx.all_actions:
+            ctx.authorize(action)
 
 
 class TokenCreationTestCase(BlueprintTestCase):

--- a/hathor_tests/nanocontracts/test_token_creation3.py
+++ b/hathor_tests/nanocontracts/test_token_creation3.py
@@ -33,6 +33,8 @@ class TokenCreatorBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_withdrawal=True)
     def create_and_withdraw_token(self, ctx: Context, amount: Amount) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         self.syscall.create_deposit_token(
             token_name='deposit-based token',
             token_symbol='DBT',
@@ -47,8 +49,10 @@ class WithdrawFromCreatorBlueprint(Blueprint):
 
     @public(allow_deposit=True, allow_withdrawal=True)
     def create_token_in_another_contract(self, ctx: Context, creator_id: ContractId) -> None:
+        for action in ctx.all_actions:
+            ctx.authorize(action)
         creator = self.syscall.get_contract(creator_id, blueprint_id=None)
-        creator.public(*ctx.actions_list).create_and_withdraw_token(1000)
+        creator.public(*ctx.all_actions).create_and_withdraw_token(1000)
 
 
 class TokenCreation3TestCase(BlueprintTestCase):

--- a/hathor_tests/nanocontracts/test_violations.py
+++ b/hathor_tests/nanocontracts/test_violations.py
@@ -14,7 +14,7 @@ class MyBlueprint(Blueprint):
 
     @public
     def modify_actions(self, ctx: Context) -> None:
-        ctx.actions[b'\00'] = NCDepositAction(token_uid=b'\00', amount=1_000)  # type: ignore
+        ctx.actions_by_token[b'\00'] = NCDepositAction(token_uid=b'\00', amount=1_000)  # type: ignore
 
     @public
     def modify_vertex(self, ctx: Context) -> None:

--- a/hathor_tests/resources/nanocontracts/test_state.py
+++ b/hathor_tests/resources/nanocontracts/test_state.py
@@ -78,6 +78,7 @@ class MyBlueprint(Blueprint):
     @public(allow_deposit=True)
     def bet(self, ctx: Context, address: Address, score: str) -> None:
         action = ctx.get_single_action(self.token_uid)
+        ctx.authorize(action)
         assert isinstance(action, NCDepositAction)
         self.total += action.amount
         partial = self.address_details.get(address, {})

--- a/hathorlib/hathorlib/nanocontracts/catalog.py
+++ b/hathorlib/hathorlib/nanocontracts/catalog.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from hathorlib.nanocontracts.blueprint import Blueprint
 
 
+_DEFAULT_BLUEPRINT_VERSION: BlueprintVersion = BlueprintVersion.V2
 _BLUEPRINTS_MAPPER: dict[str, type[Blueprint]] = {}
 
 
@@ -46,13 +47,13 @@ class NCBlueprintCatalog:
         blueprints: dict[bytes, type[Blueprint]],
         *,
         strict: bool = False,
-        blueprint_version: BlueprintVersion = BlueprintVersion.V2,
+        blueprint_version: BlueprintVersion | None = None,
     ) -> None:
         """Register blueprints in the catalog."""
         for blueprint_id, blueprint in blueprints.items():
             if strict and (existing := self._blueprints.get(blueprint_id)):
                 raise ValueError(f'Blueprint {blueprint_id.hex()} is already registered: {existing[0].__name__}')
-            self._blueprints[blueprint_id] = blueprint, blueprint_version
+            self._blueprints[blueprint_id] = blueprint, blueprint_version or _DEFAULT_BLUEPRINT_VERSION
 
     def get_all(self) -> dict[bytes, type[Blueprint]]:
         """Return a copy of all registered blueprints."""


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1628

### Motivation

Previous PRs introduced the new `BlueprintVersion.V2`, which coexists with V1. For that reason, existing tests were kept using V1 APIs. This PR updates all of them to use V2.

### Acceptance Criteria

- Update all existing tests to use `BlueprintVersion.V2` instead of V1.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 