### PR TITLE
feat: add nginx config support for testnet-shielded-outputs + fix Nginx config generation when using new @api_endpoint

### DIFF
--- a/extras/nginx_docker/Makefile
+++ b/extras/nginx_docker/Makefile
@@ -128,23 +128,25 @@ AWS_MAIN_REGISTRY = $(AWS_MAIN_ECR_REGISTRY)/webtank
 AWS_MAIN_REGION ?= us-east-1
 AWS_MAIN_PROFILE ?= hathor-network
 
+.INTERMEDIATE: .aws-main-login.stamp
+
 .PHONY: aws-main
 aws-main: aws-main-default aws-main-no-rate-limit
 	@echo "All AWS Main images built and pushed successfully!"
 
-.PHONY: aws-main-login
-aws-main-login:
+.aws-main-login.stamp:
 	@echo "Logging in to AWS Main ECR..."
 	aws ecr get-login-password --region $(AWS_MAIN_REGION) --profile $(AWS_MAIN_PROFILE) | docker login --username AWS --password-stdin $(AWS_MAIN_ECR_REGISTRY)
+	@touch $@
 
 .PHONY: aws-main-default
-aws-main-default: clean set_real_ip_from_cloudfront aws-main-login
+aws-main-default: clean set_real_ip_from_cloudfront .aws-main-login.stamp
 	@echo "Building and pushing latest image for AWS Main..."
 	$(call generate_nginx_conf,)
 	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(AWS_MAIN_REGISTRY):$(DEFAULT_LATEST_TAG) .
 
 .PHONY: aws-main-no-rate-limit
-aws-main-no-rate-limit: clean set_real_ip_from_cloudfront aws-main-login
+aws-main-no-rate-limit: clean set_real_ip_from_cloudfront .aws-main-login.stamp
 	@echo "Building and pushing no-rate-limit image for AWS Main..."
 	$(call generate_nginx_conf,--disable-rate-limits)
 	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(AWS_MAIN_REGISTRY):$(DEFAULT_NO_RATE_LIMIT_TAG) .
@@ -218,7 +220,6 @@ help:
 	@echo "  hathor-testnet-shielded-outputs-default           - Build and push default image for GCP Project Hathor Testnet Shielded Outputs"
 	@echo "  hathor-testnet-shielded-outputs-no-rate-limit     - Build and push no-rate-limit image for GCP Project Hathor Testnet Shielded Outputs"
 	@echo "  aws-main                  			- Build and push all images for AWS Main Account"
-	@echo "  aws-main-login            			- Log in to AWS Main ECR before pushing images"
 	@echo "  aws-main-default          			- Build and push default image for AWS Main Account"
 	@echo "  aws-main-no-rate-limit	  			- Build and push no-rate-limit image for AWS Main Account"
 	@echo ""

--- a/extras/nginx_docker/Makefile
+++ b/extras/nginx_docker/Makefile
@@ -102,6 +102,26 @@ hathor-testnet-playground-no-rate-limit: clean set_real_ip_from_cloudfront
 	$(call generate_nginx_conf,--override hathor-testnet-playground --disable-rate-limits $(HATHOR_TESTNET_PLAYGROUND_TRUSTED_PROXIES))
 	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(HATHOR_TESTNET_PLAYGROUND_REGISTRY):$(DEFAULT_NO_RATE_LIMIT_TAG) .
 
+# GCP / Hathor Testnet Shielded Outputs
+HATHOR_TESTNET_SHIELDED_OUTPUTS_REGISTRY = us-central1-docker.pkg.dev/hathor-testnet-shielded-output/fullnodes/webtank
+HATHOR_TESTNET_SHIELDED_OUTPUTS_TRUSTED_PROXIES = --trusted-proxy-ip 34.117.3.220 --trusted-proxy-ip 2600:1901:0:74bf::
+
+.PHONY: hathor-testnet-shielded-outputs
+hathor-testnet-shielded-outputs: hathor-testnet-shielded-outputs-default hathor-testnet-shielded-outputs-no-rate-limit
+	@echo "All Hathor Testnet Shielded Outputs images built and pushed successfully!"
+
+.PHONY: hathor-testnet-shielded-outputs-default
+hathor-testnet-shielded-outputs-default: clean set_real_ip_from_cloudfront
+	@echo "Building and pushing latest image for Hathor Testnet Shielded Outputs..."
+	$(call generate_nginx_conf,$(HATHOR_TESTNET_SHIELDED_OUTPUTS_TRUSTED_PROXIES))
+	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(HATHOR_TESTNET_SHIELDED_OUTPUTS_REGISTRY):$(DEFAULT_LATEST_TAG) .
+
+.PHONY: hathor-testnet-shielded-outputs-no-rate-limit
+hathor-testnet-shielded-outputs-no-rate-limit: clean set_real_ip_from_cloudfront
+	@echo "Building and pushing no-rate-limit image for Hathor Testnet Shielded Outputs..."
+	$(call generate_nginx_conf,--disable-rate-limits $(HATHOR_TESTNET_SHIELDED_OUTPUTS_TRUSTED_PROXIES))
+	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(HATHOR_TESTNET_SHIELDED_OUTPUTS_REGISTRY):$(DEFAULT_NO_RATE_LIMIT_TAG) .
+
 # AWS / Main Account
 AWS_MAIN_REGISTRY = 769498303037.dkr.ecr.us-east-1.amazonaws.com/webtank
 
@@ -123,7 +143,7 @@ aws-main-no-rate-limit: clean set_real_ip_from_cloudfront
 
 # Build All (convenience command)
 .PHONY: build-all
-build-all: hathor-testnet standalone-fullnodes ekvilibro hathor-testnet-playground aws-main
+build-all: hathor-testnet standalone-fullnodes ekvilibro hathor-testnet-playground hathor-testnet-shielded-outputs aws-main
 	@echo "All images built and pushed successfully!"
 
 # Legacy commands for backward compatibility
@@ -186,6 +206,9 @@ help:
 	@echo "  hathor-testnet-playground                 - Build and push all images for GCP Project Hathor Testnet Playground"
 	@echo "  hathor-testnet-playground-default         - Build and push default image for GCP Project Hathor Testnet Playground"
 	@echo "  hathor-testnet-playground-no-rate-limit   - Build and push no-rate-limit image for GCP Project Hathor Testnet Playground"
+	@echo "  hathor-testnet-shielded-outputs                   - Build and push all images for GCP Project Hathor Testnet Shielded Outputs"
+	@echo "  hathor-testnet-shielded-outputs-default           - Build and push default image for GCP Project Hathor Testnet Shielded Outputs"
+	@echo "  hathor-testnet-shielded-outputs-no-rate-limit     - Build and push no-rate-limit image for GCP Project Hathor Testnet Shielded Outputs"
 	@echo "  aws-main                  			- Build and push all images for AWS Main Account"
 	@echo "  aws-main-default          			- Build and push default image for AWS Main Account"
 	@echo "  aws-main-no-rate-limit	  			- Build and push no-rate-limit image for AWS Main Account"
@@ -206,5 +229,6 @@ help:
 	@echo "  - Standalone Fullnodes: $(STANDALONE_FULLNODES_REGISTRY)"
 	@echo "  - Ekvilibro: $(EKVILIBRO_REGISTRY)"
 	@echo "  - Hathor Testnet Playground: $(HATHOR_TESTNET_PLAYGROUND_REGISTRY)"
+	@echo "  - Hathor Testnet Shielded Outputs: $(HATHOR_TESTNET_SHIELDED_OUTPUTS_REGISTRY)"
 	@echo "  - AWS Main Account: $(AWS_MAIN_REGISTRY)"
 	@echo ""

--- a/extras/nginx_docker/Makefile
+++ b/extras/nginx_docker/Makefile
@@ -123,20 +123,28 @@ hathor-testnet-shielded-outputs-no-rate-limit: clean set_real_ip_from_cloudfront
 	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(HATHOR_TESTNET_SHIELDED_OUTPUTS_REGISTRY):$(DEFAULT_NO_RATE_LIMIT_TAG) .
 
 # AWS / Main Account
-AWS_MAIN_REGISTRY = 769498303037.dkr.ecr.us-east-1.amazonaws.com/webtank
+AWS_MAIN_ECR_REGISTRY = 769498303037.dkr.ecr.us-east-1.amazonaws.com
+AWS_MAIN_REGISTRY = $(AWS_MAIN_ECR_REGISTRY)/webtank
+AWS_MAIN_REGION ?= us-east-1
+AWS_MAIN_PROFILE ?= hathor-network
 
 .PHONY: aws-main
 aws-main: aws-main-default aws-main-no-rate-limit
 	@echo "All AWS Main images built and pushed successfully!"
 
+.PHONY: aws-main-login
+aws-main-login:
+	@echo "Logging in to AWS Main ECR..."
+	aws ecr get-login-password --region $(AWS_MAIN_REGION) --profile $(AWS_MAIN_PROFILE) | docker login --username AWS --password-stdin $(AWS_MAIN_ECR_REGISTRY)
+
 .PHONY: aws-main-default
-aws-main-default: clean set_real_ip_from_cloudfront
+aws-main-default: clean set_real_ip_from_cloudfront aws-main-login
 	@echo "Building and pushing latest image for AWS Main..."
 	$(call generate_nginx_conf,)
 	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(AWS_MAIN_REGISTRY):$(DEFAULT_LATEST_TAG) .
 
 .PHONY: aws-main-no-rate-limit
-aws-main-no-rate-limit: clean set_real_ip_from_cloudfront
+aws-main-no-rate-limit: clean set_real_ip_from_cloudfront aws-main-login
 	@echo "Building and pushing no-rate-limit image for AWS Main..."
 	$(call generate_nginx_conf,--disable-rate-limits)
 	docker buildx build --pull --push --platform linux/arm64/v8,linux/amd64 --tag $(AWS_MAIN_REGISTRY):$(DEFAULT_NO_RATE_LIMIT_TAG) .
@@ -210,6 +218,7 @@ help:
 	@echo "  hathor-testnet-shielded-outputs-default           - Build and push default image for GCP Project Hathor Testnet Shielded Outputs"
 	@echo "  hathor-testnet-shielded-outputs-no-rate-limit     - Build and push no-rate-limit image for GCP Project Hathor Testnet Shielded Outputs"
 	@echo "  aws-main                  			- Build and push all images for AWS Main Account"
+	@echo "  aws-main-login            			- Log in to AWS Main ECR before pushing images"
 	@echo "  aws-main-default          			- Build and push default image for AWS Main Account"
 	@echo "  aws-main-no-rate-limit	  			- Build and push no-rate-limit image for AWS Main Account"
 	@echo ""
@@ -231,4 +240,8 @@ help:
 	@echo "  - Hathor Testnet Playground: $(HATHOR_TESTNET_PLAYGROUND_REGISTRY)"
 	@echo "  - Hathor Testnet Shielded Outputs: $(HATHOR_TESTNET_SHIELDED_OUTPUTS_REGISTRY)"
 	@echo "  - AWS Main Account: $(AWS_MAIN_REGISTRY)"
+	@echo ""
+	@echo "AWS login variables (overridable):"
+	@echo "  - AWS_MAIN_REGION=$(AWS_MAIN_REGION)"
+	@echo "  - AWS_MAIN_PROFILE=$(AWS_MAIN_PROFILE)"
 	@echo ""

--- a/hathor_cli/nginx_config.py
+++ b/hathor_cli/nginx_config.py
@@ -110,6 +110,26 @@ def _get_visibility(source: dict[str, Any], fallback: Visibility, override: str)
         return fallback, True, False
 
 
+_HTTP_METHODS = ('get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace')
+_OPENAPI_EXTENSIONS = ('x-visibility', 'x-visibility-override', 'x-rate-limit', 'x-path-params-regex', 'x-proxy-buffers')
+
+
+def _lift_operation_extensions(params: dict[str, Any]) -> None:
+    """Lift operation-level OpenAPI extensions to path level if not already present.
+
+    Old-style resources place custom extensions (x-visibility, x-rate-limit, etc.) at the path
+    item level. New-style resources (via @api_endpoint) place them at the operation level.
+    This normalizes them to path level so the nginx config generator can find them.
+    """
+    for ext in _OPENAPI_EXTENSIONS:
+        if ext in params:
+            continue
+        for method in _HTTP_METHODS:
+            if method in params and isinstance(params[method], dict) and ext in params[method]:
+                params[ext] = params[method][ext]
+                break
+
+
 def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: float = 1.0,
                           fallback_visibility: Visibility = Visibility.PRIVATE,
                           disable_rate_limits: bool = False,
@@ -127,6 +147,7 @@ def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: 
     locations: dict[str, dict[str, Any]] = {}
     limit_rate_zones: list[RateLimitZone] = []
     for path, params in openapi['paths'].items():
+        _lift_operation_extensions(params)
         visibility, did_fallback, did_override = _get_visibility(params, fallback_visibility, override)
         if did_fallback:
             warn(f'Visibility not set for path `{path}`, falling back to {fallback_visibility}')
@@ -386,7 +407,7 @@ def main():
                         help='Input file with OpenAPI json, if not specified the spec is generated on-the-fly')
     parser.add_argument('--fallback-visibility', type=Visibility, default=Visibility.PRIVATE,
                         help='Set the visibility for paths without `x-visibility`, defaults to private')
-    parser.add_argument('--disable-rate-limits', type=bool, default=False,
+    parser.add_argument('--disable-rate-limits', action='store_true', default=False,
                         help='Disable including rate-limits in the config, defaults to False')
     parser.add_argument('--override', type=str, default='',
                         help='Override visibility for paths with `x-visibility-override` for the given value')

--- a/hathor_cli/nginx_config.py
+++ b/hathor_cli/nginx_config.py
@@ -15,6 +15,7 @@
 import json
 import os
 from enum import Enum
+from json import dumps as json_dumps
 from typing import Any, NamedTuple, Optional, TextIO
 
 BASE_PATH = os.path.join(os.path.dirname(__file__), 'nginx_files')
@@ -114,21 +115,109 @@ _HTTP_METHODS = ('get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'tr
 _OPENAPI_EXTENSIONS = ('x-visibility', 'x-visibility-override', 'x-rate-limit', 'x-path-params-regex', 'x-proxy-buffers')
 
 
-def _lift_operation_extensions(params: dict[str, Any]) -> None:
-    """Lift operation-level OpenAPI extensions to path level if not already present.
+def _iter_operation_params(params: dict[str, Any]):
+    """Yield `(method, operation)` pairs for HTTP methods present in a path item."""
+    for method in _HTTP_METHODS:
+        method_params = params.get(method)
+        if isinstance(method_params, dict):
+            yield method, method_params
 
-    Old-style resources place custom extensions (x-visibility, x-rate-limit, etc.) at the path
-    item level. New-style resources (via @api_endpoint) place them at the operation level.
-    This normalizes them to path level so the nginx config generator can find them.
+
+def _normalize_extension_value(value: Any) -> str:
+    """Serialize an extension value into a stable form for equality checks."""
+    return json_dumps(value, sort_keys=True)
+
+
+def _resolve_path_operation_extension(
+    path: str,
+    params: dict[str, Any],
+    ext: str,
+    *,
+    methods: list[str] | None = None,
+) -> Any:
+    """Resolve one path-level extension value from the relevant operations on a path.
+
+    Old-style resources place custom extensions at the path item level. New-style resources place
+    them at the operation level. Because nginx emits one location per path, operation-level values
+    can only be collapsed to a single path-level value when every relevant operation agrees.
+
+    If `methods` is provided, only those operations are considered. This is used for public-path
+    generation, where private methods do not participate in the emitted nginx location.
     """
-    for ext in _OPENAPI_EXTENSIONS:
-        if ext in params:
-            continue
-        for method in _HTTP_METHODS:
-            if method in params and isinstance(params[method], dict) and ext in params[method]:
-                params[ext] = params[method][ext]
-                break
+    if ext in params:
+        return params[ext]
 
+    relevant_methods = set(methods) if methods is not None else None
+    values_by_method: dict[str, Any] = {}
+    for method, method_params in _iter_operation_params(params):
+        if relevant_methods is not None and method not in relevant_methods:
+            continue
+        if ext in method_params:
+            values_by_method[method] = method_params[ext]
+
+    if not values_by_method:
+        return None
+
+    normalized_values = {
+        method: _normalize_extension_value(value)
+        for method, value in values_by_method.items()
+    }
+    distinct_values = set(normalized_values.values())
+    if len(distinct_values) > 1:
+        methods_str = ', '.join(sorted(values_by_method))
+        raise ValueError(f'Path `{path}` has conflicting {ext} values across relevant methods: {methods_str}')
+
+    return next(iter(values_by_method.values()))
+
+
+def _get_public_methods(params: dict[str, Any], *, override: str) -> list[str]:
+    """Return the HTTP methods on this path that remain public after visibility overrides."""
+    public_methods: list[str] = []
+    for method, method_params in _iter_operation_params(params):
+        method_visibility, _, _ = _get_visibility(method_params, Visibility.PUBLIC, override)
+        if method_visibility == Visibility.PUBLIC:
+            public_methods.append(method)
+    return public_methods
+
+
+def _resolve_path_visibility(
+    params: dict[str, Any],
+    *,
+    fallback_visibility: Visibility,
+    override: str,
+) -> tuple[Visibility, bool, bool]:
+    """Resolve path visibility from path-level metadata or the set of operation visibilities.
+
+    Returns a tuple of `(visibility, did_fallback, did_override)` where:
+    - `visibility` is the effective visibility for the whole path as seen by nginx.
+    - `did_fallback` is `True` only when no visibility metadata was found at either the path
+      or operation level, so `fallback_visibility` had to be used.
+    - `did_override` is `True` when `x-visibility-override` provided the selected value.
+
+    For new-style OpenAPI, visibility may exist only at the operation level. In that case,
+    the path must stay public if any operation is public so nginx can still emit a location
+    block and restrict private methods via `limit_except`.
+    """
+    if 'x-visibility' in params or 'x-visibility-override' in params:
+        # This is the old style resource definition where visibility is explicitly set at the path level, so we can
+        # directly use the path-level visibility.
+        return _get_visibility(params, fallback_visibility, override)
+
+    has_operation_visibility = any(
+        'x-visibility' in method_params or 'x-visibility-override' in method_params
+        for _, method_params in _iter_operation_params(params)
+    )
+
+    public_methods = _get_public_methods(params, override=override)
+    if public_methods:
+        # If any operation is public, the path is public.
+        return Visibility.PUBLIC, False, False
+
+    if has_operation_visibility:
+        # If there are no public operations but at least one has visibility metadata, the path is private.
+        return Visibility.PRIVATE, False, False
+
+    return fallback_visibility, True, False
 
 def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: float = 1.0,
                           fallback_visibility: Visibility = Visibility.PRIVATE,
@@ -147,8 +236,11 @@ def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: 
     locations: dict[str, dict[str, Any]] = {}
     limit_rate_zones: list[RateLimitZone] = []
     for path, params in openapi['paths'].items():
-        _lift_operation_extensions(params)
-        visibility, did_fallback, did_override = _get_visibility(params, fallback_visibility, override)
+        visibility, did_fallback, did_override = _resolve_path_visibility(
+            params,
+            fallback_visibility=fallback_visibility,
+            override=override,
+        )
         if did_fallback:
             warn(f'Visibility not set for path `{path}`, falling back to {fallback_visibility}')
         if did_override:
@@ -156,20 +248,26 @@ def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: 
         if visibility == Visibility.PRIVATE:
             continue
 
+        public_methods = _get_public_methods(params, override=override)
+
         location_params: dict[str, Any] = {
             'rate_limits': [],
-            'path_vars_re': params.get('x-path-params-regex', {}),
-            'proxy_buffers': params.get('x-proxy-buffers'),
+            'path_vars_re': _resolve_path_operation_extension(
+                path,
+                params,
+                'x-path-params-regex',
+                methods=public_methods,
+            ) or {},
+            'proxy_buffers': _resolve_path_operation_extension(
+                path,
+                params,
+                'x-proxy-buffers',
+                methods=public_methods,
+            ),
         }
 
         allowed_methods = {'OPTIONS'}
-        for method in 'get post put patch delete head options trace'.split():
-            if method not in params:
-                continue
-            method_params = params[method]
-            method_visibility, _, _ = _get_visibility(method_params, Visibility.PUBLIC, override)
-            if method_visibility == Visibility.PRIVATE:
-                continue
+        for method in public_methods:
             allowed_methods.add(method.upper())
         location_params['allowed_methods'] = sorted(allowed_methods)
 
@@ -177,7 +275,12 @@ def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: 
             warn(f'Path `{path}` has no public methods but is public')
             continue
 
-        rate_limits = params.get('x-rate-limit')
+        rate_limits = _resolve_path_operation_extension(
+            path,
+            params,
+            'x-rate-limit',
+            methods=public_methods,
+        )
         if not rate_limits:
             warn(f'Path `{path}` is public but has no rate limits, ignoring')
             continue

--- a/hathor_cli/nginx_config.py
+++ b/hathor_cli/nginx_config.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+from collections.abc import Iterator
 from enum import Enum
 from json import dumps as json_dumps
 from typing import Any, NamedTuple, Optional, TextIO
@@ -115,7 +116,7 @@ _HTTP_METHODS = ('get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'tr
 _OPENAPI_EXTENSIONS = ('x-visibility', 'x-visibility-override', 'x-rate-limit', 'x-path-params-regex', 'x-proxy-buffers')
 
 
-def _iter_operation_params(params: dict[str, Any]):
+def _iter_operation_params(params: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
     """Yield `(method, operation)` pairs for HTTP methods present in a path item."""
     for method in _HTTP_METHODS:
         method_params = params.get(method)

--- a/hathor_cli/nginx_config.py
+++ b/hathor_cli/nginx_config.py
@@ -271,7 +271,7 @@ def generate_nginx_config(openapi: dict[str, Any], *, out_file: TextIO, rate_k: 
             allowed_methods.add(method.upper())
         location_params['allowed_methods'] = sorted(allowed_methods)
 
-        if not allowed_methods:
+        if not public_methods:
             warn(f'Path `{path}` has no public methods but is public')
             continue
 

--- a/hathor_tests/cli/test_nginx_config.py
+++ b/hathor_tests/cli/test_nginx_config.py
@@ -9,7 +9,7 @@ from hathor_cli.nginx_config import generate_nginx_config
 
 class TestGenerateNginxConfig:
     @staticmethod
-    def _stub_settings_modules() -> None:
+    def _stub_settings_modules(monkeypatch: pytest.MonkeyPatch) -> None:
         hathor_module = ModuleType('hathor')
         conf_module = ModuleType('hathor.conf')
         get_settings_module = ModuleType('hathor.conf.get_settings')
@@ -21,12 +21,12 @@ class TestGenerateNginxConfig:
         hathor_module.conf = conf_module
         conf_module.get_settings = get_settings_module
 
-        sys.modules['hathor'] = hathor_module
-        sys.modules['hathor.conf'] = conf_module
-        sys.modules['hathor.conf.get_settings'] = get_settings_module
+        monkeypatch.setitem(sys.modules, 'hathor', hathor_module)
+        monkeypatch.setitem(sys.modules, 'hathor.conf', conf_module)
+        monkeypatch.setitem(sys.modules, 'hathor.conf.get_settings', get_settings_module)
 
-    def test_mixed_visibility_excludes_private_method_from_limit_except(self) -> None:
-        self._stub_settings_modules()
+    def test_mixed_visibility_excludes_private_method_from_limit_except(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_settings_modules(monkeypatch)
         openapi = {
             'paths': {
                 '/example': {
@@ -54,8 +54,8 @@ class TestGenerateNginxConfig:
         assert 'limit_except OPTIONS POST { deny all; }' in config
         assert 'limit_except OPTIONS GET POST { deny all; }' not in config
 
-    def test_conflicting_public_rate_limits_raise_error(self) -> None:
-        self._stub_settings_modules()
+    def test_conflicting_public_rate_limits_raise_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_settings_modules(monkeypatch)
         openapi = {
             'paths': {
                 '/example': {
@@ -78,8 +78,12 @@ class TestGenerateNginxConfig:
         with pytest.raises(ValueError, match='conflicting x-rate-limit'):
             generate_nginx_config(openapi, out_file=StringIO())
 
-    def test_private_operation_visibility_does_not_warn_as_fallback(self, capsys: pytest.CaptureFixture[str]) -> None:
-        self._stub_settings_modules()
+    def test_private_operation_visibility_does_not_warn_as_fallback(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stub_settings_modules(monkeypatch)
         openapi = {
             'paths': {
                 '/example': {
@@ -98,8 +102,8 @@ class TestGenerateNginxConfig:
         captured = capsys.readouterr()
         assert 'Visibility not set for path `/example`' not in captured.err
 
-    def test_conflicting_public_path_params_regex_raise_error(self) -> None:
-        self._stub_settings_modules()
+    def test_conflicting_public_path_params_regex_raise_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_settings_modules(monkeypatch)
         openapi = {
             'paths': {
                 '/example/{value}': {
@@ -124,8 +128,8 @@ class TestGenerateNginxConfig:
         with pytest.raises(ValueError, match='conflicting x-path-params-regex'):
             generate_nginx_config(openapi, out_file=StringIO())
 
-    def test_conflicting_public_proxy_buffers_raise_error(self) -> None:
-        self._stub_settings_modules()
+    def test_conflicting_public_proxy_buffers_raise_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_settings_modules(monkeypatch)
         openapi = {
             'paths': {
                 '/example': {

--- a/hathor_tests/cli/test_nginx_config.py
+++ b/hathor_tests/cli/test_nginx_config.py
@@ -17,9 +17,9 @@ class TestGenerateNginxConfig:
         def get_global_settings() -> SimpleNamespace:
             return SimpleNamespace(API_VERSION_PREFIX='v1a')
 
-        get_settings_module.get_global_settings = get_global_settings
-        hathor_module.conf = conf_module
-        conf_module.get_settings = get_settings_module
+        setattr(get_settings_module, 'get_global_settings', get_global_settings)
+        setattr(hathor_module, 'conf', conf_module)
+        setattr(conf_module, 'get_settings', get_settings_module)
 
         monkeypatch.setitem(sys.modules, 'hathor', hathor_module)
         monkeypatch.setitem(sys.modules, 'hathor.conf', conf_module)

--- a/hathor_tests/cli/test_nginx_config.py
+++ b/hathor_tests/cli/test_nginx_config.py
@@ -1,0 +1,151 @@
+import sys
+from io import StringIO
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from hathor_cli.nginx_config import generate_nginx_config
+
+
+class TestGenerateNginxConfig:
+    @staticmethod
+    def _stub_settings_modules() -> None:
+        hathor_module = ModuleType('hathor')
+        conf_module = ModuleType('hathor.conf')
+        get_settings_module = ModuleType('hathor.conf.get_settings')
+
+        def get_global_settings() -> SimpleNamespace:
+            return SimpleNamespace(API_VERSION_PREFIX='v1a')
+
+        get_settings_module.get_global_settings = get_global_settings
+        hathor_module.conf = conf_module
+        conf_module.get_settings = get_settings_module
+
+        sys.modules['hathor'] = hathor_module
+        sys.modules['hathor.conf'] = conf_module
+        sys.modules['hathor.conf.get_settings'] = get_settings_module
+
+    def test_mixed_visibility_excludes_private_method_from_limit_except(self) -> None:
+        self._stub_settings_modules()
+        openapi = {
+            'paths': {
+                '/example': {
+                    'get': {
+                        'x-visibility': 'private',
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                    'post': {
+                        'x-visibility': 'public',
+                        'x-rate-limit': {
+                            'global': [{'rate': '10r/s', 'burst': 10, 'delay': 0}],
+                        },
+                    },
+                },
+            },
+        }
+
+        out = StringIO()
+        generate_nginx_config(openapi, out_file=out)
+        config = out.getvalue()
+
+        assert 'location ~ ^/v1a/example/?$ {' in config
+        assert 'limit_except OPTIONS POST { deny all; }' in config
+        assert 'limit_except OPTIONS GET POST { deny all; }' not in config
+
+    def test_conflicting_public_rate_limits_raise_error(self) -> None:
+        self._stub_settings_modules()
+        openapi = {
+            'paths': {
+                '/example': {
+                    'get': {
+                        'x-visibility': 'public',
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                    'post': {
+                        'x-visibility': 'public',
+                        'x-rate-limit': {
+                            'global': [{'rate': '10r/s', 'burst': 10, 'delay': 0}],
+                        },
+                    },
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match='conflicting x-rate-limit'):
+            generate_nginx_config(openapi, out_file=StringIO())
+
+    def test_private_operation_visibility_does_not_warn_as_fallback(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._stub_settings_modules()
+        openapi = {
+            'paths': {
+                '/example': {
+                    'get': {
+                        'x-visibility': 'private',
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                },
+            },
+        }
+
+        generate_nginx_config(openapi, out_file=StringIO())
+
+        captured = capsys.readouterr()
+        assert 'Visibility not set for path `/example`' not in captured.err
+
+    def test_conflicting_public_path_params_regex_raise_error(self) -> None:
+        self._stub_settings_modules()
+        openapi = {
+            'paths': {
+                '/example/{value}': {
+                    'get': {
+                        'x-visibility': 'public',
+                        'x-path-params-regex': {'value': '[0-9]+'},
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                    'post': {
+                        'x-visibility': 'public',
+                        'x-path-params-regex': {'value': '[a-z]+'},
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match='conflicting x-path-params-regex'):
+            generate_nginx_config(openapi, out_file=StringIO())
+
+    def test_conflicting_public_proxy_buffers_raise_error(self) -> None:
+        self._stub_settings_modules()
+        openapi = {
+            'paths': {
+                '/example': {
+                    'get': {
+                        'x-visibility': 'public',
+                        'x-proxy-buffers': '16 16k',
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                    'post': {
+                        'x-visibility': 'public',
+                        'x-proxy-buffers': '32 16k',
+                        'x-rate-limit': {
+                            'global': [{'rate': '1r/s', 'burst': 1, 'delay': 0}],
+                        },
+                    },
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match='conflicting x-proxy-buffers'):
+            generate_nginx_config(openapi, out_file=StringIO())


### PR DESCRIPTION
Adds nginx configuration support while setting up the Hathor Testnet Shielded Outputs GCP project.

Fix the generation of Nginx config to make sure we support the new @api_endpoint resources. Especially because @api_endpoint only sets the OpenAPI extensions (x-visibility, x-rate-limit, etc.) at the method level (GET, POST, etc.), while our Nginx config generation was previously wired to receive them at the path level.

Now the Nginx config generation will check all the methods, lift the extensions to the path level when they are equal, or raise when they are different. Except for the x-visibility, which could be solved by using the `limit_except` directive to only include the public methods and exclude the private ones when their path is equal (i.e. a /example with public GET and private POST, for instance).

## Changes

### `extras/nginx_docker/Makefile`
- New `hathor-testnet-shielded-outputs`, `hathor-testnet-shielded-outputs-default`, and `hathor-testnet-shielded-outputs-no-rate-limit` targets for the `us-central1-docker.pkg.dev/hathor-testnet-shielded-output/fullnodes/webtank` registry
- Added the new targets to the `build-all` convenience command
- Updated `help` output to document the new targets

### `hathor_cli/nginx_config.py`
- Added path resolution for decorator-generated operation-level OpenAPI extensions instead of relying on the first HTTP method found
- Resolve mixed per-method visibility safely so a path remains public if any operation is public, while `limit_except` excludes private methods
- Raise on conflicting public per-method values for `x-rate-limit`, `x-path-params-regex`, and `x-proxy-buffers` instead of silently picking or dropping one
- Fixed the misleading fallback warning for paths whose operations are explicitly private
- Kept `--disable-rate-limits` as a proper `store_true` flag

### `hathor_tests/cli/test_nginx_config.py`
- Added focused coverage for mixed visibility on the same path
- Added regression coverage for conflicting public rate limits
- Added regression coverage for conflicting path regex and proxy buffer extensions
- Added coverage for the private-operation visibility warning behavior
