### PR TITLE
feat(nano): compose transfer headers with nano execution

### DIFF
--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -312,7 +312,7 @@ class NCBlockExecutor:
         """
         if should_skip(tx):
             # Skip transactions based on the caller-provided predicate.
-            if tx.is_nano_contract():
+            if tx.is_nano_contract() and not tx.has_transfer_header():
                 nc_header = tx.get_nano_header()
                 nc_address = Address(nc_header.nc_address)
                 seqnum = block_storage.get_address_seqnum(nc_address)
@@ -337,13 +337,20 @@ class NCBlockExecutor:
                 )
             return NCTxExecutionSuccess(tx=tx, block_storage=block_storage)
 
+        transfer_header_diffs = self._get_transfer_header_diffs(tx)
+        before_current_call_block_storage = self._nc_storage_factory.get_block_storage(block_storage.get_root_id())
         runner = self._runner_factory.create(
             runtime_version=runtime_version,
             block_storage=block_storage,
+            before_current_call_block_storage=before_current_call_block_storage,
             seed=rng_seed,
         )
 
         try:
+            if tx.has_transfer_header():
+                self._verify_transfer_header_balances(block_storage, tx)
+                self._apply_transfer_header_diffs(block_storage, transfer_header_diffs)
+
             nano_header = tx.get_nano_header()
 
             if nano_header.is_creating_a_new_contract():
@@ -384,11 +391,11 @@ class NCBlockExecutor:
             runner.discard_pending_changes()
             return NCTxExecutionFailure(
                 tx=tx,
-                block_storage=block_storage,
+                block_storage=block_storage if not tx.has_transfer_header() else None,
                 runner=runner,
                 exception=e,
                 traceback=traceback.format_exc(),
-                persist_block_storage=True,
+                persist_block_storage=not tx.has_transfer_header(),
             )
 
         # Commit is intentionally outside the NCFail handling path.

--- a/hathor/verification/transfer_header_verifier.py
+++ b/hathor/verification/transfer_header_verifier.py
@@ -42,9 +42,6 @@ class TransferHeaderVerifier:
         self._tx_storage = tx_storage
 
     def verify_inputs_and_outputs(self, tx: Transaction) -> None:
-        if tx.is_nano_contract():
-            raise InvalidToken('transfer headers are not yet supported on nano transactions')
-
         transfer_header = tx.get_transfer_header()
         if len(transfer_header.addresses) > MAX_ADDRESSES:
             raise TooManyInputs
@@ -92,6 +89,18 @@ class TransferHeaderVerifier:
 
         if any(usage_count == 0 for usage_count in input_usage_counts):
             raise InvalidToken('every transfer address must be referenced by at least one input')
+
+        if tx.is_nano_contract() and transfer_header.inputs:
+            nano_header = tx.get_nano_header()
+            if len(transfer_header.addresses) != 1:
+                raise InvalidToken('nano transactions may only debit the caller address')
+            input_address = transfer_header.addresses[0]
+            if input_address.address != nano_header.nc_address:
+                raise NCInvalidSignature('transfer header address must match the nano caller')
+            if input_address.seqnum != nano_header.nc_seqnum:
+                raise NCInvalidSeqnum('transfer header seqnum must match the nano header seqnum')
+            if any(txin.address_index != 0 for txin in transfer_header.inputs):
+                raise InvalidToken('nano transactions may only debit address_index 0')
 
     def _verify_regular_address(self, address: bytes) -> None:
         if len(address) != ADDRESS_LEN_BYTES:

--- a/hathor_tests/nanocontracts/test_consensus.py
+++ b/hathor_tests/nanocontracts/test_consensus.py
@@ -1,7 +1,7 @@
 from typing import Any, cast
 
 from hathor.conf import HathorSettings
-from hathor.crypto.util import get_address_from_public_key_bytes
+from hathor.crypto.util import get_address_b58_from_bytes, get_address_from_public_key_bytes
 from hathor.exception import InvalidNewTransaction
 from hathor.nanocontracts import NC_EXECUTION_FAIL_ID, Blueprint, Context, public
 from hathor.nanocontracts.exception import NCFail, NCInvalidSignature
@@ -90,8 +90,17 @@ class AddressBalanceBlueprint(Blueprint):
         self.token_uid = token_uid
 
     @public
+    def nop(self, ctx: Context) -> None:
+        pass
+
+    @public
     def transfer_to_caller(self, ctx: Context, amount: int) -> None:
         self.syscall.transfer_to_address(Address(ctx.caller_id), Amount(amount), self.token_uid)
+
+    @public
+    def transfer_to_caller_and_fail(self, ctx: Context, amount: int) -> None:
+        self.syscall.transfer_to_address(Address(ctx.caller_id), Amount(amount), self.token_uid)
+        raise NCFail('forced failure')
 
 
 class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
@@ -114,9 +123,19 @@ class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
         block_storage = self.manager.get_nc_block_storage(block)
         return block_storage.get_address_balance(Address(address), TokenUid(settings.HATHOR_TOKEN_UID))
 
-    def test_address_balance_execution_with_transfer_from_contract_is_successful(self) -> None:
+    def _assert_tx_success(self, tx: Transaction) -> None:
+        meta = tx.get_metadata()
+        assert meta.nc_execution == NCExecutionState.SUCCESS
+        assert meta.voided_by is None
+
+    def _assert_tx_failure(self, tx: Transaction) -> None:
+        meta = tx.get_metadata()
+        assert meta.nc_execution == NCExecutionState.FAILURE
+        assert meta.voided_by == {tx.hash, NC_EXECUTION_FAIL_ID}
+
+    def test_execution_with_transfer_header_is_successful(self) -> None:
         artifacts = self.dag_builder.build_from_str(f'''
-            blockchain genesis b[1..32]
+            blockchain genesis b[1..33]
             b10 < dummy
 
             tx_init.nc_id = "{self.blueprint_id.hex()}"
@@ -125,24 +144,39 @@ class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
             tx_init.nc_seqnum = 0
             tx_init.nc_deposit = 20 HTR
 
-            tx_contract.nc_id = tx_init
-            tx_contract.nc_method = transfer_to_caller(7)
-            tx_contract.nc_address = wallet_caller
-            tx_contract.nc_seqnum = 0
+            tx_seed.nc_id = tx_init
+            tx_seed.nc_method = transfer_to_caller(9)
+            tx_seed.nc_address = wallet_sender
+            tx_seed.nc_seqnum = 0
+
+            tx_header.nc_id = tx_init
+            tx_header.nc_method = nop()
+            tx_header.nc_address = wallet_sender
+            tx_header.nc_seqnum = 1
+            tx_header.nc_transfer_input = 4 HTR wallet_sender
+            tx_header.nc_transfer_output = 4 HTR wallet_receiver
 
             tx_init <-- b30
-            tx_contract <-- b31
+            tx_seed <-- b31
+            tx_header <-- b32
         ''')
 
         artifacts.propagate_with(self.manager)
 
-        tx_contract = artifacts.get_typed_vertex('tx_contract', Transaction)
-        assert tx_contract.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        tx_header = artifacts.get_typed_vertex('tx_header', Transaction)
+        b31, b32 = artifacts.get_typed_vertices(['b31', 'b32'], Block)
+        self._assert_tx_success(tx_header)
 
-        caller = tx_contract.get_nano_header().nc_address
-        assert self._get_address_balance(caller) == 7
+        transfer_header = tx_header.get_transfer_header()
+        sender = transfer_header.addresses[0].address
+        receiver = transfer_header.outputs[0].address
 
-    def test_standalone_transfer_header_execution_updates_state(self) -> None:
+        assert self._get_address_balance(sender, block=b31) == 9
+        assert self._get_address_balance(receiver, block=b31) == 0
+        assert self._get_address_balance(sender, block=b32) == 5
+        assert self._get_address_balance(receiver, block=b32) == 4
+
+    def test_standalone_transfer_header_execution_updates_state_and_surfaces(self) -> None:
         artifacts = self.dag_builder.build_from_str(f'''
             blockchain genesis b[1..33]
             b10 < dummy
@@ -183,6 +217,176 @@ class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
         assert self._get_address_balance(sender, block=b32) == 5
         assert self._get_address_balance(receiver, block=b32) == 4
 
+        tx_json = tx_transfer.to_json_extended()
+        assert tx_json['transfer_header']['addresses'][0]['address'] == get_address_b58_from_bytes(sender)
+        assert tx_json['transfer_header']['outputs'][0]['address'] == get_address_b58_from_bytes(receiver)
+
+        related_addresses = tx_transfer.get_related_addresses()
+        assert get_address_b58_from_bytes(sender) in related_addresses
+        assert get_address_b58_from_bytes(receiver) in related_addresses
+
+    def test_address_balance_execution_with_transfer_from_contract_is_successful(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..32]
+            b10 < dummy
+
+            tx_init.nc_id = "{self.blueprint_id.hex()}"
+            tx_init.nc_method = initialize("00")
+            tx_init.nc_address = wallet_contract
+            tx_init.nc_seqnum = 0
+            tx_init.nc_deposit = 20 HTR
+
+            tx_contract.nc_id = tx_init
+            tx_contract.nc_method = transfer_to_caller(7)
+            tx_contract.nc_address = wallet_caller
+            tx_contract.nc_seqnum = 0
+
+            tx_init <-- b30
+            tx_contract <-- b31
+        ''')
+
+        artifacts.propagate_with(self.manager)
+
+        tx_contract = artifacts.get_typed_vertex('tx_contract', Transaction)
+        self._assert_tx_success(tx_contract)
+
+        caller = tx_contract.get_nano_header().nc_address
+        assert self._get_address_balance(caller) == 7
+
+    def test_execution_with_both_transfer_header_and_contract_transfer_is_successful(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..33]
+            b10 < dummy
+
+            tx_init.nc_id = "{self.blueprint_id.hex()}"
+            tx_init.nc_method = initialize("00")
+            tx_init.nc_address = wallet_contract
+            tx_init.nc_seqnum = 0
+            tx_init.nc_deposit = 20 HTR
+
+            tx_seed.nc_id = tx_init
+            tx_seed.nc_method = transfer_to_caller(10)
+            tx_seed.nc_address = wallet_caller
+            tx_seed.nc_seqnum = 0
+
+            tx_combined.nc_id = tx_init
+            tx_combined.nc_method = transfer_to_caller(3)
+            tx_combined.nc_address = wallet_caller
+            tx_combined.nc_seqnum = 1
+            tx_combined.nc_transfer_input = 4 HTR wallet_caller
+            tx_combined.nc_transfer_output = 4 HTR wallet_receiver
+
+            tx_init <-- b30
+            tx_seed <-- b31
+            tx_combined <-- b32
+        ''')
+
+        artifacts.propagate_with(self.manager)
+
+        tx_combined = artifacts.get_typed_vertex('tx_combined', Transaction)
+        self._assert_tx_success(tx_combined)
+
+        transfer_header = tx_combined.get_transfer_header()
+        sender = transfer_header.addresses[0].address
+        receiver = transfer_header.outputs[0].address
+        caller = tx_combined.get_nano_header().nc_address
+
+        assert sender == caller
+        assert self._get_address_balance(sender) == 9
+        assert self._get_address_balance(receiver) == 4
+        assert self._get_address_balance(caller) == 9
+
+    def test_address_balance_execution_failure_not_due_to_transfer_does_not_persist_transfers(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..33]
+            b10 < dummy
+
+            tx_init.nc_id = "{self.blueprint_id.hex()}"
+            tx_init.nc_method = initialize("00")
+            tx_init.nc_address = wallet_contract
+            tx_init.nc_seqnum = 0
+            tx_init.nc_deposit = 20 HTR
+
+            tx_seed.nc_id = tx_init
+            tx_seed.nc_method = transfer_to_caller(10)
+            tx_seed.nc_address = wallet_caller
+            tx_seed.nc_seqnum = 0
+
+            tx_fail.nc_id = tx_init
+            tx_fail.nc_method = transfer_to_caller_and_fail(3)
+            tx_fail.nc_address = wallet_caller
+            tx_fail.nc_seqnum = 1
+            tx_fail.nc_transfer_input = 4 HTR wallet_caller
+            tx_fail.nc_transfer_output = 4 HTR wallet_receiver
+
+            tx_init <-- b30
+            tx_seed <-- b31
+            tx_fail <-- b32
+        ''')
+
+        artifacts.propagate_with(self.manager)
+
+        tx_fail = artifacts.get_typed_vertex('tx_fail', Transaction)
+        b31, b32 = artifacts.get_typed_vertices(['b31', 'b32'], Block)
+        self._assert_tx_failure(tx_fail)
+
+        transfer_header = tx_fail.get_transfer_header()
+        sender = transfer_header.addresses[0].address
+        receiver = transfer_header.outputs[0].address
+        caller = tx_fail.get_nano_header().nc_address
+
+        assert sender == caller
+        assert self._get_address_balance(sender, block=b31) == 10
+        assert self._get_address_balance(receiver, block=b31) == 0
+        assert self._get_address_balance(caller, block=b31) == 10
+
+        assert self._get_address_balance(sender, block=b32) == 10
+        assert self._get_address_balance(receiver, block=b32) == 0
+        assert self._get_address_balance(caller, block=b32) == 10
+
+    def test_address_balance_execution_failure_due_to_transfer_low_balance(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..33]
+            b10 < dummy
+
+            tx_init.nc_id = "{self.blueprint_id.hex()}"
+            tx_init.nc_method = initialize("00")
+            tx_init.nc_address = wallet_contract
+            tx_init.nc_seqnum = 0
+            tx_init.nc_deposit = 20 HTR
+
+            tx_seed.nc_id = tx_init
+            tx_seed.nc_method = transfer_to_caller(5)
+            tx_seed.nc_address = wallet_sender
+            tx_seed.nc_seqnum = 0
+
+            tx_low.nc_id = tx_init
+            tx_low.nc_method = nop()
+            tx_low.nc_address = wallet_sender
+            tx_low.nc_seqnum = 1
+            tx_low.nc_transfer_input = 6 HTR wallet_sender
+            tx_low.nc_transfer_output = 6 HTR wallet_receiver
+
+            tx_init <-- b30
+            tx_seed <-- b31
+            tx_low <-- b32
+        ''')
+
+        artifacts.propagate_with(self.manager)
+
+        tx_low = artifacts.get_typed_vertex('tx_low', Transaction)
+        b31, b32 = artifacts.get_typed_vertices(['b31', 'b32'], Block)
+        self._assert_tx_failure(tx_low)
+
+        transfer_header = tx_low.get_transfer_header()
+        sender = transfer_header.addresses[0].address
+        receiver = transfer_header.outputs[0].address
+
+        assert self._get_address_balance(sender, block=b31) == 5
+        assert self._get_address_balance(receiver, block=b31) == 0
+        assert self._get_address_balance(sender, block=b32) == 5
+        assert self._get_address_balance(receiver, block=b32) == 0
+
     def test_reorg_discards_losing_chain_transfer_header_state(self) -> None:
         artifacts = self.dag_builder.build_from_str(f'''
             blockchain genesis b[1..33]
@@ -200,10 +404,13 @@ class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
             tx_seed.nc_address = wallet_sender
             tx_seed.nc_seqnum = 0
 
+            # Losing chain: sender -> receiver_b (4 HTR)
             tx_header_b.transfer_seqnum = 1
             tx_header_b.nc_transfer_input = 4 HTR wallet_sender
             tx_header_b.nc_transfer_output = 4 HTR wallet_receiver_b
 
+            # Winning chain: different transfer over the same (address, token).
+            # Give it a large explicit weight so a-chain reliably wins the reorg.
             tx_header_a.transfer_seqnum = 1
             tx_header_a.nc_transfer_input = 7 HTR wallet_sender
             tx_header_a.nc_transfer_output = 7 HTR wallet_receiver_a
@@ -227,12 +434,18 @@ class NCAddressBalanceConsensusTestCase(SimulatorTestCase):
         receiver_a = tx_header_a.get_transfer_header().outputs[0].address
         receiver_b = tx_header_b.get_transfer_header().outputs[0].address
 
+        # a-chain wins the reorg.
         assert b33.get_metadata().voided_by == {b33.hash}
         assert a34.get_metadata().voided_by is None
+
+        # Losing-chain transfer's balance update is not visible.
         assert self._get_address_balance(receiver_b) == 0
+
+        # Winning chain's transfer applied on top of the common ancestor.
         assert self._get_address_balance(sender) == 3
         assert self._get_address_balance(receiver_a) == 7
 
+        # Seqnum reflects the winning chain only.
         best_block = self.manager.tx_storage.get_best_block()
         block_storage = self.manager.get_nc_block_storage(best_block)
         assert block_storage.get_address_seqnum(Address(sender)) == 1

--- a/hathor_tests/tx/test_verification_mempool.py
+++ b/hathor_tests/tx/test_verification_mempool.py
@@ -10,6 +10,7 @@ from hathor.nanocontracts.exception import (
     NanoContractDoesNotExist,
     NCFail,
     NCForbiddenAction,
+    NCInsufficientFunds,
     NCInvalidMethodCall,
     NCInvalidSeqnum,
     NCMethodNotFound,
@@ -36,6 +37,7 @@ from hathor.verification.transaction_verifier import MAX_BETWEEN_CONFLICTS, MAX_
 from hathor.verification.vertex_verifier import MAX_PAST_TIMESTAMP_ALLOWED
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.conf.settings import FeatureSetting
 
 
 class MyTestBlueprint(Blueprint):
@@ -64,6 +66,46 @@ class MyOtherTestBlueprint(Blueprint):
     @fallback(allow_withdrawal=True)
     def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> None:
         assert method_name == 'unknown'
+
+
+class TransferHeaderMempoolValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.blueprint_id = b'c' * 32
+        settings = self._settings.model_copy(update={'ENABLE_TRANSFER_HEADER': FeatureSetting.ENABLED})
+        self.manager = self.create_peer('unittests', settings=settings)
+        self.manager.blueprint_service.register_blueprint(self.blueprint_id, MyTestBlueprint)
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_transfer_header_input_rejects_when_amount_exceeds_available_balance(self) -> None:
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..32]
+            b10 < dummy
+
+            tx_init.nc_id = "{self.blueprint_id.hex()}"
+            tx_init.nc_method = initialize()
+            tx_init.nc_address = wallet1
+            tx_init.nc_seqnum = 0
+
+            tx_transfer.nc_id = tx_init
+            tx_transfer.nc_method = nop()
+            tx_transfer.nc_address = wallet1
+            tx_transfer.nc_seqnum = 1
+            tx_transfer.nc_transfer_input = 1 HTR wallet1
+            tx_transfer.nc_transfer_output = 1 HTR wallet2
+
+            tx_init <-- b30
+            b30 < tx_transfer
+        ''')
+        artifacts.propagate_with(self.manager, up_to='b30')
+        tx_transfer = artifacts.get_typed_vertex('tx_transfer', Transaction)
+
+        tx_transfer.timestamp = int(self.manager.reactor.seconds())
+        self.dag_builder._exporter._vertex_resolver(tx_transfer)
+
+        with self.assertRaises(InvalidNewTransaction) as e:
+            self.manager.vertex_handler.on_new_mempool_transaction(tx_transfer)
+        assert isinstance(e.exception.__cause__, NCInsufficientFunds)
 
 
 class VertexHeadersTest(unittest.TestCase):


### PR DESCRIPTION
### Motivation

Completes the [RFC #108](https://github.com/HathorNetwork/rfcs/pull/108) stack by combining transfer headers with nano contract execution in the same transaction. Until now, transfer headers were rejected on nano transactions; this PR lifts that restriction under tight constraints and makes the two mechanisms execute atomically so that either both effects land or neither does.

### Acceptance Criteria

- A nano transaction carrying a transfer header executes both effects atomically: the transfer balances are verified and applied before the nano method runs, and a nano failure rolls back the transfer along with the nano effects (no partial state is persisted).
- Transfer headers on nano transactions are allowed only when they debit the caller: exactly one transfer address, matching `nc_address`; matching `nc_seqnum`; and inputs restricted to `address_index = 0`. Violations raise `InvalidToken`, `NCInvalidSignature`, or `NCInvalidSeqnum` as appropriate.
- Voided nano transactions that also carry a transfer header no longer advance the nano-header address seqnum on the failure path, since seqnum bookkeeping is handled through the transfer header route.
- Mempool verification rejects a nano+transfer-header transaction whose transfer input exceeds the sender's available balance, surfaced as `NCInsufficientFunds`.
- New consensus tests cover the combined-success path, the contract-only path (regression), the nano-failure-preserves-nothing path, and the insufficient-balance failure path.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged