### PR TITLE
feat(api): expose global address balances in thin wallet

### DIFF
--- a/hathor/wallet/resources/thin_wallet/address_balance.py
+++ b/hathor/wallet/resources/thin_wallet/address_balance.py
@@ -21,6 +21,7 @@ from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, get_args, get_missing_params_msg, set_cors
 from hathor.conf.get_settings import get_global_settings
 from hathor.crypto.util import decode_address
+from hathor.nanocontracts.types import Address as NCAddress
 from hathor.transaction.scripts import parse_address_script
 from hathor.util import json_dumpb
 from hathor.wallet.exceptions import InvalidAddress
@@ -92,7 +93,7 @@ class AddressBalanceResource(Resource):
 
         try:
             # Check if address is valid
-            decode_address(requested_address)
+            requested_address_bytes = decode_address(requested_address)
         except InvalidAddress:
             return json_dumpb({
                 'success': False,
@@ -120,27 +121,38 @@ class AddressBalanceResource(Resource):
                         token_uid = tx.get_token_uid(tx_output.get_token_index())
                         tokens_data[token_uid].received += tx_output.value
 
+        def get_token_metadata(token_uid: bytes) -> tuple[str, str]:
+            if token_uid == self._settings.HATHOR_TOKEN_UID:
+                return self._settings.HATHOR_TOKEN_NAME, self._settings.HATHOR_TOKEN_SYMBOL
+            try:
+                token_info = tokens_index.get_token_info(token_uid)
+                return token_info.get_name(), token_info.get_symbol()
+            except KeyError:
+                return '- (unable to fetch token information)', '- (unable to fetch token information)'
+
         return_tokens_data: dict[str, dict[str, Any]] = {}
         for token_uid in tokens_data.keys():
-            if token_uid == self._settings.HATHOR_TOKEN_UID:
-                tokens_data[token_uid].name = self._settings.HATHOR_TOKEN_NAME
-                tokens_data[token_uid].symbol = self._settings.HATHOR_TOKEN_SYMBOL
-            else:
-                try:
-                    token_info = tokens_index.get_token_info(token_uid)
-                    tokens_data[token_uid].name = token_info.get_name()
-                    tokens_data[token_uid].symbol = token_info.get_symbol()
-                except KeyError:
-                    # Should never get here because this token appears in our wallet index
-                    # But better than get a 500 error
-                    tokens_data[token_uid].name = '- (unable to fetch token information)'
-                    tokens_data[token_uid].symbol = '- (unable to fetch token information)'
+            tokens_data[token_uid].name, tokens_data[token_uid].symbol = get_token_metadata(token_uid)
             return_tokens_data[token_uid.hex()] = tokens_data[token_uid].to_dict()
+
+        best_block = self.manager.tx_storage.get_best_block()
+        block_storage = self.manager.get_nc_block_storage(best_block)
+        requested_nc_address = NCAddress(requested_address_bytes)
+        global_tokens_data: dict[str, dict[str, Any]] = {}
+        for token_uid, balance in block_storage.iter_address_balances(requested_nc_address):
+            name, symbol = get_token_metadata(token_uid)
+            global_tokens_data[token_uid.hex()] = {
+                'balance': int(balance),
+                'name': name,
+                'symbol': symbol,
+            }
 
         data = {
             'success': True,
             'total_transactions': len(tx_hashes),
-            'tokens_data': return_tokens_data
+            'tokens_data': return_tokens_data,
+            'global_tokens_data': global_tokens_data,
+            'global_seqnum': block_storage.get_address_seqnum(requested_nc_address),
         }
         return json_dumpb(data)
 

--- a/hathor_tests/resources/wallet/test_search_address.py
+++ b/hathor_tests/resources/wallet/test_search_address.py
@@ -1,6 +1,7 @@
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.crypto.util import decode_address
+from hathor.nanocontracts.types import Address as NCAddress, TokenUid as NCTokenUid
 from hathor.simulator.utils import add_new_blocks
 from hathor.transaction.scripts import parse_address_script
 from hathor.wallet.resources.thin_wallet import AddressBalanceResource, AddressSearchResource
@@ -110,6 +111,37 @@ class SearchAddressTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(0, data['tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['spent'])
         self.assertEqual(100, data['tokens_data'][self.token_uid.hex()]['received'])
         self.assertEqual(0, data['tokens_data'][self.token_uid.hex()]['spent'])
+
+    @inlineCallbacks
+    def test_address_balance_includes_global_balance_fields(self):
+        other_address_bytes = decode_address(self.manager.wallet.get_unused_address())
+        other_address = NCAddress(other_address_bytes)
+        unrelated_token_uid = b'\xab' * 32
+
+        best_block = self.manager.tx_storage.get_best_block()
+        block_storage = self.manager.get_nc_block_storage(best_block)
+        address = NCAddress(self.address_bytes)
+        block_storage.add_address_balance(address, 7, NCTokenUid(self._settings.HATHOR_TOKEN_UID))
+        block_storage.add_address_balance(address, 11, NCTokenUid(self.token_uid))
+        # A token credited to a different address must not appear in the response for `address`.
+        block_storage.add_address_balance(other_address, 13, NCTokenUid(unrelated_token_uid))
+        block_storage.set_address_seqnum(address, 3)
+        block_storage.commit()
+        best_block.get_metadata().nc_block_root_id = block_storage.get_root_id()
+
+        resource = StubSite(AddressBalanceResource(self.manager))
+        response = yield resource.get('thin_wallet/address_balance', {b'address': self.address.encode()})
+        data = response.json_value()
+
+        self.assertTrue(data['success'])
+        self.assertEqual(3, data['global_seqnum'])
+        self.assertEqual(7, data['global_tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['balance'])
+        self.assertEqual(11, data['global_tokens_data'][self.token_uid.hex()]['balance'])
+        self.assertNotIn(unrelated_token_uid.hex(), data['global_tokens_data'])
+        self.assertEqual(
+            self._settings.HATHOR_TOKEN_NAME,
+            data['global_tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['name'],
+        )
 
     @inlineCallbacks
     def test_zero_count(self):


### PR DESCRIPTION
### Motivation

Part of the implementation of [RFC #108](https://github.com/HathorNetwork/rfcs/pull/108). With the global address-balance map and `TransferHeader` already wired into nano execution, wallets and explorers still have no way to read a user's global balance. This PR extends the existing thin-wallet `address_balance` endpoint so clients can observe the new balance domain alongside the UTXO-derived balances they already see, without introducing a separate endpoint.

### Acceptance Criteria

- `GET thin_wallet/address_balance` returns two new fields per request: `global_tokens_data`, mapping token UID to `{balance, name, symbol}` for every token the address holds in the global address-balance map, and `global_seqnum`, the address's last committed seqnum (per the RFC's replay-protection rules).
- Global balances are read from the best block's nano block storage via `iter_address_balances` / `get_address_seqnum`, so the response reflects the post-execution global state of the current chain tip.
- Token name/symbol resolution (HTR special-cased, custom tokens looked up via the tokens index, fallback string on `KeyError`) is shared between the existing `tokens_data` and the new `global_tokens_data` through a single `get_token_metadata` helper, so both surfaces stay consistent.
- Existing `tokens_data` shape and behavior are preserved; the new fields are purely additive.
- Test coverage verifies the new fields are populated for credited tokens (HTR and custom), exclude balances belonging to other addresses, surface the correct seqnum, and resolve HTR's canonical name.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged