### PR TITLE
fix: missing token version in version api

### DIFF
--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -23,6 +23,7 @@ from hathor.conf.get_settings import get_global_settings
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.utils import Features
 from hathor.manager import HathorManager
+from hathor.transaction.token_info import TokenVersion
 from hathor.types import BlockId, TransactionId
 from hathor.utils.pydantic import BaseModel, Hex
 
@@ -31,6 +32,7 @@ class NativeTokenInfo(BaseModel):
     """Information about the native token."""
     name: str = Field(description="Native token name")
     symbol: str = Field(description="Native token symbol")
+    version: int = Field(description="Native token version")
 
 
 class VersionResponse(ResponseModel):
@@ -72,7 +74,7 @@ VersionResponse.openapi_examples = {
             genesis_block_hash=BlockId(b'\x00' * 32),
             genesis_tx1_hash=TransactionId(b'\x00' * 31 + b'\x01'),
             genesis_tx2_hash=TransactionId(b'\x00' * 31 + b'\x02'),
-            native_token=NativeTokenInfo(name='Hathor', symbol='HTR'),
+            native_token=NativeTokenInfo(name='Hathor', symbol='HTR', version=TokenVersion.NATIVE),
         ),
     ),
 }
@@ -135,5 +137,6 @@ class VersionResource(Resource):
             native_token=NativeTokenInfo(
                 name=self._settings.NATIVE_TOKEN_NAME,
                 symbol=self._settings.NATIVE_TOKEN_SYMBOL,
+                version=TokenVersion.NATIVE,
             ),
         )

--- a/hathor_tests/resources/test_version.py
+++ b/hathor_tests/resources/test_version.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from twisted.internet.defer import inlineCallbacks
 
 import hathor
+from hathor.transaction.token_info import TokenVersion
 from hathor.version import BASE_VERSION, DEFAULT_VERSION_SUFFIX, _get_version
 from hathor.version_resource import VersionResource
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
@@ -26,6 +27,16 @@ class VersionTest(_BaseResourceTest._ResourceTest):
         response = yield self.web.get("version")
         data = response.json_value()
         self.assertEqual(data['version'], hathor.__version__)
+
+    @inlineCallbacks
+    def test_native_token(self):
+        response = yield self.web.get("version")
+        data = response.json_value()
+
+        native_token = data['native_token']
+        self.assertEqual(native_token['name'], self._settings.NATIVE_TOKEN_NAME)
+        self.assertEqual(native_token['symbol'], self._settings.NATIVE_TOKEN_SYMBOL)
+        self.assertEqual(native_token['version'], int(TokenVersion.NATIVE))
 
     def test_local_version(self):
         """Test that we will return a version with the default prefix when the BUILD_VERSION file


### PR DESCRIPTION
### Motivation

The native token version is not being provided in the api

### Acceptance Criteria

- Should return the native token version in the version api

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 