### PR TITLE
fix: invalid vertex for blueprint returning 500

### DIFF
--- a/hathor/nanocontracts/resources/blueprint.py
+++ b/hathor/nanocontracts/resources/blueprint.py
@@ -24,7 +24,11 @@ from hathor.api_util import Resource, set_cors
 from hathor.nanocontracts import types as nc_types
 from hathor.nanocontracts.blueprint import NC_FIELDS_ATTR
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.exception import BlueprintDoesNotExist, OCBBlueprintNotConfirmed
+from hathor.nanocontracts.exception import (
+    BlueprintDoesNotExist,
+    OCBBlueprintNotConfirmed,
+    OCBInvalidBlueprintVertexType,
+)
 from hathor.nanocontracts.types import blueprint_id_from_bytes
 from hathor.nanocontracts.utils import is_nc_public_method, is_nc_view_method
 from hathor.utils.api import ErrorResponse, QueryParams, Response
@@ -93,6 +97,12 @@ class BlueprintInfoResource(Resource):
 
         try:
             blueprint_class = self.manager.blueprint_service.get_blueprint_class(blueprint_id)
+        except OCBInvalidBlueprintVertexType:
+            request.setResponseCode(400)
+            error_response = ErrorResponse(
+                success=False, error=f'Given id is not a blueprint: {params.blueprint_id}'
+            )
+            return error_response.json_dumpb()
         except BlueprintDoesNotExist:
             request.setResponseCode(404)
             error_response = ErrorResponse(success=False, error=f'Blueprint not found: {params.blueprint_id}')

--- a/hathor/nanocontracts/resources/blueprint_source_code.py
+++ b/hathor/nanocontracts/resources/blueprint_source_code.py
@@ -16,7 +16,11 @@ from typing import TYPE_CHECKING
 
 from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, set_cors
-from hathor.nanocontracts.exception import BlueprintDoesNotExist, OCBBlueprintNotConfirmed
+from hathor.nanocontracts.exception import (
+    BlueprintDoesNotExist,
+    OCBBlueprintNotConfirmed,
+    OCBInvalidBlueprintVertexType,
+)
 from hathor.nanocontracts.types import blueprint_id_from_bytes
 from hathor.utils.api import ErrorResponse, QueryParams, Response
 
@@ -52,6 +56,12 @@ class BlueprintSourceCodeResource(Resource):
 
         try:
             blueprint_source = self.manager.blueprint_service.get_blueprint_source(blueprint_id)
+        except OCBInvalidBlueprintVertexType:
+            request.setResponseCode(400)
+            error_response = ErrorResponse(
+                success=False, error=f'Given id is not a blueprint: {params.blueprint_id}'
+            )
+            return error_response.json_dumpb()
         except OCBBlueprintNotConfirmed:
             request.setResponseCode(404)
             error_response = ErrorResponse(success=False, error=f'Blueprint not confirmed: {params.blueprint_id}')

--- a/hathor_tests/resources/nanocontracts/test_blueprint.py
+++ b/hathor_tests/resources/nanocontracts/test_blueprint.py
@@ -21,6 +21,18 @@ class BaseBlueprintInfoTest(GenericNanoResourceTest):
         self.web = StubSite(BlueprintInfoResource(self.manager))
 
     @inlineCallbacks
+    def test_fail_not_a_blueprint(self) -> Generator[Deferred[Any], Any, None]:
+        # Use the genesis block hash, which is a valid vertex but not a blueprint.
+        genesis_block = next(tx for tx in self.manager.tx_storage.get_all_genesis() if tx.is_block)
+        response = yield self.web.get(
+            'blueprint',
+            {
+                b'blueprint_id': bytes(genesis_block.hash_hex, 'utf-8'),
+            }
+        )
+        self.assertEqual(400, response.responseCode)
+
+    @inlineCallbacks
     def test_fail_missing_id(self) -> Generator[Deferred[Any], Any, None]:
         response1 = yield self.web.get('blueprint')
         self.assertEqual(400, response1.responseCode)

--- a/hathor_tests/resources/nanocontracts/test_blueprint_source_code.py
+++ b/hathor_tests/resources/nanocontracts/test_blueprint_source_code.py
@@ -21,6 +21,18 @@ class BaseBlueprintSourceCodeTest(GenericNanoResourceTest):
         self.web = StubSite(BlueprintSourceCodeResource(self.manager))
 
     @inlineCallbacks
+    def test_fail_not_a_blueprint(self):
+        # Use the genesis block hash, which is a valid vertex but not a blueprint.
+        genesis_block = next(tx for tx in self.manager.tx_storage.get_all_genesis() if tx.is_block)
+        response = yield self.web.get(
+            'blueprint/source',
+            {
+                b'blueprint_id': bytes(genesis_block.hash_hex, 'utf-8'),
+            }
+        )
+        self.assertEqual(400, response.responseCode)
+
+    @inlineCallbacks
     def test_fail_missing_id(self):
         response1 = yield self.web.get('blueprint/source')
         self.assertEqual(400, response1.responseCode)


### PR DESCRIPTION
### Motivation

Blueprint info and source code API endpoints were returning HTTP 500 when called with a valid vertex ID that is not a blueprint (e.g., a block or transaction hash).

Alert: https://hathor.app.opsgenie.com/alert/detail/aa40f6ff-a34c-4abc-b5bc-c03307cfb08b-1774630777154/details

When the vertex exists but is not a blueprint, `BlueprintService.get_blueprint_class()` / `get_blueprint_source()` raises `OCBInvalidBlueprintVertexType`, which was unhandled, causing a 500 Internal Server Error.

### Acceptance Criteria

- Handle `OCBInvalidBlueprintVertexType` in `BlueprintInfoResource`, returning HTTP 400
- Handle `OCBInvalidBlueprintVertexType` in `BlueprintSourceCodeResource`, returning HTTP 400
- Add tests for both endpoints using a non-blueprint vertex (genesis block)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged