### PR TITLE
feat(nano): add global address-balance state and syscalls

### DIFF
--- a/hathor/nanocontracts/storage/block_storage.py
+++ b/hathor/nanocontracts/storage/block_storage.py
@@ -4,6 +4,7 @@
 # Re-export from hathorlib for backward compatibility
 from hathorlib.nanocontracts.storage.block_storage import *  # noqa: F401,F403
 from hathorlib.nanocontracts.storage.block_storage import (  # noqa: F401
+    AddressBalanceKey,
     AddressKey,
     BlockTrieTag,
     ContractKey,

--- a/hathor/nanocontracts/storage/restricted_block_proxy.py
+++ b/hathor/nanocontracts/storage/restricted_block_proxy.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Re-export from hathorlib for backward compatibility
+from hathorlib.nanocontracts.storage.token_proxy import *  # noqa: F401,F403
+from hathorlib.nanocontracts.storage.token_proxy import TokenProxy  # noqa: F401
+
+
+class RestrictedBlockProxy(TokenProxy):
+    """Backward-compatible alias for the block-storage proxy."""
+    pass

--- a/hathor_tests/nanocontracts/blueprints/unittest.py
+++ b/hathor_tests/nanocontracts/blueprints/unittest.py
@@ -206,7 +206,7 @@ class BlueprintTestCase(unittest.TestCase):
         token_version: TokenVersion
     ) -> None:
         """Create a token in the runner block storage"""
-        self.runner._runner.block_storage.create_token(
+        self.runner.get_block_storage().create_token(
             token_id=token_uid,
             token_name=token_name,
             token_symbol=token_symbol,

--- a/hathor_tests/nanocontracts/test_address_balance_transfer.py
+++ b/hathor_tests/nanocontracts/test_address_balance_transfer.py
@@ -1,0 +1,260 @@
+from typing import cast
+
+import pytest
+
+from hathor import HATHOR_TOKEN_UID, Address, Amount, Blueprint, Context, ContractId, public
+from hathor.nanocontracts.exception import NCInsufficientFunds, NCInvalidSyscall
+from hathor.nanocontracts.types import TokenUid
+from hathor.transaction.token_info import TokenVersion
+from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+
+
+class AddressTransferBlueprint(Blueprint):
+    before_balance: Amount
+    current_balance: Amount
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        self.before_balance = Amount(0)
+        self.current_balance = Amount(0)
+
+    @public
+    def transfer(self, ctx: Context, to_address: Address, amount: Amount, token: TokenUid) -> None:
+        self.syscall.transfer_to_address(to_address, amount, token)
+
+    @public
+    def transfer_to_contract_id(self, ctx: Context, contract_id: ContractId, amount: Amount, token: TokenUid) -> None:
+        self.syscall.transfer_to_address(Address(contract_id), amount, token)
+
+    @public
+    def observe(self, ctx: Context, address: Address, token: TokenUid) -> None:
+        self.before_balance = self.syscall.get_address_balance_before_current_call(address, token)
+        self.current_balance = self.syscall.get_address_balance(address, token)
+
+    @public
+    def transfer_and_observe(self, ctx: Context, address: Address, amount: Amount, token: TokenUid) -> None:
+        self.syscall.transfer_to_address(address, amount, token)
+        self.before_balance = self.syscall.get_address_balance_before_current_call(address, token)
+        self.current_balance = self.syscall.get_address_balance(address, token)
+
+
+class TestAddressBalanceTransfer(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = self._register_blueprint_class(AddressTransferBlueprint)
+        self.contract_id = self.gen_random_contract_id()
+        self.runner.create_contract(self.contract_id, self.blueprint_id, self.create_context())
+
+    def _seed_contract_balance(self, token_uid: TokenUid, amount: int) -> None:
+        storage = self.runner.get_storage(self.contract_id)
+        storage.unlock()
+        storage.add_balance(token_uid, amount)
+        storage.commit()
+        storage.lock()
+        self.runner.get_block_storage().update_contract_trie(self.contract_id, storage.get_root_id())
+
+    def _set_before_current_call_snapshot(self) -> None:
+        runner = self.runner._runner
+        root_id = runner.block_storage.get_root_id()
+        runner._before_current_call_block_storage = runner.storage_factory.get_block_storage(root_id)
+        runner.block_storage = runner.storage_factory.get_block_storage(root_id)
+
+    def test_transfer_to_address_persists_in_block_storage(self) -> None:
+        destination = self.gen_random_address()
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+        self._seed_contract_balance(token_uid, 10)
+        self.runner.call_public_method(self.contract_id, 'transfer', self.create_context(), destination, 7, token_uid)
+
+        balance = self.runner.get_block_storage().get_address_balance(destination, token_uid)
+        assert balance == 7
+
+    def test_transfer_to_address_rejects_contract_id(self) -> None:
+        destination_contract = self.gen_random_contract_id()
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+
+        with pytest.raises(NCInvalidSyscall, match='address'):
+            self.runner.call_public_method(
+                self.contract_id,
+                'transfer_to_contract_id',
+                self.create_context(),
+                destination_contract,
+                7,
+                token_uid,
+            )
+
+    def test_transfer_to_address_supports_custom_token(self) -> None:
+        destination = self.gen_random_address()
+        custom_token_uid = self.gen_random_token_uid()
+        self.create_token(custom_token_uid, 'Custom Token', 'CTK', TokenVersion.DEPOSIT)
+        self._seed_contract_balance(custom_token_uid, 10)
+
+        self.runner.call_public_method(
+            self.contract_id,
+            'transfer',
+            self.create_context(),
+            destination,
+            7,
+            custom_token_uid,
+        )
+
+        custom_balance = self.runner.get_block_storage().get_address_balance(destination, custom_token_uid)
+        assert custom_balance == 7
+
+        htr_balance = self.runner.get_block_storage().get_address_balance(destination, TokenUid(HATHOR_TOKEN_UID))
+        assert htr_balance == 0
+
+    def test_transfer_to_address_rejects_when_contract_balance_is_insufficient(self) -> None:
+        destination = self.gen_random_address()
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+        self._seed_contract_balance(token_uid, 3)
+
+        with pytest.raises(NCInsufficientFunds):
+            self.runner.call_public_method(
+                self.contract_id,
+                'transfer',
+                self.create_context(),
+                destination,
+                7,
+                token_uid,
+            )
+
+        balance = self.runner.get_block_storage().get_address_balance(destination, token_uid)
+        assert balance == 0
+
+    def test_observe_reads_before_current_call_and_current_global_balance(self) -> None:
+        address = self.gen_random_address()
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+
+        self.runner.get_block_storage().add_address_balance(address, 10, token_uid)
+        self.runner.get_block_storage().commit()
+        self._set_before_current_call_snapshot()
+        self.runner.get_block_storage().add_address_balance(address, -4, token_uid)
+
+        self.runner.call_public_method(self.contract_id, 'observe', self.create_context(), address, token_uid)
+
+        contract = cast(AddressTransferBlueprint, self.get_readonly_contract(self.contract_id))
+        assert contract.before_balance == 10
+        assert contract.current_balance == 6
+
+    def test_observe_current_balance_includes_prior_transfer_to_address_calls(self) -> None:
+        address = self.gen_random_address()
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+        self._seed_contract_balance(token_uid, 10)
+        self.runner.get_block_storage().add_address_balance(address, 2, token_uid)
+        self.runner.get_block_storage().commit()
+        self._set_before_current_call_snapshot()
+
+        self.runner.call_public_method(
+            self.contract_id,
+            'transfer_and_observe',
+            self.create_context(),
+            address,
+            3,
+            token_uid,
+        )
+
+        contract = cast(AddressTransferBlueprint, self.get_readonly_contract(self.contract_id))
+        assert contract.before_balance == 2
+        assert contract.current_balance == 5
+
+    def test_transfer_to_address_rejects_unknown_token(self) -> None:
+        destination = self.gen_random_address()
+        unknown_token_uid = self.gen_random_token_uid()
+
+        with pytest.raises(NCInvalidSyscall, match='could not find'):
+            self.runner.call_public_method(
+                self.contract_id,
+                'transfer',
+                self.create_context(),
+                destination,
+                7,
+                unknown_token_uid,
+            )
+
+
+class ReentrantAddressTransferBlueprint(Blueprint):
+    observed_balance: Amount
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        self.observed_balance = Amount(0)
+
+    @public
+    def transfer_and_delegate(
+        self,
+        ctx: Context,
+        to_address: Address,
+        amount: Amount,
+        token: TokenUid,
+        delegate: ContractId,
+    ) -> None:
+        self.syscall.transfer_to_address(to_address, amount, token)
+        origin = self.syscall.get_contract_id()
+        self.syscall.get_contract(delegate, blueprint_id=None).public().delegate_observe(
+            origin=origin, address=to_address, token=token,
+        )
+
+    @public
+    def delegate_observe(
+        self,
+        ctx: Context,
+        origin: ContractId,
+        address: Address,
+        token: TokenUid,
+    ) -> None:
+        self.syscall.get_contract(origin, blueprint_id=None).public().observe(
+            address=address, token=token,
+        )
+
+    @public(allow_reentrancy=True)
+    def observe(self, ctx: Context, address: Address, token: TokenUid) -> None:
+        self.observed_balance = self.syscall.get_address_balance(address, token)
+
+
+class TestReentrantAddressBalanceReads(BlueprintTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = self._register_blueprint_class(ReentrantAddressTransferBlueprint)
+        self.origin_id = self.gen_random_contract_id()
+        self.delegate_id = self.gen_random_contract_id()
+        self.runner.create_contract(self.origin_id, self.blueprint_id, self.create_context())
+        self.runner.create_contract(self.delegate_id, self.blueprint_id, self.create_context())
+
+    def _seed_contract_balance(self, contract_id: ContractId, token_uid: TokenUid, amount: int) -> None:
+        storage = self.runner.get_storage(contract_id)
+        storage.unlock()
+        storage.add_balance(token_uid, amount)
+        storage.commit()
+        storage.lock()
+        self.runner.get_block_storage().update_contract_trie(contract_id, storage.get_root_id())
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            'get_address_balance only folds change_trackers[-1] per contract, so diffs from '
+            'outer reentrant frames are lost. Out of scope for this PR; to be fixed alongside '
+            'broader reentrancy support.'
+        ),
+    )
+    def test_reentrant_observer_sees_outer_frame_transfer_diff(self) -> None:
+        # Call path: origin.transfer_and_delegate -> delegate.delegate_observe -> origin.observe.
+        # The outer `origin` frame performs the transfer, so its changes tracker holds the diff.
+        # The inner `origin.observe` frame must see that diff when reading get_address_balance.
+        to_address = self.gen_random_address()
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+        self._seed_contract_balance(self.origin_id, token_uid, 10)
+
+        self.runner.call_public_method(
+            self.origin_id,
+            'transfer_and_delegate',
+            self.create_context(),
+            to_address,
+            7,
+            token_uid,
+            self.delegate_id,
+        )
+
+        contract = cast(
+            ReentrantAddressTransferBlueprint, self.get_readonly_contract(self.origin_id)
+        )
+        assert contract.observed_balance == 7

--- a/hathor_tests/nanocontracts/test_consensus.py
+++ b/hathor_tests/nanocontracts/test_consensus.py
@@ -13,7 +13,15 @@ from hathor.nanocontracts.exception import NCFail, NCInvalidSignature
 from hathor.nanocontracts.method import Method
 from hathor.nanocontracts.nc_types import make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage.contract_storage import Balance
-from hathor.nanocontracts.types import NCAction, NCActionType, NCDepositAction, NCWithdrawalAction, TokenUid
+from hathor.nanocontracts.types import (
+    Address,
+    Amount,
+    NCAction,
+    NCActionType,
+    NCDepositAction,
+    NCWithdrawalAction,
+    TokenUid,
+)
 from hathor.nanocontracts.utils import sign_pycoin
 from hathor.simulator.trigger import StopAfterMinimumBalance, StopAfterNMinedBlocks
 from hathor.simulator.utils import add_new_blocks
@@ -77,6 +85,64 @@ class MyBlueprint(Blueprint):
     def fail_on_zero(self, ctx: Context) -> None:
         if self.counter == 0:
             raise NCFail('counter is zero')
+
+
+class AddressBalanceBlueprint(Blueprint):
+    token_uid: TokenUid
+
+    @public(allow_deposit=True)
+    def initialize(self, ctx: Context, token_uid: TokenUid) -> None:
+        self.token_uid = token_uid
+
+    @public
+    def transfer_to_caller(self, ctx: Context, amount: int) -> None:
+        self.syscall.transfer_to_address(Address(ctx.caller_id), Amount(amount), self.token_uid)
+
+
+class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
+    __test__ = True
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = b'z' * 32
+        self.manager = self.simulator.create_peer()
+        self.manager.allow_mining_without_peers()
+        self.manager.blueprint_service.register_blueprint(self.blueprint_id, AddressBalanceBlueprint)
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def _get_address_balance(self, address: bytes, *, block: Block | None = None) -> int:
+        if block is None:
+            block = self.manager.tx_storage.get_best_block()
+        block_storage = self.manager.get_nc_block_storage(block)
+        return block_storage.get_address_balance(Address(address), TokenUid(settings.HATHOR_TOKEN_UID))
+
+    def test_address_balance_execution_with_transfer_from_contract_is_successful(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..32]
+            b10 < dummy
+
+            tx_init.nc_id = "{self.blueprint_id.hex()}"
+            tx_init.nc_method = initialize("00")
+            tx_init.nc_address = wallet_contract
+            tx_init.nc_seqnum = 0
+            tx_init.nc_deposit = 20 HTR
+
+            tx_contract.nc_id = tx_init
+            tx_contract.nc_method = transfer_to_caller(7)
+            tx_contract.nc_address = wallet_caller
+            tx_contract.nc_seqnum = 0
+
+            tx_init <-- b30
+            tx_contract <-- b31
+        ''')
+
+        artifacts.propagate_with(self.manager)
+
+        tx_contract = artifacts.get_typed_vertex('tx_contract', Transaction)
+        assert tx_contract.get_metadata().nc_execution == NCExecutionState.SUCCESS
+
+        caller = tx_contract.get_nano_header().nc_address
+        assert self._get_address_balance(caller) == 7
 
 
 class NCConsensusTestCase(SimulatorTestCase):

--- a/hathor_tests/nanocontracts/test_storage.py
+++ b/hathor_tests/nanocontracts/test_storage.py
@@ -6,8 +6,9 @@ from typing import TypeVar
 from hathor.nanocontracts import NCRocksDBStorageFactory
 from hathor.nanocontracts.nc_types import NCType, NullNCType, make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage import NCChangesTracker
-from hathor.nanocontracts.types import Amount, ContractId, Timestamp, VertexId
+from hathor.nanocontracts.types import Address, Amount, ContractId, Timestamp, TokenUid, VertexId
 from hathor_tests import unittest
+from hathorlib.conf.settings import HATHOR_TOKEN_UID
 
 T = TypeVar('T')
 
@@ -22,8 +23,8 @@ class NCRocksDBStorageTestCase(unittest.TestCase):
         super().setUp()
         rocksdb_storage = self.create_rocksdb_storage()
         factory = NCRocksDBStorageFactory(rocksdb_storage)
-        block_storage = factory.get_empty_block_storage()
-        self.storage = block_storage.get_empty_contract_storage(ContractId(VertexId(b'')))
+        self.block_storage = factory.get_empty_block_storage()
+        self.storage = self.block_storage.get_empty_contract_storage(ContractId(VertexId(b'')))
         super().setUp()
 
     def _run_test(self, data_in: T, value: NCType[T]) -> None:
@@ -138,3 +139,10 @@ class NCRocksDBStorageTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             # inner string is not int
             changes_tracker.put_obj(b'y', nested_nc_type, {1: {'foo'}})  # type: ignore[misc]
+
+    def test_add_address_balance_rejects_contract_id(self) -> None:
+        contract_id = ContractId(VertexId(b'c' * 32))
+        token_uid = TokenUid(HATHOR_TOKEN_UID)
+
+        with self.assertRaises(ValueError):
+            self.block_storage.add_address_balance(Address(contract_id), Amount(1), token_uid)

--- a/hathor_tests/nanocontracts/test_syscalls_in_view.py
+++ b/hathor_tests/nanocontracts/test_syscalls_in_view.py
@@ -6,7 +6,7 @@ import pytest
 from hathor.nanocontracts import Blueprint, Context, public, view
 from hathor.nanocontracts.blueprint_env import BlueprintEnvironment
 from hathor.nanocontracts.exception import NCViewMethodError
-from hathor.nanocontracts.types import BlueprintId, ContractId, TokenUid, VertexId
+from hathor.nanocontracts.types import Address, Amount, BlueprintId, ContractId, TokenUid, VertexId
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 
@@ -42,6 +42,14 @@ class DirectSyscalls(Blueprint):
     @view
     def get_current_balance(self) -> None:
         self.syscall.get_current_balance()
+
+    @view
+    def get_address_balance_before_current_call(self) -> None:
+        self.syscall.get_address_balance_before_current_call(Address(b'\0' * 25), TokenUid(b'\0' * 32))
+
+    @view
+    def get_address_balance(self) -> None:
+        self.syscall.get_address_balance(Address(b'\0' * 25), TokenUid(b'\0' * 32))
 
     @view
     def can_mint(self) -> None:
@@ -102,6 +110,10 @@ class DirectSyscalls(Blueprint):
     @view
     def get_settings(self) -> None:
         self.syscall.get_settings()
+
+    @view
+    def transfer_to_address(self) -> None:
+        self.syscall.transfer_to_address(Address(b''), amount=Amount(0), token=TokenUid(b''))
 
 
 class IndirectSyscalls(Blueprint):
@@ -169,6 +181,8 @@ class TestSyscallsInView(BlueprintTestCase):
             'get_blueprint_id',
             'get_balance_before_current_call',
             'get_current_balance',
+            'get_address_balance_before_current_call',
+            'get_address_balance',
             'can_mint',
             'can_mint_before_current_call',
             'can_melt',

--- a/hathor_tests/nanocontracts/utils.py
+++ b/hathor_tests/nanocontracts/utils.py
@@ -67,6 +67,7 @@ class TestRunner:
             blueprint_service=blueprint_service,
             storage_factory=storage_factory,
             block_storage=block_storage,
+            before_current_call_block_storage=None,
             settings=settings,
             reactor=reactor,
             seed=seed,
@@ -141,6 +142,9 @@ class TestRunner:
 
     def get_storage(self, contract_id: ContractId) -> NCContractStorage:
         return self._runner.get_storage(contract_id)
+
+    def get_block_storage(self) -> NCBlockStorage:
+        return self._runner.block_storage
 
     def has_contract_been_initialized(self, contract_id: ContractId) -> bool:
         return self._runner.has_contract_been_initialized(contract_id)

--- a/hathorlib/hathorlib/nanocontracts/balance_rules.py
+++ b/hathorlib/hathorlib/nanocontracts/balance_rules.py
@@ -23,7 +23,7 @@ from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.token_info import TokenVersion
 
 if TYPE_CHECKING:
-    from hathor.transaction.token_info import TokenInfoDict  # type: ignore[import-not-found]
+    from hathor.transaction.token_info import TokenInfoDict
 
 T = TypeVar('T', bound=BaseAction)
 

--- a/hathorlib/hathorlib/nanocontracts/blueprint_env.py
+++ b/hathorlib/hathorlib/nanocontracts/blueprint_env.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from hathorlib.nanocontracts.rng import NanoRNG
     from hathorlib.nanocontracts.runner import Runner
     from hathorlib.nanocontracts.storage import NCContractStorage
+    from hathorlib.nanocontracts.types import Address
 
 
 NCAttrCache: TypeAlias = dict[bytes, Any] | None
@@ -91,6 +92,14 @@ class BlueprintEnvironment:
         contract_id = self.get_contract_id()
         balance = self.__runner.get_current_balance(contract_id, token_uid)
         return Amount(balance.value)
+
+    def get_address_balance_before_current_call(self, address: Address, token_uid: TokenUid | None = None) -> Amount:
+        """Return a global address balance before the current transaction began."""
+        return self.__runner.get_address_balance_before_current_call(address, token_uid)
+
+    def get_address_balance(self, address: Address, token_uid: TokenUid | None = None) -> Amount:
+        """Return the current global address balance including in-flight execution changes."""
+        return self.__runner.get_address_balance(address, token_uid)
 
     def can_mint_before_current_call(self, token_uid: TokenUid) -> bool:
         """
@@ -263,3 +272,7 @@ class BlueprintEnvironment:
         Settings are not constant, they may be changed over time.
         """
         return self.__runner.syscall_get_nano_settings()
+
+    def transfer_to_address(self, address: Address, amount: Amount, token: TokenUid) -> None:
+        """Transfer a given amount of token from this contract treasury to an address balance."""
+        self.__runner.syscall_transfer_to_address(address, amount, token)

--- a/hathorlib/hathorlib/nanocontracts/runner/runner.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/runner.py
@@ -12,6 +12,7 @@ from typing_extensions import assert_never
 
 from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 from hathorlib.exceptions import InvalidFeeAmount, TransactionDataError, TransactionDoesNotExist
+from hathorlib.headers.nano_header import ADDRESS_LEN_BYTES
 from hathorlib.nanocontracts.balance_rules import BalanceRules
 from hathorlib.nanocontracts.blueprint import Blueprint
 from hathorlib.nanocontracts.blueprint_env import BlueprintEnvironment
@@ -23,6 +24,7 @@ from hathorlib.nanocontracts.exception import (
     NCFail,
     NCForbiddenAction,
     NCForbiddenReentrancy,
+    NCInsufficientFunds,
     NCInvalidContext,
     NCInvalidContractId,
     NCInvalidFee,
@@ -57,6 +59,8 @@ from hathorlib.nanocontracts.types import (
     NC_ALLOWED_ACTIONS_ATTR,
     NC_FALLBACK_METHOD,
     NC_INITIALIZE_METHOD,
+    Address,
+    Amount,
     BaseTokenAction,
     BlueprintId,
     ContractId,
@@ -122,12 +126,14 @@ class Runner:
         blueprint_service: BlueprintServiceProtocol,
         storage_factory: NCStorageFactory,
         block_storage: NCBlockStorage,
+        before_current_call_block_storage: NCBlockStorage | None,
         seed: bytes | None,
     ) -> None:
         self.tx_storage = tx_storage
         self.blueprint_service = blueprint_service
         self.storage_factory = storage_factory
         self.block_storage = block_storage
+        self._before_current_call_block_storage = before_current_call_block_storage or block_storage
         self._storages: dict[ContractId, NCContractStorage] = {}
         self._settings = settings
         self.reactor = reactor
@@ -545,6 +551,8 @@ class Runner:
             # Update total_diffs according to the diffs caused by each call, for each token.
             for balance_key, balance in change_tracker.get_balance_diff().items():
                 total_diffs[TokenUid(balance_key.token_uid)] += balance
+            for (_address, token_uid), balance in change_tracker.get_all_address_balance_diffs().items():
+                total_diffs[token_uid] += balance
 
         # Accumulate tokens totals from syscalls to compare with the totals from this runner.
         calculated_tokens_totals: defaultdict[TokenUid, SignedAmount] = defaultdict(SignedAmount)
@@ -852,6 +860,14 @@ class Runner:
         """
         return self._get_balance(contract_id=contract_id, token_uid=token_uid, before_current_call=False)
 
+    def get_address_balance_before_current_call(self, address: Address, token_uid: TokenUid | None) -> Amount:
+        """Return a global address balance before the current transaction began."""
+        return self._get_address_balance(address=address, token_uid=token_uid, before_current_call=True)
+
+    def get_address_balance(self, address: Address, token_uid: TokenUid | None) -> Amount:
+        """Return the current global address balance including in-flight execution changes."""
+        return self._get_address_balance(address=address, token_uid=token_uid, before_current_call=False)
+
     def _get_balance(
         self,
         *,
@@ -879,6 +895,31 @@ class Runner:
             storage = self.get_current_changes_tracker_or_storage(contract_id)
 
         return storage.get_balance(bytes(token_uid))
+
+    def _get_address_balance(
+        self,
+        *,
+        address: Address,
+        token_uid: TokenUid | None,
+        before_current_call: bool,
+    ) -> Amount:
+        """Internal implementation of global address-balance reads."""
+        if token_uid is None:
+            token_uid = TokenUid(HATHOR_TOKEN_UID)
+
+        if not isinstance(address, Address) or len(address) != ADDRESS_LEN_BYTES:
+            raise NCInvalidSyscall(f'only addresses with {ADDRESS_LEN_BYTES} bytes are allowed')
+
+        storage = self._before_current_call_block_storage if before_current_call else self.block_storage
+        balance = storage.get_address_balance(address, token_uid)
+        if before_current_call or self._call_info is None:
+            return balance
+
+        for change_trackers in self._call_info.change_trackers.values():
+            if not change_trackers:
+                continue
+            balance = Amount(balance + change_trackers[-1].get_address_balance_diff(address, token_uid))
+        return balance
 
     def get_current_call_record(self) -> CallRecord:
         """Return the call record for the current method being executed."""
@@ -1477,6 +1518,26 @@ class Runner:
         if current_call_record.type == CallType.VIEW:
             raise NCViewMethodError(f'@view method cannot call `syscall.{name}`')
 
+    @_forbid_syscall_from_view('transfer_to_address')
+    def syscall_transfer_to_address(self, address: Address, amount: Amount, token: TokenUid) -> None:
+        if amount < 0:
+            raise NCInvalidSyscall('amount cannot be negative')
+
+        if amount == 0:
+            return
+
+        if not isinstance(address, Address) or len(address) != ADDRESS_LEN_BYTES:
+            raise NCInvalidSyscall(f'only addresses with {ADDRESS_LEN_BYTES} bytes are allowed')
+
+        self._get_token(token)
+
+        changes_tracker = self.get_current_changes_tracker()
+        balance = changes_tracker.get_balance(token)
+        if balance.value < amount:
+            raise NCInsufficientFunds
+        changes_tracker.add_balance(token, -amount)
+        changes_tracker.add_address_balance(address, amount, token)
+
 
 class RunnerFactory:
     __slots__ = ('reactor', 'settings', 'tx_storage', 'nc_storage_factory', 'blueprint_service')
@@ -1502,6 +1563,7 @@ class RunnerFactory:
         runtime_version: NanoRuntimeVersion,
         token_amount_version: TokenAmountVersion,
         block_storage: NCBlockStorage,
+        before_current_call_block_storage: NCBlockStorage | None = None,
         seed: bytes | None = None,
     ) -> Runner:
         return Runner(
@@ -1513,5 +1575,6 @@ class RunnerFactory:
             storage_factory=self.nc_storage_factory,
             blueprint_service=self.blueprint_service,
             block_storage=block_storage,
+            before_current_call_block_storage=before_current_call_block_storage,
             seed=seed,
         )

--- a/hathorlib/hathorlib/nanocontracts/storage/block_storage.py
+++ b/hathorlib/hathorlib/nanocontracts/storage/block_storage.py
@@ -4,16 +4,16 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import NamedTuple, Optional
+from typing import Iterator, NamedTuple, Optional
 
-from hathorlib.headers.nano_header import ADDRESS_SEQNUM_SIZE
+from hathorlib.headers.nano_header import ADDRESS_LEN_BYTES, ADDRESS_SEQNUM_SIZE
 from hathorlib.nanocontracts.exception import NanoContractDoesNotExist
 from hathorlib.nanocontracts.nc_types.dataclass_nc_type import make_dataclass_nc_type
 from hathorlib.nanocontracts.nc_types.token_version_nc_type import TokenVersionNCType
 from hathorlib.nanocontracts.storage.contract_storage import NCContractStorage
 from hathorlib.nanocontracts.storage.patricia_trie import NodeId, PatriciaTrie
 from hathorlib.nanocontracts.storage.token_proxy import TokenProxy
-from hathorlib.nanocontracts.types import Address, ContractId, TokenUid
+from hathorlib.nanocontracts.types import Address, Amount, ContractId, TokenUid
 from hathorlib.token_info import TokenDescription, TokenVersion
 from hathorlib.utils import leb128
 
@@ -21,7 +21,8 @@ from hathorlib.utils import leb128
 class BlockTrieTag(Enum):
     CONTRACT = b'\0'
     TOKEN = b'\1'
-    ADDRESS = b'\2'
+    ADDRESS_SEQNUM = b'\2'
+    ADDRESS_BALANCE = b'\3'
 
 
 class ContractKey(NamedTuple):
@@ -42,7 +43,15 @@ class AddressKey(NamedTuple):
     address: Address
 
     def __bytes__(self):
-        return BlockTrieTag.ADDRESS.value + self.address
+        return BlockTrieTag.ADDRESS_SEQNUM.value + self.address
+
+
+class AddressBalanceKey(NamedTuple):
+    address: Address
+    token_id: TokenUid
+
+    def __bytes__(self):
+        return BlockTrieTag.ADDRESS_BALANCE.value + self.address + self.token_id
 
 
 class NCBlockStorage:
@@ -147,6 +156,56 @@ class NCBlockStorage:
         )
         token_description_bytes = self._TOKEN_DESCRIPTION_NC_TYPE.to_bytes(token_description)
         self._block_trie.update(bytes(key), token_description_bytes)
+
+    def get_address_balance(self, address: Address, token_id: TokenUid) -> Amount:
+        key = AddressBalanceKey(address, token_id)
+        try:
+            balance_bytes = self._block_trie.get(bytes(key))
+        except KeyError:
+            return Amount(0)
+        else:
+            balance, buf = leb128.decode_unsigned(balance_bytes)
+            assert len(buf) == 0
+            return Amount(balance)
+
+    def add_address_balance(self, address: Address, amount: Amount, token_id: TokenUid) -> None:
+        if not isinstance(address, Address) or len(address) != ADDRESS_LEN_BYTES:
+            raise ValueError(f'address must be Address with {ADDRESS_LEN_BYTES} bytes')
+
+        key = AddressBalanceKey(address, token_id)
+        balance = Amount(self.get_address_balance(address, token_id) + amount)
+        assert balance >= 0
+        balance_bytes = leb128.encode_unsigned(balance)
+        self._block_trie.update(bytes(key), balance_bytes)
+
+    def iter_address_balances(self, address: Address) -> Iterator[tuple[TokenUid, Amount]]:
+        """Yield (token_id, balance) pairs for every token with a nonzero balance for the given address."""
+        if not isinstance(address, Address) or len(address) != ADDRESS_LEN_BYTES:
+            raise ValueError(f'address must be Address with {ADDRESS_LEN_BYTES} bytes')
+
+        prefix = self._block_trie._encode_key(BlockTrieTag.ADDRESS_BALANCE.value + address)
+        node = self._block_trie._find_nearest_node(prefix)
+        if node.key.startswith(prefix):
+            subtree_root = node
+        else:
+            for _child_suffix, child_id in node.children.items():
+                child = self._block_trie.get_node(child_id)
+                if child.key.startswith(prefix):
+                    subtree_root = child
+                    break
+            else:
+                return
+
+        for dfs_node in self._block_trie.iter_dfs(node=subtree_root):
+            if dfs_node.node.content is None:
+                continue
+            decoded = self._block_trie._decode_key(dfs_node.node.key)
+            token_id = TokenUid(decoded[1 + ADDRESS_LEN_BYTES:])
+            balance, buf = leb128.decode_unsigned(dfs_node.node.content)
+            assert len(buf) == 0
+            if balance == 0:
+                continue
+            yield token_id, Amount(balance)
 
     def get_address_seqnum(self, address: Address) -> int:
         """Get the latest seqnum for an address.

--- a/hathorlib/hathorlib/nanocontracts/storage/changes_tracker.py
+++ b/hathorlib/hathorlib/nanocontracts/storage/changes_tracker.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from types import MappingProxyType
@@ -20,7 +21,7 @@ from hathorlib.nanocontracts.storage.contract_storage import (
     NCContractStorage,
 )
 from hathorlib.nanocontracts.storage.types import _NOT_PROVIDED, DeletedKey, DeletedKeyType
-from hathorlib.nanocontracts.types import BlueprintId, ContractId, TokenUid
+from hathorlib.nanocontracts.types import Address, Amount, BlueprintId, ContractId, TokenUid
 from hathorlib.token_amount import SignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion
 
@@ -71,6 +72,7 @@ class NCChangesTracker(NCContractStorage):
         self._balance_diff: dict[BalanceKey, SignedAmount] = {}
         self._authorities_diff: dict[BalanceKey, _NCAuthorityDiff] = {}
         self._created_tokens: dict[TokenUid, TokenDescription] = {}
+        self._transfers: defaultdict[tuple[Address, TokenUid], int] = defaultdict(int)
         self._blueprint_id: BlueprintId | None = None
 
         self.has_been_commited = False
@@ -106,6 +108,24 @@ class NCChangesTracker(NCContractStorage):
         if token_description is not None:
             return token_description
         return self.storage.get_token(token_id)
+
+    def add_address_balance(
+        self,
+        address: Address,
+        amount: Amount,
+        token_id: TokenUid,
+    ) -> None:
+        self.check_if_locked()
+        assert amount >= 0
+        self._transfers[(address, token_id)] += amount
+
+    def get_address_balance_diff(self, address: Address, token_id: TokenUid) -> Amount:
+        """Return the in-flight global-balance diff for a given address/token."""
+        return Amount(self._transfers.get((address, token_id), 0))
+
+    def get_all_address_balance_diffs(self) -> MappingProxyType[tuple[Address, TokenUid], int]:
+        """Return every in-flight global-balance diff for this changes tracker."""
+        return MappingProxyType(self._transfers)
 
     def get_balance_diff(self) -> MappingProxyType[BalanceKey, SignedAmount]:
         """Return the balance diff of this change tracker."""
@@ -198,6 +218,9 @@ class NCChangesTracker(NCContractStorage):
                 token_version=TokenVersion(td.token_version)
             )
 
+        for (address, token_id), amount in self._transfers.items():
+            self.storage.add_address_balance(address, Amount(amount), token_id)
+
         if self._blueprint_id is not None:
             self.storage.set_blueprint_id(self._blueprint_id)
 
@@ -277,6 +300,7 @@ class NCChangesTracker(NCContractStorage):
         assert not bool(self._balance_diff)
         assert not bool(self._authorities_diff)
         assert not bool(self._created_tokens)
+        assert not bool(self._transfers)
         assert not bool(self._blueprint_id)
         return not bool(self.data)
 

--- a/hathorlib/hathorlib/nanocontracts/storage/contract_storage.py
+++ b/hathorlib/hathorlib/nanocontracts/storage/contract_storage.py
@@ -16,7 +16,7 @@ from hathorlib.nanocontracts.storage.maybedeleted_nc_type import MaybeDeletedNCT
 from hathorlib.nanocontracts.storage.patricia_trie import PatriciaTrie
 from hathorlib.nanocontracts.storage.token_proxy import TokenProxy
 from hathorlib.nanocontracts.storage.types import _NOT_PROVIDED, DeletedKey, DeletedKeyType
-from hathorlib.nanocontracts.types import BlueprintId, TokenUid, VertexId
+from hathorlib.nanocontracts.types import Address, Amount, BlueprintId, TokenUid, VertexId
 from hathorlib.serialization import Deserializer, Serializer
 from hathorlib.token_amount import SignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion
@@ -164,6 +164,9 @@ class NCContractStorage:
             token_symbol=token_symbol,
             token_version=token_version
         )
+
+    def add_address_balance(self, address: Address, amount: Amount, token_id: TokenUid) -> None:
+        self._token_proxy.add_address_balance(address, amount, token_id)
 
     def lock(self) -> None:
         """Lock the storage for changes or commits."""

--- a/hathorlib/hathorlib/nanocontracts/storage/token_proxy.py
+++ b/hathorlib/hathorlib/nanocontracts/storage/token_proxy.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hathorlib.nanocontracts.storage.block_storage import NCBlockStorage
-    from hathorlib.nanocontracts.types import TokenUid
+    from hathorlib.nanocontracts.types import Address, Amount, TokenUid
     from hathorlib.token_info import TokenDescription, TokenVersion
 
 
@@ -40,3 +40,7 @@ class TokenProxy:
             token_symbol=token_symbol,
             token_version=token_version
         )
+
+    def add_address_balance(self, address: Address, amount: Amount, token_id: TokenUid) -> None:
+        """Proxy to block_storage.add_address_balance()."""
+        self.__block_storage.add_address_balance(address, amount, token_id)

--- a/hathorlib/pyproject.toml
+++ b/hathorlib/pyproject.toml
@@ -90,6 +90,11 @@ module = [
 check_untyped_defs = false
 disallow_untyped_defs = false
 
+[[tool.mypy.overrides]]
+module = ["hathor.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = ["tests"]

--- a/hathorlib/tests/test_global_address_balance.py
+++ b/hathorlib/tests/test_global_address_balance.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from hathorlib.headers.nano_header import ADDRESS_LEN_BYTES
+from hathorlib.nanocontracts.nc_types.token_uid_nc_type import HATHOR_TOKEN_UID
+from hathorlib.nanocontracts.storage.block_storage import NCBlockStorage
+from hathorlib.nanocontracts.storage.changes_tracker import NCChangesTracker
+from hathorlib.nanocontracts.storage.memory_backends import InMemoryNodeTrieStore
+from hathorlib.nanocontracts.storage.patricia_trie import PatriciaTrie
+from hathorlib.nanocontracts.types import Address, Amount, ContractId, TokenUid, VertexId
+
+
+def _make_block_storage() -> NCBlockStorage:
+    return NCBlockStorage(PatriciaTrie(InMemoryNodeTrieStore()))
+
+
+def _addr(byte: int) -> Address:
+    return Address(bytes([byte]) * ADDRESS_LEN_BYTES)
+
+
+class NCBlockStorageAddressBalanceTestCase(unittest.TestCase):
+    def test_get_address_balance_defaults_to_zero(self) -> None:
+        block_storage = _make_block_storage()
+        assert block_storage.get_address_balance(_addr(1), TokenUid(HATHOR_TOKEN_UID)) == 0
+
+    def test_add_and_get_address_balance_roundtrip(self) -> None:
+        block_storage = _make_block_storage()
+        address = _addr(1)
+        token = TokenUid(HATHOR_TOKEN_UID)
+
+        block_storage.add_address_balance(address, Amount(5), token)
+        block_storage.add_address_balance(address, Amount(3), token)
+
+        assert block_storage.get_address_balance(address, token) == 8
+
+    def test_add_address_balance_supports_negative_delta(self) -> None:
+        block_storage = _make_block_storage()
+        address = _addr(1)
+        token = TokenUid(HATHOR_TOKEN_UID)
+        block_storage.add_address_balance(address, Amount(5), token)
+
+        block_storage.add_address_balance(address, Amount(-2), token)
+
+        assert block_storage.get_address_balance(address, token) == 3
+
+    def test_add_address_balance_rejects_wrong_address_length(self) -> None:
+        block_storage = _make_block_storage()
+        bad_address = Address(b'\x00' * (ADDRESS_LEN_BYTES - 1))
+
+        with self.assertRaises(ValueError):
+            block_storage.add_address_balance(bad_address, Amount(1), TokenUid(HATHOR_TOKEN_UID))
+
+    def test_add_address_balance_rejects_non_address_bytes(self) -> None:
+        block_storage = _make_block_storage()
+        not_an_address = b'\x00' * ADDRESS_LEN_BYTES
+
+        with self.assertRaises(ValueError):
+            # Feed raw bytes that have the right length but the wrong type.
+            block_storage.add_address_balance(not_an_address, Amount(1), TokenUid(HATHOR_TOKEN_UID))  # type: ignore[arg-type]
+
+    def test_add_address_balance_supports_multiple_tokens(self) -> None:
+        block_storage = _make_block_storage()
+        address = _addr(1)
+        htr = TokenUid(HATHOR_TOKEN_UID)
+        other = TokenUid(b'\x11' * 32)
+
+        block_storage.add_address_balance(address, Amount(5), htr)
+        block_storage.add_address_balance(address, Amount(9), other)
+
+        assert block_storage.get_address_balance(address, htr) == 5
+        assert block_storage.get_address_balance(address, other) == 9
+
+    def test_iter_address_balances_yields_only_target_address(self) -> None:
+        block_storage = _make_block_storage()
+        target = _addr(1)
+        other = _addr(2)
+        htr = TokenUid(HATHOR_TOKEN_UID)
+        custom = TokenUid(b'\x22' * 32)
+
+        block_storage.add_address_balance(target, Amount(7), htr)
+        block_storage.add_address_balance(target, Amount(4), custom)
+        block_storage.add_address_balance(other, Amount(100), htr)
+
+        entries = dict(block_storage.iter_address_balances(target))
+
+        assert entries == {htr: Amount(7), custom: Amount(4)}
+
+    def test_iter_address_balances_is_empty_when_no_entries(self) -> None:
+        block_storage = _make_block_storage()
+        # Populate some other address so the trie is non-empty.
+        block_storage.add_address_balance(_addr(2), Amount(1), TokenUid(HATHOR_TOKEN_UID))
+
+        assert list(block_storage.iter_address_balances(_addr(1))) == []
+
+    def test_iter_address_balances_skips_zero_balance_entries(self) -> None:
+        block_storage = _make_block_storage()
+        address = _addr(1)
+        htr = TokenUid(HATHOR_TOKEN_UID)
+        custom = TokenUid(b'\x33' * 32)
+
+        block_storage.add_address_balance(address, Amount(5), htr)
+        block_storage.add_address_balance(address, Amount(2), custom)
+        # Zero out the custom-token balance.
+        block_storage.add_address_balance(address, Amount(-2), custom)
+
+        entries = dict(block_storage.iter_address_balances(address))
+        assert entries == {htr: Amount(5)}
+
+    def test_iter_address_balances_rejects_wrong_address_length(self) -> None:
+        block_storage = _make_block_storage()
+        with self.assertRaises(ValueError):
+            list(block_storage.iter_address_balances(Address(b'\x00' * 5)))
+
+
+class NCChangesTrackerAddressBalanceTestCase(unittest.TestCase):
+    def _make_tracker(self) -> tuple[NCBlockStorage, NCChangesTracker, ContractId]:
+        block_storage = _make_block_storage()
+        contract_id = ContractId(VertexId(b'\xaa' * 32))
+        contract_storage = block_storage.get_empty_contract_storage(contract_id)
+        tracker = NCChangesTracker(contract_id, contract_storage)
+        return block_storage, tracker, contract_id
+
+    def test_add_address_balance_accumulates_in_transfers_diff(self) -> None:
+        _, tracker, _ = self._make_tracker()
+        address = _addr(1)
+        token = TokenUid(HATHOR_TOKEN_UID)
+
+        tracker.add_address_balance(address, Amount(4), token)
+        tracker.add_address_balance(address, Amount(3), token)
+
+        assert tracker.get_address_balance_diff(address, token) == 7
+
+    def test_address_balance_diff_defaults_to_zero(self) -> None:
+        _, tracker, _ = self._make_tracker()
+        assert tracker.get_address_balance_diff(_addr(1), TokenUid(HATHOR_TOKEN_UID)) == 0
+
+    def test_all_address_balance_diffs_returns_live_view(self) -> None:
+        _, tracker, _ = self._make_tracker()
+        address = _addr(1)
+        token = TokenUid(HATHOR_TOKEN_UID)
+
+        diffs = tracker.get_all_address_balance_diffs()
+        assert diffs == {}
+
+        tracker.add_address_balance(address, Amount(5), token)
+        assert dict(diffs) == {(address, token): 5}
+
+    def test_commit_flushes_transfers_to_block_storage(self) -> None:
+        block_storage, tracker, _ = self._make_tracker()
+        address = _addr(1)
+        token = TokenUid(HATHOR_TOKEN_UID)
+        tracker.add_address_balance(address, Amount(6), token)
+
+        assert block_storage.get_address_balance(address, token) == 0
+
+        tracker.commit()
+
+        assert block_storage.get_address_balance(address, token) == 6
+
+    def test_add_address_balance_rejects_negative_amount(self) -> None:
+        _, tracker, _ = self._make_tracker()
+        with self.assertRaises(AssertionError):
+            tracker.add_address_balance(_addr(1), Amount(-1), TokenUid(HATHOR_TOKEN_UID))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

Implements the storage and syscall surface from [RFC#108](https://github.com/HathorNetwork/rfcs/pull/108) so that nano contracts can hold and move value into addresses that exist outside any contract's treasury. This is the first step toward letting blueprints credit users directly, without requiring those users to be wrapped in a contract.

### Acceptance Criteria

- The block trie persists per-address, per-token balances under a new `ADDRESS_BALANCE` tag, with `get_address_balance`, `add_address_balance`, and `iter_address_balances` exposed on `NCBlockStorage`. The pre-existing per-address seqnum entries are preserved under a renamed `ADDRESS_SEQNUM` tag (no behavior change for seqnums).
- Blueprints can call a new `syscall.transfer_to_address(address, amount, token)` that debits the contract's treasury and credits the destination address's global balance. Transfers are rejected when the amount is negative, when funds are insufficient, when the token is unknown, or when the destination is not a 25-byte address (e.g. a `ContractId`). Zero-amount transfers are a no-op.
- Blueprints can read global address balances via two new syscalls: `get_address_balance` (current value, including in-flight changes from the active call stack) and `get_address_balance_before_current_call` (snapshot taken before the transaction began). Both default the token to HTR when omitted, and both are forbidden inside `@view` methods that lack the runner context.
- In-flight transfers accumulate inside `NCChangesTracker` and are flushed to the block storage on commit, so partial executions cannot leak credits and the runner's token-conservation check accounts for outflows to address balances alongside contract-treasury diffs.
- The runner accepts an optional `before_current_call_block_storage` snapshot so the "before current call" reads are served from the pre-transaction trie rather than the mutating one.
- A `RestrictedBlockProxy` shim and an updated `block_storage` re-export keep existing imports working after the proxy/key reorganization.
- New unit and consensus tests cover successful transfers (HTR and custom tokens), rejection paths (insufficient funds, contract-id destination, unknown token), the `before`/`current` observation semantics, and end-to-end execution through the DAG builder.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged