### PR TITLE
chore: fix module settings and license notices

### DIFF
--- a/hathorlib/hathorlib/base_transaction.py
+++ b/hathorlib/hathorlib/base_transaction.py
@@ -28,8 +28,6 @@ from hathorlib.scripts import P2PKH, DataScript, MultiSig, parse_address_script
 from hathorlib.utils import int_to_bytes, unpack, unpack_len
 from hathorlib.vertex_parser import VertexParser
 
-settings = HathorSettings()
-
 MAX_NONCE = 2**32
 
 MAX_OUTPUT_VALUE = 2**63  # max value (inclusive) that is possible to encode: 9223372036854775808 ~= 9.22337e+18
@@ -452,11 +450,26 @@ class BaseTransaction(ABC):
         """Returns True if it's an NFT creation transaction"""
         return False
 
-    def is_standard(self, std_max_output_script_size: int = settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE,
-                    only_standard_script_type: bool = True,
-                    max_number_of_data_script_outputs: int = settings.MAX_DATA_SCRIPT_OUTPUTS) -> bool:
+    def is_standard(
+        self,
+        std_max_output_script_size: Optional[int] = None,
+        only_standard_script_type: bool = True,
+        max_number_of_data_script_outputs: Optional[int] = None,
+    ) -> bool:
         """ Return True is the transaction is standard
         """
+        settings = HathorSettings()
+        std_max_output_script_size = (
+            settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE
+            if std_max_output_script_size is None
+            else std_max_output_script_size
+        )
+        max_number_of_data_script_outputs = (
+            settings.MAX_DATA_SCRIPT_OUTPUTS
+            if max_number_of_data_script_outputs is None
+            else max_number_of_data_script_outputs
+        )
+
         # TODO in the future we should have a way to know which standard validation failed
         # we could have an array of errors from args that we append an error object
         # or a bool parameter "raise_on_non_standard", which will raise an error if it's non standard
@@ -665,8 +678,14 @@ class TxOutput:
             data['decoded'] = self.to_human_readable()
         return data
 
-    def is_script_size_valid(self, max_output_script_size: int = settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE) -> bool:
+    def is_script_size_valid(self, max_output_script_size: Optional[int] = None) -> bool:
         """Return True if output script size is valid"""
+        settings = HathorSettings()
+        max_output_script_size = (
+            settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE
+            if max_output_script_size is None
+            else max_output_script_size
+        )
         if len(self.script) > max_output_script_size:
             return False
 
@@ -676,9 +695,18 @@ class TxOutput:
         """Return True if output script is a DataScript"""
         return DataScript.parse_script(self.script) is not None
 
-    def is_standard_script(self, std_max_output_script_size: int = settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE,
-                           only_standard_script_type: bool = True) -> bool:
+    def is_standard_script(
+        self,
+        std_max_output_script_size: Optional[int] = None,
+        only_standard_script_type: bool = True,
+    ) -> bool:
         """Return True if this output has a standard script."""
+        settings = HathorSettings()
+        std_max_output_script_size = (
+            settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE
+            if std_max_output_script_size is None
+            else std_max_output_script_size
+        )
         # First check: script size limit
         if not self.is_script_size_valid(std_max_output_script_size):
             return False

--- a/hathorlib/hathorlib/base_transaction.py
+++ b/hathorlib/hathorlib/base_transaction.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import base64
 import datetime
 import hashlib

--- a/hathorlib/hathorlib/block.py
+++ b/hathorlib/hathorlib/block.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from struct import pack
 from typing import Dict

--- a/hathorlib/hathorlib/client.py
+++ b/hathorlib/hathorlib/client.py
@@ -1,7 +1,16 @@
-# Copyright (c) Hathor Labs and its affiliates.
+# Copyright 2026 Hathor Labs
 #
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import re
 from typing import Any, Dict, List, NamedTuple, Optional, cast

--- a/hathorlib/hathorlib/conf/mainnet.py
+++ b/hathorlib/hathorlib/conf/mainnet.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from hathorlib.conf.settings import HathorSettings
 

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 from enum import StrEnum, auto, unique

--- a/hathorlib/hathorlib/conf/testnet.py
+++ b/hathorlib/hathorlib/conf/testnet.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from hathorlib.conf.settings import HathorSettings
 

--- a/hathorlib/hathorlib/conf/utils.py
+++ b/hathorlib/hathorlib/conf/utils.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import importlib
 from pathlib import Path
 from typing import TypeVar, Union

--- a/hathorlib/hathorlib/daa.py
+++ b/hathorlib/hathorlib/daa.py
@@ -1,7 +1,16 @@
-# Copyright (c) Hathor Labs and its affiliates.
+# Copyright 2026 Hathor Labs
 #
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from math import log
 from typing import TYPE_CHECKING

--- a/hathorlib/hathorlib/daa.py
+++ b/hathorlib/hathorlib/daa.py
@@ -20,8 +20,6 @@ from hathorlib.conf import HathorSettings
 if TYPE_CHECKING:
     from hathorlib import Transaction
 
-settings = HathorSettings()
-
 
 def minimum_tx_weight(tx: 'Transaction', *, fix_parents: bool = True) -> float:
     """Return the minimum weight for the tx.
@@ -32,6 +30,7 @@ def minimum_tx_weight(tx: 'Transaction', *, fix_parents: bool = True) -> float:
                                   ----------------
                                    1 + k / amount
     """
+    settings = HathorSettings()
     tx_size = len(tx.get_struct())
 
     # When a transaction is still being create, it might not have its parents yet.

--- a/hathorlib/hathorlib/nanocontracts/on_chain_blueprint.py
+++ b/hathorlib/hathorlib/nanocontracts/on_chain_blueprint.py
@@ -19,8 +19,6 @@ from hathorlib.conf import HathorSettings
 from hathorlib.transaction import Transaction
 from hathorlib.utils import int_to_bytes, unpack, unpack_len
 
-settings = HathorSettings()
-
 # used to allow new versions of the serialization format in the future
 ON_CHAIN_BLUEPRINT_VERSION: int = 1
 
@@ -96,6 +94,7 @@ class OnChainBlueprint(Transaction):
     @classmethod
     def deserialize_code(_cls, buf: bytes) -> tuple[Code, bytes]:
         """Parses the self.code field, returns the parse result and the remaining bytes."""
+        settings = HathorSettings()
         (ocb_version,), buf = unpack('!B', buf)
         if ocb_version != ON_CHAIN_BLUEPRINT_VERSION:
             raise ValueError(f'unknown on-chain blueprint version: {ocb_version}')

--- a/hathorlib/hathorlib/scripts.py
+++ b/hathorlib/hathorlib/scripts.py
@@ -26,8 +26,6 @@ from hathorlib.utils import (
     get_address_b58_from_redeem_script_hash,
 )
 
-settings = HathorSettings()
-
 
 def re_compile(pattern: str) -> Pattern[bytes]:
     """ Transform a given script pattern into a regular expression.
@@ -482,6 +480,7 @@ def create_output_script(address: bytes, timelock: Optional[Any] = None) -> byte
 
         :rtype: bytes
     """
+    settings = HathorSettings()
     if address[0] == binary_to_int(settings.P2PKH_VERSION_BYTE):
         return P2PKH.create_output_script(address, timelock)
     elif address[0] == binary_to_int(settings.MULTISIG_VERSION_BYTE):

--- a/hathorlib/hathorlib/scripts.py
+++ b/hathorlib/hathorlib/scripts.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import re
 import struct

--- a/hathorlib/hathorlib/token_creation_tx.py
+++ b/hathorlib/hathorlib/token_creation_tx.py
@@ -24,8 +24,6 @@ from hathorlib.token_info import TokenVersion
 from hathorlib.transaction import Transaction
 from hathorlib.utils import clean_token_string, int_to_bytes, unpack, unpack_len
 
-settings = HathorSettings()
-
 # Signal bits (B), version (B), inputs len (B), outputs len (B)
 _FUNDS_FORMAT_STRING = '!BBBB'
 
@@ -190,6 +188,7 @@ class TokenCreationTransaction(Transaction):
     def verify_token_info(self) -> None:
         """ Validates token info
         """
+        settings = HathorSettings()
         name_len = len(self.token_name)
         symbol_len = len(self.token_symbol)
         if name_len == 0 or name_len > settings.MAX_LENGTH_TOKEN_NAME:

--- a/hathorlib/hathorlib/transaction.py
+++ b/hathorlib/hathorlib/transaction.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 

--- a/hathorlib/hathorlib/transaction.py
+++ b/hathorlib/hathorlib/transaction.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
 
 T = TypeVar('T', bound=VertexBaseHeader)
 
-settings = HathorSettings()
-
 # Signal bits (B), version (B), token uids len (B) and inputs len (B), outputs len (B).
 _FUNDS_FORMAT_STRING = '!BBBBB'
 
@@ -221,6 +219,7 @@ class Transaction(BaseTransaction):
         :return: the token uid
         :rtype: bytes
         """
+        settings = HathorSettings()
         if index == 0:
             return settings.HATHOR_TOKEN_UID
         return self.tokens[index - 1]

--- a/hathorlib/hathorlib/utils/__init__.py
+++ b/hathorlib/hathorlib/utils/__init__.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import re
 import struct
 from math import ceil, floor

--- a/hathorlib/hathorlib/utils/address.py
+++ b/hathorlib/hathorlib/utils/address.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import hashlib
-from typing import cast
+from typing import Optional, cast
 
 import base58
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -20,8 +20,6 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import InvalidAddress
-
-settings = HathorSettings()
 
 
 def get_checksum(address_bytes: bytes) -> bytes:
@@ -90,7 +88,7 @@ def get_address_b58_from_public_key_hash(public_key_hash: bytes) -> str:
 
 
 def get_address_from_public_key_hash(
-    public_key_hash: bytes, version_byte: bytes = settings.P2PKH_VERSION_BYTE
+    public_key_hash: bytes, version_byte: Optional[bytes] = None
 ) -> bytes:
     """Gets the address in bytes from the public key hash
 
@@ -103,6 +101,12 @@ def get_address_from_public_key_hash(
         :return: address in bytes
         :rtype: bytes
     """
+    settings = HathorSettings()
+    version_byte = (
+        settings.P2PKH_VERSION_BYTE
+        if version_byte is None
+        else version_byte
+    )
     address = b''
     # Version byte
     address += version_byte
@@ -114,7 +118,7 @@ def get_address_from_public_key_hash(
 
 
 def get_address_b58_from_redeem_script_hash(redeem_script_hash: bytes,
-                                            version_byte: bytes = settings.MULTISIG_VERSION_BYTE) -> str:
+                                            version_byte: Optional[bytes] = None) -> str:
     """Gets the b58 address from the hash of the redeem script in multisig.
 
         :param redeem_script_hash: hash of the redeem script (sha256 and ripemd160)
@@ -123,12 +127,18 @@ def get_address_b58_from_redeem_script_hash(redeem_script_hash: bytes,
         :return: address in base 58
         :rtype: string
     """
+    settings = HathorSettings()
+    version_byte = (
+        settings.MULTISIG_VERSION_BYTE
+        if version_byte is None
+        else version_byte
+    )
     address = get_address_from_redeem_script_hash(redeem_script_hash, version_byte)
     return base58.b58encode(address).decode('utf-8')
 
 
 def get_address_from_redeem_script_hash(redeem_script_hash: bytes,
-                                        version_byte: bytes = settings.MULTISIG_VERSION_BYTE) -> bytes:
+                                        version_byte: Optional[bytes] = None) -> bytes:
     """Gets the address in bytes from the redeem script hash
 
         :param redeem_script_hash: hash of redeem script (sha256 and ripemd160)
@@ -140,6 +150,12 @@ def get_address_from_redeem_script_hash(redeem_script_hash: bytes,
         :return: address in bytes
         :rtype: bytes
     """
+    settings = HathorSettings()
+    version_byte = (
+        settings.MULTISIG_VERSION_BYTE
+        if version_byte is None
+        else version_byte
+    )
     address = b''
     # Version byte
     address += version_byte

--- a/hathorlib/hathorlib/utils/address.py
+++ b/hathorlib/hathorlib/utils/address.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import hashlib
 from typing import cast
 

--- a/hathorlib/tests/test_basic.py
+++ b/hathorlib/tests/test_basic.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 

--- a/hathorlib/tests/test_client.py
+++ b/hathorlib/tests/test_client.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from contextlib import asynccontextmanager
 from typing import AsyncIterator

--- a/hathorlib/tests/test_daa.py
+++ b/hathorlib/tests/test_daa.py
@@ -1,7 +1,16 @@
-# Copyright (c) Hathor Labs and its affiliates.
+# Copyright 2026 Hathor Labs
 #
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 

--- a/hathorlib/tests/test_data_script.py
+++ b/hathorlib/tests/test_data_script.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 

--- a/hathorlib/tests/test_nanocontract.py
+++ b/hathorlib/tests/test_nanocontract.py
@@ -1,7 +1,16 @@
-# Copyright (c) Hathor Labs and its affiliates.
+# Copyright 2026 Hathor Labs
 #
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 

--- a/hathorlib/tests/test_nft.py
+++ b/hathorlib/tests/test_nft.py
@@ -1,9 +1,16 @@
-"""
-Copyright (c) Hathor Labs and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 

--- a/hathorlib/tests/test_on_chain_blueprint.py
+++ b/hathorlib/tests/test_on_chain_blueprint.py
@@ -1,7 +1,16 @@
-# Copyright (c) Hathor Labs and its affiliates.
+# Copyright 2026 Hathor Labs
 #
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import unittest
 

--- a/hathorlib/tests/test_util.py
+++ b/hathorlib/tests/test_util.py
@@ -1,7 +1,16 @@
-# Copyright (c) Hathor Labs and its affiliates.
+# Copyright 2026 Hathor Labs
 #
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import base64
 import unittest


### PR DESCRIPTION
### Motivation

Some license notices were outdated and needed to be updated.

hathorlib sometimes uses a module level settings and this made the sync fail in the latest release

### Acceptance Criteria

- Update license notices in hathorlib
- Remove all instances of module level settings on hathorlib

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 