### PR TITLE
feat(nano): add --x-nc-sync-check for debugging

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -193,6 +193,7 @@ class Builder:
 
         self._enable_ipv6: bool = False
         self._disable_ipv4: bool = False
+        self._nc_sync_check_start_height: int | None = None
 
         self._nc_storage_factory: NCStorageFactory | None = None
         self._nc_log_storage: NCLogStorage | None = None
@@ -481,13 +482,26 @@ class Builder:
             enable_ipv6=self._enable_ipv6,
             disable_ipv4=self._disable_ipv4,
         )
+        vertex_handler = self._get_or_create_vertex_handler()
         SyncSupportLevel.add_factories(
             self._get_or_create_settings(),
             self._p2p_manager,
             self._sync_v2_support,
             self._get_or_create_vertex_parser(),
-            self._get_or_create_vertex_handler(),
+            vertex_handler,
         )
+
+        if self._nc_sync_check_start_height is not None:
+            from hathor.nanocontracts.nc_sync_checker import NCSyncChecker
+            nc_sync_checker = NCSyncChecker(
+                tx_storage=self._get_or_create_tx_storage(),
+                p2p_manager=self._p2p_manager,
+                nc_storage_factory=self._get_or_create_nc_storage_factory(),
+                reactor=self._get_reactor(),
+                start_height=self._nc_sync_check_start_height,
+            )
+            vertex_handler.set_nc_sync_checker(nc_sync_checker)
+
         return self._p2p_manager
 
     def _get_or_create_indexes_manager(self) -> IndexesManager:
@@ -866,6 +880,11 @@ class Builder:
     def disable_ipv4(self) -> 'Builder':
         self.check_if_can_modify()
         self._disable_ipv4 = True
+        return self
+
+    def set_nc_sync_check_start_height(self, height: int) -> 'Builder':
+        self.check_if_can_modify()
+        self._nc_sync_check_start_height = height
         return self
 
     def set_soft_voided_tx_ids(self, soft_voided_tx_ids: set[bytes]) -> 'Builder':

--- a/hathor/consensus/block_consensus.py
+++ b/hathor/consensus/block_consensus.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from structlog import get_logger
 
@@ -24,7 +24,6 @@ from hathor.execution_manager import non_critical_code
 from hathor.feature_activation.utils import Features
 from hathor.transaction import BaseTransaction, Block, Transaction
 from hathor.transaction.nc_execution_state import NCExecutionState
-from hathor.util import classproperty
 from hathor.utils.weight import weight_to_work
 
 if TYPE_CHECKING:
@@ -35,8 +34,6 @@ if TYPE_CHECKING:
     from hathor.nanocontracts.nc_exec_logs import NCLogStorage
 
 logger = get_logger()
-
-_base_transaction_log = logger.new()
 
 
 class BlockConsensusAlgorithm:
@@ -49,18 +46,11 @@ class BlockConsensusAlgorithm:
         block_executor: 'NCConsensusBlockExecutor',
         feature_service: 'FeatureService',
     ) -> None:
+        self.log = logger.new()
         self._settings = settings
         self.context = context
         self._block_executor = block_executor
         self.feature_service = feature_service
-
-    @classproperty
-    def log(cls) -> Any:
-        """ This is a workaround because of a bug on structlog (or abc).
-
-        See: https://github.com/hynek/structlog/issues/229
-        """
-        return _base_transaction_log
 
     def update_consensus(self, block: Block) -> None:
         assert self.context.nc_events is None

--- a/hathor/consensus/consensus.py
+++ b/hathor/consensus/consensus.py
@@ -45,8 +45,6 @@ if TYPE_CHECKING:
 logger = get_logger()
 cpu = get_cpu_profiler()
 
-_base_transaction_log = logger.new()
-
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class ConsensusEvent:

--- a/hathor/consensus/context.py
+++ b/hathor/consensus/context.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from structlog import get_logger
-
 from hathor.transaction import BaseTransaction, Block, Transaction
 
 if TYPE_CHECKING:
@@ -26,10 +24,6 @@ if TYPE_CHECKING:
     from hathor.consensus.consensus import ConsensusAlgorithm
     from hathor.consensus.transaction_consensus import TransactionConsensusAlgorithm
     from hathor.nanocontracts.nc_exec_logs import NCEvent
-
-logger = get_logger()
-
-_base_transaction_log = logger.new()
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)

--- a/hathor/consensus/transaction_consensus.py
+++ b/hathor/consensus/transaction_consensus.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Iterable, cast
+from typing import TYPE_CHECKING, Iterable, cast
 
 from structlog import get_logger
 
@@ -20,7 +20,6 @@ from hathor.conf.get_settings import get_global_settings
 from hathor.execution_manager import non_critical_code
 from hathor.transaction import BaseTransaction, Block, Transaction, TxInput
 from hathor.types import VertexId
-from hathor.util import classproperty
 from hathor.utils.weight import weight_to_work
 
 if TYPE_CHECKING:
@@ -28,23 +27,14 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-_base_transaction_log = logger.new()
-
 
 class TransactionConsensusAlgorithm:
     """Implement the consensus algorithm for transactions."""
 
     def __init__(self, context: 'ConsensusAlgorithmContext') -> None:
+        self.log = logger.new()
         self._settings = get_global_settings()
         self.context = context
-
-    @classproperty
-    def log(cls) -> Any:
-        """ This is a workaround because of a bug on structlog (or abc).
-
-        See: https://github.com/hynek/structlog/issues/229
-        """
-        return _base_transaction_log
 
     def update_consensus(self, tx: Transaction) -> None:
         self.mark_inputs_as_used(tx)

--- a/hathor/nanocontracts/execution/consensus_block_executor.py
+++ b/hathor/nanocontracts/execution/consensus_block_executor.py
@@ -46,8 +46,6 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-_base_transaction_log = logger.new()
-
 
 class NCConsensusBlockExecutor:
     """
@@ -82,10 +80,7 @@ class NCConsensusBlockExecutor:
         self._nc_storage_factory = nc_storage_factory
         self._nc_log_storage = nc_log_storage
         self._nc_exec_fail_trace = nc_exec_fail_trace
-
-    @property
-    def log(self) -> Any:
-        return _base_transaction_log
+        self.log = logger.new()
 
     def initialize_empty(self, block: Block, context: 'ConsensusAlgorithmContext') -> None:
         """Initialize a block with an empty contract trie."""

--- a/hathor/nanocontracts/nc_sync_checker.py
+++ b/hathor/nanocontracts/nc_sync_checker.py
@@ -1,0 +1,206 @@
+# Copyright 2024 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from structlog import get_logger
+from twisted.internet.task import deferLater
+
+from hathor.nanocontracts.storage.block_storage import ContractKey
+from hathor.nanocontracts.storage.patricia_trie import NodeId
+from hathor.nanocontracts.types import ContractId
+from hathor.p2p.states import ReadyState
+from hathor.transaction import Block
+
+if TYPE_CHECKING:
+    from hathor.p2p.manager import ConnectionsManager
+    from hathor.reactor import ReactorProtocol as Reactor
+    from hathor.transaction.storage import TransactionStorage
+    from hathorlib.nanocontracts.storage.factory import NCStorageFactory
+
+_GET_READY_DELAY_SECS: float = 1.0
+_MAX_GET_READY_RETRIES: int = 5
+
+logger = get_logger()
+
+
+class NCSyncChecker:
+    """Compares the local NC state trie root with a connected peer's for each processed block.
+
+    This check is peer-independent: it picks any available connected peer to query,
+    and runs once per block regardless of which sync path delivered it.
+    """
+
+    __slots__ = (
+        '_log',
+        '_reactor',
+        '_tx_storage',
+        '_p2p_manager',
+        '_nc_storage_factory',
+        '_start_height',
+        '_found_incompatible',
+    )
+
+    def __init__(
+        self,
+        *,
+        reactor: Reactor,
+        tx_storage: TransactionStorage,
+        p2p_manager: ConnectionsManager,
+        nc_storage_factory: NCStorageFactory,
+        start_height: int,
+    ) -> None:
+        self._log = logger.new()
+        self._reactor = reactor
+        self._tx_storage = tx_storage
+        self._p2p_manager = p2p_manager
+        self._nc_storage_factory = nc_storage_factory
+        self._start_height = start_height
+        self._found_incompatible: bool = False
+
+    async def check_block(self, block: Block) -> None:
+        """Compare our NC state trie root with a peer's for this block.
+
+        If the roots differ, iterate the block's NC transactions to identify which contracts diverged.
+        """
+        if self._found_incompatible:
+            # We only check the first incompatible block we find, then stop the full node.
+            return
+
+        block = self._tx_storage.get_block(block.hash)  # Re-fetch to make sure static metadata is set.
+        if block.get_height() < self._start_height:
+            # We're not interested in checking this height.
+            return
+
+        my_root_id = block.get_metadata().nc_block_root_id
+        if my_root_id is None:
+            # This block doesn't have nano state.
+            return
+
+        ready_state = await self._get_ready_state()
+        peer_root_id = await ready_state.send_get_block_nc_root_id(block.hash)
+
+        if self._found_incompatible:
+            # Another concurrent check_block set this while we were awaiting.
+            return
+
+        if peer_root_id == my_root_id:
+            ready_state.log.debug('compatible block state', block=block.hash_hex, height=block.get_height())
+            return
+
+        self._found_incompatible = True
+        ready_state.log.error(
+            'incompatible block state',
+            block=block.hash_hex,
+            my_root=my_root_id.hex(),
+            peer_root=peer_root_id.hex(),
+            height=block.get_height(),
+        )
+
+        block_storage = self._nc_storage_factory.get_block_storage(my_root_id)
+        checked_contracts: set[ContractId] = set()
+
+        # TODO: Future improvement - this is not the order of execution, which would be better.
+        for tx in block.iter_transactions_in_this_block():
+            if not tx.is_nano_contract():
+                continue
+
+            contract_id = tx.get_nano_header().get_contract_id()
+            if contract_id in checked_contracts:
+                continue
+
+            checked_contracts.add(contract_id)
+
+            try:
+                my_contract_root = block_storage.get_contract_root_id(contract_id)
+            except KeyError:
+                # The contract might not exist in our block trie if the tx execution was skipped or failed.
+                my_contract_root = None
+
+            peer_contract_root = await self._get_peer_contract_root(ready_state, peer_root_id, contract_id)
+            if my_contract_root != peer_contract_root:
+                ready_state.log.error(
+                    'incompatible contract state',
+                    tx=tx.hash_hex,
+                    contract_id=contract_id.hex(),
+                    my_root=my_contract_root.hex() if my_contract_root else None,
+                    peer_root=peer_contract_root.hex() if peer_contract_root else None,
+                )
+                continue
+
+        ready_state.log.error('stopping node due to incompatible NC state')
+        try:
+            self._reactor.stop()
+        except Exception:
+            pass
+
+    @staticmethod
+    async def _get_peer_contract_root(
+        state: ReadyState,
+        peer_block_root_id: NodeId,
+        contract_id: ContractId,
+    ) -> bytes | None:
+        """Walk the peer's block Patricia trie to find a specific contract's root_id.
+
+        This method traverses from the trie root, following child nodes whose key is a prefix
+        of the remaining suffix, until it finds the target key or determines it doesn't exist.
+        It's analogous to `PatriciaTrie._find_nearest_node` but adapted for async and using JSON
+        data instead of typed `Node`s.
+        """
+        raw_key = bytes(ContractKey(contract_id))
+        target_key = raw_key.hex().encode('ascii')
+        node_data: dict[str, Any] = await state.send_get_nc_db_node(peer_block_root_id)
+
+        while True:
+            current_key = bytes.fromhex(node_data['key'])
+            if current_key == target_key:
+                if content := node_data.get('content'):
+                    return bytes.fromhex(content)
+                return None
+
+            if not target_key.startswith(current_key):
+                return None
+
+            suffix = target_key[len(current_key):]
+            children = node_data.get('children', {})
+
+            found = False
+            for child_key_hex, child_id_hex in children.items():
+                child_key = bytes.fromhex(child_key_hex)
+                if suffix.startswith(child_key):
+                    child_id = NodeId(bytes.fromhex(child_id_hex))
+                    node_data = await state.send_get_nc_db_node(child_id)
+                    found = True
+                    break
+
+            if not found:
+                return None
+
+    async def _get_ready_state(self, *, retries: int = 0) -> ReadyState:
+        """Pick any connected peer in ReadyState that isn't busy with a pending NC check."""
+        if retries > _MAX_GET_READY_RETRIES:
+            msg = 'could not get ready peer'
+            self._log.error(msg, retries=retries)
+            raise Exception(msg)
+
+        for conn in self._p2p_manager.iter_ready_connections():
+            if not isinstance(conn.state, ReadyState):
+                continue
+            return conn.state
+
+        # There are no ready connections available, wait and try again.
+        await deferLater(self._reactor, _GET_READY_DELAY_SECS, lambda: None)
+        return await self._get_ready_state(retries=retries + 1)

--- a/hathor/p2p/states/ready.py
+++ b/hathor/p2p/states/ready.py
@@ -16,6 +16,7 @@ from collections import deque
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from structlog import get_logger
+from twisted.internet.defer import Deferred
 from twisted.internet.task import LoopingCall
 
 from hathor.conf.settings import HathorSettings
@@ -76,9 +77,9 @@ class ReadyState(BaseState):
         # The last blocks from the best blockchain in the peer
         self.peer_best_blockchain: list[HeightInfo] = []
 
-        # The last nc-state received
-        self.peer_nc_block_root_id: tuple[VertexId, NodeId] | None = None
-        self.peer_nc_node: dict[str, Any] | None = None
+        # Pending nc-state request deferreds (carry their result when resolved)
+        self._pending_nc_block_root_ids: dict[VertexId, list[Deferred[NodeId]]] = {}
+        self._pending_nc_db_nodes: dict[NodeId, list[Deferred[dict[str, Any]]]] = {}
 
         self.cmd_map.update({
             # p2p control messages
@@ -306,11 +307,17 @@ class ReadyState(BaseState):
             return
         self.peer_best_blockchain = best_blockchain
 
-    def send_get_block_nc_root_id(self, block_hash: VertexId) -> None:
-        """ Send a GET-NC-DB-NODE command requesting a node with a given node-id.
+    def send_get_block_nc_root_id(self, block_hash: VertexId) -> Deferred[NodeId]:
+        """ Send a GET-BLOCK-NC-ROOT-ID command requesting the NC root-id for a given block hash.
         """
+        deferred: Deferred[NodeId] = Deferred()
+        if pending := self._pending_nc_block_root_ids.get(block_hash):
+            pending.append(deferred)
+            return deferred
+        self._pending_nc_block_root_ids[block_hash] = [deferred]
         payload = block_hash.hex()
         self.send_message(ProtocolMessages.GET_BLOCK_NC_ROOT_ID, payload)
+        return deferred
 
     def handle_get_block_nc_root_id(self, payload: str) -> None:
         """ Handle a GET-BLOCK-NC-ROOT-ID command by returning the root_id of a given block hash.
@@ -337,38 +344,63 @@ class ReadyState(BaseState):
         self.send_message(ProtocolMessages.BLOCK_NC_ROOT_ID, payload)
 
     def handle_block_nc_root_id(self, payload: str) -> None:
-        """ Handle a BLOCK-NC-ROOT-ID command, to be implemented in the future, for now just logs the response.
+        """ Handle a BLOCK-NC-ROOT-ID response by resolving the pending deferred.
         """
         payload_list = payload.split(maxsplit=1)
         if len(payload_list) != 2:
             self.protocol.send_error_and_close_connection('Invalid BLOCK-NC-ROOT-ID received (missing data).')
             return
+
         block_hash_payload, nc_root_id_payload = payload_list
         try:
             block_hash = bytes.fromhex(block_hash_payload)
         except ValueError:
             self.protocol.send_error_and_close_connection('Invalid block-hash received (not hex).')
             return
+
         if len(block_hash) != 32:
             self.protocol.send_error_and_close_connection('Invalid block-hash received (bad size).')
             return
-        block_id: VertexId = VertexId(block_hash)
+
+        block_id = VertexId(block_hash)
+        if block_id not in self._pending_nc_block_root_ids:
+            self.protocol.send_error_and_close_connection('Unexpected BLOCK-NC-ROOT-ID.')
+            return
+
+        pending = self._pending_nc_block_root_ids.pop(block_id)
         try:
             nc_root_id: NodeId = NodeId(bytes.fromhex(nc_root_id_payload))
         except ValueError:
-            self.protocol.send_error_and_close_connection('Invalid root-id received (not hex)')
+            self._errback_nc_block_root_id(pending, 'Invalid root-id received (not hex)')
             return
-        if len(nc_root_id) != 32:
-            self.protocol.send_error_and_close_connection('Invalid root-id received (bad size)')
-            return
-        self.peer_nc_block_root_id = (block_id, nc_root_id)
-        self.log.info('response received', block_id=block_id.hex(), nc_root_id=nc_root_id.hex())
 
-    def send_get_nc_db_node(self, node_id: NodeId) -> None:
+        if len(nc_root_id) != 32:
+            self._errback_nc_block_root_id(pending, 'Invalid root-id received (bad size)')
+            return
+
+        self.log.debug('response received', block_id=block_id.hex(), nc_root_id=nc_root_id.hex())
+        for deferred in pending:
+            deferred.callback(nc_root_id)
+
+    def _errback_nc_block_root_id(self, pending: list[Deferred[NodeId]], reason: str) -> None:
+        """Errback all pending deferreds and close the connection."""
+        exc = Exception(reason)
+        for deferred in pending:
+            deferred.errback(exc)
+        self.protocol.send_error_and_close_connection(reason)
+
+    def send_get_nc_db_node(self, node_id: NodeId) -> Deferred[dict[str, Any]]:
         """ Send a GET-NC-DB-NODE command requesting a node with a given node-id.
         """
+        deferred: Deferred[dict[str, Any]] = Deferred()
+        pending = self._pending_nc_db_nodes.get(node_id)
+        if pending is not None:
+            pending.append(deferred)
+            return deferred
+        self._pending_nc_db_nodes[node_id] = [deferred]
         payload = node_id.hex()
         self.send_message(ProtocolMessages.GET_NC_DB_NODE, payload)
+        return deferred
 
     def handle_get_nc_db_node(self, payload: str) -> None:
         """ Handle a GET-NC-DB-NODE command by returning the storage Node of a given NodeId.
@@ -401,12 +433,30 @@ class ReadyState(BaseState):
         self.send_message(ProtocolMessages.NC_DB_NODE, json_dumps(data))
 
     def handle_nc_db_node(self, payload: str) -> None:
-        """ Handle a NC-DB-NODE command, to be implemented in the future, for now just logs the response.
+        """ Handle a NC-DB-NODE response by resolving the pending deferred.
         """
         try:
             nc_db_node_data = json_loads(payload)
         except ValueError:  # works for JSONDecodeError too
             self.protocol.send_error_and_close_connection('invalid nc-db-node received (not a json)')
             return
-        self.peer_nc_node = nc_db_node_data
-        self.log.info('response received', nc_node=nc_db_node_data)
+
+        node_id_hex = nc_db_node_data.get('id')
+        if node_id_hex is None:
+            self.protocol.send_error_and_close_connection('invalid nc-db-node received (missing node id)')
+            return
+
+        try:
+            node_id = NodeId(bytes.fromhex(node_id_hex))
+        except (ValueError, TypeError):
+            self.protocol.send_error_and_close_connection('invalid nc-db-node received (bad node id)')
+            return
+
+        pending = self._pending_nc_db_nodes.pop(node_id, None)
+        if pending is None:
+            self.protocol.send_error_and_close_connection('unexpected nc-db-node')
+            return
+
+        self.log.debug('response received', nc_node=nc_db_node_data)
+        for deferred in pending:
+            deferred.callback(nc_db_node_data)

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -36,7 +36,6 @@ from hathor.transaction.transaction_metadata import TransactionMetadata
 from hathor.transaction.util import VerboseCallback
 from hathor.transaction.validation_state import ValidationState
 from hathor.types import TokenUid, TxOutputScript, VertexId
-from hathor.util import classproperty
 from hathor.utils.weight import weight_to_work
 from hathorlib.base_transaction import TxVersion  # noqa: F401
 
@@ -106,8 +105,6 @@ def get_cls_from_tx_version(tx_version: TxVersion) -> type['BaseTransaction']:
         return cls
 
 
-_base_transaction_log = logger.new()
-
 StaticMetadataT = TypeVar('StaticMetadataT', bound=VertexStaticMetadata, covariant=True)
 
 
@@ -116,7 +113,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
     __slots__ = ['version', 'signal_bits', 'weight', 'timestamp', 'nonce', 'inputs', 'outputs', 'parents', '_hash',
                  'storage', '_settings', '_metadata', '_static_metadata', 'headers', 'name', 'MAX_NUM_INPUTS',
-                 'MAX_NUM_OUTPUTS', '__weakref__']
+                 'MAX_NUM_OUTPUTS', '__weakref__', 'log']
 
     # Even though nonce is serialized with different sizes for tx and blocks
     # the same size is used for hashes to enable mining algorithm compatibility
@@ -159,6 +156,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         assert signal_bits <= _ONE_BYTE, f'signal_bits {hex(signal_bits)} must not be larger than one byte'
         assert version <= _ONE_BYTE, f'version {hex(version)} must not be larger than one byte'
 
+        self.log = logger.new()
         self._settings = settings or get_global_settings()
         self.nonce = nonce
         self.timestamp = timestamp or int(time.time())
@@ -179,14 +177,6 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         self.MAX_NUM_INPUTS = self._settings.MAX_NUM_INPUTS
         self.MAX_NUM_OUTPUTS = self._settings.MAX_NUM_OUTPUTS
-
-    @classproperty
-    def log(cls):
-        """ This is a workaround because of a bug on structlog (or abc).
-
-        See: https://github.com/hynek/structlog/issues/229
-        """
-        return _base_transaction_log
 
     def _get_formatted_fields_dict(self, short: bool = True) -> dict[str, str]:
         """ Used internally on __repr__ and __str__, returns a dict of `field_name: formatted_value`.

--- a/hathor/util.py
+++ b/hathor/util.py
@@ -138,19 +138,6 @@ def iwindows(iterable: Iterable[T], window_size: int) -> Iterator[tuple[T, ...]]
         yield tuple(res_item)
 
 
-class classproperty:
-    """ This function is used to make a property that can be accessed from the class. Only getter is supported.
-
-    See: https://stackoverflow.com/a/5192374/947511
-    """
-
-    def __init__(self, f):
-        self.f = f
-
-    def __get__(self, obj, owner):
-        return self.f(owner)
-
-
 class MaxSizeOrderedDict(OrderedDict):
     """ And OrderedDict that has a maximum size, if new elements are added, the oldest elements are silently deleted.
 

--- a/hathor/vertex_handler/vertex_handler.py
+++ b/hathor/vertex_handler/vertex_handler.py
@@ -27,6 +27,7 @@ from hathor.exception import HathorError, InvalidNewTransaction
 from hathor.execution_manager import ExecutionManager, non_critical_code
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.utils import Features
+from hathor.nanocontracts.nc_sync_checker import NCSyncChecker
 from hathor.profiler import get_cpu_profiler
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol
@@ -52,6 +53,7 @@ class VertexHandler:
         '_pubsub',
         '_execution_manager',
         '_log_vertex_bytes',
+        '_nc_sync_checker',
     )
 
     def __init__(
@@ -77,6 +79,10 @@ class VertexHandler:
         self._pubsub = pubsub
         self._execution_manager = execution_manager
         self._log_vertex_bytes = log_vertex_bytes
+        self._nc_sync_checker: NCSyncChecker | None = None
+
+    def set_nc_sync_checker(self, checker: NCSyncChecker) -> None:
+        self._nc_sync_checker = checker
 
     @cpu.profiler('on_new_block')
     @inlineCallbacks
@@ -108,6 +114,9 @@ class VertexHandler:
         if not self._tx_storage.transaction_exists(block.hash):
             if not self._old_on_new_vertex(block, params):
                 return False
+
+        if self._nc_sync_checker is not None:
+            yield self._nc_sync_checker.check_block(block)
 
         return True
 

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -334,6 +334,17 @@ class CliBuilder:
             log_vertex_bytes=self._args.log_vertex_bytes,
         )
 
+        if self._args.x_nc_sync_check is not None:
+            from hathor.nanocontracts.nc_sync_checker import NCSyncChecker
+            nc_sync_checker = NCSyncChecker(
+                tx_storage=tx_storage,
+                p2p_manager=p2p_manager,
+                nc_storage_factory=self.nc_storage_factory,
+                reactor=reactor,
+                start_height=self._args.x_nc_sync_check,
+            )
+            vertex_handler.set_nc_sync_checker(nc_sync_checker)
+
         SyncSupportLevel.add_factories(settings, p2p_manager, SyncSupportLevel.ENABLED, vertex_parser, vertex_handler)
 
         vertex_json_serializer = VertexJsonSerializer(

--- a/hathor_cli/run_node.py
+++ b/hathor_cli/run_node.py
@@ -178,6 +178,10 @@ class RunNode:
         parser.add_argument('--nc-exec-logs', default=NCLogConfig.NONE, choices=possible_nc_exec_logs,
                             help=f'Enable saving Nano Contracts execution logs. One of {possible_nc_exec_logs}')
         parser.add_argument('--nc-exec-fail-trace', action='store_true', help=SUPPRESS)
+        parser.add_argument('--x-nc-sync-check', type=int, nargs='?', const=0, default=None,
+                            help='Enable NC state comparison check during block sync.'
+                            ' Optionally specify a starting block height (default: 0, checks all blocks). '
+                            'Useful to combine with `--nc-exec-fail-trace`.')
         return parser
 
     def prepare(self, *, register_resources: bool = True) -> None:

--- a/hathor_cli/run_node_args.py
+++ b/hathor_cli/run_node_args.py
@@ -96,3 +96,4 @@ class RunNodeArgs(BaseModel):
     nc_indexes: bool
     nc_exec_logs: NCLogConfig
     nc_exec_fail_trace: bool
+    x_nc_sync_check: Optional[int]

--- a/hathor_tests/p2p/test_nc_state.py
+++ b/hathor_tests/p2p/test_nc_state.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.states import ReadyState
 from hathor.simulator import FakeConnection
@@ -61,27 +63,35 @@ class NCStateTestCase(SimulatorTestCase):
         block_id = best_block1.hash
 
         # test simple GET-BLOCK-NC-ROOT-ID/BLOCK-NC-ROOT-ID
-        assert state1.peer_nc_block_root_id is None
-        assert state2.peer_nc_block_root_id is None
-        state1.send_get_block_nc_root_id(block_id)
-        state2.send_get_block_nc_root_id(block_id)
+        # send_get_block_nc_root_id now returns a Deferred[NodeId] directly
+        assert len(state1._pending_nc_block_root_ids) == 0
+        assert len(state2._pending_nc_block_root_ids) == 0
+        deferred1 = state1.send_get_block_nc_root_id(block_id)
+        deferred2 = state2.send_get_block_nc_root_id(block_id)
+        assert block_id in state1._pending_nc_block_root_ids
+        assert block_id in state2._pending_nc_block_root_ids
+        root_results: list[Any] = []
+        deferred1.addCallback(root_results.append)
+        deferred2.addCallback(root_results.append)
         self.simulator.run(5)
-        assert state1.peer_nc_block_root_id is not None
-        assert state2.peer_nc_block_root_id is not None
-        assert state1.peer_nc_block_root_id == state2.peer_nc_block_root_id
-        peer_block_id, peer_node_id = state1.peer_nc_block_root_id
-        assert peer_block_id == block_id
+        assert len(root_results) == 2
+        # Results are now NodeId directly (not tuples)
+        assert root_results[0] == root_results[1]
+        peer_node_id = root_results[0]
 
         # test simple GET-NC-DB-NODE/NC-DB-NODE
-        assert state1.peer_nc_node is None
-        assert state2.peer_nc_node is None
-        state1.send_get_nc_db_node(peer_node_id)
-        state2.send_get_nc_db_node(peer_node_id)
+        # send_get_nc_db_node now returns a Deferred[dict] directly
+        assert len(state1._pending_nc_db_nodes) == 0
+        assert len(state2._pending_nc_db_nodes) == 0
+        deferred3 = state1.send_get_nc_db_node(peer_node_id)
+        deferred4 = state2.send_get_nc_db_node(peer_node_id)
+        node_results: list[Any] = []
+        deferred3.addCallback(node_results.append)
+        deferred4.addCallback(node_results.append)
         self.simulator.run(5)
-        assert state1.peer_nc_node is not None
-        assert state2.peer_nc_node is not None
-        assert state1.peer_nc_node == state2.peer_nc_node
-        peer_node_data = state1.peer_nc_node
+        assert len(node_results) == 2
+        assert node_results[0] == node_results[1]
+        peer_node_data = node_results[0]
         # XXX: empty state is expected since there aren't any nano transactions
         expected_node_data = {
             'id': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',

--- a/hathor_tests/p2p/test_nc_sync_check.py
+++ b/hathor_tests/p2p/test_nc_sync_check.py
@@ -1,0 +1,110 @@
+from typing import Any
+from unittest.mock import Mock, patch
+
+from twisted.internet.defer import Deferred, succeed
+
+from hathor.manager import HathorManager
+from hathor.nanocontracts.nc_sync_checker import NCSyncChecker
+from hathor.nanocontracts.storage.patricia_trie import NodeId
+from hathor.p2p.states import ReadyState
+from hathor.simulator import FakeConnection
+from hathor.simulator.trigger import StopAfterNMinedBlocks
+from hathor_tests.simulation.base import SimulatorTestCase
+
+
+class NCSyncCheckTestCase(SimulatorTestCase):
+    def _create_peer_with_nc_sync_check(self, start_height: int = 0) -> HathorManager:
+        builder = self.simulator.get_default_builder() \
+            .set_nc_sync_check_start_height(start_height)
+        return self.simulator.create_peer(builder)
+
+    def test_compatible_state(self) -> None:
+        """When both peers have the same state, sync completes without errors."""
+        manager1 = self._create_peer_with_nc_sync_check()
+        manager1.allow_mining_without_peers()
+
+        miner = self.simulator.create_miner(manager1, hashpower=1e6)
+        miner.start()
+        trigger = StopAfterNMinedBlocks(miner, quantity=5)
+        self.assertTrue(self.simulator.run(1000, trigger=trigger))
+        miner.stop()
+        self.simulator.run(10)
+
+        manager2 = self._create_peer_with_nc_sync_check()
+        conn12 = FakeConnection(manager1, manager2, latency=0.05)
+        self.simulator.add_connection(conn12)
+        self.simulator.run(3600)
+
+        # Verify sync completed successfully
+        best1 = manager1.tx_storage.get_best_block()
+        best2 = manager2.tx_storage.get_best_block()
+        self.assertEqual(best1.hash, best2.hash)
+
+        # The block should have an nc_block_root_id
+        meta = best1.get_metadata()
+        self.assertIsNotNone(meta.nc_block_root_id)
+
+    def test_incompatible_block_root(self) -> None:
+        """When the peer returns a different root_id, an error should be logged."""
+        manager1 = self._create_peer_with_nc_sync_check()
+        manager1.allow_mining_without_peers()
+
+        # Mine blocks and sync
+        miner = self.simulator.create_miner(manager1, hashpower=1e6)
+        miner.start()
+        trigger = StopAfterNMinedBlocks(miner, quantity=3)
+        self.assertTrue(self.simulator.run(1000, trigger=trigger))
+        miner.stop()
+        self.simulator.run(10)
+
+        manager2 = self._create_peer_with_nc_sync_check()
+        conn12 = FakeConnection(manager1, manager2, latency=0.05)
+        self.simulator.add_connection(conn12)
+        self.simulator.run(3600)
+
+        best_block = manager2.tx_storage.get_best_block()
+        meta = best_block.get_metadata()
+        self.assertIsNotNone(meta.nc_block_root_id)
+
+        # Get the NC sync checker from the vertex handler
+        nc_sync_checker = manager2.vertex_handler._nc_sync_checker
+        assert isinstance(nc_sync_checker, NCSyncChecker)
+
+        # Get a ready state from a connected peer to mock
+        state2 = conn12.proto2.state
+        assert isinstance(state2, ReadyState)
+
+        # Mock send_get_block_nc_root_id to return a different root_id.
+        # The refactored API returns a Deferred[NodeId] directly.
+        fake_root = NodeId(b'\xff' * 32)
+
+        def fake_send_get_block_nc_root_id(block_hash: bytes) -> Deferred[NodeId]:
+            return succeed(fake_root)
+
+        mock_log = Mock()
+        original_log = state2.log
+
+        mock_reactor_stop = Mock()
+        original_running = nc_sync_checker._reactor.running
+
+        with patch.object(state2, 'send_get_block_nc_root_id', new=fake_send_get_block_nc_root_id), \
+             patch.object(nc_sync_checker._reactor, 'stop', mock_reactor_stop):
+            nc_sync_checker._reactor.running = True
+            state2.log = mock_log
+            d = Deferred.fromCoroutine(nc_sync_checker.check_block(best_block))
+            result: list[Any] = []
+            d.addCallback(result.append)
+            d.addErrback(result.append)
+
+        state2.log = original_log
+        nc_sync_checker._reactor.running = original_running
+
+        # Check that 'incompatible block state' error was logged
+        error_calls = [c for c in mock_log.error.call_args_list if c[0][0] == 'incompatible block state']
+        self.assertTrue(
+            len(error_calls) > 0,
+            f'Expected "incompatible block state" error log, got: {mock_log.error.call_args_list}'
+        )
+
+        # Check that the reactor was stopped
+        mock_reactor_stop.assert_called_once()


### PR DESCRIPTION
### Motivation

Current mechanisms to debug divergent nano states between nodes rely on syncing them and then comparing state trie dumps manually. To improve this, PR introduces a mechanism to check states during block sync via the `--x-nc-sync-check` CLI flag. When a divergent block state is found, the full node logs all diverging contracts and stops cleanly. When used in combination with `--nc-exec-fail-trace`, the dev can easily identify whether divergent contracts reached conflicting execution states. 

### Acceptance Criteria

- Add new `--x-nc-sync-check [HEIGHT]` CLI flag to enable NC state comparison during block sync. Optionally accepts a starting block height.
- Refactor the `GET_BLOCK_NC_ROOT_ID` and `GET_NC_DB_NODE` P2P message handlers to use a deferred-based request/response pattern (instead of storing on state attributes).
- Clean up `classproperty` workaround: replace class-level `log` with instance-level `self.log` across consensus and vertex classes, and remove the now-unused `classproperty` utility (this was outdated and preventing some logs from being correctly formatted).
- No changes in behavior for production code when the new CLI flag is not used.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 