### PR TITLE
chore(ci): temporarily remove macOS from CI matrix

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -26,7 +26,8 @@ jobs:
           - "3.12"
         os:
           - ubuntu-22.04
-          - macos-15
+          # XXX: temporarily disable macOS because of rocksdb breakage
+          # - macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,9 @@ jobs:
           full_matrix = {
             'python': ['3.11', '3.12', '3.13'],
             # available OS's: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
-            'os': ['ubuntu-22.04', 'macos-15'],
+            # XXX: temporarily disable macOS because of rocksdb breakage
+            # 'os': ['ubuntu-22.04', 'macos-15'],
+            'os': ['ubuntu-22.04'],
           }
           # this is the fastest one:
           reduced_matrix = {


### PR DESCRIPTION
### Motivation

The CI has been failing on `master` because of some rocksdb updates that affect macOS, the bindings likely need updating.

### Acceptance Criteria

- Temporarily remove `macos-15` from CI.
- NOTE: macOS testing only covers development environment, no production setup can be affected. We do not publish macOS-specific builds.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 