### PR TITLE
chore(linter): replace flake8 and isort with ruff

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
         if: steps.prep.outputs.check-version
         env:
           VERSION: ${{ steps.prep.outputs.check-version }}
-        run: make check-custom
+        run: make check-version
       - name: Set up QEMU  # arm64 is not available natively
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,16 @@ mypy:
 dmypy:
 	dmypy run --timeout 86400 -- -p hathor -p hathor_tests -p extras.custom_tests
 
+.PHONY: ruff
+ruff:
+	ruff check $(py_sources)
+
 .PHONY: flake8
-flake8:
-	flake8 $(py_sources)
+flake8: ruff
 
 .PHONY: isort-check
 isort-check:
-	isort --ac --check-only $(py_sources)
+	ruff check $(py_sources) --select I
 
 .PHONY: yamllint
 yamllint:
@@ -92,20 +95,28 @@ yamllint:
 check-custom:
 	bash ./extras/custom_checks.sh
 
+.PHONY: check-version
+check-version:
+	bash ./extras/custom_checks.sh check_version_match
+
 .PHONY: check
-check: check-custom yamllint flake8 isort-check mypy
+check: check-custom yamllint ruff mypy
 
 .PHONY: dcheck
-dcheck: check-custom yamllint flake8 isort-check dmypy
+dcheck: check-custom yamllint ruff dmypy
 
 # formatting:
 
 .PHONY: fmt
 fmt: isort
 
+.PHONY: ruff-fmt
+ruff-fmt:
+	ruff format hathor/ hathor_tests/ extras/custom_tests/ hathor_cli/
+
 .PHONY: isort
 isort:
-	isort --ac $(py_sources)
+	ruff check $(py_sources) --select I --fix
 
 # generation:
 

--- a/extras/custom_checks.sh
+++ b/extras/custom_checks.sh
@@ -51,69 +51,52 @@ function check_version_match() {
     return $EXITCODE
 }
 
-function check_do_not_use_builtin_random_in_tests() {
-	# If the check fails, return 1
-	# If the check passes, return 0
-	exclude=(
-		hathor/merged_mining/debug_api.py
-		hathor/client.py
-		hathor_cli/tx_generator.py
-		hathor_tests/test_utils/test_leb128.py
-	)
-	exclude_params=()
-	for item in "${exclude[@]}"; do
-		exclude_params+=(-not -path "*$item*")
-	done
-	if find "${SOURCE_DIRS[@]}" "${exclude_params[@]}" -type f -print0 | xargs -0 grep -l '\<import .*\<random\>'; then
-		echo '"import random" found in the files above'
-		echo 'use `self.rng` or `hathor.util.Random` instead of `random`'
-		return 1
-	fi
-	return 0
+function check_deprecated_typing() {
+    local args=(
+        check hathor hathor_tests
+        --select TID251
+        --config "lint.flake8-tidy-imports.banned-api = {'typing.List' = {msg = 'use builtin list instead'}, 'typing.Tuple' = {msg = 'use builtin tuple instead'}, 'typing.Dict' = {msg = 'use builtin dict instead'}, 'typing.Set' = {msg = 'use builtin set instead'}, 'typing.FrozenSet' = {msg = 'use builtin frozenset instead'}, 'typing.AbstractSet' = {msg = 'use builtin set or collections.abc.Set as appropriate instead'}, 'typing.DefaultDict' = {msg = 'use collections.defaultdict or builtin dict instead'}, 'typing.OrderedDict' = {msg = 'use collections.OrderedDict or builtin dict instead'}}"
+    )
+    ruff -q "${args[@]}"
 }
 
-function check_deprecated_typing() {
-	if grep -RIn '\<typing .*\<import .*\<\(Tuple\|List\|Dict\|Set\|FrozenSet\|AbstractSet\|DefaultDict\|OrderedDict\)\>' "${SOURCE_DIRS[@]}"; then
-		echo 'do not use typing.List/Tuple/Dict/... for type annotations use builtin list/tuple/dict/... instead'
-		echo 'for more info check the PEP 585 doc: https://peps.python.org/pep-0585/'
-		return 1
-	fi
-	return 0
+function check_do_not_use_builtin_random_in_tests() {
+    local args=(
+        check hathor hathor_tests
+        --select TID251
+        --config "lint.flake8-tidy-imports.banned-api = {'random' = {msg = 'use self.rng or hathor.util.Random instead of random'}}"
+        --config "lint.per-file-ignores = {'hathor/client.py' = ['TID251'], 'hathor/merged_mining/debug_api.py' = ['TID251'], 'hathor/util.py' = ['TID251'], 'hathor_tests/test_utils/test_leb128.py' = ['TID251']}"
+    )
+    ruff -q "${args[@]}"
 }
 
 function check_do_not_import_tests_in_hathor() {
-	if grep -Rn '\<.*import .*hathor_tests.*\>\|\<.*from .*hathor_tests.* import\>' "hathor" | grep -v '# skip-import-tests-custom-check'; then
-		echo 'do not import test definitions in the hathor module'
-		echo 'move them from hathor_tests to hathor instead'
-		echo 'alternatively, comment `# skip-import-tests-custom-check` to exclude a line.'
-		return 1
-	fi
-	return 0
+    local args=(
+        check hathor
+        --select TID251
+        --config "lint.flake8-tidy-imports.banned-api = {'hathor_tests' = {msg = 'do not import test definitions in the hathor module'}}"
+    )
+    ruff -q "${args[@]}"
 }
 
 function check_do_not_import_from_hathor_in_entrypoints() {
-    EXCLUDES=(--exclude=builder.py)
-    PATTERN='^import .*hathor.*\|^from .*hathor.* import'
-
-    if grep -Rn $EXCLUDES "$PATTERN" "hathor_cli" | grep -v 'from hathor_cli.run_node import RunNode' | grep -v '# skip-cli-import-custom-check'; then
-        echo 'do not import from `hathor` in the module-level of a CLI entrypoint.'
-        echo 'instead, import locally inside the function that uses the import.'
-        echo 'alternatively, comment `# skip-cli-import-custom-check` to exclude a line.'
-        return 1
-    fi
-    return 0
+    local args=(
+        check hathor_cli
+        --select TID253
+        --config "lint.flake8-tidy-imports.banned-module-level-imports = ['hathor']"
+        --config "lint.per-file-ignores = {'hathor_cli/builder.py' = ['TID253'], 'hathor_cli/generate_genesis.py' = ['TID253'], 'hathor_cli/run_node_args.py' = ['TID253'], 'hathor_cli/events_simulator/event_forwarding_websocket_factory.py' = ['TID253'], 'hathor_cli/events_simulator/event_forwarding_websocket_protocol.py' = ['TID253']}"
+    )
+    ruff -q "${args[@]}"
 }
 
 function check_do_not_import_twisted_reactor_directly() {
-    EXCLUDES="--exclude=reactor.py --exclude=conftest.py"
-    PATTERN='\<.*from .*twisted.internet import .*reactor\>'
-
-    if grep -Rn $EXCLUDES "$PATTERN" "${SOURCE_DIRS[@]}"; then
-        echo 'do not use `from twisted.internet import reactor` directly.'
-        echo 'instead, use `hathor.reactor.get_global_reactor()`.'
-        return 1
-    fi
-    return 0
+    local args=(
+        check hathor
+        --select TID251
+        --config "lint.flake8-tidy-imports.banned-api = {'twisted.internet.reactor' = {msg = 'use hathor.reactor.get_global_reactor() instead'}}"
+        --config "lint.per-file-ignores = {'hathor/reactor/reactor.py' = ['TID251']}"
+    )
+    ruff -q "${args[@]}"
 }
 
 function check_do_not_compare_enums_with_is() {
@@ -129,27 +112,41 @@ function check_do_not_compare_enums_with_is() {
 # List of functions to be executed
 checks=(
 	check_version_match
-	check_do_not_use_builtin_random_in_tests
 	check_deprecated_typing
+	check_do_not_use_builtin_random_in_tests
 	check_do_not_import_tests_in_hathor
 	check_do_not_import_from_hathor_in_entrypoints
 	check_do_not_import_twisted_reactor_directly
 	check_do_not_compare_enums_with_is
 )
 
+function run_check() {
+    local check_name="$1"
+    shift
+
+    "$@"
+    local result=$?
+    if [ $result -ne 0 ]; then
+        echo -e "${RED}Check ${check_name} FAILED${NC}"
+        any_check_failed=1
+    else
+        echo -e "${GREEN}Check ${check_name} PASSED${NC}"
+    fi
+}
+
+selected_checks=()
+if [ $# -gt 0 ]; then
+    selected_checks=("$@")
+else
+    selected_checks=("${checks[@]}")
+fi
+
 # Initialize a variable to track if any check fails
 any_check_failed=0
 
 # Loop over all checks
-for check in "${checks[@]}"; do
-	$check
-	result=$?
-	if [ $result -ne 0 ]; then
-		echo -e "${RED}Check $check FAILED${NC}"
-		any_check_failed=1
-	else
-		echo -e "${GREEN}Check $check PASSED${NC}"
-	fi
+for check in "${selected_checks[@]}"; do
+	run_check "$check" "$check"
 done
 
 # Exit with code 0 if no check failed, otherwise exit with code 1

--- a/hathor/_openapi/register.py
+++ b/hathor/_openapi/register.py
@@ -34,17 +34,17 @@ def register_resource(resource_class: ResourceClass) -> ResourceClass:
 def get_registered_resources() -> list[type[Resource]]:
     """ Returns a list with all the resources registered for the docs
     """
-    import hathor.event.resources.event  # noqa: F401
-    import hathor.feature_activation.resources.feature  # noqa: F401
-    import hathor.healthcheck.resources.healthcheck  # noqa: F401
-    import hathor.nanocontracts.resources  # noqa: F401
-    import hathor.p2p.resources  # noqa: F401
-    import hathor.profiler.resources  # noqa: F401
-    import hathor.stratum.resources  # noqa: F401
-    import hathor.transaction.resources  # noqa: F401
-    import hathor.version_resource  # noqa: F401
-    import hathor.wallet.resources.nano_contracts  # noqa: F401
-    import hathor.wallet.resources.thin_wallet  # noqa: F401
-    import hathor.websocket  # noqa: F401
+    import hathor.event.resources.event
+    import hathor.feature_activation.resources.feature
+    import hathor.healthcheck.resources.healthcheck
+    import hathor.nanocontracts.resources
+    import hathor.p2p.resources
+    import hathor.profiler.resources
+    import hathor.stratum.resources
+    import hathor.transaction.resources
+    import hathor.version_resource
+    import hathor.wallet.resources.nano_contracts
+    import hathor.wallet.resources.thin_wallet
+    import hathor.websocket
     global _registered_resources
     return _registered_resources

--- a/hathor/nanocontracts/context.py
+++ b/hathor/nanocontracts/context.py
@@ -21,6 +21,7 @@ from hathor.nanocontracts.exception import NCInvalidContext
 from hathor.nanocontracts.types import CallerId, NCAction, TokenUid
 from hathor.nanocontracts.vertex_data import create_block_data_from_block, create_vertex_data_from_vertex
 from hathor.transaction.exceptions import TxValidationError
+
 # Re-export from hathorlib for backward compatibility
 from hathorlib.nanocontracts.context import *  # noqa: F401,F403
 from hathorlib.nanocontracts.context import Context  # noqa: F401

--- a/hathor/nanocontracts/nc_exec_logs.py
+++ b/hathor/nanocontracts/nc_exec_logs.py
@@ -24,6 +24,7 @@ from hathor.nanocontracts import NCFail
 from hathor.nanocontracts.runner import CallInfo
 from hathor.transaction import Transaction
 from hathor.types import VertexId
+
 # Re-export from hathorlib for backward compatibility
 from hathorlib.nanocontracts.nc_exec_logs import (  # noqa: F401
     MAX_EVENT_SIZE,

--- a/hathor/nanocontracts/vertex_data.py
+++ b/hathor/nanocontracts/vertex_data.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from hathor.transaction.scripts import P2PKH, MultiSig, parse_address_script
 from hathor.utils.weight import weight_to_work
 from hathorlib.nanocontracts.types import VertexId
+
 # Re-export from hathorlib for backward compatibility
 from hathorlib.nanocontracts.vertex_data import *  # noqa: F401,F403
 from hathorlib.nanocontracts.vertex_data import (  # noqa: F401

--- a/hathor_tests/resources/test_openapi_register.py
+++ b/hathor_tests/resources/test_openapi_register.py
@@ -1,0 +1,16 @@
+import unittest
+
+from hathor._openapi.register import get_registered_resources
+from hathor.api_util import Resource
+
+
+class TestOpenAPIRegister(unittest.TestCase):
+    def test_get_registered_resources_imports_resource_modules(self) -> None:
+        resources = get_registered_resources()
+
+        self.assertGreater(len(resources), 0)
+        self.assertTrue(all(issubclass(resource, Resource) for resource in resources))
+
+        from hathor.event.resources.event import EventResource
+
+        self.assertIn(EventResource, resources)

--- a/poetry.lock
+++ b/poetry.lock
@@ -381,6 +381,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
@@ -619,23 +620,6 @@ files = [
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
 
 [[package]]
-name = "flake8"
-version = "7.1.1"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-groups = ["dev"]
-files = [
-    {file = "flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"},
-    {file = "flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.12.0,<2.13.0"
-pyflakes = ">=3.2.0,<3.3.0"
-
-[[package]]
 name = "flaky"
 version = "3.8.1"
 description = "Plugin for pytest that automatically reruns flaky tests."
@@ -753,7 +737,7 @@ test = ["coverage", "mock (>=4)", "pytest (>=7)", "pytest-cov", "pytest-mock (>=
 
 [[package]]
 name = "hathorlib"
-version = "0.14.0"
+version = "0.14.1"
 description = "Hathor Network base objects library"
 optional = false
 python-versions = ">=3.9,<4"
@@ -905,24 +889,6 @@ parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.20)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-groups = ["dev"]
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.4.6", optional = true, markers = "extra == \"colors\""}
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jedi"
@@ -1089,18 +1055,6 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "mnemonic"
@@ -1591,18 +1545,6 @@ files = [
 pyasn1 = ">=0.4.6,<0.6.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.12.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
-    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
-]
-
-[[package]]
 name = "pycoin"
 version = "0.92.20230326"
 description = "Utilities for Bitcoin and altcoin addresses and transaction manipulation."
@@ -1758,18 +1700,6 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
-
-[[package]]
-name = "pyflakes"
-version = "3.2.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
-]
 
 [[package]]
 name = "pygments"
@@ -2127,6 +2057,34 @@ type = "git"
 url = "https://github.com/hathornetwork/python-rocksdb.git"
 reference = "HEAD"
 resolved_reference = "f1da1157464db7ed050dff9a66da920394909e7b"
+
+[[package]]
+name = "ruff"
+version = "0.15.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e"},
+    {file = "ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477"},
+    {file = "ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5"},
+    {file = "ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12"},
+    {file = "ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c"},
+    {file = "ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4"},
+    {file = "ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d"},
+    {file = "ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580"},
+    {file = "ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de"},
+    {file = "ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1"},
+    {file = "ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2"},
+    {file = "ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac"},
+]
 
 [[package]]
 name = "sentry-sdk"
@@ -2828,4 +2786,4 @@ sentry = ["sentry-sdk", "structlog-sentry"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4"
-content-hash = "7c0832c1a10d81282c4994b7ea8488570484f3046fab0f3624708130dbc73220"
+content-hash = "a4f2c18ac2f07b5fd5d2270b125bc8ec7d9d76a8b4eeb9f44a180e8329968b6a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,13 @@ packages = [
 hathor-cli = 'hathor_cli.main:main'
 
 [tool.poetry.group.dev.dependencies]
-flake8 = "~7.1.1"
-isort = {version = "~5.13.2", extras = ["colors"]}
 mypy = {version = "^1.19.1", markers = "implementation_name == 'cpython'"}
 mypy-zope = {version = "^1.0.14", markers = "implementation_name == 'cpython'"}
 pytest = "~8.3.2"
 pytest-cov = "~5.0.0"
 flaky = "~3.8.1"
 pytest-xdist = "~3.6.1"
+ruff = "~0.15.5"
 yamllint = "~1.35.1"
 # stubs:
 types-requests = "=2.28.11.4"
@@ -90,13 +89,32 @@ packaging = "=26.0"
 [tool.poetry.extras]
 sentry = ["sentry-sdk", "structlog-sentry"]
 
-[tool.isort]
-combine_as_imports = true
-default_section = "THIRDPARTY"
-include_trailing_comma = true
-known_first_party = "hathor,hathor_tests"
-line_length = 119
-multi_line_output = 3
+[tool.ruff]
+line-length = 119
+target-version = "py311"
+
+[tool.ruff.lint]
+# E/W: pycodestyle errors and warnings. F: Pyflakes. I: import sorting.
+select = ["E", "F", "W", "I"]
+# Keep existing lambda assignments accepted by flake8.
+ignore = ["E731"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["hathor", "hathor_tests", "hathorlib"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-export the public blueprint API.
+"hathor/__init__.py" = ["F401"]
+# Imports resources for their registration side effects.
+"hathor/_openapi/register.py" = ["F401"]
+# Keeps the pattern-matching dispatch compact.
+"hathor/event/websocket/protocol.py" = ["E701"]
+# Re-export modules keep compatibility imports grouped with their source package.
+"hathor/nanocontracts/exception.py" = ["I001"]
+"hathor/nanocontracts/storage/__init__.py" = ["I001"]
+"hathor/nanocontracts/storage/backends.py" = ["I001"]
+"hathor/nanocontracts/storage/factory.py" = ["I001"]
 
 [tool.mypy]
 pretty = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,6 @@ exclude_lines =
 [coverage:html]
 directory = coverage_html_report
 
-[flake8]
-max-line-length = 119
-# E731 do not assign a lambda expression, use a def
-extend-ignore = E731
-# Ignore unused imports on nano contract re-export file
-per-file-ignores =
-    hathor/__init__.py:F401
-
 [mypy]
 ignore_missing_imports = True
 strict_optional = True


### PR DESCRIPTION
### Motivation

We want to consolidate Python linting and import sorting under Ruff so the project relies on a single, faster toolchain instead of separate `flake8`, `isort`, and several grep-based custom checks. This keeps existing developer and CI entry points intact while moving project-specific lint policies into centrally managed Ruff configuration.

### Acceptance Criteria

- `make check` and `make dcheck` should validate Python code with Ruff instead of `flake8` and `isort`, while the legacy `make flake8` and `make isort-check` targets should continue to work as compatibility aliases.
- some specific lints that were previously implemented in `extras/custom_checks.sh` should run as dedicated Ruff checks with the same scope and allowlists preserved, while the shell custom checks should continue covering the remaining rules for version consistency and enum comparisons.
- The repository should declare `ruff` as the development linting dependency, remove `flake8` and `isort` from project configuration and the lockfile.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged