### PR TITLE
refactor: update code according to VM requirements

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -110,6 +110,7 @@ class BuildArtifacts(NamedTuple):
     wallet: Optional[BaseWallet]
     rocksdb_storage: RocksDBStorage
     stratum_factory: Optional[StratumFactory]
+    blueprint_service: BlueprintService
 
 
 _VertexVerifiersBuilder: TypeAlias = Callable[
@@ -307,6 +308,7 @@ class Builder:
             stratum_factory=stratum_factory,
             feature_service=feature_service,
             bit_signaling_service=bit_signaling_service,
+            blueprint_service=blueprint_service,
         )
 
         return self.artifacts

--- a/hathor/nanocontracts/execution/consensus_block_executor.py
+++ b/hathor/nanocontracts/execution/consensus_block_executor.py
@@ -303,7 +303,7 @@ class NCConsensusBlockExecutor:
                 if tx.name:
                     kwargs['__name'] = tx.name
                 if self._nc_exec_fail_trace:
-                    kwargs['exc_info'] = True
+                    kwargs['traceback'] = tb
                 self.log.info(
                     'nc execution failed',
                     tx=tx.hash.hex(),

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 
 from structlog import get_logger
 
+from hathorlib.nanocontracts import ENABLE_HTR_VM
 from hathor.consensus import ConsensusAlgorithm
 from hathor.daa import DifficultyAdjustmentAlgorithm
 from hathor.event import EventManager
@@ -107,6 +108,10 @@ class CliBuilder:
             peer = PrivatePeer.auto_generated()
         python = f'{platform.python_version()}-{platform.python_implementation()}'
 
+        log_kwargs: dict[str, Any] = {}
+        if ENABLE_HTR_VM:
+            log_kwargs['htr_vm'] = True
+
         self.log.info(
             'hathor-core v{hathor}',
             hathor=hathor.__version__,
@@ -117,6 +122,7 @@ class CliBuilder:
             platform=platform.platform(),
             settings=settings_source,
             reactor_type=type(reactor).__name__,
+            **log_kwargs,
         )
 
         vertex_parser = VertexParser(settings=settings)

--- a/hathor_cli/run_node.py
+++ b/hathor_cli/run_node.py
@@ -269,6 +269,7 @@ class RunNode:
             stratum_factory=self.manager.stratum_factory,
             feature_service=self.manager.vertex_handler._feature_service,
             bit_signaling_service=self.manager._bit_signaling_service,
+            blueprint_service=self.manager.blueprint_service,
         )
 
     def start_sentry_if_possible(self) -> None:

--- a/hathor_tests/conftest.py
+++ b/hathor_tests/conftest.py
@@ -1,9 +1,16 @@
 import os
 
 from hathor.reactor import initialize_global_reactor
+from hathor_cli.util import LoggingOptions, LoggingOutput, setup_logging
 from hathorlib.conf import UNITTESTS_SETTINGS_FILEPATH
 
 os.environ['HATHOR_CONFIG_YAML'] = os.environ.get('HATHOR_TEST_CONFIG_YAML', UNITTESTS_SETTINGS_FILEPATH)
+
+
+setup_logging(
+    logging_output=LoggingOutput.PRETTY,
+    logging_options=LoggingOptions(debug=True, sentry=False),
+)
 
 # TODO: We should remove this call from the module level.
 initialize_global_reactor(use_asyncio_reactor=True)

--- a/hathor_tests/nanocontracts/fields/test_compound_field.py
+++ b/hathor_tests/nanocontracts/fields/test_compound_field.py
@@ -1,9 +1,11 @@
-from hathor.nanocontracts import Blueprint, Context, public
+from hathor.nanocontracts import NC_EXECUTION_FAIL_ID, Blueprint, Context, public
 from hathor.nanocontracts.fields.container import INIT_NC_TYPE
+from hathor.nanocontracts.nc_exec_logs import NCLogConfig
 from hathor.nanocontracts.nc_types import VarInt32NCType
 from hathor.transaction import Block, Transaction
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
 from hathorlib.nanocontracts.fields.deque_container import _METADATA_NC_TYPE as METADATA_NC_TYPE
 
 INT_NC_TYPE = VarInt32NCType()
@@ -38,43 +40,52 @@ class BlueprintWithCompoundField(Blueprint):
         assert len(self.dc) == 1
         assert 'bar' in self.dc
         assert 'foo' not in self.dc
-        # XXX: implicit creation fails:
-        try:
-            self.dc['foo']
-        except KeyError as e:
-            assert e.args == ('foo',)
-        else:
-            assert False
+
+    @public
+    def test_implicit_creation_fail(self, ctx: Context) -> None:
+        _ = self.dc['foo']
+
+    @public
+    def assert_len(self, ctx: Context) -> None:
         assert len(self.dc) == 1
-        # remove foo, test will check it was removed from the storage
-        del self.dc['foo']
 
 
 class TestDictField(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.manager = self.create_peer('unittests')
+        self.manager = self.create_peer('unittests', nc_log_config=NCLogConfig.ALL)
         self.bp_dict = b'1' * 32
         self.manager.blueprint_service.register_blueprint(self.bp_dict, BlueprintWithCompoundField)
 
     def test_dict_field(self) -> None:
         dag_builder = TestDAGBuilder.from_manager(self.manager)
         artifacts = dag_builder.build_from_str(f'''
-            blockchain genesis b[1..12]
+            blockchain genesis b[1..14]
             b10 < dummy
 
             nc1.nc_id = "{self.bp_dict.hex()}"
             nc1.nc_method = initialize()
 
+            nc2.nc_id = nc1
+            nc2.nc_method = test_implicit_creation_fail()
+
+            nc3.nc_id = nc1
+            nc3.nc_method = assert_len()
+
             nc1 <-- b11
             nc1 <-- b12
+            nc2 <-- b13
+            nc3 <-- b14
         ''')
         artifacts.propagate_with(self.manager)
 
-        b11, b12 = artifacts.get_typed_vertices(['b11', 'b12'], Block)
-        nc1, = artifacts.get_typed_vertices(['nc1'], Transaction)
+        b11, b12, b13, b14 = artifacts.get_typed_vertices(['b11', 'b12', 'b13', 'b14'], Block)
+        nc1, nc2, nc3 = artifacts.get_typed_vertices(['nc1', 'nc2', 'nc3'], Transaction)
 
         assert b11.get_metadata().voided_by is None
+        assert b12.get_metadata().voided_by is None
+        assert b13.get_metadata().voided_by is None
+        assert b14.get_metadata().voided_by is None
         assert nc1.get_metadata().voided_by is None
         assert nc1.get_metadata().first_block == b11.hash
 
@@ -101,3 +112,15 @@ class TestDictField(unittest.TestCase):
         assert metadata.last_index == 3
         assert metadata.length == 4
         assert not metadata.reversed
+
+        assert nc2.get_metadata().voided_by == {nc2.hash, NC_EXECUTION_FAIL_ID}
+        assert nc2.get_metadata().first_block == b13.hash
+        assert_nc_failure_reason(
+            manager=self.manager,
+            tx_id=nc2.hash,
+            block_id=b13.hash,
+            reason='KeyError: \'foo\'',
+        )
+
+        assert nc3.get_metadata().voided_by is None
+        assert nc3.get_metadata().first_block == b14.hash

--- a/hathor_tests/nanocontracts/fields/test_deque_field.py
+++ b/hathor_tests/nanocontracts/fields/test_deque_field.py
@@ -15,11 +15,14 @@
 from collections import deque
 from typing import cast
 
+import pytest
+
 from hathor.nanocontracts import Blueprint, Context, public
 from hathor.nanocontracts.nc_types import VarInt32NCType
 from hathor.transaction import Block, Transaction
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.nanocontracts import ENABLE_HTR_VM
 
 INT_NC_TYPE = VarInt32NCType()
 
@@ -153,6 +156,7 @@ class TestDequeField(unittest.TestCase):
         with self.assertRaises(KeyError):
             b12_storage.get_obj(b'dq:\x04', INT_NC_TYPE)
 
+    @pytest.mark.skipif(ENABLE_HTR_VM, reason='deque is not in allowed imports')
     def test_deque_field_with_deque(self) -> None:
         self._test_deque_field(self.bp_deque)
 

--- a/hathor_tests/nanocontracts/test_authorities_index.py
+++ b/hathor_tests/nanocontracts/test_authorities_index.py
@@ -17,7 +17,7 @@ import pytest
 from hathor.nanocontracts import Blueprint, Context, public
 from hathor.nanocontracts.exception import NanoContractDoesNotExist
 from hathor.nanocontracts.storage.contract_storage import Balance
-from hathor.nanocontracts.types import ContractId, NCAcquireAuthorityAction, NCActionType, TokenUid, VertexId
+from hathor.nanocontracts.types import ContractId, NCAcquireAuthorityAction, NCActionType, TokenUid, VertexId, view
 from hathor.nanocontracts.utils import derive_child_token_id
 from hathor.transaction import Block, Transaction, TxOutput
 from hathor.transaction.headers.nano_header import NanoHeaderAction
@@ -52,9 +52,14 @@ class MyBlueprint(Blueprint):
 
     @public
     def acquire_authority(self, ctx: Context, other_id: ContractId) -> None:
-        self.token_uid = derive_child_token_id(other_id, 'TKA')
+        contract = self.syscall.get_contract(other_id, blueprint_id=None)
+        self.token_uid = contract.view().get_token_uid()
         action = NCAcquireAuthorityAction(token_uid=self.token_uid, mint=True, melt=True)
-        self.syscall.get_contract(other_id, blueprint_id=None).public(action).allow_acquire_authority()
+        contract.public(action).allow_acquire_authority()
+
+    @view
+    def get_token_uid(self) -> TokenUid | None:
+        return self.token_uid
 
 
 class TestAuthoritiesIndex(BlueprintTestCase):

--- a/hathor_tests/nanocontracts/test_call_other_contract.py
+++ b/hathor_tests/nanocontracts/test_call_other_contract.py
@@ -54,7 +54,7 @@ class MyBlueprint(Blueprint):
             return
 
         actions = []
-        for action in ctx.__all_actions__:
+        for action in ctx.actions_list:
             assert isinstance(action, NCDepositAction)
             amount = 1 + action.amount // 2
             actions.append(NCDepositAction(token_uid=action.token_uid, amount=amount))
@@ -66,7 +66,7 @@ class MyBlueprint(Blueprint):
             return
 
         actions = []
-        for action in ctx.__all_actions__:
+        for action in ctx.actions_list:
             assert isinstance(action, NCWithdrawalAction)
             balance = self.syscall.get_balance_before_current_call(action.token_uid)
             diff = balance - action.amount

--- a/hathor_tests/nanocontracts/test_context.py
+++ b/hathor_tests/nanocontracts/test_context.py
@@ -1,52 +1,136 @@
-import copy
+from typing import NamedTuple
 
 from hathor.nanocontracts import Blueprint, public
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.vertex_data import BlockData, NanoHeaderData, VertexData
+from hathor.nanocontracts.nc_types import make_nc_type_for_field_type
 from hathor.transaction import Block, Transaction
 from hathor.transaction.base_transaction import TxVersion
+from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor.transaction.scripts import parse_address_script
 from hathor.util import not_none
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.nanocontracts.test_blueprint import BYTES_NC_TYPE
+from hathorlib.nanocontracts.fields.deque_container import _INDEX_NC_TYPE, _METADATA_NC_TYPE as DQ_METADATA_NC_TYPE
 
-GLOBAL_CTX_DATA: tuple[VertexData, BlockData] | None = None
+
+class TxInputDataTuple(NamedTuple):
+    tx_id: bytes
+    index_: int
+    data: bytes
+
+
+class ScriptInfoTuple(NamedTuple):
+    type: str
+    address: str
+    timelock: int | None
+
+
+class TxOutputDataTuple(NamedTuple):
+    value: int
+    raw_script: bytes
+    parsed_script: ScriptInfoTuple | None
+    token_data: int
+
+
+class NanoHeaderDataTuple(NamedTuple):
+    nc_id: bytes
+    nc_method: str
+    nc_args_bytes: bytes
+
+
+class VertexDataTuple(NamedTuple):
+    version: int
+    hash: bytes
+    nonce: int
+    signal_bits: int
+    work: int
+
+
+class BlockDataTuple(NamedTuple):
+    hash: bytes
+    timestamp: int
+    height: int
 
 
 class RememberVertexDataBlueprint(Blueprint):
+    vertex_data: VertexDataTuple | None
+    block_data: BlockDataTuple | None
+    vertex_tokens: list[bytes]
+    vertex_parents: list[bytes]
+    vertex_inputs: list[TxInputDataTuple]
+    vertex_outputs: list[TxOutputDataTuple]
+    nano_header: NanoHeaderDataTuple | None
+
     @public
     def initialize(self, ctx: Context) -> None:
-        pass
+        self.vertex_data = None
+        self.block_data = None
+        self.vertex_tokens = []
+        self.vertex_parents = []
+        self.vertex_inputs = []
+        self.vertex_outputs = []
+        self.nano_header = None
 
     @public
     def remember_context(self, ctx: Context) -> None:
-        global GLOBAL_CTX_DATA
-        GLOBAL_CTX_DATA = copy.deepcopy((ctx.vertex, ctx.block))
+        self.vertex_data = VertexDataTuple(
+            version=ctx.vertex.version,
+            hash=ctx.vertex.hash,
+            nonce=ctx.vertex.nonce,
+            signal_bits=ctx.vertex.signal_bits,
+            work=ctx.vertex.work,
+        )
+        self.block_data = BlockDataTuple(
+            hash=ctx.block.hash,
+            timestamp=ctx.block.timestamp,
+            height=ctx.block.height
+        )
+        self.vertex_tokens.extend(ctx.vertex.tokens)
+        self.vertex_parents.extend(ctx.vertex.parents)
+
+        for tx_input in ctx.vertex.inputs:
+            self.vertex_inputs.append(
+                TxInputDataTuple(
+                    tx_id=tx_input.tx_id,
+                    index_=tx_input.index,
+                    data=tx_input.data,
+                )
+            )
+
+        for tx_out in ctx.vertex.outputs:
+            assert tx_out.parsed_script is not None
+            self.vertex_outputs.append(
+                TxOutputDataTuple(
+                    value=tx_out.value,
+                    raw_script=tx_out.raw_script,
+                    parsed_script=ScriptInfoTuple(
+                        type=tx_out.parsed_script.type,
+                        address=tx_out.parsed_script.address,
+                        timelock=tx_out.parsed_script.timelock,
+                    ),
+                    token_data=tx_out.token_data,
+                )
+            )
+
+        assert len(ctx.vertex.headers) == 1
+        nano_header = ctx.vertex.headers[0]
+        self.nano_header = NanoHeaderDataTuple(
+            nc_id=nano_header.nc_id,  # type: ignore[attr-defined]
+            nc_method=nano_header.nc_method,  # type: ignore[attr-defined]
+            nc_args_bytes=nano_header.nc_args_bytes  # type: ignore[attr-defined]
+        )
 
 
 class ContextTestCase(BlueprintTestCase):
     def setUp(self) -> None:
-        global GLOBAL_CTX_DATA
-
         super().setUp()
 
         self.blueprint_id = self.gen_random_contract_id()
         self.manager.blueprint_service.register_blueprint(self.blueprint_id, RememberVertexDataBlueprint)
         self.address = self.gen_random_address()
 
-        # clear vertex-data before and after
-        GLOBAL_CTX_DATA = None
-
-    def tearDown(self) -> None:
-        global GLOBAL_CTX_DATA
-
-        super().tearDown()
-        # clear vertex-data before and after
-        GLOBAL_CTX_DATA = None
-
     def test_vertex_data(self) -> None:
-        global GLOBAL_CTX_DATA
-
         dag_builder = TestDAGBuilder.from_manager(self.manager)
         artifacts = dag_builder.build_from_str(f'''
             blockchain genesis b[1..12]
@@ -62,38 +146,63 @@ class ContextTestCase(BlueprintTestCase):
         b12, = artifacts.get_typed_vertices(['b12'], Block)
         nc1, nc2 = artifacts.get_typed_vertices(['nc1', 'nc2'], Transaction)
 
+        assert nc1.get_metadata().nc_execution == NCExecutionState.SUCCESS
+        assert nc2.get_metadata().nc_execution == NCExecutionState.SUCCESS
+
         # this is the vertex data that was observed by nc2 when remember_context was called
-        assert GLOBAL_CTX_DATA is not None
-        vertex_data, block_data = copy.deepcopy(GLOBAL_CTX_DATA)
+        nc_storage = self.manager.get_nc_storage(b12, nc1.hash)
+
+        vertex_data_nc_type = make_nc_type_for_field_type(VertexDataTuple | None)  # type: ignore[arg-type]
+        block_data_nc_type = make_nc_type_for_field_type(BlockDataTuple | None)  # type: ignore[arg-type]
+        vertex_data = nc_storage.get_obj(b'vertex_data', vertex_data_nc_type)
+        block_data = nc_storage.get_obj(b'block_data', block_data_nc_type)
+        vertex_tokens = nc_storage.get_obj(b'vertex_tokens:__metadata__', DQ_METADATA_NC_TYPE)
 
         self.assertEqual(vertex_data.version, TxVersion.REGULAR_TRANSACTION)
         self.assertEqual(vertex_data.hash, nc2.hash)
         self.assertEqual(vertex_data.signal_bits, 0)
         self.assertEqual(vertex_data.work, 2)
-        self.assertEqual(vertex_data.tokens, ())
+        self.assertEqual(vertex_tokens.length, 0)
         self.assertEqual(block_data.hash, b12.hash)
         self.assertEqual(block_data.timestamp, b12.timestamp)
         self.assertEqual(block_data.height, b12.get_height())
         self.assertEqual(vertex_data.nonce, nc2.nonce)
-        self.assertEqual(vertex_data.parents, tuple(nc2.parents))
 
+        for i, parent_tx in enumerate(nc2.parents):
+            storage_parent = nc_storage.get_obj(
+                b':'.join([b'vertex_parents', _INDEX_NC_TYPE.to_bytes(i)]),
+                BYTES_NC_TYPE
+            )
+            assert storage_parent == parent_tx
+
+        input_nc_type = make_nc_type_for_field_type(TxInputDataTuple)
         for i, input_tx in enumerate(nc2.inputs):
-            assert vertex_data.inputs[i].tx_id == input_tx.tx_id
-            assert vertex_data.inputs[i].index == input_tx.index
-            assert vertex_data.inputs[i].data == input_tx.data
+            storage_input = nc_storage.get_obj(
+                b':'.join([b'vertex_inputs', _INDEX_NC_TYPE.to_bytes(i)]),
+                input_nc_type,
+            )
+            assert storage_input.tx_id == input_tx.tx_id
+            assert storage_input.index_ == input_tx.index
+            assert storage_input.data == input_tx.data
 
+        output_nc_type = make_nc_type_for_field_type(TxOutputDataTuple)
         for i, output in enumerate(nc2.outputs):
+            storage_out = nc_storage.get_obj(
+                b':'.join([b'vertex_outputs', _INDEX_NC_TYPE.to_bytes(i)]),
+                output_nc_type,
+            )
             parsed = not_none(parse_address_script(output.script))
-            assert vertex_data.outputs[i].value == output.value
-            assert vertex_data.outputs[i].raw_script == output.script
-            assert not_none(vertex_data.outputs[i].parsed_script).type == parsed.get_type()
-            assert not_none(vertex_data.outputs[i].parsed_script).address == parsed.get_address()
-            assert not_none(vertex_data.outputs[i].parsed_script).timelock == parsed.get_timelock()
-            assert vertex_data.outputs[i].token_data == output.token_data
+            assert storage_out.value == output.value
+            assert storage_out.raw_script == output.script
+            assert not_none(storage_out.parsed_script).type == parsed.get_type()
+            assert not_none(storage_out.parsed_script).address == parsed.get_address()
+            assert not_none(storage_out.parsed_script).timelock == parsed.get_timelock()
+            assert storage_out.token_data == output.token_data
 
-        self.assertEqual(set(vertex_data.parents), set(nc2.parents))
-        nano_header_data, = vertex_data.headers
-        assert isinstance(nano_header_data, NanoHeaderData)
+        nano_header_data = nc_storage.get_obj(
+            b'nano_header',
+            make_nc_type_for_field_type(NanoHeaderDataTuple | None),  # type: ignore[arg-type]
+        )
         self.assertEqual(nano_header_data.nc_id, nc1.hash)
         self.assertEqual(nano_header_data.nc_method, 'remember_context')
         self.assertEqual(nano_header_data.nc_args_bytes, b'\x00')

--- a/hathor_tests/nanocontracts/test_custom_import.py
+++ b/hathor_tests/nanocontracts/test_custom_import.py
@@ -17,10 +17,14 @@ from io import StringIO
 from textwrap import dedent
 from unittest.mock import ANY, Mock, call, patch
 
+import pytest
+
 from hathor.nanocontracts.custom_builtins import EXEC_BUILTINS
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathorlib.nanocontracts import ENABLE_HTR_VM
 
 
+@pytest.mark.skipif(ENABLE_HTR_VM, reason='tests specific CPython implementation, irrelevant to HtrVM')
 class TestCustomImport(BlueprintTestCase):
     def test_custom_import_is_used(self) -> None:
         """Guarantee our custom import function is being called, instead of the builtin one."""

--- a/hathor_tests/nanocontracts/test_exposed_properties.py
+++ b/hathor_tests/nanocontracts/test_exposed_properties.py
@@ -3,10 +3,13 @@ from sys import version_info
 from types import MethodType
 from typing import Any
 
+import pytest
+
 from hathor.nanocontracts import Blueprint, Context, public
 from hathor.nanocontracts.allowed_imports import ALLOWED_IMPORTS
 from hathor.nanocontracts.custom_builtins import EXEC_BUILTINS
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathorlib.nanocontracts import ENABLE_HTR_VM
 
 MAX_DEPTH = 20
 NEW_PROP_NAME = 'some_new_attribute'
@@ -273,6 +276,7 @@ class MyBlueprint(Blueprint):
         return mutable_props
 
 
+@pytest.mark.skipif(ENABLE_HTR_VM, reason='tests specific CPython implementation, irrelevant to HtrVM')
 class TestMutableAttributes(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/hathor_tests/nanocontracts/test_fallback_method.py
+++ b/hathor_tests/nanocontracts/test_fallback_method.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import assert_never
 from unittest.mock import ANY
 
 import pytest
@@ -39,24 +38,24 @@ class MyBlueprint(Blueprint):
     @fallback(allow_deposit=True)
     def fallback(self, ctx: Context, method_name: str, nc_args: NCArgs) -> str:
         assert method_name == 'unknown'
-        match nc_args:
-            case NCRawArgs():
-                # XXX: we might need to provide a better way to describe the expected signature to `try_parse_as`,
-                #      because only looking a a tuple of types might not be enough, currently it is implemented
-                #      without the knowledge of default arguments, what this implies is that considering a signature
-                #      with types (str, int), it is possible for an empty tuple () to be a valid call, as long as the
-                #      function has default values for its two arguments, the parser takes the optimist path and
-                #      accepts parsing an empty tuple, so in this case args_bytes=b'\x00' parses to (), because it is
-                #      possible that that is a valid call
-                result = nc_args.try_parse_as((str, int))
-                if result is None:
-                    raise NCFail(f'unsupported args: {nc_args}')
-                greeting, x = result
-                return self.greet_double(ctx, greeting, x)
-            case NCParsedArgs(args, kwargs):
-                return self.greet_double(ctx, *args, **kwargs)
-            case _:
-                assert_never(nc_args)
+        if isinstance(nc_args, NCRawArgs):
+            # XXX: we might need to provide a better way to describe the expected signature to `try_parse_as`,
+            #      because only looking a a tuple of types might not be enough, currently it is implemented
+            #      without the knowledge of default arguments, what this implies is that considering a signature
+            #      with types (str, int), it is possible for an empty tuple () to be a valid call, as long as the
+            #      function has default values for its two arguments, the parser takes the optimist path and
+            #      accepts parsing an empty tuple, so in this case args_bytes=b'\x00' parses to (), because it is
+            #      possible that that is a valid call
+            result = nc_args.try_parse_as((str, int))
+            if result is None:
+                raise NCFail(f'unsupported args: {nc_args}')
+            greeting, x = result
+            return self.greet_double(ctx, greeting, x)
+
+        if isinstance(nc_args, NCParsedArgs):
+            return self.greet_double(ctx, *nc_args.args, **nc_args.kwargs)
+
+        raise AssertionError('unreachable')
 
     def greet_double(self, ctx: Context, greeting: str, x: int) -> str:
         return f'{greeting} {x + x}'

--- a/hathor_tests/nanocontracts/test_syscalls.py
+++ b/hathor_tests/nanocontracts/test_syscalls.py
@@ -123,10 +123,8 @@ class TargetBlueprint(Blueprint):
         return self.counter
 
     @public(allow_deposit=True)
-    def proxy_increment(self, ctx: Context, blueprint_id: BlueprintId, value: int) -> int:
+    def proxy_increment(self, ctx: Context, blueprint_id: BlueprintId, args_bytes: bytes) -> int:
         """Call the increment method of another blueprint using proxy_call_public_method_nc_args."""
-        args_parser = ArgsOnly.from_arg_types((int,))
-        args_bytes = args_parser.serialize_args_bytes((value,))
         nc_args = NCRawArgs(args_bytes)
         # Pay 1 HTR as fee for the proxy call
         fees: list[NCFee] = [NCFee(token_uid=TokenUid(HATHOR_TOKEN_UID), amount=1)]
@@ -722,8 +720,11 @@ class NCNanoContractTestCase(BlueprintTestCase):
             [NCDepositAction(token_uid=fee_token_uid, amount=20)],
             self.get_genesis_tx()
         )
+        value = 5
+        args_parser = ArgsOnly.from_arg_types((int,))
+        args_bytes = args_parser.serialize_args_bytes((value,))
         result = self.runner.call_public_method(
-            target_nc_id, 'proxy_increment', ctx_with_deposit, self.proxy_caller_blueprint_id, 5
+            target_nc_id, 'proxy_increment', ctx_with_deposit, self.proxy_caller_blueprint_id, args_bytes
         )
         assert result == 5
 

--- a/hathor_tests/nanocontracts/test_utils_functions.py
+++ b/hathor_tests/nanocontracts/test_utils_functions.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import hashlib
+import json
 
 import pytest
 from cryptography.hazmat.backends import default_backend
@@ -21,7 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 from hathor import ContractId
 from hathor.crypto.util import get_public_key_bytes_compressed
-from hathor.nanocontracts import Blueprint, Context, NCFail, public, utils as nc_utils, view
+from hathor.nanocontracts import Blueprint, Context, NCFail, public, view
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 
@@ -32,16 +33,19 @@ class MyBlueprint(Blueprint):
 
     @view
     def test_sha3(self, data: bytes) -> bytes:
-        return nc_utils.sha3(data)
+        from hathor import sha3
+        return sha3(data)
 
     @view
     def test_verify_ecdsa(self, public_key: bytes, data: bytes, signature: bytes) -> bool:
-        return nc_utils.verify_ecdsa(public_key, data, signature)
+        from hathor import verify_ecdsa
+        return verify_ecdsa(public_key, data, signature)
 
     @view
     def test_json_dumps(self) -> str:
+        from hathor import json_dumps
         obj = dict(a=[1, 2, 3], b=123, c='abc', d=ContractId(b'\x01' * 32))
-        return nc_utils.json_dumps(obj)
+        return json_dumps(obj)
 
 
 class TestUtilsFunctions(BlueprintTestCase):
@@ -85,6 +89,11 @@ class TestUtilsFunctions(BlueprintTestCase):
     def test_json_dumps(self) -> None:
         result = self.runner.call_view_method(self.contract_id, 'test_json_dumps')
 
-        assert result == (
-            '{"a":[1,2,3],"b":123,"c":"abc","d":"0101010101010101010101010101010101010101010101010101010101010101"}'
+        assert json.loads(result) == (
+            dict(
+                a=[1, 2, 3],
+                b=123,
+                c='abc',
+                d='0101010101010101010101010101010101010101010101010101010101010101',
+            )
         )

--- a/hathor_tests/resources/nanocontracts/test_state.py
+++ b/hathor_tests/resources/nanocontracts/test_state.py
@@ -1,5 +1,4 @@
 import hashlib
-import math
 from typing import Any, NamedTuple, Optional, TypeAlias
 
 from cryptography.hazmat.primitives import hashes
@@ -7,7 +6,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from twisted.internet.defer import inlineCallbacks
 
 from hathor.conf import HathorSettings
-from hathor.crypto.util import decode_address, get_address_b58_from_bytes, get_public_key_bytes_compressed
+from hathor.crypto.util import decode_address, get_public_key_bytes_compressed
 from hathor.nanocontracts import Blueprint, Context, public, view
 from hathor.nanocontracts.method import Method
 from hathor.nanocontracts.resources import NanoContractStateResource
@@ -108,15 +107,18 @@ class MyBlueprint(Blueprint):
         """A method only for testing that sums amount1 + amount2, in case
         the address is equal to WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN
         """
-        conditional_address = 'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN'
-        if test_tuple.address and get_address_b58_from_bytes(test_tuple.address) == conditional_address:
+        conditional_address = Address.from_str('WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN')
+        if test_tuple.address and test_tuple.address == conditional_address:
             return test_tuple.amount1 + test_tuple.amount2
 
         return None
 
     @view
     def multiply(self, elements: list[int]) -> int:
-        return math.prod(elements)
+        prod = 1
+        for el in elements:
+            prod *= el
+        return prod
 
     @view
     def conditional_multiply_bytes(self, t: tuple[int, Optional[bytes]]) -> Optional[bytes]:

--- a/hathorlib/hathorlib/nanocontracts/__init__.py
+++ b/hathorlib/hathorlib/nanocontracts/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from hathorlib.nanocontracts.faux_immutable import (
     ALLOW_DUNDER_ATTR,
     ALLOW_INHERITANCE_ATTR,
@@ -23,6 +25,8 @@ from hathorlib.nanocontracts.faux_immutable import (
 )
 from hathorlib.nanocontracts.on_chain_blueprint import OnChainBlueprint
 
+ENABLE_HTR_VM: bool = bool(os.environ.get('ENABLE_HTR_VM', False))
+
 __all__ = [
     'ALLOW_DUNDER_ATTR',
     'ALLOW_INHERITANCE_ATTR',
@@ -32,4 +36,5 @@ __all__ = [
     'SKIP_VALIDATION_ATTR',
     '__set_faux_immutable__',
     'create_with_shell',
+    'ENABLE_HTR_VM',
 ]

--- a/hathorlib/hathorlib/nanocontracts/blueprint.py
+++ b/hathorlib/hathorlib/nanocontracts/blueprint.py
@@ -29,7 +29,7 @@ FORBIDDEN_NAMES = {
     'log',
 }
 
-NC_FIELDS_ATTR: str = '__fields'
+NC_FIELDS_ATTR: str = '__blueprint_fields'
 
 
 class _BlueprintBase(type):

--- a/hathorlib/hathorlib/nanocontracts/runner/runner.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/runner.py
@@ -24,7 +24,7 @@ from typing_extensions import assert_never
 from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 from hathorlib.exceptions import InvalidFeeAmount, TransactionDataError, TransactionDoesNotExist
 from hathorlib.nanocontracts.balance_rules import BalanceRules
-from hathorlib.nanocontracts.blueprint import Blueprint
+from hathorlib.nanocontracts.blueprint import NC_FIELDS_ATTR, Blueprint
 from hathorlib.nanocontracts.blueprint_env import BlueprintEnvironment
 from hathorlib.nanocontracts.blueprint_exec import SandboxedExecutor
 from hathorlib.nanocontracts.blueprint_service import BlueprintServiceProtocol
@@ -309,7 +309,7 @@ class Runner:
     def _check_all_field_initialized(self, blueprint: Blueprint) -> None:
         """ Invoked after the initialize method is called to initialize uninitialized containers.
         """
-        field_names = getattr_static(blueprint, '__fields').keys()
+        field_names = getattr_static(blueprint, NC_FIELDS_ATTR).keys()
         uninit_field_names = []
         for field_name in field_names:
             field = getattr_static(blueprint, field_name)

--- a/hathorlib/hathorlib/nanocontracts/types.py
+++ b/hathorlib/hathorlib/nanocontracts/types.py
@@ -218,7 +218,7 @@ class SignedData(InnerTypeMixin[T], Generic[T]):
 
 
 def _set_method_type(fn: Callable, method_type: NCMethodType) -> None:
-    if hasattr(fn, NC_METHOD_TYPE_ATTR):
+    if hasattr(fn, NC_METHOD_TYPE_ATTR) and getattr(fn, NC_METHOD_TYPE_ATTR) is not None:
         raise BlueprintSyntaxError(f'method must be annotated with at most one method type: `{fn.__name__}()`')
     setattr(fn, NC_METHOD_TYPE_ATTR, method_type)
 

--- a/hathorlib/hathorlib/utils/address.py
+++ b/hathorlib/hathorlib/utils/address.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import hashlib
 from typing import Optional, cast
 
@@ -18,7 +19,6 @@ import base58
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import InvalidAddress
 
 
@@ -101,6 +101,7 @@ def get_address_from_public_key_hash(
         :return: address in bytes
         :rtype: bytes
     """
+    from hathorlib.conf import HathorSettings
     settings = HathorSettings()
     version_byte = (
         settings.P2PKH_VERSION_BYTE
@@ -127,6 +128,7 @@ def get_address_b58_from_redeem_script_hash(redeem_script_hash: bytes,
         :return: address in base 58
         :rtype: string
     """
+    from hathorlib.conf import HathorSettings
     settings = HathorSettings()
     version_byte = (
         settings.MULTISIG_VERSION_BYTE
@@ -150,6 +152,7 @@ def get_address_from_redeem_script_hash(redeem_script_hash: bytes,
         :return: address in bytes
         :rtype: bytes
     """
+    from hathorlib.conf import HathorSettings
     settings = HathorSettings()
     version_byte = (
         settings.MULTISIG_VERSION_BYTE


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1666

### Motivation

The new Nano runtime will start being tested soon. In preparation for it, in order to keep all hathor-core tests passing, we must update test Blueprints to remove prohibited items. This PR also includes some other related small refactors/improvements.

### Acceptance Criteria

- Fix `--nc-exec-fail-trace` (it wasn't working after the block executor refactor).
- Add `ENABLE_HTR_VM` flag, which is used to skip some implementation-specific tests.
- Update Blueprint tests to remove usage of prohibited types/functions/syntax/etc.
- Call `setup_logging` for tests.
- Update `NC_FIELDS_ATTR` from `__fields` to `__blueprint_fields`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 