### PR TITLE
refactor: improve handling of new vertices

### DIFF
--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -80,7 +80,7 @@ class BlockConsensusAlgorithm:
         assert not block.is_genesis
 
         parent = block.get_block_parent()
-        features = Features.from_vertex(settings=self._settings, feature_service=self.feature_service, vertex=parent)
+        features = Features.for_vertex(settings=self._settings, feature_service=self.feature_service, vertex=parent)
         return features.nanocontracts
 
     def mark_as_nc_fail_execution(self, tx: Transaction) -> None:

--- a/hathor/dag_builder/artifacts.py
+++ b/hathor/dag_builder/artifacts.py
@@ -61,8 +61,8 @@ class DAGArtifacts:
         Use `up_to` to stop propagation after the specified node has been propagated. Alternatively, use `up_to_before`
         to stop right before propagating the specified node.
 
-        Propagations are performed using `VertexHandler._old_on_new_vertex()`, which bypasses mempool rules by default.
-        Set `new_relayed_vertex` to True to apply these rules during propagation.
+        Propagations use the trusted entry point (`on_new_trusted_vertex`), which does not apply the
+        mempool-entry restrictions, so arbitrary DAGs can be built and replayed.
         """
         found_begin = self._last_propagated is None
         found_end = False
@@ -74,7 +74,7 @@ class DAGArtifacts:
 
             if found_begin:
                 try:
-                    assert manager.vertex_handler.on_new_relayed_vertex(vertex)
+                    assert manager.vertex_handler.on_new_trusted_vertex(vertex)
                 except Exception as e:
                     raise Exception(f'failed on_new_tx({node.name})') from e
                 for step_fn in self._step_fns:

--- a/hathor/feature_activation/utils.py
+++ b/hathor/feature_activation/utils.py
@@ -50,7 +50,7 @@ class Features:
         }
 
     @staticmethod
-    def from_vertex(*, settings: HathorSettings, feature_service: FeatureService, vertex: Vertex) -> Features:
+    def for_vertex(*, settings: HathorSettings, feature_service: FeatureService, vertex: Vertex) -> Features:
         """Return information about each feature according to the state in the provided vertex."""
         feature_states = feature_service.get_feature_states(vertex=vertex)
         feature_settings = Features.get_settings(settings)
@@ -92,7 +92,7 @@ class Features:
         block, and restrictive features are always enabled. This means restrictive features are applied in
         mempool verification regardless of features states in the current best block.
         """
-        features = Features.from_vertex(settings=settings, feature_service=feature_service, vertex=best_block)
+        features = Features.for_vertex(settings=settings, feature_service=feature_service, vertex=best_block)
         return Features(
             # Restrictive features (hardcoded as enabled):
             count_checkdatasig_op=True,

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -405,7 +405,7 @@ class HathorManager:
         """Return a contract runner for a given block."""
         nc_storage_factory = self.consensus_algorithm.nc_storage_factory
         block_storage = get_block_storage_from_block(nc_storage_factory, block)
-        features = Features.from_vertex(settings=self._settings, feature_service=self.feature_service, vertex=block)
+        features = Features.for_vertex(settings=self._settings, feature_service=self.feature_service, vertex=block)
         return self.runner_factory.create(
             runtime_version=features.nano_runtime_version,
             block_storage=block_storage,
@@ -856,23 +856,21 @@ class HathorManager:
 
         return self.on_new_tx(tx, propagate_to_peers=True)
 
-    def on_new_tx(
-        self,
-        vertex: BaseTransaction,
-        *,
-        quiet: bool = False,
-        propagate_to_peers: bool = True,
-        reject_locked_reward: bool = True,
-    ) -> bool:
+    def on_new_tx(self, vertex: BaseTransaction, *, propagate_to_peers: bool = True) -> bool:
         """ New method for adding transactions or blocks that steps the validation state machine.
 
+        Transactions enter the mempool here, so they are verified with the mempool-entry restrictions.
+
         :param vertex: transaction to be added
-        :param quiet: if True will not log when a new tx is accepted
         :param propagate_to_peers: if True will relay the tx to other peers if it is accepted
         """
-        success = self.vertex_handler.on_new_relayed_vertex(
-            vertex, quiet=quiet, reject_locked_reward=reject_locked_reward
-        )
+        match vertex:
+            case Transaction():
+                success = self.vertex_handler.on_new_mempool_transaction(vertex)
+            case Block():
+                success = self.vertex_handler.on_new_relayed_block(vertex)
+            case _:
+                raise AssertionError('unreachable')
 
         if propagate_to_peers and success:
             self.connections.send_tx_to_peers(vertex)

--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -197,7 +197,7 @@ class NCBlockExecutor:
         nc_cyclic_txs = sorted_txs.cyclic if sorted_txs else tuple()
         block_storage = self._nc_storage_factory.get_block_storage(parent_root_id)
         assert block_storage.get_root_id() == parent_root_id
-        features = Features.from_vertex(settings=self._settings, feature_service=self._feature_service, vertex=block)
+        features = Features.for_vertex(settings=self._settings, feature_service=self._feature_service, vertex=block)
 
         yield NCBeginBlock(
             block=block,

--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -603,7 +603,7 @@ class NodeBlockSync(SyncAgent):
         """This method is called when a block and its transactions are downloaded."""
         # Note: Any vertex and block could have already been added by another concurrent syncing peer.
         try:
-            yield self.vertex_handler.on_new_block(blk, deps=vertex_list)
+            yield self.vertex_handler.on_new_sync_block(blk, deps=vertex_list)
         except InvalidNewTransaction:
             self.protocol.send_error_and_close_connection('invalid vertex received')
 
@@ -1165,7 +1165,13 @@ class NodeBlockSync(SyncAgent):
         # Finally, it is either an unsolicited new transaction or block.
         self.log.debug('tx received in real time from peer', tx=tx.hash_hex, peer=self.protocol.get_peer_id())
         try:
-            success = self.vertex_handler.on_new_relayed_vertex(tx)
+            match tx:
+                case Transaction():
+                    success = self.vertex_handler.on_new_mempool_transaction(tx)
+                case Block():
+                    success = self.vertex_handler.on_new_relayed_block(tx)
+                case _:
+                    raise AssertionError('unreachable')
             if success:
                 self.protocol.connections.send_tx_to_peers(tx)
         except InvalidNewTransaction:

--- a/hathor/p2p/sync_v2/blockchain_streaming_client.py
+++ b/hathor/p2p/sync_v2/blockchain_streaming_client.py
@@ -117,7 +117,7 @@ class BlockchainStreamingClient:
 
         if self.tx_storage.can_validate_full(blk):
             try:
-                self.vertex_handler.on_new_block(blk, deps=[])
+                self.vertex_handler.on_new_sync_block(blk, deps=[])
             except HathorError:
                 self.fails(InvalidVertexError(blk.hash.hex()))
                 return

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -7,7 +7,6 @@ from hathor._openapi.register import register_resource
 from hathor.api_util import APIVersion, Resource, set_cors
 from hathor.crypto.util import decode_address
 from hathor.exception import InvalidNewTransaction
-from hathor.feature_activation.utils import Features
 from hathor.manager import HathorManager
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import create_output_script
@@ -108,7 +107,7 @@ class CreateTxResource(Resource):
         verifiers.vertex.verify_sigops_output(tx, enable_checkdatasig_count=True)
         verifiers.tx.verify_sigops_input(tx, enable_checkdatasig_count=True)
         best_block = self.manager.tx_storage.get_best_block()
-        params = VerificationParams.for_mempool(best_block=best_block, features=Features.all_enabled())
+        params = VerificationParams.for_apis(self.manager.tx_storage)
         # need to run verify_inputs first to check if all inputs exist
         verifiers.tx.verify_inputs(tx, params, skip_script=True)
         verifiers.vertex.verify_parents(tx)

--- a/hathor/verification/nano_header_verifier.py
+++ b/hathor/verification/nano_header_verifier.py
@@ -117,7 +117,7 @@ class NanoHeaderVerifier:
                 )
 
     def verify_method_call(self, tx: BaseTransaction, params: VerificationParams) -> None:
-        if not params.harden_nano_restrictions:
+        if not params.apply_mempool_restrictions:
             return
 
         assert tx.is_nano_contract()
@@ -172,7 +172,7 @@ class NanoHeaderVerifier:
                 raise NCTxValidationError from exception
 
     def verify_seqnum(self, tx: BaseTransaction, params: VerificationParams) -> None:
-        if not params.harden_nano_restrictions:
+        if not params.apply_mempool_restrictions:
             return
 
         assert tx.is_nano_contract()

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -361,7 +361,7 @@ class TransactionVerifier:
 
     def verify_tokens(self, tx: Transaction, params: VerificationParams) -> None:
         """Verify that all tokens are used and unique."""
-        if not params.harden_token_restrictions:
+        if not params.apply_mempool_restrictions:
             return
 
         if len(tx.tokens) > MAX_TOKENS_LENGTH:
@@ -392,7 +392,7 @@ class TransactionVerifier:
         """Verify that this transaction has no conflicts with confirmed transactions."""
         assert tx.storage is not None
 
-        if not params.reject_conflicts_with_confirmed_txs:
+        if not params.apply_mempool_restrictions:
             return
 
         between_counter = 0

--- a/hathor/verification/verification_params.py
+++ b/hathor/verification/verification_params.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from hathor.conf.settings import HathorSettings
+from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.utils import Features
 from hathor.transaction import Block
+from hathor.transaction.storage import TransactionStorage
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -14,30 +17,77 @@ class VerificationParams:
     """Contains every parameter/setting to run a single verification."""
 
     nc_block_root_id: bytes | None
-    reject_locked_reward: bool = True
     skip_block_weight_verification: bool = False
+    apply_mempool_restrictions: bool = False
     features: Features
 
-    reject_too_old_vertices: bool = False
-    harden_token_restrictions: bool = False
-    harden_nano_restrictions: bool = False
-    reject_conflicts_with_confirmed_txs: bool = False
+    @classmethod
+    def for_block(
+        cls,
+        *,
+        settings: HathorSettings,
+        feature_service: FeatureService,
+        parent_block: Block,
+    ) -> VerificationParams:
+        """Parameters for verifying blocks entering via sync."""
+        parent_meta = parent_block.get_metadata()
+        features = Features.for_vertex(settings=settings, feature_service=feature_service, vertex=parent_block)
+        return cls(nc_block_root_id=parent_meta.nc_block_root_id, features=features)
 
     @classmethod
-    def for_mempool(cls, *, best_block: Block, features: Features) -> VerificationParams:
-        """This is the appropriate parameters for verifying mempool transactions, realtime blocks and API pushes.
-
-        Other cases should instantiate `VerificationParams` manually with the appropriate parameter values.
-        """
-        best_block_meta = best_block.get_metadata()
-        if best_block_meta.nc_block_root_id is None:
-            assert best_block.is_genesis
-
+    def for_mempool(
+        cls,
+        *,
+        settings: HathorSettings,
+        tx_storage: TransactionStorage,
+        feature_service: FeatureService,
+    ) -> VerificationParams:
+        """Parameters for verifying transactions entering the mempool via mempool sync."""
+        best_block, root_id = _get_best_block_root_id(tx_storage)
+        features = Features.for_mempool(settings=settings, feature_service=feature_service, best_block=best_block)
         return cls(
-            nc_block_root_id=best_block_meta.nc_block_root_id,
+            nc_block_root_id=root_id,
+            apply_mempool_restrictions=True,
             features=features,
-            reject_too_old_vertices=True,
-            harden_token_restrictions=True,
-            harden_nano_restrictions=True,
-            reject_conflicts_with_confirmed_txs=True,
         )
+
+    @classmethod
+    def for_relay(
+        cls,
+        *,
+        settings: HathorSettings,
+        tx_storage: TransactionStorage,
+        feature_service: FeatureService,
+    ) -> VerificationParams:
+        """Parameters for verifying relayed/locally-created blocks and trusted locally-injected vertices.
+
+        These use the current feature states at the best block but do not apply the mempool-entry restrictions.
+        Transactions coming from the network or from APIs must use `for_mempool`/`for_apis` instead.
+        """
+        best_block, root_id = _get_best_block_root_id(tx_storage)
+        features = Features.for_mempool(settings=settings, feature_service=feature_service, best_block=best_block)
+        return cls(nc_block_root_id=root_id, features=features)
+
+    @classmethod
+    def for_apis(cls, tx_storage: TransactionStorage) -> VerificationParams:
+        """Parameters for verifying transactions submitted through public APIs.
+
+        API submissions are mempool-entry points, so they apply the same mempool-entry restrictions
+        (`apply_mempool_restrictions`) as `for_mempool`: `verify_old_timestamp`, `verify_tokens`,
+        `verify_conflict`, and the nano method-call/seqnum checks. All feature-gated verifications are
+        enabled so that submissions are checked against the full feature set.
+        """
+        _, root_id = _get_best_block_root_id(tx_storage)
+        return cls(
+            nc_block_root_id=root_id,
+            apply_mempool_restrictions=True,
+            features=Features.all_enabled(),
+        )
+
+
+def _get_best_block_root_id(tx_storage: TransactionStorage) -> tuple[Block, bytes | None]:
+    best_block = tx_storage.get_best_block()
+    meta = best_block.get_metadata()
+    if meta.nc_block_root_id is None:
+        assert best_block.is_genesis
+    return best_block, meta.nc_block_root_id

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -263,8 +263,7 @@ class VerificationService:
         )
         self.verifiers.vertex.verify_parents(tx)
         self.verifiers.tx.verify_conflict(tx, params)
-        if params.reject_locked_reward:
-            self.verifiers.tx.verify_reward_locked(tx)
+        self.verifiers.tx.verify_reward_locked(tx)
 
     def _verify_token_creation_tx(self, tx: TokenCreationTransaction, params: VerificationParams) -> None:
         """ Run all validations as regular transactions plus validation on token info.

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -255,7 +255,7 @@ class VertexVerifier:
 
     def verify_old_timestamp(self, vertex: BaseTransaction, params: VerificationParams) -> None:
         """Verify that the timestamp is not too old. Mempool only."""
-        if not params.reject_too_old_vertices:
+        if not params.apply_mempool_restrictions:
             return
 
         now = self._reactor.seconds()

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -114,7 +114,7 @@ class VersionResource(Resource):
             :rtype: string (json)
         """
         best_block = self.manager.tx_storage.get_best_block()
-        features = Features.from_vertex(
+        features = Features.for_vertex(
             settings=self._settings, vertex=best_block, feature_service=self.feature_service
         )
         nano_contracts_enabled = features.nanocontracts

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -15,7 +15,6 @@ from hathor.consensus.consensus import ConsensusEvent
 from hathor.exception import HathorError, InvalidNewTransaction
 from hathor.execution_manager import ExecutionManager, non_critical_code
 from hathor.feature_activation.feature_service import FeatureService
-from hathor.feature_activation.utils import Features
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol
@@ -67,9 +66,9 @@ class VertexHandler:
         self._execution_manager = execution_manager
         self._log_vertex_bytes = log_vertex_bytes
 
-    @cpu.profiler('on_new_block')
+    @cpu.profiler('on_new_sync_block')
     @inlineCallbacks
-    def on_new_block(self, block: Block, *, deps: list[Transaction]) -> Generator[Any, Any, bool]:
+    def on_new_sync_block(self, block: Block, *, deps: list[Transaction]) -> Generator[Any, Any, bool]:
         """Called by block sync."""
         parent_block_hash = block.get_block_parent_hash()
         parent_block = self._tx_storage.get_block(parent_block_hash)
@@ -79,70 +78,66 @@ class VertexHandler:
             # This case only happens for the genesis and during sync of a voided chain.
             assert parent_block.is_genesis or parent_meta.voided_by
 
-        params = VerificationParams(
-            nc_block_root_id=parent_meta.nc_block_root_id,
-            features=Features.from_vertex(
-                settings=self._settings,
-                feature_service=self._feature_service,
-                vertex=parent_block,
-            ),
+        params = VerificationParams.for_block(
+            settings=self._settings,
+            feature_service=self._feature_service,
+            parent_block=parent_block,
         )
 
         for tx in deps:
             if not self._tx_storage.transaction_exists(tx.hash):
-                if not self._old_on_new_vertex(tx, params):
+                if not self._internal_on_new_vertex(tx, params):
                     return False
                 yield deferLater(self._reactor, 0, lambda: None)
 
         if not self._tx_storage.transaction_exists(block.hash):
-            if not self._old_on_new_vertex(block, params):
+            if not self._internal_on_new_vertex(block, params):
                 return False
 
         return True
 
     @cpu.profiler('on_new_mempool_transaction')
     def on_new_mempool_transaction(self, tx: Transaction) -> bool:
-        """Called by mempool sync."""
-        best_block = self._tx_storage.get_best_block()
-        features = Features.for_mempool(
-            settings=self._settings,
-            feature_service=self._feature_service,
-            best_block=best_block,
-        )
+        """Called for every transaction entering the mempool: mempool sync, real-time relay from peers, and
+        local submission (`on_new_tx`, APIs). Applies the mempool-entry restrictions."""
+        assert isinstance(tx, Transaction)
         params = VerificationParams.for_mempool(
-            best_block=best_block,
-            features=features,
-        )
-        return self._old_on_new_vertex(tx, params)
-
-    @cpu.profiler('on_new_relayed_vertex')
-    def on_new_relayed_vertex(
-        self,
-        vertex: BaseTransaction,
-        *,
-        quiet: bool = False,
-        reject_locked_reward: bool = True,
-    ) -> bool:
-        """Called for unsolicited vertex received, usually due to real time relay."""
-        best_block = self._tx_storage.get_best_block()
-        best_block_meta = best_block.get_metadata()
-        if best_block_meta.nc_block_root_id is None:
-            assert best_block.is_genesis
-
-        features = Features.for_mempool(
             settings=self._settings,
             feature_service=self._feature_service,
-            best_block=best_block,
+            tx_storage=self._tx_storage,
         )
-        params = VerificationParams(
-            reject_locked_reward=reject_locked_reward,
-            nc_block_root_id=best_block_meta.nc_block_root_id,
-            features=features,
-        )
-        return self._old_on_new_vertex(vertex, params, quiet=quiet)
+        return self._internal_on_new_vertex(tx, params)
 
-    @cpu.profiler('_old_on_new_vertex')
-    def _old_on_new_vertex(
+    @cpu.profiler('on_new_relayed_block')
+    def on_new_relayed_block(self, block: Block) -> bool:
+        """Called for relayed and locally-created blocks (real-time relay, `on_new_tx`, `push_tx` API)."""
+        assert isinstance(block, Block)
+        params = VerificationParams.for_relay(
+            settings=self._settings,
+            feature_service=self._feature_service,
+            tx_storage=self._tx_storage,
+        )
+        return self._internal_on_new_vertex(block, params)
+
+    @cpu.profiler('on_new_trusted_vertex')
+    def on_new_trusted_vertex(self, vertex: BaseTransaction, *, quiet: bool = False) -> bool:
+        """Called for trusted, locally-injected vertices (database import, test DAG builder).
+
+        These vertices belong to a history the caller vouches for — they were confirmed by blocks or are
+        being replayed deterministically — so the mempool-entry restrictions do not apply. Never use this
+        for vertices received from the network or submitted through APIs.
+
+        :param quiet: if True will not log when a new vertex is accepted
+        """
+        params = VerificationParams.for_relay(
+            settings=self._settings,
+            feature_service=self._feature_service,
+            tx_storage=self._tx_storage,
+        )
+        return self._internal_on_new_vertex(vertex, params, quiet=quiet)
+
+    @cpu.profiler('_internal_on_new_vertex')
+    def _internal_on_new_vertex(
         self,
         vertex: BaseTransaction,
         params: VerificationParams,
@@ -152,7 +147,7 @@ class VertexHandler:
         """ New method for adding transactions or blocks that steps the validation state machine.
 
         :param vertex: transaction to be added
-        :param quiet: if True will not log when a new tx is accepted
+        :param quiet: if True will not log when a new vertex is accepted
         """
         is_valid = self._validate_vertex(vertex, params)
 
@@ -224,12 +219,14 @@ class VertexHandler:
         params: VerificationParams,
         consensus_events: list[ConsensusEvent],
         *,
-        quiet: bool,
+        quiet: bool = False,
     ) -> None:
         """ Handle operations that need to happen once the tx becomes fully validated.
 
         This might happen immediately after we receive the tx, if we have all dependencies
         already. Or it might happen later.
+
+        :param quiet: if True will not log when a new vertex is accepted
         """
         # XXX: during post consensus we don't need to verify weights again, so we can disable it
         params = replace(params, skip_block_weight_verification=True)
@@ -250,8 +247,10 @@ class VertexHandler:
 
             self._log_new_object(vertex, 'new {}', quiet=quiet)
 
-    def _log_new_object(self, tx: BaseTransaction, message_fmt: str, *, quiet: bool) -> None:
+    def _log_new_object(self, tx: BaseTransaction, message_fmt: str, *, quiet: bool = False) -> None:
         """ A shortcut for logging additional information for block/txs.
+
+        :param quiet: when True logs at debug level; when False logs at info level
         """
         metadata = tx.get_metadata()
         now = datetime.datetime.fromtimestamp(self._reactor.seconds())
@@ -280,11 +279,8 @@ class VertexHandler:
                 message = message_fmt.format('tx')
             else:
                 message = message_fmt.format('voided tx')
-        if not quiet:
-            log_func = self._log.info
-        else:
-            log_func = self._log.debug
 
         if tx.name:
             kwargs['__name'] = tx.name
+        log_func = self._log.debug if quiet else self._log.info
         log_func(message, **kwargs)

--- a/hathor/wallet/resources/send_tokens.py
+++ b/hathor/wallet/resources/send_tokens.py
@@ -11,7 +11,6 @@ from hathor.api_util import APIVersion, Resource, render_options, set_cors
 from hathor.conf.settings import HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.exception import InvalidNewTransaction
-from hathor.feature_activation.utils import Features
 from hathor.manager import HathorManager
 from hathor.transaction import Transaction
 from hathor.transaction.exceptions import TxValidationError
@@ -123,8 +122,7 @@ class SendTokensResource(Resource):
         tx.weight = weight
         self.manager.cpu_mining_service.resolve(tx)
         tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
-        best_block = self.manager.tx_storage.get_best_block()
-        params = VerificationParams.for_mempool(best_block=best_block, features=Features.all_enabled())
+        params = VerificationParams.for_apis(self.manager.tx_storage)
         self.manager.verification_service.verify(tx, params)
         return tx
 

--- a/hathor/wallet/resources/thin_wallet/send_tokens.py
+++ b/hathor/wallet/resources/thin_wallet/send_tokens.py
@@ -17,7 +17,6 @@ from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, render_options, set_cors
 from hathor.conf.get_settings import get_global_settings
 from hathor.exception import InvalidNewTransaction
-from hathor.feature_activation.utils import Features
 from hathor.reactor import get_global_reactor
 from hathor.transaction import Transaction
 from hathor.transaction.exceptions import TxValidationError
@@ -211,8 +210,7 @@ class SendTokensResource(Resource):
     def _stratum_thread_verify(self, context: _Context) -> _Context:
         """ Method to verify the transaction that runs in a separated thread
         """
-        best_block = self.manager.tx_storage.get_best_block()
-        params = VerificationParams.for_mempool(best_block=best_block, features=Features.all_enabled())
+        params = VerificationParams.for_apis(self.manager.tx_storage)
         self.manager.verification_service.verify(context.tx, params)
         return context
 
@@ -270,8 +268,7 @@ class SendTokensResource(Resource):
             raise CancelledError()
         context.tx.update_hash()
         context.tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
-        best_block = self.manager.tx_storage.get_best_block()
-        params = VerificationParams.for_mempool(best_block=best_block, features=Features.all_enabled())
+        params = VerificationParams.for_apis(self.manager.tx_storage)
         self.manager.verification_service.verify(context.tx, params)
         return context
 

--- a/hathor_cli/db_import.py
+++ b/hathor_cli/db_import.py
@@ -79,7 +79,7 @@ class DbImport(RunNode):
             tx = parser.deserialize(tx_bytes)
             assert tx is not None
             tx.storage = self.tx_storage
-            self.manager.on_new_tx(tx, quiet=True)
+            self.manager.vertex_handler.on_new_trusted_vertex(tx, quiet=True)
             yield tx
 
 

--- a/hathor_cli/quick_test.py
+++ b/hathor_cli/quick_test.py
@@ -26,8 +26,8 @@ class VertexHandlerWrapper:
         self._n_blocks = n_blocks or 0
 
     @inlineCallbacks
-    def on_new_block(self, block: Block, *args: Any, **kwargs: Any) -> Generator[Any, Any, bool]:
-        res = yield self._vertex_handler.on_new_block(block, *args, **kwargs)
+    def on_new_sync_block(self, block: Block, *args: Any, **kwargs: Any) -> Generator[Any, Any, bool]:
+        res = yield self._vertex_handler.on_new_sync_block(block, *args, **kwargs)
         if block.get_height() >= self._n_blocks:
             self.log.info(f'successfully reached height {block.get_height()}, exit now')
             self._manager.connections.disconnect_all_peers(force=True)
@@ -35,11 +35,9 @@ class VertexHandlerWrapper:
             os._exit(0)
         return res
 
-    def on_new_mempool_transaction(self, tx: Transaction) -> bool:
-        return self._vertex_handler.on_new_mempool_transaction(tx)
-
-    def on_new_relayed_vertex(self, vertex: BaseTransaction, *args: Any, **kwargs: Any) -> bool:
-        return self._vertex_handler.on_new_mempool_transaction(vertex, *args, **kwargs)
+    def __getattr__(self, name: str) -> Any:
+        """Forward every handler method not overridden here (mempool/relayed entry points) to the wrapped handler."""
+        return getattr(self._vertex_handler, name)
 
 
 class QuickTest(RunNode):
@@ -58,7 +56,7 @@ class QuickTest(RunNode):
         super().prepare(register_resources=False)
         self._no_wait = self._args.no_wait
 
-        self.log.info('patching vertex_handler.on_new_vertex to quit on success')
+        self.log.info('patching vertex_handler to quit on success')
         p2p_factory = self.manager.connections.get_sync_factory(SyncVersion.V2)
         assert isinstance(p2p_factory, SyncV2Factory)
         p2p_factory.vertex_handler = VertexHandlerWrapper(

--- a/hathor_tests/consensus/test_soft_voided3.py
+++ b/hathor_tests/consensus/test_soft_voided3.py
@@ -109,7 +109,9 @@ class SoftVoidedTestCase(SimulatorTestCase):
         txD2 = gen_custom_tx(manager2, [(txB, 0)])
         txD2.timestamp = txD1.timestamp + 2
         txD2.update_hash()
-        manager2.propagate_tx(txD2)
+        # txD2 spends an output of the voided-and-confirmed txB, so it must enter through the trusted
+        # entry point, which skips the mempool-entry conflict check.
+        manager2.vertex_handler.on_new_trusted_vertex(txD2)
         graphviz.labels[txD2.hash] = 'txD2'
 
         blk1meta = blk1.get_metadata()

--- a/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
+++ b/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
@@ -162,7 +162,7 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
         address = get_address_b58_from_public_key_bytes(blueprint.nc_pubkey)
         self.assertIn(address, related_addresses)
 
-        assert self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+        assert self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         add_new_blocks(self.manager, 1, advance_clock=30)  # confirm the on-chain blueprint vertex
         assert blueprint.get_metadata().first_block is not None
 
@@ -173,7 +173,7 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
 
         # initialize an on-chain Bet nanocontract
         nc_init_tx = self._gen_nc_initialize_tx(blueprint, [self.oracle_script, self.token_uid, self.date_last_bet])
-        assert self.manager.vertex_handler.on_new_relayed_vertex(nc_init_tx)
+        assert self.manager.vertex_handler.on_new_trusted_vertex(nc_init_tx)
         block, = add_new_blocks(self.manager, 1, advance_clock=30)  # confirm the initialization nc transaction
         assert nc_init_tx.get_metadata().first_block is not None
 

--- a/hathor_tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/hathor_tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -57,7 +57,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
     def _test_forbid_syntax(self, code: str, *, syntax_errors: tuple[str, ...]) -> None:
         blueprint = self._create_on_chain_blueprint(code)
         with self.assertRaises(InvalidNewTransaction) as cm:
-            self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+            self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
         assert isinstance(cm.exception.__cause__.__cause__, SyntaxError)
         assert 'full validation failed: forbidden syntax' in cm.exception.args[0]
@@ -438,7 +438,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
         code = 'x ++= 1'
         blueprint = self._create_on_chain_blueprint(code)
         with self.assertRaises(InvalidNewTransaction) as cm:
-            self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+            self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
         assert isinstance(cm.exception.__cause__.__cause__, SyntaxError)
         assert cm.exception.args[0] == 'full validation failed: Could not correctly parse the script'
@@ -451,7 +451,7 @@ def Foo():
     pass
 ''')
         with self.assertRaises(InvalidNewTransaction) as cm:
-            self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+            self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
         assert cm.exception.args[0] == 'full validation failed: Could not find a main Blueprint definition'
 
@@ -463,7 +463,7 @@ class Foo():
     pass
 ''')
         with self.assertRaises(InvalidNewTransaction) as cm:
-            self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+            self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
         assert cm.exception.args[0] == 'full validation failed: exported Blueprint is not a Blueprint subclass'
 

--- a/hathor_tests/nanocontracts/test_actions.py
+++ b/hathor_tests/nanocontracts/test_actions.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 
-from hathor.feature_activation.utils import Features
 from hathor.indexes.tokens_index import TokensIndex
 from hathor.nanocontracts import HATHOR_TOKEN_UID, NC_EXECUTION_FAIL_ID, Blueprint, Context, public
 from hathor.nanocontracts.exception import NCInvalidAction
@@ -104,11 +103,7 @@ class TestActions(unittest.TestCase):
             ['tx0', 'tx1', 'tx2', 'TKA'],
             Transaction,
         )
-        best_block = self.manager.tx_storage.get_best_block()
-        self.verification_params = VerificationParams.for_mempool(
-            best_block=best_block,
-            features=Features.all_enabled()
-        )
+        self.verification_params = VerificationParams.for_apis(self.manager.tx_storage)
 
         # We finish a manual setup of tx1, so it can be used directly in verification methods.
         self.tx1.storage = self.manager.tx_storage
@@ -957,7 +952,9 @@ class TestActions(unittest.TestCase):
             NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=2, amount=UnsignedAmount.from_v1(1)),
         ])
 
-        params = dataclasses.replace(self.verification_params, harden_token_restrictions=False)
+        # Disable the mempool token-hygiene check so the out-of-bounds action is reached: `tx1` carries
+        # an unused TKA token that `verify_tokens` would otherwise reject first.
+        params = dataclasses.replace(self.verification_params, apply_mempool_restrictions=False)
         with pytest.raises(NCInvalidAction) as e:
             self.manager.verification_service.verify(self.tx1, params)
         assert str(e.value) == 'DEPOSIT token index 2 not found'

--- a/hathor_tests/nanocontracts/test_consensus.py
+++ b/hathor_tests/nanocontracts/test_consensus.py
@@ -162,7 +162,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def _run_invalid_signature(self, attr, value, cause=NCInvalidSignature):
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         tx = self._gen_nc_tx(nc.hash, 'deposit', [])
@@ -174,7 +174,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         tx.clear_sighash_cache()
         with self.assertRaises(InvalidNewTransaction) as cm:
-            self.manager.on_new_tx(tx)
+            self.manager.vertex_handler.on_new_trusted_vertex(tx)
         exc = cm.exception
         self.assertIsInstance(exc.__cause__, cause)
 
@@ -199,12 +199,12 @@ class NCConsensusTestCase(SimulatorTestCase):
     def test_nc_consensus_execution_fails(self):
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         tx = self._gen_nc_tx(nc.hash, 'deposit', [])
         self.manager.cpu_mining_service.resolve(tx)
-        self.manager.on_new_tx(tx)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx)
         self.assertIsNone(tx.get_metadata().voided_by)
 
         trigger = StopAfterNMinedBlocks(self.miner, quantity=2)
@@ -226,7 +226,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         token_creation_tx = create_tokens(self.manager, mint_amount=100, use_genesis=False, propagate=False)
         self._finish_preparing_tx(token_creation_tx, set_timestamp=False)
         self.manager.cpu_mining_service.resolve(token_creation_tx)
-        self.manager.on_new_tx(token_creation_tx)
+        self.manager.vertex_handler.on_new_trusted_vertex(token_creation_tx)
 
         self.token_uid = token_creation_tx.hash
         self.test_nc_consensus_success(is_custom_token=True)
@@ -234,7 +234,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def test_nc_consensus_success(self, *, is_custom_token: bool = False) -> None:
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         nc_id = nc.hash
@@ -266,7 +266,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             )
         ])
         self.manager.cpu_mining_service.resolve(tx)
-        self.manager.on_new_tx(tx)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx)
         self.assertIsNone(tx.get_metadata().voided_by)
 
         add_new_blocks(self.manager, 2, advance_clock=1)
@@ -304,7 +304,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             )
         ])
         self.manager.cpu_mining_service.resolve(tx2)
-        self.manager.on_new_tx(tx2)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx2)
         self.assertIsNone(tx2.get_metadata().voided_by)
 
         add_new_blocks(self.manager, 2, advance_clock=1)
@@ -335,7 +335,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             )
         ])
         self.manager.cpu_mining_service.resolve(tx3)
-        self.manager.on_new_tx(tx3)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx3)
         self.assertIsNone(tx3.get_metadata().voided_by)
 
         add_new_blocks(self.manager, 2, advance_clock=1)
@@ -371,7 +371,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             )
         ])
         self.manager.cpu_mining_service.resolve(tx4)
-        self.manager.on_new_tx(tx4)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx4)
         self.assertIsNone(tx4.get_metadata().voided_by)
 
         add_new_blocks(self.manager, 2, advance_clock=1)
@@ -405,7 +405,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def test_nc_consensus_failure_voided_by_propagation(self):
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         # Find some blocks.
@@ -420,7 +420,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         tx1 = self.wallet.prepare_transaction_compute_inputs(Transaction, _outputs, self.manager.tx_storage)
         tx1 = self._gen_nc_tx(nc.hash, 'deposit', [], nc=tx1)
         self.manager.cpu_mining_service.resolve(tx1)
-        self.manager.on_new_tx(tx1)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx1)
         self.assertIsNone(tx1.get_metadata().voided_by)
 
         # add tx21 spending tx1 in mempool before tx1 has been executed
@@ -437,7 +437,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         self._finish_preparing_tx(tx22)
         tx22.parents[0] = tx1.hash
         self.manager.cpu_mining_service.resolve(tx22)
-        self.manager.on_new_tx(tx22)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx22)
         tx22_meta = tx22.get_metadata()
         self.assertIsNone(tx22_meta.voided_by)
 
@@ -486,7 +486,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def test_nc_consensus_chain_fail(self):
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         # Find some blocks.
@@ -507,8 +507,8 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.manager.cpu_mining_service.resolve(tx2)
 
         # propagate both tx1 and tx2
-        self.assertTrue(self.manager.on_new_tx(tx1))
-        self.assertTrue(self.manager.on_new_tx(tx2))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx1))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx2))
 
         # tx3 is a NanoContract transaction that has tx1 as parent
         tx3 = self._gen_nc_tx(nc.hash, 'nop', [1])
@@ -516,7 +516,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             tx3.parents[0] = tx1.hash
         tx3.timestamp += 1
         self.manager.cpu_mining_service.resolve(tx3)
-        self.assertTrue(self.manager.on_new_tx(tx3))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx3))
 
         # tx4 is a NanoContract transaction that spents tx1 output.
         tx4 = gen_custom_base_tx(self.manager, tx_inputs=[(tx1, 0)])
@@ -524,7 +524,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         tx4.timestamp += 2
         # self.assertNotIn(tx1.hash, tx4.parents)
         self.manager.cpu_mining_service.resolve(tx4)
-        self.assertTrue(self.manager.on_new_tx(tx4))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx4))
 
         # tx5 is a NanoContract transaction that spents tx4 output.
         tx5 = gen_custom_base_tx(self.manager, tx_inputs=[(tx4, 0)])
@@ -532,7 +532,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         tx5.timestamp += 3
         # self.assertNotIn(tx1.hash, tx5.parents)
         self.manager.cpu_mining_service.resolve(tx5)
-        self.assertTrue(self.manager.on_new_tx(tx5))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx5))
 
         # execute all transactions.
         trigger = StopAfterNMinedBlocks(self.miner, quantity=2)
@@ -571,7 +571,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def test_nc_consensus_reorg(self):
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         nc_id = nc.hash
@@ -632,9 +632,9 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.assertGreater(withdrawal_amount_1, deposit_amount_2)
 
         # Propagate tx1, tx2, and tx11.
-        self.manager.on_new_tx(tx1)
-        self.manager.on_new_tx(tx2)
-        self.manager.on_new_tx(tx11)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx1)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx2)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx11)
 
         # Add a block that executes tx1 and tx11 (but not tx2).
         blk10 = self._add_new_block(tx_parents=[
@@ -700,7 +700,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def test_nc_consensus_reorg_fail_before_reorg(self):
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         nc_id = nc.hash
@@ -761,9 +761,9 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.assertGreater(withdrawal_amount_1, deposit_amount_1)
 
         # Propagate tx1, tx2, and tx11.
-        self.manager.on_new_tx(tx1)
-        self.manager.on_new_tx(tx2)
-        self.manager.on_new_tx(tx11)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx1)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx2)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx11)
 
         # Add a block that executes tx1 and tx11 (but not tx2).
         blk10 = self._add_new_block(tx_parents=[
@@ -819,7 +819,7 @@ class NCConsensusTestCase(SimulatorTestCase):
     def _prepare_nc_consensus_conflict(self, *, conflict_with_nano: bool) -> tuple[Transaction, ...]:
         nc = self._gen_nc_tx(self.myblueprint_id, 'initialize', [self.token_uid])
         self.manager.cpu_mining_service.resolve(nc)
-        self.manager.on_new_tx(nc)
+        self.manager.vertex_handler.on_new_trusted_vertex(nc)
         self.assertIsNone(nc.get_metadata().voided_by)
 
         # Find some blocks.
@@ -862,10 +862,10 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.manager.cpu_mining_service.resolve(tx1b)
 
         # propagate both tx1 and tx2
-        self.assertTrue(self.manager.on_new_tx(tx0))
-        self.assertTrue(self.manager.on_new_tx(tx1))
-        self.assertTrue(self.manager.on_new_tx(tx1b))
-        self.assertTrue(self.manager.on_new_tx(tx2))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx0))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx1))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx1b))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx2))
 
         return cast(tuple[Transaction, ...], (tx0, tx1, tx1b, tx2))
 
@@ -880,7 +880,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             tx1b.hash,
         ]
         self.manager.cpu_mining_service.resolve(block)
-        self.assertTrue(self.manager.on_new_tx(block))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(block))
         self.assertTrue(block.get_metadata().voided_by)
 
     def test_nc_consensus_conflict_block_voided_1(self) -> None:
@@ -900,7 +900,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             tx2.hash,
         ]
         self.manager.cpu_mining_service.resolve(b0)
-        self.assertTrue(self.manager.on_new_tx(b0))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(b0))
         self.assertIsNone(b0.get_metadata().voided_by)
 
         # this block will be voided because it confirms tx1b.
@@ -911,7 +911,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             tx1b.parents[0],
         ]
         self.manager.cpu_mining_service.resolve(b1)
-        self.assertTrue(self.manager.on_new_tx(b1))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(b1))
         self.assertIsNotNone(b1.get_metadata().voided_by)
 
     @pytest.mark.xfail(strict=True, reason='temporarily broken')
@@ -944,9 +944,9 @@ class NCConsensusTestCase(SimulatorTestCase):
         ]
         self.manager.cpu_mining_service.resolve(b1)
 
-        self.assertTrue(self.manager.on_new_tx(b0))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(b0))
         self.assertIsNone(b0.get_metadata().voided_by)
-        self.assertTrue(self.manager.on_new_tx(b1))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(b1))
         self.assertIsNotNone(b0.get_metadata().voided_by)
         self.assertIsNone(b1.get_metadata().voided_by)
         self.assertIsNone(tx1.get_metadata().voided_by)
@@ -981,13 +981,13 @@ class NCConsensusTestCase(SimulatorTestCase):
         ]
         self.manager.cpu_mining_service.resolve(b1)
 
-        self.assertTrue(self.manager.on_new_tx(b0))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(b0))
         self.assertIsNone(b0.get_metadata().voided_by)
         self.assertIsNotNone(tx1.get_metadata().voided_by)
         self.assertIsNotNone(tx2.get_metadata().voided_by)
         self.assertIsNone(tx1b.get_metadata().voided_by)
 
-        self.assertTrue(self.manager.on_new_tx(b1))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(b1))
         self.assertIsNotNone(b0.get_metadata().voided_by)
         self.assertIsNone(b1.get_metadata().voided_by)
         self.assertIsNone(tx1.get_metadata().voided_by)
@@ -1030,7 +1030,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             print()
             print(node.name)
             print()
-            self.manager.on_new_tx(vertex)
+            self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
         b31 = vertices.by_name['b31'].vertex
         b32 = vertices.by_name['b32'].vertex
@@ -1099,7 +1099,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         found_b33 = False
         for node, vertex in artifacts.list:
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
             if node.name == 'b33':
                 found_b33 = True
@@ -1166,7 +1166,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         found_b33 = False
         for node, vertex in artifacts.list:
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
             if node.name == 'b33':
                 found_b33 = True
@@ -1327,7 +1327,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         found_b33 = False
         for node, vertex in artifacts.list:
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
             if node.name == 'b33':
                 found_b33 = True

--- a/hathor_tests/nanocontracts/test_feature_activations.py
+++ b/hathor_tests/nanocontracts/test_feature_activations.py
@@ -188,13 +188,13 @@ class TestFeatureActivations(unittest.TestCase):
         # but deprecated opcodes are already rejected on the mempool
         msg = 'full validation failed: unknown opcode: 208'
         with pytest.raises(InvalidNewTransaction, match=msg):
-            self.vertex_handler.on_new_relayed_vertex(op_v2_b)
+            self.vertex_handler.on_new_trusted_vertex(op_v2_b)
         assert op_v2_b.get_metadata().validation.is_initial()
         assert op_v2_b.get_metadata().voided_by is None
 
         # However, deprecated opcodes would be accepted if relayed inside a block.
         # We have to manually propagate it.
-        d = self.vertex_handler.on_new_block(b11, deps=[op_v2_b])
+        d = self.vertex_handler.on_new_sync_block(b11, deps=[op_v2_b])
         self.clock.advance(1)
         assert d.called and d.result is True
         artifacts._last_propagated = 'b11'
@@ -208,21 +208,21 @@ class TestFeatureActivations(unittest.TestCase):
         # At this point the nano feature is not active, so nano header is rejected on the mempool
         msg = 'full validation failed: Header `NanoHeader` not supported by `Transaction`'
         with pytest.raises(InvalidNewTransaction, match=msg):
-            self.vertex_handler.on_new_relayed_vertex(nc1)
+            self.vertex_handler.on_new_trusted_vertex(nc1)
         assert nc1.get_metadata().validation.is_initial()
         assert nc1.get_metadata().voided_by is None
 
         # At this point the nano feature is not active, so OCB is rejected on the mempool
         msg = 'full validation failed: invalid vertex version: 6'
         with pytest.raises(InvalidNewTransaction, match=msg):
-            self.vertex_handler.on_new_relayed_vertex(ocb1)
+            self.vertex_handler.on_new_trusted_vertex(ocb1)
         assert ocb1.get_metadata().validation.is_initial()
         assert ocb1.get_metadata().voided_by is None
 
         # At this point the fee feature is not active, so fee header is rejected on the mempool
         msg = 'full validation failed: Header `FeeHeader` not supported by `TokenCreationTransaction`'
         with pytest.raises(InvalidNewTransaction, match=msg):
-            self.vertex_handler.on_new_relayed_vertex(fbt)
+            self.vertex_handler.on_new_trusted_vertex(fbt)
         assert fbt.get_metadata().validation.is_initial()
         assert fbt.get_metadata().voided_by is None
 
@@ -305,28 +305,28 @@ class TestFeatureActivations(unittest.TestCase):
 
         # The nc and fee txs are re-accepted on the mempool.
         self._reset_vertex(nc1)
-        self.vertex_handler.on_new_relayed_vertex(nc1)
+        self.vertex_handler.on_new_trusted_vertex(nc1)
         assert nc1.get_metadata().validation.is_valid()
         assert nc1.get_metadata().voided_by is None
         assert self.manager.tx_storage.transaction_exists(nc1.hash)
         assert nc1 in list(self.manager.tx_storage.iter_mempool_tips())
 
         self._reset_vertex(ocb1)
-        self.vertex_handler.on_new_relayed_vertex(ocb1)
+        self.vertex_handler.on_new_trusted_vertex(ocb1)
         assert ocb1.get_metadata().validation.is_valid()
         assert ocb1.get_metadata().voided_by is None
         assert self.manager.tx_storage.transaction_exists(ocb1.hash)
         assert ocb1 in list(self.manager.tx_storage.iter_mempool_tips())
 
         self._reset_vertex(fbt)
-        self.vertex_handler.on_new_relayed_vertex(fbt)
+        self.vertex_handler.on_new_trusted_vertex(fbt)
         assert fbt.get_metadata().validation.is_valid()
         assert fbt.get_metadata().voided_by is None
         assert self.manager.tx_storage.transaction_exists(fbt.hash)
         assert fbt in list(self.manager.tx_storage.iter_mempool_tips())
 
         self._reset_vertex(fee_tx)
-        self.vertex_handler.on_new_relayed_vertex(fee_tx)
+        self.vertex_handler.on_new_trusted_vertex(fee_tx)
         assert fee_tx.get_metadata().validation.is_valid()
         assert fee_tx.get_metadata().voided_by is None
         assert self.manager.tx_storage.transaction_exists(fee_tx.hash)
@@ -409,13 +409,13 @@ class TestFeatureActivations(unittest.TestCase):
         # but duplicate actions are already rejected on the mempool
         msg = 'full validation failed: duplicate actions for token 00'
         with pytest.raises(InvalidNewTransaction, match=msg):
-            self.vertex_handler.on_new_relayed_vertex(nc1)
+            self.vertex_handler.on_new_trusted_vertex(nc1)
         assert nc1.get_metadata().validation.is_initial()
         assert nc1.get_metadata().voided_by is None
 
         # However, duplicate actions would be accepted if relayed inside a block.
         # We have to manually propagate it.
-        d = self.vertex_handler.on_new_block(b11, deps=[nc1])
+        d = self.vertex_handler.on_new_sync_block(b11, deps=[nc1])
         self.clock.advance(1)
         assert d.called and d.result is True
         artifacts._last_propagated = 'b11'

--- a/hathor_tests/nanocontracts/test_fee_tokens.py
+++ b/hathor_tests/nanocontracts/test_fee_tokens.py
@@ -501,13 +501,13 @@ class FeeTokensTestCase(BlueprintTestCase):
         assert isinstance(e.value.__cause__, InvalidNewTransaction)
         assert e.value.__cause__.args[0] == f'full validation failed: token uid {fbt_id.hex()} not found.'
 
-        assert self.manager.vertex_handler.on_new_relayed_vertex(b12)
+        assert self.manager.vertex_handler.on_new_relayed_block(b12)
         assert tx2.get_metadata().first_block == b12.hash
         assert tx2.get_metadata().nc_execution == NCExecutionState.SUCCESS
         assert tx2.get_metadata().voided_by is None
 
         # Now, it's valid and accepted.
-        assert self.manager.vertex_handler.on_new_relayed_vertex(tx3)
+        assert self.manager.vertex_handler.on_new_trusted_vertex(tx3)
         assert tx3.get_metadata().validation.is_valid()
         assert tx3.get_metadata().voided_by is None
 
@@ -560,7 +560,7 @@ class FeeTokensTestCase(BlueprintTestCase):
         assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
         assert tx1.get_metadata().voided_by is None
 
-        deferred = self.manager.vertex_handler.on_new_block(block=b12, deps=[tx2, tx3])
+        deferred = self.manager.vertex_handler.on_new_sync_block(block=b12, deps=[tx2, tx3])
         self.reactor.advance(1)
 
         msg = f'full validation failed: token uid {fbt_id.hex()} not found.'

--- a/hathor_tests/nanocontracts/test_indexes.py
+++ b/hathor_tests/nanocontracts/test_indexes.py
@@ -100,7 +100,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
 
         # broadcast
         self.manager.cpu_mining_service.resolve(tx)
-        self.manager.on_new_tx(tx)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx)
         trigger = StopAfterNMinedBlocks(self.miner, quantity=confirmations)
         self.assertTrue(self.simulator.run(7200, trigger=trigger))
 
@@ -190,7 +190,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
             print()
             print(node.name)
             print()
-            self.manager.on_new_tx(vertex)
+            self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
         tx1 = vertices.by_name['tx1'].vertex
         tx2 = vertices.by_name['tx2'].vertex

--- a/hathor_tests/nanocontracts/test_nanocontract.py
+++ b/hathor_tests/nanocontracts/test_nanocontract.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any
-from unittest.mock import Mock
 
 import pytest
 from cryptography.hazmat.primitives import hashes
@@ -14,7 +13,6 @@ from hathor.crypto.util import (
     get_address_from_public_key_bytes,
     get_public_key_bytes_compressed,
 )
-from hathor.feature_activation.utils import Features
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCInvalidSignature
@@ -90,7 +88,7 @@ class NCNanoContractTestCase(unittest.TestCase):
         self.genesis = self.peer.tx_storage.get_all_genesis()
         self.genesis_txs = [tx for tx in self.genesis if not tx.is_block]
 
-        self.verification_params = VerificationParams.for_mempool(best_block=Mock(), features=Features.all_enabled())
+        self.verification_params = VerificationParams.for_apis(self.peer.tx_storage)
 
     def _create_nc(
         self,
@@ -394,7 +392,7 @@ class NCNanoContractTestCase(unittest.TestCase):
         timestamp = 1 + max(tx.timestamp for tx in self.genesis)
 
         nc = self._get_nc(parents=parents, timestamp=timestamp)
-        self.assertTrue(self.peer.on_new_tx(nc))
+        self.assertTrue(self.peer.vertex_handler.on_new_trusted_vertex(nc))
         return nc
 
     def test_dag_call_public_method(self) -> None:
@@ -410,7 +408,7 @@ class NCNanoContractTestCase(unittest.TestCase):
             parents=parents,
             timestamp=timestamp,
         )
-        self.assertTrue(self.peer.on_new_tx(nc2))
+        self.assertTrue(self.peer.vertex_handler.on_new_trusted_vertex(nc2))
 
     def test_get_context(self) -> None:
         tx_storage = self.peer.tx_storage

--- a/hathor_tests/nanocontracts/test_rng.py
+++ b/hathor_tests/nanocontracts/test_rng.py
@@ -353,7 +353,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         ''')
 
         for node, vertex in artifacts.list:
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
         nc1, = artifacts.get_typed_vertices(['nc1'], Transaction)
         assert nc1.is_nano_contract()
@@ -418,7 +418,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         ''')
 
         for node, vertex in artifacts.list:
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
         nc1, = artifacts.get_typed_vertices(['nc1'], Transaction)
         assert nc1.is_nano_contract()

--- a/hathor_tests/nanocontracts/test_voided_contract_serialization.py
+++ b/hathor_tests/nanocontracts/test_voided_contract_serialization.py
@@ -58,17 +58,17 @@ class VoidedContractSerializationTest(BlueprintTestCase):
         assert b12.storage is None
         assert b12.get_metadata().validation.is_initial()
 
-        # manually add call_tx as if it was received from the push_tx endpoint
-        # XXX: in the future if this has to be refactored check `hathor/transaction/resources/push_tx.py` and mimick it
+        # manually add call_tx as a valid unconfirmed tx; the trusted entry point skips the
+        # mempool-entry restrictions, which would reject the DAG builder's historical timestamp
         call_tx.storage = self.manager.tx_storage
-        self.manager.push_tx(call_tx, allow_non_standard_script=True)
+        assert self.manager.vertex_handler.on_new_trusted_vertex(call_tx)
         call_meta = call_tx.get_metadata()
         assert call_meta.validation.is_valid()
         assert call_meta.first_block is None
         assert call_meta.voided_by is None
 
         # now manually add b12 as if it was received from the network
-        assert self.manager.vertex_handler.on_new_block(b12, deps=[])
+        assert self.manager.vertex_handler.on_new_sync_block(b12, deps=[])
 
         call_meta = call_tx.get_metadata()
         assert call_meta.first_block == b12.hash

--- a/hathor_tests/others/test_bfs_regression.py
+++ b/hathor_tests/others/test_bfs_regression.py
@@ -72,7 +72,7 @@ class TestBfsRegression(unittest.TestCase):
 
         # add tx1 before a8, this way tx1 will continue in the mempool after the re-org triggered by a8
         artifacts.propagate_with(self.manager, up_to_before='a8')
-        self.manager.vertex_handler.on_new_relayed_vertex(tx1)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx1)
 
         # sanity check:
         assert not b7.get_metadata().validation.is_initial()
@@ -101,7 +101,7 @@ class TestBfsRegression(unittest.TestCase):
         self.tx_storage.get_transaction = patched_get_transaction  # type: ignore[method-assign]
 
         # add a8, this triggers a re-org such that tx1 is affected and the mempool is scanned for affected txs
-        self.manager.vertex_handler.on_new_relayed_vertex(a8)
+        self.manager.vertex_handler.on_new_relayed_block(a8)
 
         # sanity check:
         assert not b7.get_metadata().validation.is_initial()

--- a/hathor_tests/p2p/test_sync_v2.py
+++ b/hathor_tests/p2p/test_sync_v2.py
@@ -327,13 +327,14 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         for node, vertex in artifacts.list:
             if node.name.startswith('lose') or node.name.startswith('b'):
                 cloned = vertex.clone(include_metadata=True, include_storage=False)
-                assert manager.vertex_handler.on_new_relayed_vertex(cloned)
+                assert isinstance(cloned, Block)
+                assert manager.vertex_handler.on_new_relayed_block(cloned)
 
         # Simulate a previous partial sync by adding 10 winning blocks, but not the one that would reorg.
         for i in range(1, 11):
             win_blk = artifacts.get_typed_vertex(f'win{i}', Block)
             cloned = win_blk.clone(include_metadata=False, include_storage=False)
-            assert manager.vertex_handler.on_new_relayed_vertex(cloned)
+            assert manager.vertex_handler.on_new_relayed_block(cloned)
             assert cloned.get_metadata().voided_by == {cloned.hash}
 
         win11 = artifacts.get_typed_vertex('win11', Block)

--- a/hathor_tests/poa/test_poa_simulation.py
+++ b/hathor_tests/poa/test_poa_simulation.py
@@ -556,4 +556,4 @@ class PoaSimulationTest(SimulatorTestCase):
         token_tx.inputs[0].data = P2PKH.create_input_data(public_key_bytes, signature)
         token_tx.update_hash()
 
-        assert manager.on_new_tx(token_tx)
+        assert manager.vertex_handler.on_new_trusted_vertex(token_tx)

--- a/hathor_tests/resources/nanocontracts/test_blueprint.py
+++ b/hathor_tests/resources/nanocontracts/test_blueprint.py
@@ -170,6 +170,6 @@ class OCBBlueprintInfoTest(BaseBlueprintInfoTest):
         from hathor_tests.resources import nanocontracts
         nc_code = load_builtin_blueprint_for_ocb('my_blueprint.py', 'MyBlueprint', nanocontracts)
         blueprint = self.create_on_chain_blueprint(self.manager, nc_code)
-        self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+        self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         add_new_blocks(self.manager, 1, advance_clock=30)  # confirm the on-chain blueprint vertex
         self.blueprint_id = BlueprintId(VertexId(blueprint.hash))

--- a/hathor_tests/resources/nanocontracts/test_blueprint_source_code.py
+++ b/hathor_tests/resources/nanocontracts/test_blueprint_source_code.py
@@ -128,6 +128,6 @@ class TestBlueprint(Blueprint):
         from hathor_tests.resources import nanocontracts
         nc_code = load_builtin_blueprint_for_ocb('dummy_blueprint.py', 'TestBlueprint', nanocontracts)
         blueprint = self.create_on_chain_blueprint(self.manager, nc_code)
-        self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
+        self.manager.vertex_handler.on_new_trusted_vertex(blueprint)
         add_new_blocks(self.manager, 1, advance_clock=30)  # confirm the on-chain blueprint vertex
         self.blueprint_id = BlueprintId(blueprint.hash)

--- a/hathor_tests/resources/nanocontracts/test_history.py
+++ b/hathor_tests/resources/nanocontracts/test_history.py
@@ -132,7 +132,7 @@ class NanoContractHistoryTest(_BaseResourceTest._ResourceTest):
             timestamp=timestamp
         )
         self._fill_nc(nc, self.blueprint_id, 'initialize', [0], self.genesis_private_key)
-        self.assertTrue(self.manager.on_new_tx(nc))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(nc))
         add_new_block(self.manager)
         return nc
 
@@ -168,7 +168,7 @@ class NanoContractHistoryTest(_BaseResourceTest._ResourceTest):
             timestamp=timestamp
         )
         self._fill_nc(tx1, nc1.hash, 'set_a', [1], self.genesis_private_key)
-        self.assertTrue(self.manager.on_new_tx(tx1))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(tx1))
         add_new_block(self.manager)
 
         # Check both transactions belongs to nc1 history.

--- a/hathor_tests/resources/nanocontracts/test_nc_exec_logs.py
+++ b/hathor_tests/resources/nanocontracts/test_nc_exec_logs.py
@@ -30,7 +30,7 @@ class NCExecLogsResourceTest(BaseNCExecLogs):
         """)
 
         for _, vertex in artifacts.list:
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
         self.nc1 = artifacts.get_typed_vertex('nc1', Transaction)
         assert self.nc1.is_nano_contract()

--- a/hathor_tests/resources/nanocontracts/test_state.py
+++ b/hathor_tests/resources/nanocontracts/test_state.py
@@ -239,7 +239,7 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
             [settings.HATHOR_TOKEN_UID, timestamp],
             self.genesis_private_key,
         )
-        self.assertTrue(self.manager.on_new_tx(nc))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(nc))
         add_new_block(self.manager)
 
         response = yield self.web.get(
@@ -287,7 +287,7 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
             [settings.HATHOR_TOKEN_UID, date_last_bet],
             self.genesis_private_key,
         )
-        self.assertTrue(self.manager.on_new_tx(nc))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(nc))
 
         # Before the execution we can't get the state
         response0 = yield self.web.get(
@@ -376,7 +376,7 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
 
         self.manager.cpu_mining_service.resolve(nc_bet)
         # Add to DAG.
-        self.assertTrue(self.manager.on_new_tx(nc_bet))
+        self.assertTrue(self.manager.vertex_handler.on_new_trusted_vertex(nc_bet))
         # Execute the deposit
         block2 = add_new_block(self.manager)
 

--- a/hathor_tests/tx/test_fee_tokens.py
+++ b/hathor_tests/tx/test_fee_tokens.py
@@ -748,8 +748,10 @@ class FeeTokenTest(unittest.TestCase):
             _input.data = signature_data
 
     def resolve_and_propagate(self, tx: Transaction) -> None:
+        # The trusted entry point skips the mempool-entry restrictions, so consensus-valid full melts
+        # (which reference a token only in inputs) can be injected.
         self.manager.cpu_mining_service.resolve(tx)
-        self.manager.propagate_tx(tx)
+        self.manager.vertex_handler.on_new_trusted_vertex(tx)
         self.run_to_completion()
 
     def test_pay_fee_with_fbt(self) -> None:

--- a/hathor_tests/tx/test_nano_header.py
+++ b/hathor_tests/tx/test_nano_header.py
@@ -204,7 +204,7 @@ class VertexHeadersTest(unittest.TestCase):
             vertex.storage = self.manager.tx_storage
             clone = vertex.clone(include_metadata=False, include_storage=True)
             assert bytes(clone) == bytes(vertex)
-            assert self.manager.on_new_tx(vertex)
+            assert self.manager.vertex_handler.on_new_trusted_vertex(vertex)
 
         expected_to_fail: list[tuple[str, type[BaseTransaction], bool]] = [
             ('b12', Block, True),
@@ -214,7 +214,7 @@ class VertexHeadersTest(unittest.TestCase):
             vertex = self.artifacts.get_typed_vertex(name, _type)
             assert self.has_nano_header(vertex) == should_have_nano_header
             with pytest.raises(InvalidNewTransaction) as e:
-                self.manager.on_new_tx(vertex)
+                self.manager.vertex_handler.on_new_trusted_vertex(vertex)
             assert isinstance(e.value.__cause__, HeaderNotSupported)
 
     def test_nano_header_round_trip(self) -> None:

--- a/hathor_tests/tx/test_reward_lock.py
+++ b/hathor_tests/tx/test_reward_lock.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import patch
+
 import pytest
 
 from hathor.crypto.util import get_address_b58_from_bytes, get_address_from_public_key
@@ -11,6 +13,7 @@ from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import RewardLocked
 from hathor.transaction.scripts import P2PKH
+from hathor.verification.transaction_verifier import TransactionVerifier
 from hathor.wallet import Wallet
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
@@ -100,7 +103,8 @@ class TransactionTest(unittest.TestCase):
         #      transaction before it can the RewardLocked exception is raised
         tx, _ = self._spend_reward_tx(self.manager, reward_block)
         self.assertEqual(tx.static_metadata.min_height, unlock_height)
-        self.assertTrue(self.manager.on_new_tx(tx, reject_locked_reward=False))
+        with patch.object(TransactionVerifier, 'verify_reward_locked'):
+            self.assertTrue(self.manager.on_new_tx(tx))
 
         # new block will try to confirm it and fail
         with pytest.raises(InvalidNewTransaction) as e:

--- a/hathor_tests/tx/test_shielded_gating.py
+++ b/hathor_tests/tx/test_shielded_gating.py
@@ -98,8 +98,8 @@ def test_allowed_headers_excludes_shielded_when_disabled() -> None:
 
     features_on = Features.all_enabled()
     features_off = dataclasses.replace(features_on, shielded_transactions=False)
-    params_off = VerificationParams.for_mempool(best_block=Mock(), features=features_off)
-    params_on = VerificationParams.for_mempool(best_block=Mock(), features=features_on)
+    params_off = VerificationParams(nc_block_root_id=None, features=features_off)
+    params_on = VerificationParams(nc_block_root_id=None, features=features_on)
 
     allowed_off = verifier.get_allowed_headers(tx, params_off)
     assert ShieldedOutputsHeader not in allowed_off

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -4,7 +4,7 @@
 import base64
 import hashlib
 from math import isinf, isnan
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -13,7 +13,6 @@ from hathor.daa import DAAFactory, TestMode
 from hathor.exception import InvalidNewTransaction
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
-from hathor.feature_activation.utils import Features
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import MAX_OUTPUT_VALUE, Block, Transaction, TxInput, TxOutput, Vertex
 from hathor.transaction.base_transaction import get_cls_from_tx_version
@@ -77,7 +76,7 @@ class TransactionTest(unittest.TestCase):
         blocks = add_blocks_unlock_reward(self.manager)
         self.last_block = blocks[-1]
 
-        self.verification_params = VerificationParams.for_mempool(best_block=Mock(), features=Features.all_enabled())
+        self.verification_params = VerificationParams.for_apis(self.manager.tx_storage)
 
     def test_input_output_match_less_htr(self):
         genesis_block = self.genesis_blocks[0]

--- a/hathor_tests/tx/test_verification_mempool.py
+++ b/hathor_tests/tx/test_verification_mempool.py
@@ -6,6 +6,7 @@ from typing import Generator
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.checkpoint import Checkpoint
+from hathor.dag_builder.artifacts import DAGArtifacts
 from hathor.exception import InvalidNewTransaction
 from hathor.nanocontracts import NC_EXECUTION_FAIL_ID, Blueprint, Context, fallback, public
 from hathor.nanocontracts.exception import (
@@ -20,7 +21,7 @@ from hathor.nanocontracts.exception import (
     OCBBlueprintNotConfirmed,
 )
 from hathor.nanocontracts.types import NCArgs
-from hathor.transaction import Block, Transaction
+from hathor.transaction import Block, Transaction, TxInput, TxOutput
 from hathor.transaction.exceptions import (
     CheckpointError,
     ConflictWithConfirmedTxError,
@@ -39,6 +40,7 @@ from hathor.verification.transaction_verifier import MAX_BETWEEN_CONFLICTS, MAX_
 from hathor.verification.vertex_verifier import MAX_PAST_TIMESTAMP_ALLOWED
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class MyTestBlueprint(Blueprint):
@@ -168,6 +170,111 @@ class VertexHeadersTest(unittest.TestCase):
             self.manager.vertex_handler.on_new_mempool_transaction(tx3)
         assert isinstance(e.exception.__cause__, UnusedTokensError)
 
+    def _build_final_melt_setup(self) -> tuple[DAGArtifacts, Transaction]:
+        """Build a DAG holding 100 TKA and a consensus-valid final-melt tx that lists TKA.
+
+        The melt tx burns the full 100 TKA balance and the melt authority, withdrawing the 1 HTR deposit
+        (1% of 100). It references TKA only through its inputs, with no TKA output, so listing TKA in the
+        tokens list makes `verify_tokens` consider it unused. The DAG's `b31` is left unpropagated so
+        tests can deliver the melt tx through the block-sync path.
+        """
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..31]
+            b10 < dummy
+
+            tx1.out[0] = 100 TKA
+
+            tx1 <-- b31
+            tx1 < b31
+        ''')
+        artifacts.propagate_with(self.manager, up_to_before='b31')
+        melt_tx = self._build_final_melt_tx(artifacts, list_token=True)
+        return artifacts, melt_tx
+
+    def _build_final_melt_tx(self, artifacts: DAGArtifacts, *, list_token: bool) -> Transaction:
+        """Build the final-melt tx, listing the melted token in the tokens list or omitting it."""
+        tka = artifacts.get_typed_vertex('TKA', TokenCreationTransaction)
+        tx1 = artifacts.get_typed_vertex('tx1', Transaction)
+        melt_authority_index = next(
+            index for index, output in enumerate(tka.outputs)
+            if output.is_token_authority() and output.can_melt_token()
+        )
+
+        melt_tx = Transaction(
+            inputs=[
+                TxInput(tx1.hash, 0, b''),
+                TxInput(tka.hash, melt_authority_index, b''),
+            ],
+            outputs=[TxOutput(UnsignedAmount.from_v1(1), tx1.outputs[0].script, 0)],
+            parents=self.manager.get_new_tx_parents(),
+            tokens=[tka.hash] if list_token else [],
+            storage=self.manager.tx_storage,
+            timestamp=int(self.manager.reactor.seconds()),
+        )
+        self.dag_builder._exporter.sign_all_inputs(melt_tx)
+        melt_tx.weight = self.manager.daa_factory.minimum_tx_weight(melt_tx)
+        self.dag_builder._exporter._vertex_resolver(melt_tx)
+        return melt_tx
+
+    def test_final_melt_rejected_at_mempool_entry(self) -> None:
+        """A tokens-list entry referenced only by inputs is rejected at every mempool entry.
+
+        A final melt references the melted token only through its inputs, so the tokens list decides
+        admission: listing the token trips the unused-tokens check, while the same melt with the token
+        omitted from the list is accepted.
+        """
+        artifacts, melt_tx = self._build_final_melt_setup()
+
+        with self.assertRaises(InvalidNewTransaction) as e:
+            self.manager.vertex_handler.on_new_mempool_transaction(melt_tx)
+        assert isinstance(e.exception.__cause__, UnusedTokensError)
+        assert str(e.exception.__cause__) == 'unused tokens are not allowed'
+        assert not self.manager.tx_storage.transaction_exists(melt_tx.hash)
+
+        clean_melt_tx = self._build_final_melt_tx(artifacts, list_token=False)
+        assert self.manager.vertex_handler.on_new_mempool_transaction(clean_melt_tx)
+        assert self.manager.tx_storage.transaction_exists(clean_melt_tx.hash)
+
+    @inlineCallbacks
+    def test_final_melt_accepted_inside_block(self) -> Generator:
+        """A tx listing a token referenced only by inputs is admitted when it arrives inside a block."""
+        artifacts, melt_tx = self._build_final_melt_setup()
+        b31 = artifacts.get_typed_vertex('b31', Block)
+        tx1 = artifacts.get_typed_vertex('tx1', Transaction)
+
+        # Align the melt tx with chain time: the block path has no freshness requirement, and b31 must
+        # stay close to b30 to satisfy the max distance between blocks. The timestamp must still exceed
+        # every parent's and every spent tx's.
+        b30 = artifacts.get_typed_vertex('b30', Block)
+        melt_tx_deps = list(melt_tx.parents) + [tx_input.tx_id for tx_input in melt_tx.inputs]
+        melt_tx.timestamp = 1 + max(
+            self.manager.tx_storage.get_transaction(vertex_id).timestamp for vertex_id in melt_tx_deps
+        )
+        self.dag_builder._exporter._vertex_resolver(melt_tx)
+
+        # Make b31 confirm the melt tx by replacing its auto-filled tx parent (index 0 is the block
+        # parent, and tx1 is kept as the other tx parent).
+        other_parent_index = next(
+            index for index, parent in enumerate(b31.parents)
+            if index > 0 and parent != tx1.hash
+        )
+        b31.parents[other_parent_index] = melt_tx.hash
+        b31.timestamp = max(b30.timestamp, melt_tx.timestamp) + 1
+        self.dag_builder._exporter._vertex_resolver(b31)
+
+        deferred = self.manager.vertex_handler.on_new_sync_block(b31, deps=[melt_tx])
+        # `on_new_sync_block` schedules a zero-delay `deferLater` after each dep, which only fires when
+        # the test clock ticks.
+        self.clock.advance(0)
+        success = yield deferred
+        assert success
+
+        stored_melt_tx = self.manager.tx_storage.get_transaction(melt_tx.hash)
+        melt_meta = stored_melt_tx.get_metadata()
+        assert melt_meta.validation.is_fully_connected()
+        assert melt_meta.voided_by is None
+        assert melt_meta.first_block == b31.hash
+
     def test_conflict_with_confirmed_tx(self) -> None:
         artifacts = self.dag_builder.build_from_str('''
             blockchain genesis b[1..30]
@@ -292,7 +399,7 @@ class VertexHeadersTest(unittest.TestCase):
         }
         assert tx_ok.hash in mempool_hashes
 
-        assert self.manager.vertex_handler.on_new_relayed_vertex(b32)
+        assert self.manager.vertex_handler.on_new_relayed_block(b32)
 
         tx_ok_confirmed = self.manager.tx_storage.get_transaction(tx_ok.hash)
         assert tx_ok_confirmed.get_metadata().first_block == b32.hash
@@ -301,7 +408,7 @@ class VertexHeadersTest(unittest.TestCase):
         }
         assert tx_ok.hash not in mempool_hashes
 
-        assert self.manager.vertex_handler.on_new_relayed_vertex(a32)
+        assert self.manager.vertex_handler.on_new_relayed_block(a32)
 
         tx_ok_reorged = self.manager.tx_storage.get_transaction(tx_ok.hash)
         assert tx_ok_reorged.get_metadata().first_block is None
@@ -377,7 +484,7 @@ class VertexHeadersTest(unittest.TestCase):
         c5.timestamp = int(self.manager.reactor.seconds())
         self.dag_builder._exporter._vertex_resolver(c5)
         with self.assertRaises(InvalidNewTransaction) as e:
-            yield manager2.vertex_handler.on_new_block(c5, deps=[])
+            yield manager2.vertex_handler.on_new_sync_block(c5, deps=[])
         assert isinstance(e.exception.__cause__, CheckpointError)
 
     def test_nano_header_seqnum(self) -> None:

--- a/hathor_tests/unittest.py
+++ b/hathor_tests/unittest.py
@@ -23,7 +23,6 @@ from hathor.conf.settings import HathorSettings
 from hathor.daa import DAAFactory, TestMode
 from hathor.event import EventManager
 from hathor.event.storage import EventStorage
-from hathor.feature_activation.utils import Features
 from hathor.manager import HathorManager
 from hathor.nanocontracts.nc_exec_logs import NCLogConfig
 from hathor.p2p.peer import PrivatePeer
@@ -534,5 +533,4 @@ class TestCase(unittest.TestCase):
 
     @staticmethod
     def get_verification_params(manager: HathorManager | None = None) -> VerificationParams:
-        best_block = manager.tx_storage.get_best_block() if manager else None
-        return VerificationParams.for_mempool(best_block=best_block or Mock(), features=Features.all_enabled())
+        return VerificationParams.for_apis(manager.tx_storage if manager else Mock())

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -69,7 +69,11 @@ def add_custom_tx(
     address: Optional[str] = None,
     inc_timestamp: int = 0
 ) -> Transaction:
-    """Add a custom tx based on the gen_custom_tx(...) method."""
+    """Add a custom tx based on the gen_custom_tx(...) method.
+
+    Injects through the trusted entry point, which skips the mempool-entry restrictions, so custom DAG
+    patterns (conflicts with confirmed txs, spends of voided txs, old timestamps) can be built freely.
+    """
     tx = gen_custom_tx(manager,
                        tx_inputs,
                        n_outputs=n_outputs,
@@ -78,7 +82,7 @@ def add_custom_tx(
                        resolve=resolve,
                        address=address,
                        inc_timestamp=inc_timestamp)
-    manager.propagate_tx(tx)
+    manager.vertex_handler.on_new_trusted_vertex(tx)
     return tx
 
 
@@ -184,9 +188,14 @@ def gen_custom_base_tx(manager: HathorManager,
 
 def add_new_double_spending(manager: HathorManager, *, use_same_parents: bool = False,
                             tx: Optional[Transaction] = None, weight: float = 1) -> Transaction:
-    tx = gen_new_double_spending(manager, use_same_parents=use_same_parents, tx=tx, weight=weight)
-    manager.propagate_tx(tx)
-    return tx
+    """Add a deliberately double-spending tx.
+
+    Injects through the trusted entry point, which skips the mempool-entry conflict checks, so the
+    double spend reaches consensus and can be voided there.
+    """
+    new_tx = gen_new_double_spending(manager, use_same_parents=use_same_parents, tx=tx, weight=weight)
+    manager.vertex_handler.on_new_trusted_vertex(new_tx)
+    return new_tx
 
 
 def add_new_tx(


### PR DESCRIPTION
### Motivation

`VertexHandler` accumulated overlapping entry points (`on_new_block`, `on_new_relayed_vertex`, `_old_on_new_vertex`) and a `VerificationParams` carrying a bag of boolean flags that callers had to set correctly and verifiers had to branch on. This made it hard to tell which restrictions apply in which context.

This PR makes the call context explicit and replaces the per-check flags with context-specific constructors, so the applicable restrictions follow from the call context rather than from caller-supplied flags. The guiding rule is that every transaction entering the mempool — via mempool sync, real-time relay from peers, or local submission through APIs — is verified with the mempool-entry restrictions; only transactions that arrive inside blocks skip them.

### Acceptance Criteria

- Rename `Features.from_vertex` to `for_vertex`, for consistency with `for_mempool`.
- Replace the `VerificationParams` boolean flags with context-specific constructors carrying a single `apply_mempool_restrictions` flag.
- Apply the mempool-entry restrictions to every transaction entering the mempool — mempool sync, the sync agent's real-time relay, and `on_new_tx` (APIs, wallet, mining).
- Split `VertexHandler` entry points by vertex source:
    - `on_new_sync_block` (block sync; block-carried transactions keep the lenient rules), `on_new_mempool_transaction` (hardened, all mempool-entry transaction paths).
    - `on_new_relayed_block` (relayed/locally-created blocks).
    - `on_new_trusted_vertex` (lenient, trusted local injection only).
- Rename internal `_old_on_new_vertex` to `_internal_on_new_vertex`.
- Drop the now-unused `quiet` and `reject_locked_reward` parameters from `HathorManager.on_new_tx`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
