### PR TITLE
feat(verification): VerificationContext completeness mechanism

### DIFF
--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -289,6 +289,11 @@ class NCBlockExecutor:
             # after the execution we have the latest state in the storage
             # and at this point no tokens pending creation
             self._verify_sum_after_execution(tx, block_storage)
+
+            # Defense-in-depth: the flag-set must now be complete.
+            # If _verify_sum_after_execution is ever removed or bypassed, the tx
+            # will arrive here with BALANCE_POSTPONED but no BALANCE → void it.
+            self._assert_verification_checks_complete_after_execution(tx)
         except NCFail as e:
             return NCTxExecutionFailure(
                 tx=tx,
@@ -300,14 +305,37 @@ class NCBlockExecutor:
         return NCTxExecutionSuccess(tx=tx, runner=runner)
 
     def _verify_sum_after_execution(self, tx: Transaction, block_storage: 'NCBlockStorage') -> None:
-        """Verify token sums after execution for dynamically created tokens."""
+        """Verify token sums after execution for dynamically created tokens.
+
+        Passes a VerificationContext so verify_sum records BALANCE into tx
+        metadata on success — letting the post-execution completeness check
+        confirm re-verification ran."""
         from hathor.verification.transaction_verifier import TransactionVerifier
+        from hathor.verification.verification_context import VerificationContext
         try:
             token_dict = tx.get_complete_token_info(block_storage)
-            TransactionVerifier.verify_sum(self._settings, tx, token_dict)
+            ctx = VerificationContext(vertex_hash=tx.hash or b'')
+            TransactionVerifier.verify_sum(self._settings, tx, token_dict, ctx=ctx)
+            tx.get_metadata().verification_checks |= ctx.checks_run
         except TokenNotFound as e:
             # At this point, any nonexistent token would have made a prior validation fail. For example, if there
             # was a withdrawal of a nonexistent token, it would have failed in the balance validation before.
             raise AssertionError from e
         except Exception as e:
             raise NCFail from e
+
+    def _assert_verification_checks_complete_after_execution(self, tx: Transaction) -> None:
+        """After nano execution, every required VerificationCheck flag must be
+        recorded. Missing flags mean a check was silently skipped — void the
+        tx by raising NCFail, which the caller converts to NCTxExecutionFailure."""
+        from hathor.transaction.exceptions import VerificationChecksMissingError
+        from hathor.verification.required_checks import Stage, required_post_nano_checks
+        from hathor.verification.verification_context import VerificationContext
+
+        meta = tx.get_metadata()
+        ctx = VerificationContext(vertex_hash=tx.hash or b'', checks_run=meta.verification_checks)
+        required = required_post_nano_checks(tx, self._settings)
+        try:
+            ctx.check(required, stage=Stage.POST_NANO_EXECUTION.value)
+        except VerificationChecksMissingError as e:
+            raise NCFail(str(e)) from e

--- a/hathor/simulator/patches.py
+++ b/hathor/simulator/patches.py
@@ -19,6 +19,8 @@ from typing_extensions import override
 
 from hathor.mining.cpu_mining_service import CpuMiningService
 from hathor.transaction import BaseTransaction
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.vertex_verifier import VertexVerifier
 
 logger = get_logger()
@@ -26,8 +28,15 @@ logger = get_logger()
 
 class SimulatorVertexVerifier(VertexVerifier):
     @classmethod
-    def verify_pow(cls, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+    def verify_pow(
+        cls,
+        vertex: BaseTransaction,
+        *,
+        override_weight: Optional[float] = None,
+        ctx: VerificationContext,
+    ) -> None:
         logger.new().debug('Skipping VertexVerifier.verify_pow() for simulator')
+        ctx.record(VerificationCheck.POW)
 
 
 class SimulatorCpuMiningService(CpuMiningService):

--- a/hathor/stratum/stratum.py
+++ b/hathor/stratum/stratum.py
@@ -43,6 +43,7 @@ from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction, BitcoinAuxPow, Block, MergeMinedBlock, Transaction, sum_weights
 from hathor.transaction.exceptions import PowError, ScriptError, TxValidationError
 from hathor.util import json_dumpb, json_loadb
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.vertex_verifier import VertexVerifier
 from hathor.wallet.exceptions import InvalidAddress
 
@@ -537,7 +538,7 @@ class StratumProtocol(JSONRPC):
         )
 
         try:
-            verifier.verify_pow(tx, override_weight=job.weight)
+            verifier.verify_pow(tx, override_weight=job.weight, ctx=VerificationContext(vertex_hash=tx.hash or b''))
         except PowError:
             self.log.error('bad share, discard', job_weight=job.weight, tx=tx)
             return self.send_error(INVALID_SOLUTION, msgid, {
@@ -553,7 +554,7 @@ class StratumProtocol(JSONRPC):
         self.manager.reactor.callLater(0, self.job_request)
 
         try:
-            verifier.verify_pow(tx)
+            verifier.verify_pow(tx, ctx=VerificationContext(vertex_hash=tx.hash or b''))
         except PowError:
             # Transaction pow was not enough, but the share was succesfully submited
             self.log.info('high hash, keep mining', tx=tx)

--- a/hathor/transaction/exceptions.py
+++ b/hathor/transaction/exceptions.py
@@ -75,6 +75,12 @@ from hathorlib.exceptions import (  # noqa: F401
 )
 
 
+class VerificationChecksMissingError(TxValidationError):
+    """Raised when the verification pipeline finishes a stage without having
+    recorded every required VerificationCheck flag — indicates a dispatcher
+    bug where a check was silently skipped."""
+
+
 class ForbiddenMint(InputOutputMismatch):
     """Tokens were minted without authority inputs"""
 

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -23,6 +23,7 @@ from hathor.manager import HathorManager
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import create_output_script
 from hathor.util import api_catch_exceptions, json_dumpb, json_loadb
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 
 
@@ -112,20 +113,23 @@ class CreateTxResource(Resource):
         """ Same as .verify but skipping pow and signature verification."""
         assert type(tx) is Transaction
         verifiers = self.manager.verification_service.verifiers
-        verifiers.tx.verify_number_of_inputs(tx)
-        verifiers.vertex.verify_number_of_outputs(tx)
-        verifiers.vertex.verify_outputs(tx)
-        verifiers.tx.verify_output_token_indexes(tx)
-        verifiers.vertex.verify_sigops_output(tx, enable_checkdatasig_count=True)
-        verifiers.tx.verify_sigops_input(tx, enable_checkdatasig_count=True)
+        ctx = VerificationContext()
+        verifiers.tx.verify_number_of_inputs(tx, ctx=ctx)
+        verifiers.vertex.verify_number_of_outputs(tx, ctx=ctx)
+        verifiers.vertex.verify_outputs(tx, ctx=ctx)
+        verifiers.tx.verify_output_token_indexes(tx, ctx=ctx)
+        verifiers.vertex.verify_sigops_output(tx, enable_checkdatasig_count=True, ctx=ctx)
+        verifiers.tx.verify_sigops_input(tx, enable_checkdatasig_count=True, ctx=ctx)
         best_block = self.manager.tx_storage.get_best_block()
         params = VerificationParams.for_mempool(best_block=best_block, features=Features.all_enabled())
         # need to run verify_inputs first to check if all inputs exist
-        verifiers.tx.verify_inputs(tx, params, skip_script=True)
-        verifiers.vertex.verify_parents(tx)
+        verifiers.tx.verify_inputs(tx, params, skip_script=True, ctx=ctx)
+        verifiers.vertex.verify_parents(tx, ctx=ctx)
 
         block_storage = self.manager.get_nc_block_storage(best_block)
-        verifiers.tx.verify_sum(self.manager._settings, tx, tx.get_complete_token_info(block_storage))
+        verifiers.tx.verify_sum(
+            self.manager._settings, tx, tx.get_complete_token_info(block_storage), ctx=ctx,
+        )
 
 
 CreateTxResource.openapi = {

--- a/hathor/transaction/transaction_metadata.py
+++ b/hathor/transaction/transaction_metadata.py
@@ -25,6 +25,7 @@ from hathor.transaction.types import MetaNCCallRecord
 from hathor.transaction.validation_state import ValidationState
 from hathor.util import collect_n, json_dumpb, json_loadb, practically_equal
 from hathor.utils.weight import work_to_weight
+from hathor.verification.verification_check import VerificationCheck
 
 if TYPE_CHECKING:
     from weakref import ReferenceType  # noqa: F401
@@ -49,6 +50,12 @@ class TransactionMetadata:
     score: int
     first_block: Optional[bytes]
     validation: ValidationState
+
+    # Bitfield of VerificationCheck flags recorded during verification. Used
+    # by VerificationContext to enforce that every required check actually
+    # ran. Persisted so postponed checks (nano contracts) can be tracked
+    # across the verify → block-execution boundary.
+    verification_checks: VerificationCheck
 
     # Used to store the root node id of the contract tree related to this block.
     nc_block_root_id: Optional[bytes]
@@ -126,6 +133,7 @@ class TransactionMetadata:
 
         # Validation
         self.validation = ValidationState.INITIAL
+        self.verification_checks = VerificationCheck(0)
 
         settings = settings or get_global_settings()
 
@@ -190,6 +198,7 @@ class TransactionMetadata:
             return False
         for field in ['hash', 'conflict_with', 'voided_by', 'received_by',
                       'accumulated_weight', 'twins', 'score', 'first_block', 'validation',
+                      'verification_checks',
                       'feature_states', 'nc_block_root_id', 'nc_calls', 'nc_execution', 'nc_events']:
             if (getattr(self, field) or None) != (getattr(other, field) or None):
                 return False
@@ -244,6 +253,7 @@ class TransactionMetadata:
         else:
             data['first_block'] = None
         data['validation'] = self.validation.name.lower()
+        data['verification_checks'] = int(self.verification_checks)
         data['nc_block_root_id'] = self.nc_block_root_id.hex() if self.nc_block_root_id else None
         data['nc_calls'] = [x.to_json() for x in self.nc_calls] if self.nc_calls else None
         data['nc_execution'] = self.nc_execution.value if self.nc_execution else None
@@ -262,6 +272,10 @@ class TransactionMetadata:
         limited_children, has_more_children = collect_n(iter(self.get_tx().get_children()), _MAX_JSON_CHILDREN)
         data['children'] = [child_id.hex() for child_id in limited_children]
         data['has_more_children'] = has_more_children
+
+        # Internal bookkeeping — not API surface. Kept in storage JSON for
+        # persistence so postponed checks can be tracked across restarts.
+        data.pop('verification_checks', None)
 
         return data
 
@@ -316,6 +330,8 @@ class TransactionMetadata:
 
         _val_name = data.get('validation', None)
         meta.validation = ValidationState.from_name(_val_name) if _val_name is not None else ValidationState.INITIAL
+
+        meta.verification_checks = VerificationCheck(data.get('verification_checks', 0))
 
         nc_block_root_id_raw = data.get('nc_block_root_id')
         if nc_block_root_id_raw is not None:

--- a/hathor/verification/block_verifier.py
+++ b/hathor/verification/block_verifier.py
@@ -30,6 +30,8 @@ from hathor.transaction.exceptions import (
     WeightError,
 )
 from hathor.transaction.storage import TransactionStorage
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 
 
 class BlockVerifier:
@@ -50,14 +52,15 @@ class BlockVerifier:
         self._checkpoints: dict[int, Checkpoint] = {cp.height: cp for cp in settings.CHECKPOINTS}
         self._latest_checkpoint: Checkpoint | None = settings.CHECKPOINTS[-1] if settings.CHECKPOINTS else None
 
-    def verify_height(self, block: Block) -> None:
+    def verify_height(self, block: Block, *, ctx: VerificationContext) -> None:
         """Validate that the block height is enough to confirm all transactions being confirmed."""
         height = block.static_metadata.height
         min_height = block.static_metadata.min_height
         if height < min_height:
             raise RewardLocked(f'Block needs {min_height} height but has {height}')
+        ctx.record(VerificationCheck.HEIGHT)
 
-    def verify_weight(self, block: Block) -> None:
+    def verify_weight(self, block: Block, *, ctx: VerificationContext) -> None:
         """Validate minimum block difficulty."""
         assert self._settings.CONSENSUS_ALGORITHM.is_pow()
         assert block.storage is not None
@@ -65,8 +68,9 @@ class BlockVerifier:
         if block.weight < min_block_weight - self._settings.WEIGHT_TOL:
             raise WeightError(f'Invalid new block {block.hash_hex}: weight ({block.weight}) is '
                               f'smaller than the minimum weight ({min_block_weight})')
+        ctx.record(VerificationCheck.BLOCK_WEIGHT)
 
-    def verify_reward(self, block: Block) -> None:
+    def verify_reward(self, block: Block, *, ctx: VerificationContext) -> None:
         """Validate reward amount."""
         parent_block = block.get_block_parent()
         tokens_issued_per_block = self._daa.get_tokens_issued_per_block(parent_block.get_height() + 1)
@@ -75,49 +79,51 @@ class BlockVerifier:
                 f'Invalid number of issued tokens tag=invalid_issued_tokens tx.hash={block.hash_hex} '
                 f'issued={block.sum_outputs} allowed={tokens_issued_per_block}'
             )
+        ctx.record(VerificationCheck.REWARD)
 
-    def verify_no_inputs(self, block: Block) -> None:
+    def verify_no_inputs(self, block: Block, *, ctx: VerificationContext) -> None:
         inputs = getattr(block, 'inputs', None)
         if inputs:
             raise BlockWithInputs('number of inputs {}'.format(len(inputs)))
+        ctx.record(VerificationCheck.NO_INPUTS)
 
-    def verify_output_token_indexes(self, block: Block) -> None:
+    def verify_output_token_indexes(self, block: Block, *, ctx: VerificationContext) -> None:
         for output in block.outputs:
             if output.get_token_index() > 0:
                 raise BlockWithTokensError('in output: {}'.format(output.to_human_readable()))
+        ctx.record(VerificationCheck.BLOCK_OUTPUT_TOKEN_INDEXES)
 
-    def verify_data(self, block: Block) -> None:
+    def verify_data(self, block: Block, *, ctx: VerificationContext) -> None:
         if len(block.data) > self._settings.BLOCK_DATA_MAX_SIZE:
             raise TransactionDataError('block data has {} bytes'.format(len(block.data)))
+        ctx.record(VerificationCheck.BLOCK_DATA)
 
-    def verify_mandatory_signaling(self, block: Block) -> None:
+    def verify_mandatory_signaling(self, block: Block, *, ctx: VerificationContext) -> None:
         """Verify whether this block is missing mandatory signaling for any feature."""
         signaling_state = self._feature_service.is_signaling_mandatory_features(block)
 
         match signaling_state:
             case BlockIsSignaling():
-                return
+                pass
             case BlockIsMissingSignal(feature):
                 raise BlockMustSignalError(
                     f"Block must signal support for feature '{feature.value}' during MUST_SIGNAL phase."
                 )
             case _:
                 assert_never(signaling_state)
+        ctx.record(VerificationCheck.MANDATORY_SIGNALING)
 
-    def verify_checkpoints(self, block: Block) -> None:
+    def verify_checkpoints(self, block: Block, *, ctx: VerificationContext) -> None:
         """Verify whether this block would fork a checkpoint."""
-        if self._latest_checkpoint is None:
-            return
+        if self._latest_checkpoint is not None:
+            block_height = block.get_height()
+            if block_height <= self._latest_checkpoint.height:
+                best_block = self._tx_storage.get_best_block()
+                if best_block.get_height() >= self._latest_checkpoint.height:
+                    raise CheckpointError('forking within checkpoints is forbidden')
 
-        block_height = block.get_height()
-        if block_height > self._latest_checkpoint.height:
-            return
-
-        best_block = self._tx_storage.get_best_block()
-        if best_block.get_height() >= self._latest_checkpoint.height:
-            raise CheckpointError('forking within checkpoints is forbidden')
-
-        # still syncing checkpoints, so we just enforce the hash at checkpoint heights.
-        cp = self._checkpoints.get(block.get_height())
-        if cp is not None and cp.hash != block.hash:
-            raise CheckpointError(f'invalid checkpoint block (height={cp.height})')
+                # still syncing checkpoints, so we just enforce the hash at checkpoint heights.
+                cp = self._checkpoints.get(block.get_height())
+                if cp is not None and cp.hash != block.hash:
+                    raise CheckpointError(f'invalid checkpoint block (height={cp.height})')
+        ctx.record(VerificationCheck.CHECKPOINTS)

--- a/hathor/verification/fee_header_verifier.py
+++ b/hathor/verification/fee_header_verifier.py
@@ -19,6 +19,8 @@ from typing import Sequence
 from hathor.transaction import Transaction
 from hathor.transaction.exceptions import FeeHeaderTokenNotFound, InvalidFeeHeader
 from hathor.transaction.headers import FeeHeader
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 
 MAX_FEES_LEN: int = 16
 
@@ -26,7 +28,9 @@ MAX_FEES_LEN: int = 16
 class FeeHeaderVerifier:
 
     @staticmethod
-    def verify_fee_list(fee_header: 'FeeHeader', tx: Transaction) -> None:
+    def verify_fee_list(
+        fee_header: 'FeeHeader', tx: Transaction, *, ctx: VerificationContext
+    ) -> None:
         """Perform FeeHeader verifications that do not depend on the tx storage."""
         fees = fee_header.fees
         FeeHeaderVerifier._verify_fee_list_size('fees', len(fees))
@@ -39,6 +43,7 @@ class FeeHeaderVerifier:
         for fee in fees:
             FeeHeaderVerifier._verify_token_index('fees', fee.token_index, len(tx.tokens))
             validate_fee_amount(fee_header.settings, tx.get_token_uid(fee.token_index), fee.amount)
+        ctx.record(VerificationCheck.FEE_LIST)
 
     @staticmethod
     def _verify_token_index(prop: str, token_index: int, tx_token_len: int) -> None:

--- a/hathor/verification/merge_mined_block_verifier.py
+++ b/hathor/verification/merge_mined_block_verifier.py
@@ -16,6 +16,8 @@ from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.transaction import MergeMinedBlock
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 
 
 class MergeMinedBlockVerifier:
@@ -25,7 +27,7 @@ class MergeMinedBlockVerifier:
         self._settings = settings
         self._feature_service = feature_service
 
-    def verify_aux_pow(self, block: MergeMinedBlock) -> None:
+    def verify_aux_pow(self, block: MergeMinedBlock, *, ctx: VerificationContext) -> None:
         """ Verify auxiliary proof-of-work (for merged mining).
         """
         assert block.aux_pow is not None
@@ -40,3 +42,4 @@ class MergeMinedBlockVerifier:
         )
 
         block.aux_pow.verify(block.get_mining_base_hash(), max_merkle_path_length)
+        ctx.record(VerificationCheck.AUX_POW)

--- a/hathor/verification/nano_header_verifier.py
+++ b/hathor/verification/nano_header_verifier.py
@@ -51,6 +51,8 @@ from hathor.transaction.scripts import SigopCounter, create_output_script
 from hathor.transaction.scripts.execute import ScriptExtras, raw_script_eval
 from hathor.transaction.scripts.opcode import OpcodesVersion
 from hathor.transaction.storage import TransactionStorage
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 
 MAX_SEQNUM_DIFF_MEMPOOL = MAX_SEQNUM_JUMP_SIZE + 30
@@ -85,9 +87,12 @@ class NanoHeaderVerifier:
         self._tx_storage = tx_storage
         self.blueprint_service = blueprint_service
 
-    def verify_nc_signature(self, tx: BaseTransaction, params: VerificationParams) -> None:
+    def verify_nc_signature(
+        self, tx: BaseTransaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
         """Verify if the caller's signature is valid."""
         self._verify_nc_signature(self._settings, tx, params.features.opcodes_version)
+        ctx.record(VerificationCheck.NANO_NC_SIGNATURE)
 
     @staticmethod
     def _verify_nc_signature(settings: HathorSettings, tx: BaseTransaction, opcodes_version: OpcodesVersion) -> None:
@@ -122,7 +127,7 @@ class NanoHeaderVerifier:
             raise NCInvalidSignature from e
 
     @staticmethod
-    def verify_actions(tx: BaseTransaction) -> None:
+    def verify_actions(tx: BaseTransaction, *, ctx: VerificationContext) -> None:
         """Verify nc_actions."""
         assert tx.is_nano_contract()
         assert isinstance(tx, Transaction)
@@ -141,6 +146,7 @@ class NanoHeaderVerifier:
                 raise NCInvalidAction(
                     f'{action.name} action requires token {action.token_uid.hex()} in tokens list'
                 )
+        ctx.record(VerificationCheck.NANO_ACTIONS)
 
     @staticmethod
     def verify_action_list(actions: Sequence[NCAction]) -> None:
@@ -157,72 +163,74 @@ class NanoHeaderVerifier:
             if action_types not in ALLOWED_ACTION_SETS:
                 raise NCInvalidAction(f'conflicting actions for token {token_uid.hex()}')
 
-    def verify_method_call(self, tx: BaseTransaction, params: VerificationParams) -> None:
-        if not params.harden_nano_restrictions:
-            return
+    def verify_method_call(
+        self, tx: BaseTransaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
+        if params.harden_nano_restrictions:
+            assert tx.is_nano_contract()
+            assert isinstance(tx, Transaction)
 
-        assert tx.is_nano_contract()
-        assert isinstance(tx, Transaction)
+            blueprint_id: BlueprintId
+            nano_header = tx.get_nano_header()
+            if nano_header.is_creating_a_new_contract():
+                # creating a new contract
+                blueprint_id = BlueprintId(nano_header.nc_id)
+                allow_fallback = False
+            else:
+                # contract already exists
+                best_block = self._tx_storage.get_best_block()
+                block_storage = self._tx_storage.get_nc_block_storage(best_block)
+                try:
+                    contract_storage = block_storage.get_contract_storage(ContractId(nano_header.nc_id))
+                except NanoContractDoesNotExist as e:
+                    raise NCTxValidationError from e
+                blueprint_id = contract_storage.get_blueprint_id()
+                allow_fallback = True
 
-        blueprint_id: BlueprintId
-        nano_header = tx.get_nano_header()
-        if nano_header.is_creating_a_new_contract():
-            # creating a new contract
-            blueprint_id = BlueprintId(nano_header.nc_id)
-            allow_fallback = False
-        else:
-            # contract already exists
-            best_block = self._tx_storage.get_best_block()
-            block_storage = self._tx_storage.get_nc_block_storage(best_block)
             try:
-                contract_storage = block_storage.get_contract_storage(ContractId(nano_header.nc_id))
-            except NanoContractDoesNotExist as e:
-                raise NCTxValidationError from e
-            blueprint_id = contract_storage.get_blueprint_id()
-            allow_fallback = True
-
-        try:
-            blueprint_class = self.blueprint_service.get_blueprint_class(blueprint_id)
-        except NCFail as e:
-            raise NCTxValidationError from e
-
-        method_name = nano_header.nc_method
-        method = getattr(blueprint_class, method_name, None)
-        allowed_actions: set[NCActionType]
-        if method is None:
-            if not allow_fallback:
-                raise NCMethodNotFound(f'method `{method_name}` not found and no fallback is allowed')
-            method = getattr(blueprint_class, NC_FALLBACK_METHOD, None)
-            if method is None:
-                raise NCMethodNotFound(f'method `{method_name}` not found and no fallback is provided')
-            method_name = 'fallback'
-        else:
-            if not is_nc_public_method(method):
-                raise NCInvalidMethodCall(f'method `{method_name}` is not a public method')
-            parser = Method.from_callable(method)
-            try:
-                parser.deserialize_args_bytes(nano_header.nc_args_bytes)
+                blueprint_class = self.blueprint_service.get_blueprint_class(blueprint_id)
             except NCFail as e:
                 raise NCTxValidationError from e
 
-        allowed_actions = getattr(method, NC_ALLOWED_ACTIONS_ATTR, set())
-        assert isinstance(allowed_actions, set)
-        for action in nano_header.nc_actions:
-            if action.type not in allowed_actions:
-                exception = NCForbiddenAction(f'action {action.type} is forbidden on method `{method_name}`')
-                raise NCTxValidationError from exception
+            method_name = nano_header.nc_method
+            method = getattr(blueprint_class, method_name, None)
+            allowed_actions: set[NCActionType]
+            if method is None:
+                if not allow_fallback:
+                    raise NCMethodNotFound(f'method `{method_name}` not found and no fallback is allowed')
+                method = getattr(blueprint_class, NC_FALLBACK_METHOD, None)
+                if method is None:
+                    raise NCMethodNotFound(f'method `{method_name}` not found and no fallback is provided')
+                method_name = 'fallback'
+            else:
+                if not is_nc_public_method(method):
+                    raise NCInvalidMethodCall(f'method `{method_name}` is not a public method')
+                parser = Method.from_callable(method)
+                try:
+                    parser.deserialize_args_bytes(nano_header.nc_args_bytes)
+                except NCFail as e:
+                    raise NCTxValidationError from e
 
-    def verify_seqnum(self, tx: BaseTransaction, params: VerificationParams) -> None:
-        if not params.harden_nano_restrictions:
-            return
+            allowed_actions = getattr(method, NC_ALLOWED_ACTIONS_ATTR, set())
+            assert isinstance(allowed_actions, set)
+            for action in nano_header.nc_actions:
+                if action.type not in allowed_actions:
+                    exception = NCForbiddenAction(f'action {action.type} is forbidden on method `{method_name}`')
+                    raise NCTxValidationError from exception
+        ctx.record(VerificationCheck.NANO_METHOD_CALL)
 
-        assert tx.is_nano_contract()
-        assert isinstance(tx, Transaction)
+    def verify_seqnum(
+        self, tx: BaseTransaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
+        if params.harden_nano_restrictions:
+            assert tx.is_nano_contract()
+            assert isinstance(tx, Transaction)
 
-        nano_header = tx.get_nano_header()
-        best_block = self._tx_storage.get_best_block()
-        block_storage = self._tx_storage.get_nc_block_storage(best_block)
-        seqnum = block_storage.get_address_seqnum(Address(nano_header.nc_address))
-        diff = nano_header.nc_seqnum - seqnum
-        if diff < 0 or diff > MAX_SEQNUM_DIFF_MEMPOOL:
-            raise NCInvalidSeqnum(f'invalid seqnum (diff={diff})')
+            nano_header = tx.get_nano_header()
+            best_block = self._tx_storage.get_best_block()
+            block_storage = self._tx_storage.get_nc_block_storage(best_block)
+            seqnum = block_storage.get_address_seqnum(Address(nano_header.nc_address))
+            diff = nano_header.nc_seqnum - seqnum
+            if diff < 0 or diff > MAX_SEQNUM_DIFF_MEMPOOL:
+                raise NCInvalidSeqnum(f'invalid seqnum (diff={diff})')
+        ctx.record(VerificationCheck.NANO_SEQNUM)

--- a/hathor/verification/on_chain_blueprint_verifier.py
+++ b/hathor/verification/on_chain_blueprint_verifier.py
@@ -26,6 +26,8 @@ from hathor.nanocontracts.allowed_imports import ALLOWED_IMPORTS
 from hathor.nanocontracts.custom_builtins import AST_NAME_BLACKLIST
 from hathor.nanocontracts.exception import NCInvalidPubKey, NCInvalidSignature, OCBInvalidScript, OCBPubKeyNotAllowed
 from hathor.nanocontracts.on_chain_blueprint import PYTHON_CODE_COMPAT_VERSION
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 
 
 class _RestrictionsVisitor(ast.NodeVisitor):
@@ -141,14 +143,15 @@ class OnChainBlueprintVerifier:
     def __init__(self, *, settings: HathorSettings):
         self._settings = settings
 
-    def verify_pubkey_is_allowed(self, tx: OnChainBlueprint) -> None:
+    def verify_pubkey_is_allowed(self, tx: OnChainBlueprint, *, ctx: VerificationContext) -> None:
         """Verify if the on-chain blueprint's pubkey is allowed."""
         if self._settings.NC_ON_CHAIN_BLUEPRINT_RESTRICTED:
             address = get_address_b58_from_public_key_bytes(tx.nc_pubkey)
             if address not in self._settings.NC_ON_CHAIN_BLUEPRINT_ALLOWED_ADDRESSES:
                 raise OCBPubKeyNotAllowed(f'nc_pubkey with address {address} is not allowed')
+        ctx.record(VerificationCheck.OCB_PUBKEY_ALLOWED)
 
-    def verify_nc_signature(self, tx: OnChainBlueprint) -> None:
+    def verify_nc_signature(self, tx: OnChainBlueprint, *, ctx: VerificationContext) -> None:
         """Verify if the creatos's signature is valid."""
         data = tx.get_sighash_all_data()
 
@@ -162,6 +165,7 @@ class OnChainBlueprintVerifier:
             pubkey.verify(tx.nc_signature, data, ec.ECDSA(hashes.SHA256()))
         except InvalidSignature as e:
             raise NCInvalidSignature from e
+        ctx.record(VerificationCheck.OCB_NC_SIGNATURE)
 
     def _get_python_code_ast(self, tx: OnChainBlueprint) -> ast.Module:
         from hathor.nanocontracts.on_chain_blueprint import CodeKind
@@ -227,13 +231,14 @@ class OnChainBlueprintVerifier:
             self._verify_blueprint_type,
         )
 
-    def verify_code(self, tx: OnChainBlueprint) -> None:
+    def verify_code(self, tx: OnChainBlueprint, *, ctx: VerificationContext) -> None:
         """Run all verification related to the blueprint code."""
         for rule in self.blueprint_code_rules():
             try:
                 rule(tx)
             except SyntaxError as e:
                 raise OCBInvalidScript('forbidden syntax') from e
+        ctx.record(VerificationCheck.OCB_CODE)
 
     def _verify_python_script(self, tx: OnChainBlueprint) -> None:
         """Verify that the script can be parsed at all."""

--- a/hathor/verification/poa_block_verifier.py
+++ b/hathor/verification/poa_block_verifier.py
@@ -17,6 +17,8 @@ from hathor.consensus import poa
 from hathor.consensus.consensus_settings import PoaSettings
 from hathor.transaction.exceptions import PoaValidationError
 from hathor.transaction.poa import PoaBlock
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 
 
 class PoaBlockVerifier:
@@ -25,7 +27,7 @@ class PoaBlockVerifier:
     def __init__(self, *, settings: HathorSettings):
         self._settings = settings
 
-    def verify_poa(self, block: PoaBlock) -> None:
+    def verify_poa(self, block: PoaBlock, *, ctx: VerificationContext) -> None:
         """Validate the Proof-of-Authority."""
         poa_settings = self._settings.CONSENSUS_ALGORITHM
         assert isinstance(poa_settings, PoaSettings)
@@ -49,3 +51,4 @@ class PoaBlockVerifier:
         expected_weight = poa.calculate_weight(poa_settings, block, signature_validation.signer_index)
         if block.weight != expected_weight:
             raise PoaValidationError(f'block weight is {block.weight}, expected {expected_weight}')
+        ctx.record(VerificationCheck.POA)

--- a/hathor/verification/required_checks.py
+++ b/hathor/verification/required_checks.py
@@ -1,0 +1,193 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Required-checks table for the verification pipeline.
+
+Encodes which VerificationCheck flags must be recorded for each (vertex type,
+stage, conditional) combination. Must stay in sync with the dispatcher in
+verification_service.py — drift is caught by test_required_checks_match_dispatcher.
+"""
+
+from enum import Enum
+
+from hathor.conf.settings import HathorSettings
+from hathor.transaction import BaseTransaction, Block, MergeMinedBlock, Transaction, TxVersion
+from hathor.transaction.poa import PoaBlock
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.verification.verification_check import VerificationCheck as VC
+from hathor.verification.verification_context import RequiredChecks
+from hathor.verification.verification_params import VerificationParams
+
+
+class Stage(Enum):
+    VERIFY_BASIC = 'verify_basic'
+    VERIFY = 'verify'
+    POST_NANO_EXECUTION = 'post_nano_execution'
+
+
+# Flags produced by verify_without_storage, by vertex kind.
+# Note: verify_outputs internally calls verify_number_of_outputs, so
+# NUMBER_OF_OUTPUTS is always recorded alongside OUTPUTS.
+
+_BASE_BLOCK_WITHOUT_STORAGE = (
+    VC.NO_INPUTS | VC.OUTPUTS | VC.NUMBER_OF_OUTPUTS | VC.BLOCK_OUTPUT_TOKEN_INDEXES
+    | VC.BLOCK_DATA | VC.SIGOPS_OUTPUT
+)
+
+
+def _tx_without_storage_flags(*, is_pow: bool) -> VC:
+    flags = (
+        VC.NUMBER_OF_INPUTS | VC.OUTPUTS | VC.NUMBER_OF_OUTPUTS
+        | VC.OUTPUT_TOKEN_INDEXES | VC.SIGOPS_OUTPUT | VC.TOKENS
+    )
+    if is_pow:
+        flags |= VC.POW
+    return flags
+
+
+def _without_storage_for(vertex: BaseTransaction, *, is_pow: bool) -> VC:
+    """Flags produced by verify_without_storage() for this vertex."""
+    match vertex.version:
+        case TxVersion.REGULAR_BLOCK | TxVersion.MERGE_MINED_BLOCK:
+            flags = VC.POW | _BASE_BLOCK_WITHOUT_STORAGE
+        case TxVersion.POA_BLOCK:
+            flags = _BASE_BLOCK_WITHOUT_STORAGE  # no POW in PoA
+        case TxVersion.REGULAR_TRANSACTION | TxVersion.TOKEN_CREATION_TRANSACTION:
+            flags = _tx_without_storage_flags(is_pow=is_pow)
+        case TxVersion.ON_CHAIN_BLUEPRINT:
+            flags = (
+                _tx_without_storage_flags(is_pow=is_pow)
+                | VC.OCB_PUBKEY_ALLOWED | VC.OCB_NC_SIGNATURE | VC.OCB_CODE
+            )
+        case _:
+            flags = VC(0)
+
+    if vertex.has_fees():
+        flags |= VC.FEE_LIST
+
+    if vertex.is_nano_contract():
+        flags |= VC.NANO_NC_SIGNATURE | VC.NANO_ACTIONS
+
+    return flags
+
+
+def _is_genesis_or_skipped(vertex: BaseTransaction, settings: HathorSettings) -> bool:
+    if vertex.hash in settings.SKIP_VERIFICATION:
+        return True
+    if getattr(vertex, 'is_genesis', False):
+        return True
+    return False
+
+
+def required_checks_for(
+    vertex: BaseTransaction,
+    params: VerificationParams,
+    settings: HathorSettings,
+    stage: Stage,
+) -> RequiredChecks:
+    """Return the flags that must be recorded in the VerificationContext after
+    the given stage runs for the given vertex. Empty for genesis/skipped."""
+    if _is_genesis_or_skipped(vertex, settings):
+        return RequiredChecks()
+
+    is_pow = settings.CONSENSUS_ALGORITHM.is_pow()
+
+    if stage is Stage.VERIFY_BASIC:
+        return _required_verify_basic(vertex, params, is_pow=is_pow)
+    if stage is Stage.VERIFY:
+        return _required_verify(vertex, params, is_pow=is_pow)
+    if stage is Stage.POST_NANO_EXECUTION:
+        return _required_post_nano(vertex)
+    raise AssertionError(f'unknown stage {stage!r}')
+
+
+def required_post_nano_checks(
+    vertex: BaseTransaction,
+    settings: HathorSettings,
+) -> RequiredChecks:
+    """Post-nano-execution required flags. Does not depend on VerificationParams,
+    so it can be called from the block executor without threading params through."""
+    if _is_genesis_or_skipped(vertex, settings):
+        return RequiredChecks()
+    return _required_post_nano(vertex)
+
+
+def _required_verify_basic(
+    vertex: BaseTransaction,
+    params: VerificationParams,
+    *,
+    is_pow: bool,
+) -> RequiredChecks:
+    all_of = VC.VERSION_BASIC | VC.OLD_TIMESTAMP
+
+    match vertex.version:
+        case TxVersion.REGULAR_BLOCK | TxVersion.MERGE_MINED_BLOCK:
+            all_of |= VC.REWARD | VC.CHECKPOINTS
+            if not params.skip_block_weight_verification:
+                all_of |= VC.BLOCK_WEIGHT
+        case TxVersion.POA_BLOCK:
+            all_of |= VC.POA | VC.REWARD
+        case TxVersion.REGULAR_TRANSACTION | TxVersion.TOKEN_CREATION_TRANSACTION | TxVersion.ON_CHAIN_BLUEPRINT:
+            # _verify_basic_tx: parents_basic + (weight if pow) + verify_without_storage.
+            all_of |= VC.PARENTS_BASIC
+            if is_pow:
+                all_of |= VC.WEIGHT
+            all_of |= _without_storage_for(vertex, is_pow=is_pow)
+
+    return RequiredChecks(all_of=all_of)
+
+
+def _required_verify(
+    vertex: BaseTransaction,
+    params: VerificationParams,
+    *,
+    is_pow: bool,
+) -> RequiredChecks:
+    """Incremental verify() stage requirements — only the flags that verify()
+    itself records. verify_basic's flags are asserted separately by its own
+    stage check, so verify() stays testable in isolation and the two stages
+    remain orthogonal."""
+    all_of = VC.HEADERS
+    any_of_groups: tuple[VC, ...] = ()
+
+    if isinstance(vertex, (Block, MergeMinedBlock, PoaBlock)):
+        all_of |= _without_storage_for(vertex, is_pow=is_pow)
+        all_of |= VC.PARENTS | VC.HEIGHT | VC.MANDATORY_SIGNALING
+        if isinstance(vertex, MergeMinedBlock):
+            all_of |= VC.AUX_POW
+    elif isinstance(vertex, Transaction):
+        # verify_without_storage re-runs inside _verify_tx for freshness, so its
+        # flags are recorded again into the verify-stage ctx. Declare them here
+        # so the dispatcher-completeness cross-check stays symmetric.
+        all_of |= _without_storage_for(vertex, is_pow=is_pow)
+        all_of |= VC.SIGOPS_INPUT | VC.INPUTS | VC.VERSION | VC.PARENTS | VC.CONFLICT
+        if params.reject_locked_reward:
+            all_of |= VC.REWARD_LOCKED
+        # Balance: either BALANCE (fully verified) or BALANCE_POSTPONED (deferred
+        # to nano execution) satisfies this stage. Post-nano we tighten to BALANCE.
+        any_of_groups = any_of_groups + (VC.BALANCE | VC.BALANCE_POSTPONED,)
+        if isinstance(vertex, TokenCreationTransaction):
+            all_of |= VC.TOKEN_INFO | VC.MINTED_TOKENS
+        if vertex.is_nano_contract():
+            all_of |= VC.NANO_METHOD_CALL | VC.NANO_SEQNUM
+
+    return RequiredChecks(all_of=all_of, any_of_groups=any_of_groups)
+
+
+def _required_post_nano(vertex: BaseTransaction) -> RequiredChecks:
+    """After nano-contract execution, the tx must have BALANCE recorded
+    (not just BALANCE_POSTPONED). Applies to transactions only."""
+    if not isinstance(vertex, Transaction):
+        return RequiredChecks()
+    return RequiredChecks(all_of=VC.BALANCE)

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -18,6 +18,8 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenInfo, TokenVersion
 from hathor.transaction.util import validate_token_name_and_symbol
 from hathor.types import TokenUid
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 
 
@@ -27,7 +29,13 @@ class TokenCreationTransactionVerifier:
     def __init__(self, *, settings: HathorSettings) -> None:
         self._settings = settings
 
-    def verify_minted_tokens(self, tx: TokenCreationTransaction, token_dict: dict[TokenUid, TokenInfo]) -> None:
+    def verify_minted_tokens(
+        self,
+        tx: TokenCreationTransaction,
+        token_dict: dict[TokenUid, TokenInfo],
+        *,
+        ctx: VerificationContext,
+    ) -> None:
         """ Besides all checks made on regular transactions, a few extra ones are made:
         - only HTR tokens on the inputs;
         - new tokens are actually being minted;
@@ -39,8 +47,15 @@ class TokenCreationTransactionVerifier:
         token_info = token_dict[tx.hash]
         if token_info.amount <= 0:
             raise InvalidToken('Token creation transaction must mint new tokens')
+        ctx.record(VerificationCheck.MINTED_TOKENS)
 
-    def verify_token_info(self, tx: TokenCreationTransaction, params: VerificationParams) -> None:
+    def verify_token_info(
+        self,
+        tx: TokenCreationTransaction,
+        params: VerificationParams,
+        *,
+        ctx: VerificationContext,
+    ) -> None:
         """ Validates token info
         """
         validate_token_name_and_symbol(self._settings, tx.token_name, tx.token_symbol)
@@ -53,3 +68,4 @@ class TokenCreationTransactionVerifier:
 
         if any(version_validations):
             raise TransactionDataError('Invalid token version ({})'.format(tx.token_version))
+        ctx.record(VerificationCheck.TOKEN_INFO)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -53,6 +53,8 @@ from hathor.transaction.scripts.opcode import OpcodesVersion
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount
 from hathor.types import TokenUid, VertexId
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 
 if TYPE_CHECKING:
@@ -79,7 +81,7 @@ class TransactionVerifier:
         self._daa = daa
         self._feature_service = feature_service
 
-    def verify_parents_basic(self, tx: Transaction) -> None:
+    def verify_parents_basic(self, tx: Transaction, *, ctx: VerificationContext) -> None:
         """Verify number and non-duplicity of parents."""
         assert tx.storage is not None
 
@@ -90,8 +92,9 @@ class TransactionVerifier:
 
         if len(tx.parents) != 2:
             raise IncorrectParents(f'wrong number of parents (tx type): {len(tx.parents)}, expecting 2')
+        ctx.record(VerificationCheck.PARENTS_BASIC)
 
-    def verify_weight(self, tx: Transaction) -> None:
+    def verify_weight(self, tx: Transaction, *, ctx: VerificationContext) -> None:
         """Validate minimum tx difficulty."""
         assert self._settings.CONSENSUS_ALGORITHM.is_pow()
         min_tx_weight = self._daa.minimum_tx_weight(tx)
@@ -102,8 +105,15 @@ class TransactionVerifier:
         elif min_tx_weight > self._settings.MAX_TX_WEIGHT_DIFF_ACTIVATION and tx.weight > max_tx_weight:
             raise WeightError(f'Invalid new tx {tx.hash_hex}: weight ({tx.weight}) is '
                               f'greater than the maximum allowed ({max_tx_weight})')
+        ctx.record(VerificationCheck.WEIGHT)
 
-    def verify_sigops_input(self, tx: Transaction, enable_checkdatasig_count: bool = True) -> None:
+    def verify_sigops_input(
+        self,
+        tx: Transaction,
+        enable_checkdatasig_count: bool = True,
+        *,
+        ctx: VerificationContext,
+    ) -> None:
         """ Count sig operations on all inputs and verify that the total sum is below the limit
         """
         from hathor.transaction.scripts import SigopCounter
@@ -128,10 +138,19 @@ class TransactionVerifier:
         if n_txops > self._settings.MAX_TX_SIGOPS_INPUT:
             raise TooManySigOps(
                 'TX[{}]: Max number of sigops for inputs exceeded ({})'.format(tx.hash_hex, n_txops))
+        ctx.record(VerificationCheck.SIGOPS_INPUT)
 
-    def verify_inputs(self, tx: Transaction, params: VerificationParams, *, skip_script: bool = False) -> None:
+    def verify_inputs(
+        self,
+        tx: Transaction,
+        params: VerificationParams,
+        *,
+        skip_script: bool = False,
+        ctx: VerificationContext,
+    ) -> None:
         """Verify inputs signatures and ownership and all inputs actually exist"""
         self._verify_inputs(self._settings, tx, params.features.opcodes_version, skip_script=skip_script)
+        ctx.record(VerificationCheck.INPUTS)
 
     @classmethod
     def _verify_inputs(
@@ -189,12 +208,13 @@ class TransactionVerifier:
         except ScriptError as e:
             raise InvalidInputData(e) from e
 
-    def verify_reward_locked(self, tx: Transaction) -> None:
+    def verify_reward_locked(self, tx: Transaction, *, ctx: VerificationContext) -> None:
         """Will raise `RewardLocked` if any reward is spent before the best block height is enough, considering both
         the block rewards spent by this tx itself, and the inherited `min_height`."""
         assert tx.storage is not None
         best_height = get_minimum_best_height(tx.storage)
         self.verify_reward_locked_for_height(self._settings, tx, best_height)
+        ctx.record(VerificationCheck.REWARD_LOCKED)
 
     @staticmethod
     def verify_reward_locked_for_height(
@@ -235,7 +255,7 @@ class TransactionVerifier:
                 f'Tx {tx.hash_hex} has min_height={min_height}, but the best_height={best_height}.'
             )
 
-    def verify_number_of_inputs(self, tx: Transaction) -> None:
+    def verify_number_of_inputs(self, tx: Transaction, *, ctx: VerificationContext) -> None:
         """Verify number of inputs is in a valid range"""
         if len(tx.inputs) > self._settings.MAX_NUM_INPUTS:
             raise TooManyInputs('Maximum number of inputs exceeded')
@@ -244,8 +264,9 @@ class TransactionVerifier:
         if len(tx.inputs) < minimum:
             if not tx.is_genesis:
                 raise TooFewInputs(f'Transaction must have at least {minimum} input(s)')
+        ctx.record(VerificationCheck.NUMBER_OF_INPUTS)
 
-    def verify_output_token_indexes(self, tx: Transaction) -> None:
+    def verify_output_token_indexes(self, tx: Transaction, *, ctx: VerificationContext) -> None:
         """Verify outputs reference an existing token uid in the tokens list
 
         :raises InvalidToken: output references non existent token uid
@@ -254,6 +275,7 @@ class TransactionVerifier:
             # check index is valid
             if output.get_token_index() > len(tx.tokens):
                 raise InvalidToken('token uid index not available: index {}'.format(output.get_token_index()))
+        ctx.record(VerificationCheck.OUTPUT_TOKEN_INDEXES)
 
     @classmethod
     def verify_sum(
@@ -262,6 +284,8 @@ class TransactionVerifier:
         tx: Transaction,
         token_dict: TokenInfoDict,
         allow_nonexistent_tokens: bool = False,
+        *,
+        ctx: VerificationContext,
     ) -> None:
         """Verify that the sum of outputs is equal of the sum of inputs, for each token. If sum of inputs
         and outputs is not 0, make sure inputs have mint/melt authority.
@@ -273,6 +297,11 @@ class TransactionVerifier:
         amount = outputs - inputs, thus:
         - amount < 0 when melting
         - amount > 0 when minting
+
+        Records into `ctx` (if provided):
+            VerificationCheck.BALANCE when fully verified, or
+            VerificationCheck.BALANCE_POSTPONED when a nonexistent token was encountered
+            and the check was deferred to block-execution time (nano contracts only).
 
         :raises InputOutputMismatch: if sum of inputs is not equal to outputs and there's no mint/melt
         """
@@ -320,6 +349,7 @@ class TransactionVerifier:
             # The skipped checks below are simply postponed to execution-time
             # and run when a block confirms the nano tx.
             assert tx.is_nano_contract()
+            ctx.record(VerificationCheck.BALANCE_POSTPONED)
             return
 
         expected_fee = token_dict.calculate_fee(settings)
@@ -334,6 +364,7 @@ class TransactionVerifier:
             ))
 
         assert htr_info.amount == htr_expected_amount
+        ctx.record(VerificationCheck.BALANCE)
 
     @staticmethod
     def _check_token_permissions(token_uid: TokenUid, token_info: TokenInfo) -> None:
@@ -350,7 +381,9 @@ class TransactionVerifier:
         if token_info.has_been_minted() and not token_info.can_mint:
             raise ForbiddenMint(token_info.amount, token_uid)
 
-    def verify_version(self, tx: Transaction, params: VerificationParams) -> None:
+    def verify_version(
+        self, tx: Transaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
         """Verify that the vertex version is valid."""
         allowed_tx_versions = {
             TxVersion.REGULAR_TRANSACTION,
@@ -362,66 +395,72 @@ class TransactionVerifier:
 
         if tx.version not in allowed_tx_versions:
             raise InvalidVersionError(f'invalid vertex version: {tx.version}')
+        ctx.record(VerificationCheck.VERSION)
 
-    def verify_tokens(self, tx: Transaction, params: VerificationParams) -> None:
-        """Verify that all tokens are used and unique."""
-        if not params.harden_token_restrictions:
-            return
+    def verify_tokens(
+        self, tx: Transaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
+        """Verify that all tokens are used and unique. Records TOKENS
+        unconditionally — the invariant is "this check ran for these params"."""
+        if params.harden_token_restrictions:
+            if len(tx.tokens) > MAX_TOKENS_LENGTH:
+                raise TooManyTokens('too many tokens')
 
-        if len(tx.tokens) > MAX_TOKENS_LENGTH:
-            raise TooManyTokens('too many tokens')
+            if len(tx.tokens) != len(set(tx.tokens)):
+                raise InvalidToken('repeated tokens are not allowed')
 
-        if len(tx.tokens) != len(set(tx.tokens)):
-            raise InvalidToken('repeated tokens are not allowed')
+            seen_token_indexes = set()
+            for txout in tx.outputs:
+                seen_token_indexes.add(txout.get_token_index())
 
-        seen_token_indexes = set()
-        for txout in tx.outputs:
-            seen_token_indexes.add(txout.get_token_index())
+            if tx.is_nano_contract():
+                nano_header = tx.get_nano_header()
+                for action in nano_header.nc_actions:
+                    seen_token_indexes.add(action.token_index)
 
-        if tx.is_nano_contract():
-            nano_header = tx.get_nano_header()
-            for action in nano_header.nc_actions:
-                seen_token_indexes.add(action.token_index)
+            seen_token_indexes.discard(0)
+            if sorted(seen_token_indexes) != list(range(1, len(tx.tokens) + 1)):
+                raise UnusedTokensError('unused tokens are not allowed')
+        ctx.record(VerificationCheck.TOKENS)
 
-        seen_token_indexes.discard(0)
-        if sorted(seen_token_indexes) != list(range(1, len(tx.tokens) + 1)):
-            raise UnusedTokensError('unused tokens are not allowed')
-
-    def verify_conflict(self, tx: Transaction, params: VerificationParams) -> None:
+    def verify_conflict(
+        self, tx: Transaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
         """Verify that this transaction has no conflicts with confirmed transactions."""
         assert tx.storage is not None
 
-        if not params.reject_conflicts_with_confirmed_txs:
-            return
-
-        between_counter = 0
-        for txin in tx.inputs:
-            spent_tx = tx.get_spent_tx(txin)
-            spent_tx_meta = spent_tx.get_metadata()
-            if spent_tx_meta.first_block is not None and spent_tx_meta.voided_by:
-                # spent_tx has been confirmed by a block and is voided, so its
-                # outputs cannot be spent.
-                raise InputVoidedAndConfirmed(spent_tx.hash.hex())
-            if txin.index not in spent_tx_meta.spent_outputs:
-                continue
-            spent_by_list = spent_tx_meta.spent_outputs[txin.index]
-            within_counter = 0
-            for h in spent_by_list:
-                if h == tx.hash:
-                    # Skip tx itself.
+        if params.reject_conflicts_with_confirmed_txs:
+            between_counter = 0
+            for txin in tx.inputs:
+                spent_tx = tx.get_spent_tx(txin)
+                spent_tx_meta = spent_tx.get_metadata()
+                if spent_tx_meta.first_block is not None and spent_tx_meta.voided_by:
+                    # spent_tx has been confirmed by a block and is voided, so its
+                    # outputs cannot be spent.
+                    raise InputVoidedAndConfirmed(spent_tx.hash.hex())
+                if txin.index not in spent_tx_meta.spent_outputs:
                     continue
-                conflict_tx = tx.storage.get_transaction(h)
-                conflict_meta = conflict_tx.get_metadata()
-                if conflict_meta.first_block is not None and not conflict_meta.voided_by:
-                    # only mempool conflicts are allowed or failed nano executions
-                    raise ConflictWithConfirmedTxError('transaction has a conflict with a confirmed transaction')
-                if within_counter == 0:
-                    # Only increment once per input.
-                    between_counter += 1
-                within_counter += 1
+                spent_by_list = spent_tx_meta.spent_outputs[txin.index]
+                within_counter = 0
+                for h in spent_by_list:
+                    if h == tx.hash:
+                        # Skip tx itself.
+                        continue
+                    conflict_tx = tx.storage.get_transaction(h)
+                    conflict_meta = conflict_tx.get_metadata()
+                    if conflict_meta.first_block is not None and not conflict_meta.voided_by:
+                        # only mempool conflicts are allowed or failed nano executions
+                        raise ConflictWithConfirmedTxError(
+                            'transaction has a conflict with a confirmed transaction'
+                        )
+                    if within_counter == 0:
+                        # Only increment once per input.
+                        between_counter += 1
+                    within_counter += 1
 
-            if within_counter >= MAX_WITHIN_CONFLICTS:
-                raise TooManyWithinConflicts
+                if within_counter >= MAX_WITHIN_CONFLICTS:
+                    raise TooManyWithinConflicts
 
-        if between_counter > MAX_BETWEEN_CONFLICTS:
-            raise TooManyBetweenConflicts
+            if between_counter > MAX_BETWEEN_CONFLICTS:
+                raise TooManyBetweenConflicts
+        ctx.record(VerificationCheck.CONFLICT)

--- a/hathor/verification/verification_check.py
+++ b/hathor/verification/verification_check.py
@@ -1,0 +1,82 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import IntFlag, auto
+
+
+class VerificationCheck(IntFlag):
+    """Each flag represents one invariant enforced by a verify_* method.
+
+    The verification pipeline records flags into a VerificationContext as
+    checks run, and at the end of each stage asserts the recorded set covers
+    the required set for the vertex's shape. Prevents silent "double skip"
+    bugs where two gates disagree and no check fires.
+    """
+    # Vertex-level (all vertex types)
+    VERSION_BASIC = auto()
+    OLD_TIMESTAMP = auto()
+    POW = auto()
+    PARENTS = auto()
+    HEADERS = auto()
+    OUTPUTS = auto()
+    NUMBER_OF_OUTPUTS = auto()
+    SIGOPS_OUTPUT = auto()
+
+    # Transaction-level
+    PARENTS_BASIC = auto()
+    WEIGHT = auto()
+    NUMBER_OF_INPUTS = auto()
+    SIGOPS_INPUT = auto()
+    INPUTS = auto()
+    VERSION = auto()
+    TOKENS = auto()
+    OUTPUT_TOKEN_INDEXES = auto()
+    CONFLICT = auto()
+    REWARD_LOCKED = auto()
+
+    # Balance: exactly one of BALANCE or BALANCE_POSTPONED must be set after
+    # verify(). Nano contracts may produce BALANCE_POSTPONED at verification
+    # time; the block executor must upgrade it to BALANCE post-execution.
+    BALANCE = auto()
+    BALANCE_POSTPONED = auto()
+
+    # Block-level
+    NO_INPUTS = auto()
+    BLOCK_WEIGHT = auto()
+    REWARD = auto()
+    CHECKPOINTS = auto()
+    HEIGHT = auto()
+    MANDATORY_SIGNALING = auto()
+    BLOCK_DATA = auto()
+    BLOCK_OUTPUT_TOKEN_INDEXES = auto()
+    AUX_POW = auto()
+    POA = auto()
+
+    # Fee header
+    FEE_LIST = auto()
+
+    # Nano header
+    NANO_NC_SIGNATURE = auto()
+    NANO_ACTIONS = auto()
+    NANO_METHOD_CALL = auto()
+    NANO_SEQNUM = auto()
+
+    # Token creation
+    TOKEN_INFO = auto()
+    MINTED_TOKENS = auto()
+
+    # On-chain blueprint
+    OCB_PUBKEY_ALLOWED = auto()
+    OCB_NC_SIGNATURE = auto()
+    OCB_CODE = auto()

--- a/hathor/verification/verification_context.py
+++ b/hathor/verification/verification_context.py
@@ -1,0 +1,65 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dataclasses import dataclass, field
+
+from hathor.transaction.exceptions import VerificationChecksMissingError
+from hathor.verification.verification_check import VerificationCheck
+
+
+@dataclass(frozen=True)
+class RequiredChecks:
+    """The set of VerificationCheck flags that MUST be recorded for a vertex.
+
+    all_of: every flag must be recorded (bit-AND semantics).
+    any_of_groups: each group is a flag mask; at least one bit from each group
+      must be recorded. Used for invariants like "BALANCE or BALANCE_POSTPONED"
+      where either satisfies the verify-time requirement.
+    """
+    all_of: VerificationCheck = VerificationCheck(0)
+    any_of_groups: tuple[VerificationCheck, ...] = ()
+
+    def __or__(self, other: 'RequiredChecks') -> 'RequiredChecks':
+        return RequiredChecks(
+            all_of=self.all_of | other.all_of,
+            any_of_groups=self.any_of_groups + other.any_of_groups,
+        )
+
+
+@dataclass
+class VerificationContext:
+    """Travels through the verification pipeline collecting check flags.
+
+    Each verify_* call in the dispatcher is followed by ctx.record(flag).
+    At the end of each stage, ctx.check(required, stage=...) asserts the
+    recorded set covers the required set for the vertex's shape. Missing
+    flags raise VerificationChecksMissingError — a loud failure, not silent.
+    """
+    vertex_hash: bytes = b''
+    checks_run: VerificationCheck = field(default_factory=lambda: VerificationCheck(0))
+
+    def record(self, check: VerificationCheck) -> None:
+        self.checks_run |= check
+
+    def has(self, check: VerificationCheck) -> bool:
+        return bool(self.checks_run & check)
+
+    def check(self, required: RequiredChecks, *, stage: str) -> None:
+        missing_all = required.all_of & ~self.checks_run
+        missing_any = tuple(g for g in required.any_of_groups if not (self.checks_run & g))
+        if missing_all or missing_any:
+            raise VerificationChecksMissingError(
+                f'vertex {self.vertex_hash.hex()} stage={stage}: '
+                f'missing_all={missing_all!r}, missing_any_groups={missing_any!r}'
+            )

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -25,6 +25,8 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenInfoDict
 from hathor.transaction.validation_state import ValidationState
 from hathor.verification.fee_header_verifier import FeeHeaderVerifier
+from hathor.verification.required_checks import Stage, required_checks_for
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 from hathor.verification.vertex_verifiers import VertexVerifiers
 
@@ -97,6 +99,19 @@ class VerificationService:
         vertex.set_validation(validation)
         return True
 
+    def _new_context(self, vertex: BaseTransaction) -> VerificationContext:
+        """Start a fresh VerificationContext for a verification stage. Each
+        stage records its own incremental flags; we avoid touching metadata
+        here so verify() can fail cheaply (e.g. WeightError) before any
+        metadata read that could itself raise (weight→work on NaN/inf)."""
+        return VerificationContext(vertex_hash=vertex.hash or b'')
+
+    def _persist_context(self, vertex: BaseTransaction, ctx: VerificationContext) -> None:
+        """Accumulate this stage's flags into metadata. OR semantics — prior
+        stages' flags are preserved."""
+        meta = vertex.get_metadata()
+        meta.verification_checks |= ctx.checks_run
+
     def verify_basic(
         self,
         vertex: BaseTransaction,
@@ -108,30 +123,32 @@ class VerificationService:
         if vertex.hash in self._settings.SKIP_VERIFICATION:
             return
 
-        self.verifiers.vertex.verify_version_basic(vertex)
-        self.verifiers.vertex.verify_old_timestamp(vertex, params)
+        ctx = self._new_context(vertex)
+
+        self.verifiers.vertex.verify_version_basic(vertex, ctx=ctx)
+        self.verifiers.vertex.verify_old_timestamp(vertex, params, ctx=ctx)
 
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
                 assert type(vertex) is Block
-                self._verify_basic_block(vertex, params)
+                self._verify_basic_block(vertex, params, ctx)
             case TxVersion.MERGE_MINED_BLOCK:
                 assert type(vertex) is MergeMinedBlock
-                self._verify_basic_merge_mined_block(vertex, params)
+                self._verify_basic_merge_mined_block(vertex, params, ctx)
             case TxVersion.POA_BLOCK:
                 assert type(vertex) is PoaBlock
-                self._verify_basic_poa_block(vertex)
+                self._verify_basic_poa_block(vertex, ctx)
             case TxVersion.REGULAR_TRANSACTION:
                 assert type(vertex) is Transaction
-                self._verify_basic_tx(vertex, params)
+                self._verify_basic_tx(vertex, params, ctx)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
                 assert type(vertex) is TokenCreationTransaction
-                self._verify_basic_token_creation_tx(vertex, params)
+                self._verify_basic_token_creation_tx(vertex, params, ctx)
             case TxVersion.ON_CHAIN_BLUEPRINT:
                 assert type(vertex) is OnChainBlueprint
                 assert self._settings.ENABLE_NANO_CONTRACTS
-                self._verify_basic_on_chain_blueprint(vertex, params)
+                self._verify_basic_on_chain_blueprint(vertex, params, ctx)
             case _:  # pragma: no cover
                 assert_never(vertex.version)
 
@@ -139,35 +156,45 @@ class VerificationService:
             assert self._settings.ENABLE_NANO_CONTRACTS
             # nothing to do
 
-    def _verify_basic_block(self, block: Block, params: VerificationParams) -> None:
+        required = required_checks_for(vertex, params, self._settings, Stage.VERIFY_BASIC)
+        ctx.check(required, stage=Stage.VERIFY_BASIC.value)
+        self._persist_context(vertex, ctx)
+
+    def _verify_basic_block(self, block: Block, params: VerificationParams, ctx: VerificationContext) -> None:
         """Partially run validations, the ones that need parents/inputs are skipped."""
         if not params.skip_block_weight_verification:
-            self.verifiers.block.verify_weight(block)
-        self.verifiers.block.verify_reward(block)
-        self.verifiers.block.verify_checkpoints(block)
+            self.verifiers.block.verify_weight(block, ctx=ctx)
+        self.verifiers.block.verify_reward(block, ctx=ctx)
+        self.verifiers.block.verify_checkpoints(block, ctx=ctx)
 
-    def _verify_basic_merge_mined_block(self, block: MergeMinedBlock, params: VerificationParams) -> None:
-        self._verify_basic_block(block, params)
+    def _verify_basic_merge_mined_block(
+        self, block: MergeMinedBlock, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self._verify_basic_block(block, params, ctx)
 
-    def _verify_basic_poa_block(self, block: PoaBlock) -> None:
-        self.verifiers.poa_block.verify_poa(block)
-        self.verifiers.block.verify_reward(block)
+    def _verify_basic_poa_block(self, block: PoaBlock, ctx: VerificationContext) -> None:
+        self.verifiers.poa_block.verify_poa(block, ctx=ctx)
+        self.verifiers.block.verify_reward(block, ctx=ctx)
 
-    def _verify_basic_tx(self, tx: Transaction, params: VerificationParams) -> None:
+    def _verify_basic_tx(self, tx: Transaction, params: VerificationParams, ctx: VerificationContext) -> None:
         """Partially run validations, the ones that need parents/inputs are skipped."""
         if tx.is_genesis:
             # TODO do genesis validation?
             return
-        self.verifiers.tx.verify_parents_basic(tx)
+        self.verifiers.tx.verify_parents_basic(tx, ctx=ctx)
         if self._settings.CONSENSUS_ALGORITHM.is_pow():
-            self.verifiers.tx.verify_weight(tx)
-        self.verify_without_storage(tx, params)
+            self.verifiers.tx.verify_weight(tx, ctx=ctx)
+        self._verify_without_storage(tx, params, ctx)
 
-    def _verify_basic_token_creation_tx(self, tx: TokenCreationTransaction, params: VerificationParams) -> None:
-        self._verify_basic_tx(tx, params)
+    def _verify_basic_token_creation_tx(
+        self, tx: TokenCreationTransaction, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self._verify_basic_tx(tx, params, ctx)
 
-    def _verify_basic_on_chain_blueprint(self, tx: OnChainBlueprint, params: VerificationParams) -> None:
-        self._verify_basic_tx(tx, params)
+    def _verify_basic_on_chain_blueprint(
+        self, tx: OnChainBlueprint, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self._verify_basic_tx(tx, params, ctx)
 
     def verify(self, vertex: BaseTransaction, params: VerificationParams) -> None:
         """Run all verifications. Raises on error.
@@ -176,38 +203,44 @@ class VerificationService:
         if vertex.hash in self._settings.SKIP_VERIFICATION:
             return
 
-        self.verifiers.vertex.verify_headers(vertex, params)
+        ctx = self._new_context(vertex)
+
+        self.verifiers.vertex.verify_headers(vertex, params, ctx=ctx)
 
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
                 assert type(vertex) is Block
-                self._verify_block(vertex, params)
+                self._verify_block(vertex, params, ctx)
             case TxVersion.MERGE_MINED_BLOCK:
                 assert type(vertex) is MergeMinedBlock
-                self._verify_merge_mined_block(vertex, params)
+                self._verify_merge_mined_block(vertex, params, ctx)
             case TxVersion.POA_BLOCK:
                 assert type(vertex) is PoaBlock
-                self._verify_poa_block(vertex, params)
+                self._verify_poa_block(vertex, params, ctx)
             case TxVersion.REGULAR_TRANSACTION:
                 assert type(vertex) is Transaction
-                self._verify_tx(vertex, params)
+                self._verify_tx(vertex, params, ctx)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
                 assert type(vertex) is TokenCreationTransaction
-                self._verify_token_creation_tx(vertex, params)
+                self._verify_token_creation_tx(vertex, params, ctx)
             case TxVersion.ON_CHAIN_BLUEPRINT:
                 assert type(vertex) is OnChainBlueprint
-                self._verify_tx(vertex, params)
+                self._verify_tx(vertex, params, ctx)
             case _:  # pragma: no cover
                 assert_never(vertex.version)
 
         if vertex.is_nano_contract():
             assert self._settings.ENABLE_NANO_CONTRACTS
-            self.verifiers.nano_header.verify_method_call(vertex, params)
-            self.verifiers.nano_header.verify_seqnum(vertex, params)
+            self.verifiers.nano_header.verify_method_call(vertex, params, ctx=ctx)
+            self.verifiers.nano_header.verify_seqnum(vertex, params, ctx=ctx)
 
-    @cpu.profiler(key=lambda _, block: 'block-verify!{}'.format(block.hash.hex()))
-    def _verify_block(self, block: Block, params: VerificationParams) -> None:
+        required = required_checks_for(vertex, params, self._settings, Stage.VERIFY)
+        ctx.check(required, stage=Stage.VERIFY.value)
+        self._persist_context(vertex, ctx)
+
+    @cpu.profiler(key=lambda _, block, params, ctx: 'block-verify!{}'.format(block.hash.hex()))
+    def _verify_block(self, block: Block, params: VerificationParams, ctx: VerificationContext) -> None:
         """
             (1) confirms at least two pending transactions and references last block
             (2) solves the pow with the correct weight (done in HathorManager)
@@ -221,27 +254,28 @@ class VerificationService:
             # TODO do genesis validation
             return
 
-        self.verify_without_storage(block, params)
+        self._verify_without_storage(block, params, ctx)
 
         # (1) and (4)
-        self.verifiers.vertex.verify_parents(block)
+        self.verifiers.vertex.verify_parents(block, ctx=ctx)
+        self.verifiers.block.verify_height(block, ctx=ctx)
+        self.verifiers.block.verify_mandatory_signaling(block, ctx=ctx)
 
-        self.verifiers.block.verify_height(block)
+    def _verify_merge_mined_block(
+        self, block: MergeMinedBlock, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self.verifiers.merge_mined_block.verify_aux_pow(block, ctx=ctx)
+        self._verify_block(block, params, ctx)
 
-        self.verifiers.block.verify_mandatory_signaling(block)
+    def _verify_poa_block(self, block: PoaBlock, params: VerificationParams, ctx: VerificationContext) -> None:
+        self._verify_block(block, params, ctx)
 
-    def _verify_merge_mined_block(self, block: MergeMinedBlock, params: VerificationParams) -> None:
-        self.verifiers.merge_mined_block.verify_aux_pow(block)
-        self._verify_block(block, params)
-
-    def _verify_poa_block(self, block: PoaBlock, params: VerificationParams) -> None:
-        self._verify_block(block, params)
-
-    @cpu.profiler(key=lambda _, tx: 'tx-verify!{}'.format(tx.hash.hex()))
+    @cpu.profiler(key=lambda _, tx, params, ctx, **kw: 'tx-verify!{}'.format(tx.hash.hex()))
     def _verify_tx(
         self,
         tx: Transaction,
         params: VerificationParams,
+        ctx: VerificationContext,
         *,
         token_dict: TokenInfoDict | None = None
     ) -> None:
@@ -259,10 +293,10 @@ class VerificationService:
         if tx.is_genesis:
             # TODO do genesis validation
             return
-        self.verify_without_storage(tx, params)
-        self.verifiers.tx.verify_sigops_input(tx, params.features.count_checkdatasig_op)
-        self.verifiers.tx.verify_inputs(tx, params)  # need to run verify_inputs first to check if all inputs exist
-        self.verifiers.tx.verify_version(tx, params)
+        self._verify_without_storage(tx, params, ctx)
+        self.verifiers.tx.verify_sigops_input(tx, params.features.count_checkdatasig_op, ctx=ctx)
+        self.verifiers.tx.verify_inputs(tx, params, ctx=ctx)
+        self.verifiers.tx.verify_version(tx, params, ctx=ctx)
 
         block_storage = self._get_block_storage(params)
         self.verifiers.tx.verify_sum(
@@ -270,114 +304,144 @@ class VerificationService:
             tx,
             token_dict or tx.get_complete_token_info(block_storage),
             # if this tx isn't a nano contract we assume we can find all the tokens to validate this tx
-            allow_nonexistent_tokens=tx.is_nano_contract()
+            allow_nonexistent_tokens=tx.is_nano_contract(),
+            ctx=ctx,
         )
-        self.verifiers.vertex.verify_parents(tx)
-        self.verifiers.tx.verify_conflict(tx, params)
-        if params.reject_locked_reward:
-            self.verifiers.tx.verify_reward_locked(tx)
 
-    def _verify_token_creation_tx(self, tx: TokenCreationTransaction, params: VerificationParams) -> None:
+        self.verifiers.vertex.verify_parents(tx, ctx=ctx)
+        self.verifiers.tx.verify_conflict(tx, params, ctx=ctx)
+        if params.reject_locked_reward:
+            self.verifiers.tx.verify_reward_locked(tx, ctx=ctx)
+
+    def _verify_token_creation_tx(
+        self, tx: TokenCreationTransaction, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
         """ Run all validations as regular transactions plus validation on token info.
 
         We also overload verify_sum to make some different checks
         """
         # we should validate the token info before verifying the tx
-        self.verifiers.token_creation_tx.verify_token_info(tx, params)
+        self.verifiers.token_creation_tx.verify_token_info(tx, params, ctx=ctx)
         token_dict = tx.get_complete_token_info(self._get_block_storage(params))
-        self._verify_tx(tx, params, token_dict=token_dict)
-        self.verifiers.token_creation_tx.verify_minted_tokens(tx, token_dict)
+        self._verify_tx(tx, params, ctx, token_dict=token_dict)
+        self.verifiers.token_creation_tx.verify_minted_tokens(tx, token_dict, ctx=ctx)
 
     def verify_without_storage(self, vertex: BaseTransaction, params: VerificationParams) -> None:
+        """Public entry point for verify_without_storage — creates a standalone
+        context, runs the checks, persists flags. Used only by callers outside
+        the normal verify_basic/verify flow (no completeness assertion)."""
+        if vertex.hash in self._settings.SKIP_VERIFICATION:
+            return
+        ctx = self._new_context(vertex)
+        self._verify_without_storage(vertex, params, ctx)
+        self._persist_context(vertex, ctx)
+
+    def _verify_without_storage(
+        self, vertex: BaseTransaction, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
         if vertex.hash in self._settings.SKIP_VERIFICATION:
             return
 
         if vertex.has_fees():
-            self._verify_without_storage_fee_header(vertex)
+            self._verify_without_storage_fee_header(vertex, ctx)
 
         # We assert with type() instead of isinstance() because each subclass has a specific branch.
         match vertex.version:
             case TxVersion.REGULAR_BLOCK:
                 assert type(vertex) is Block
-                self._verify_without_storage_block(vertex, params)
+                self._verify_without_storage_block(vertex, params, ctx)
             case TxVersion.MERGE_MINED_BLOCK:
                 assert type(vertex) is MergeMinedBlock
-                self._verify_without_storage_merge_mined_block(vertex, params)
+                self._verify_without_storage_merge_mined_block(vertex, params, ctx)
             case TxVersion.POA_BLOCK:
                 assert type(vertex) is PoaBlock
-                self._verify_without_storage_poa_block(vertex, params)
+                self._verify_without_storage_poa_block(vertex, params, ctx)
             case TxVersion.REGULAR_TRANSACTION:
                 assert type(vertex) is Transaction
-                self._verify_without_storage_tx(vertex, params)
+                self._verify_without_storage_tx(vertex, params, ctx)
             case TxVersion.TOKEN_CREATION_TRANSACTION:
                 assert type(vertex) is TokenCreationTransaction
-                self._verify_without_storage_token_creation_tx(vertex, params)
+                self._verify_without_storage_token_creation_tx(vertex, params, ctx)
             case TxVersion.ON_CHAIN_BLUEPRINT:
                 assert type(vertex) is OnChainBlueprint
-                self._verify_without_storage_on_chain_blueprint(vertex, params)
+                self._verify_without_storage_on_chain_blueprint(vertex, params, ctx)
             case _:  # pragma: no cover
                 assert_never(vertex.version)
 
         if vertex.is_nano_contract():
             assert self._settings.ENABLE_NANO_CONTRACTS
-            self._verify_without_storage_nano_header(vertex, params)
+            self._verify_without_storage_nano_header(vertex, params, ctx)
 
-    def _verify_without_storage_base_block(self, block: Block, params: VerificationParams) -> None:
-        self.verifiers.block.verify_no_inputs(block)
-        self.verifiers.vertex.verify_outputs(block)
-        self.verifiers.block.verify_output_token_indexes(block)
-        self.verifiers.block.verify_data(block)
-        self.verifiers.vertex.verify_sigops_output(block, params.features.count_checkdatasig_op)
+    def _verify_without_storage_base_block(
+        self, block: Block, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self.verifiers.block.verify_no_inputs(block, ctx=ctx)
+        self.verifiers.vertex.verify_outputs(block, ctx=ctx)
+        self.verifiers.block.verify_output_token_indexes(block, ctx=ctx)
+        self.verifiers.block.verify_data(block, ctx=ctx)
+        self.verifiers.vertex.verify_sigops_output(block, params.features.count_checkdatasig_op, ctx=ctx)
 
-    def _verify_without_storage_block(self, block: Block, params: VerificationParams) -> None:
+    def _verify_without_storage_block(
+        self, block: Block, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
         """ Run all verifications that do not need a storage.
         """
-        self.verifiers.vertex.verify_pow(block)
-        self._verify_without_storage_base_block(block, params)
+        self.verifiers.vertex.verify_pow(block, ctx=ctx)
+        self._verify_without_storage_base_block(block, params, ctx)
 
-    def _verify_without_storage_merge_mined_block(self, block: MergeMinedBlock, params: VerificationParams) -> None:
-        self._verify_without_storage_block(block, params)
+    def _verify_without_storage_merge_mined_block(
+        self, block: MergeMinedBlock, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self._verify_without_storage_block(block, params, ctx)
 
-    def _verify_without_storage_poa_block(self, block: PoaBlock, params: VerificationParams) -> None:
-        self._verify_without_storage_base_block(block, params)
+    def _verify_without_storage_poa_block(
+        self, block: PoaBlock, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
+        self._verify_without_storage_base_block(block, params, ctx)
 
-    def _verify_without_storage_tx(self, tx: Transaction, params: VerificationParams) -> None:
+    def _verify_without_storage_tx(
+        self, tx: Transaction, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
         """ Run all verifications that do not need a storage.
         """
         if self._settings.CONSENSUS_ALGORITHM.is_pow():
-            self.verifiers.vertex.verify_pow(tx)
-        self.verifiers.tx.verify_number_of_inputs(tx)
-        self.verifiers.vertex.verify_outputs(tx)
-        self.verifiers.tx.verify_output_token_indexes(tx)
-        self.verifiers.vertex.verify_sigops_output(tx, params.features.count_checkdatasig_op)
-        self.verifiers.tx.verify_tokens(tx, params)
+            self.verifiers.vertex.verify_pow(tx, ctx=ctx)
+        self.verifiers.tx.verify_number_of_inputs(tx, ctx=ctx)
+        self.verifiers.vertex.verify_outputs(tx, ctx=ctx)
+        self.verifiers.tx.verify_output_token_indexes(tx, ctx=ctx)
+        self.verifiers.vertex.verify_sigops_output(tx, params.features.count_checkdatasig_op, ctx=ctx)
+        self.verifiers.tx.verify_tokens(tx, params, ctx=ctx)
 
     def _verify_without_storage_token_creation_tx(
         self,
         tx: TokenCreationTransaction,
         params: VerificationParams,
+        ctx: VerificationContext,
     ) -> None:
-        self._verify_without_storage_tx(tx, params)
+        self._verify_without_storage_tx(tx, params, ctx)
 
-    def _verify_without_storage_nano_header(self, tx: BaseTransaction, params: VerificationParams) -> None:
+    def _verify_without_storage_nano_header(
+        self, tx: BaseTransaction, params: VerificationParams, ctx: VerificationContext
+    ) -> None:
         assert tx.is_nano_contract()
-        self.verifiers.nano_header.verify_nc_signature(tx, params)
-        self.verifiers.nano_header.verify_actions(tx)
+        self.verifiers.nano_header.verify_nc_signature(tx, params, ctx=ctx)
+        self.verifiers.nano_header.verify_actions(tx, ctx=ctx)
 
-    def _verify_without_storage_fee_header(self, tx: BaseTransaction) -> None:
+    def _verify_without_storage_fee_header(self, tx: BaseTransaction, ctx: VerificationContext) -> None:
         assert tx.has_fees()
         assert isinstance(tx, Transaction)
-        FeeHeaderVerifier.verify_fee_list(tx.get_fee_header(), tx)
+        FeeHeaderVerifier.verify_fee_list(tx.get_fee_header(), tx, ctx=ctx)
 
     def _verify_without_storage_on_chain_blueprint(
         self,
         tx: OnChainBlueprint,
         params: VerificationParams,
+        ctx: VerificationContext,
     ) -> None:
-        self._verify_without_storage_tx(tx, params)
-        self.verifiers.on_chain_blueprint.verify_pubkey_is_allowed(tx)
-        self.verifiers.on_chain_blueprint.verify_nc_signature(tx)
-        self.verifiers.on_chain_blueprint.verify_code(tx)
+        self._verify_without_storage_tx(tx, params, ctx)
+        self.verifiers.on_chain_blueprint.verify_pubkey_is_allowed(tx, ctx=ctx)
+        self.verifiers.on_chain_blueprint.verify_nc_signature(tx, ctx=ctx)
+        self.verifiers.on_chain_blueprint.verify_code(tx, ctx=ctx)
 
     def _get_block_storage(self, params: VerificationParams) -> NCBlockStorage:
         assert self._nc_storage_factory is not None

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -36,6 +36,8 @@ from hathor.transaction.exceptions import (
     TooManySigOps,
 )
 from hathor.transaction.headers import FeeHeader, NanoHeader, VertexBaseHeader
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 
 # tx should have 2 parents, both other transactions
@@ -57,12 +59,13 @@ class VertexVerifier:
         self._settings = settings
         self._feature_service = feature_service
 
-    def verify_version_basic(self, vertex: BaseTransaction) -> None:
+    def verify_version_basic(self, vertex: BaseTransaction, *, ctx: VerificationContext) -> None:
         """Verify that the vertex version is valid."""
         if not self._settings.CONSENSUS_ALGORITHM.is_vertex_version_valid(vertex.version, settings=self._settings):
             raise InvalidVersionError(f"invalid vertex version: {vertex.version}")
+        ctx.record(VerificationCheck.VERSION_BASIC)
 
-    def verify_parents(self, vertex: BaseTransaction) -> None:
+    def verify_parents(self, vertex: BaseTransaction, *, ctx: VerificationContext) -> None:
         """All parents must exist and their timestamps must be smaller than ours.
 
         Also, txs should have 2 other txs as parents, while blocks should have 2 txs + 1 block.
@@ -138,8 +141,15 @@ class VertexVerifier:
         if my_parents_txs != parents_txs:
             raise IncorrectParents('wrong number of parents (tx type): {}, expecting {}'.format(
                 my_parents_txs, parents_txs))
+        ctx.record(VerificationCheck.PARENTS)
 
-    def verify_pow(self, vertex: BaseTransaction, *, override_weight: Optional[float] = None) -> None:
+    def verify_pow(
+        self,
+        vertex: BaseTransaction,
+        *,
+        override_weight: Optional[float] = None,
+        ctx: VerificationContext,
+    ) -> None:
         """Verify proof-of-work
 
         :raises PowError: when the hash is equal or greater than the target
@@ -149,15 +159,16 @@ class VertexVerifier:
         minimum_target = vertex.get_target(override_weight)
         if numeric_hash >= minimum_target:
             raise PowError(f'Transaction has invalid data ({numeric_hash} < {minimum_target})')
+        ctx.record(VerificationCheck.POW)
 
-    def verify_outputs(self, vertex: BaseTransaction) -> None:
+    def verify_outputs(self, vertex: BaseTransaction, *, ctx: VerificationContext) -> None:
         """Verify there are no hathor authority UTXOs and outputs are all positive
 
         :raises InvalidToken: when there's a hathor authority utxo
         :raises InvalidOutputValue: output has negative value
         :raises TooManyOutputs: when there are too many outputs
         """
-        self.verify_number_of_outputs(vertex)
+        self.verify_number_of_outputs(vertex, ctx=ctx)
         for index, output in enumerate(vertex.outputs):
             # no hathor authority UTXO
             if (output.get_token_index() == 0) and output.is_token_authority():
@@ -173,19 +184,30 @@ class VertexVerifier:
                 raise InvalidOutputScriptSize('size: {} and max-size: {}'.format(
                     len(output.script), self._settings.MAX_OUTPUT_SCRIPT_SIZE
                 ))
+        ctx.record(VerificationCheck.OUTPUTS)
 
-    def verify_number_of_outputs(self, vertex: BaseTransaction) -> None:
+    def verify_number_of_outputs(
+        self, vertex: BaseTransaction, *, ctx: VerificationContext
+    ) -> None:
         """Verify number of outputs does not exceed the limit"""
         if len(vertex.outputs) > self._settings.MAX_NUM_OUTPUTS:
             raise TooManyOutputs('Maximum number of outputs exceeded')
+        ctx.record(VerificationCheck.NUMBER_OF_OUTPUTS)
 
-    def verify_sigops_output(self, vertex: BaseTransaction, enable_checkdatasig_count: bool = True) -> None:
+    def verify_sigops_output(
+        self,
+        vertex: BaseTransaction,
+        enable_checkdatasig_count: bool = True,
+        *,
+        ctx: VerificationContext,
+    ) -> None:
         """Alias to `_verify_sigops_output` for compatibility."""
         self._verify_sigops_output(
             settings=self._settings,
             vertex=vertex,
             enable_checkdatasig_count=enable_checkdatasig_count,
         )
+        ctx.record(VerificationCheck.SIGOPS_OUTPUT)
 
     @staticmethod
     def _verify_sigops_output(
@@ -234,7 +256,9 @@ class VertexVerifier:
                 assert_never(vertex.version)
         return allowed_headers
 
-    def verify_headers(self, vertex: BaseTransaction, params: VerificationParams) -> None:
+    def verify_headers(
+        self, vertex: BaseTransaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
         """Verify the headers."""
         if len(vertex.headers) > vertex.get_maximum_number_of_headers():
             raise TooManyHeaders('Maximum number of headers exceeded')
@@ -251,13 +275,19 @@ class VertexVerifier:
                     f'Header `{type(header).__name__}` not supported by `{type(vertex).__name__}`'
                 )
             seen_header_types.add(type(header))
+        ctx.record(VerificationCheck.HEADERS)
 
-    def verify_old_timestamp(self, vertex: BaseTransaction, params: VerificationParams) -> None:
-        """Verify that the timestamp is not too old. Mempool only."""
-        if not params.reject_too_old_vertices:
-            return
-
-        now = self._reactor.seconds()
-        t_diff = now - vertex.timestamp
-        if t_diff > MAX_PAST_TIMESTAMP_ALLOWED:
-            raise TimestampError(f'transaction is too old (now={now}, timestamp={vertex.timestamp}, diff={t_diff})')
+    def verify_old_timestamp(
+        self, vertex: BaseTransaction, params: VerificationParams, *, ctx: VerificationContext
+    ) -> None:
+        """Verify that the timestamp is not too old. Mempool only. Records
+        OLD_TIMESTAMP either way — the invariant is "this check ran", regardless
+        of whether it was a no-op for these params."""
+        if params.reject_too_old_vertices:
+            now = self._reactor.seconds()
+            t_diff = now - vertex.timestamp
+            if t_diff > MAX_PAST_TIMESTAMP_ALLOWED:
+                raise TimestampError(
+                    f'transaction is too old (now={now}, timestamp={vertex.timestamp}, diff={t_diff})'
+                )
+        ctx.record(VerificationCheck.OLD_TIMESTAMP)

--- a/hathor_tests/cli/test_twin_tx.py
+++ b/hathor_tests/cli/test_twin_tx.py
@@ -50,9 +50,10 @@ class TwinTxTest(unittest.TestCase):
         self.assertEqual(twin_tx.parents[0], self.tx.parents[1])
         self.assertEqual(twin_tx.parents[1], self.tx.parents[0])
 
-        # Testing metadata creation from json
+        # Testing metadata creation from json — use storage-json for a
+        # lossless round-trip (to_json is public API and omits internal fields).
         meta_before_conflict = self.tx.get_metadata()
-        meta_before_conflict_json = meta_before_conflict.to_json()
+        meta_before_conflict_json = meta_before_conflict.to_storage_json()
         del meta_before_conflict_json['conflict_with']
         del meta_before_conflict_json['voided_by']
         del meta_before_conflict_json['twins']

--- a/hathor_tests/nanocontracts/blueprints/unittest.py
+++ b/hathor_tests/nanocontracts/blueprints/unittest.py
@@ -111,8 +111,9 @@ class BlueprintTestCase(unittest.TestCase):
         ocb = OnChainBlueprint(hash=b'', code=code)
 
         if not skip_verification:
+            from hathor.verification.verification_context import VerificationContext
             verifier = OnChainBlueprintVerifier(settings=self._settings)
-            verifier.verify_code(ocb)
+            verifier.verify_code(ocb, ctx=VerificationContext())
 
         blueprint_class = ocb.get_blueprint_class()
         if inject_in_class is not None:

--- a/hathor_tests/nanocontracts/test_actions.py
+++ b/hathor_tests/nanocontracts/test_actions.py
@@ -30,6 +30,7 @@ from hathor.transaction.exceptions import InvalidToken
 from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.util import not_none
 from hathor.verification.nano_header_verifier import MAX_ACTIONS_LEN
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import HDWallet
 from hathor_tests import unittest
@@ -768,7 +769,9 @@ class TestActions(unittest.TestCase):
         )
 
         with pytest.raises(NCInvalidAction) as e:
-            self.manager.verification_service.verifiers.nano_header.verify_actions(self.tx1)
+            self.manager.verification_service.verifiers.nano_header.verify_actions(
+                self.tx1, ctx=VerificationContext(),
+            )
         assert str(e.value) == f'conflicting actions for token {self.tka.hash_hex}'
 
     def test_acquire_and_grant_same_token_not_allowed(self) -> None:
@@ -788,7 +791,9 @@ class TestActions(unittest.TestCase):
         self._set_nano_header(tx=self.tx1, nc_actions=nc_actions)
 
         with pytest.raises(NCInvalidAction) as e:
-            self.manager.verification_service.verifiers.nano_header.verify_actions(self.tx1)
+            self.manager.verification_service.verifiers.nano_header.verify_actions(
+                self.tx1, ctx=VerificationContext(),
+            )
         assert str(e.value) == 'conflicting actions for token 00'
 
     def test_conflicting_actions(self) -> None:
@@ -857,7 +862,9 @@ class TestActions(unittest.TestCase):
 
         with patch('hathor.transaction.headers.NanoHeader.get_actions', lambda _: fake_actions):
             with pytest.raises(NCInvalidAction) as e:
-                self.manager.verification_service.verifiers.nano_header.verify_actions(self.tx1)
+                self.manager.verification_service.verifiers.nano_header.verify_actions(
+                    self.tx1, ctx=VerificationContext(),
+                )
         assert str(e.value) == f'DEPOSIT action requires token {fake_token_uid.hex()} in tokens list'
 
     def _test_invalid_unknown_authority(self, action_type: NCActionType) -> None:

--- a/hathor_tests/nanocontracts/test_nanocontract.py
+++ b/hathor_tests/nanocontracts/test_nanocontract.py
@@ -40,6 +40,7 @@ from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.transaction.scripts import P2PKH, HathorScript, Opcode
 from hathor.transaction.validation_state import ValidationState
 from hathor.verification.nano_header_verifier import MAX_NC_SCRIPT_SIGOPS_COUNT, MAX_NC_SCRIPT_SIZE
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import KeyPair
 from hathor_tests import unittest
@@ -173,7 +174,9 @@ class NCNanoContractTestCase(unittest.TestCase):
     def test_verify_signature_success(self) -> None:
         nc = self._get_nc()
         nc.clear_sighash_cache()
-        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+            nc, self.verification_params, ctx=VerificationContext(),
+        )
 
     def test_verify_signature_fails_nc_id(self) -> None:
         nc = self._get_nc()
@@ -181,7 +184,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_id = b'a' * 32
         nc.clear_sighash_cache()
         with self.assertRaises(NCInvalidSignature):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_fails_nc_method(self) -> None:
         nc = self._get_nc()
@@ -189,7 +194,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_method = 'other_nc_method'
         nc.clear_sighash_cache()
         with self.assertRaises(NCInvalidSignature):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_fails_nc_args_bytes(self) -> None:
         nc = self._get_nc()
@@ -197,7 +204,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_args_bytes = b'other_nc_args_bytes'
         nc.clear_sighash_cache()
         with self.assertRaises(NCInvalidSignature):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_fails_invalid_nc_address(self) -> None:
         nc = self._get_nc()
@@ -205,7 +214,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_address = b'invalid-address'
         nc.clear_sighash_cache()
         with pytest.raises(NCInvalidSignature, match=f'invalid address: {nano_header.nc_address.hex()}'):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_fails_invalid_nc_script(self) -> None:
         nc = self._get_nc()
@@ -213,7 +224,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = b'invalid-script'
         nc.clear_sighash_cache()
         with pytest.raises(InvalidScriptError, match='Invalid Opcode'):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_fails_wrong_nc_address(self) -> None:
         key = KeyPair.create(b'xyz')
@@ -226,7 +239,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_address = get_address_from_public_key_bytes(pubkey_bytes)
         nc.clear_sighash_cache()
         with pytest.raises(NCInvalidSignature) as e:
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
         assert isinstance(e.value.__cause__, EqualVerifyFailed)
 
     def test_verify_signature_fails_wrong_pubkey(self) -> None:
@@ -245,7 +260,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = P2PKH.create_input_data(public_key_bytes=pubkey_bytes, signature=signature)
 
         # First, it's passing with the key from above
-        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+            nc, self.verification_params, ctx=VerificationContext(),
+        )
 
         # We change the script to use a new pubkey, but with the same signature
         key = KeyPair.create(b'wrong')
@@ -255,7 +272,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = P2PKH.create_input_data(public_key_bytes=pubkey_bytes, signature=signature)
 
         with pytest.raises(NCInvalidSignature) as e:
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
         assert isinstance(e.value.__cause__, EqualVerifyFailed)
 
     def test_verify_signature_fails_wrong_signature(self) -> None:
@@ -274,7 +293,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = P2PKH.create_input_data(public_key_bytes=pubkey_bytes, signature=signature)
 
         # First, it's passing with the key from above
-        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+            nc, self.verification_params, ctx=VerificationContext(),
+        )
 
         # We change the script to use a new signature, but with the same pubkey
         key = KeyPair.create(b'wrong')
@@ -283,7 +304,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = P2PKH.create_input_data(public_key_bytes=pubkey_bytes, signature=signature)
 
         with pytest.raises(NCInvalidSignature) as e:
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
         assert isinstance(e.value.__cause__, FinalStackInvalid)
         assert 'Stack left with False value' in e.value.__cause__.args[0]
 
@@ -293,7 +316,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = b'\x00' * (MAX_NC_SCRIPT_SIZE + 1)
 
         with pytest.raises(NCInvalidSignature, match='nc_script larger than max: 1025 > 1024'):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_fails_nc_script_too_many_sigops(self) -> None:
         nc = self._get_nc()
@@ -306,7 +331,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         nano_header.nc_script = script.data
 
         with pytest.raises(TooManySigOps, match='sigops count greater than max: 21 > 20'):
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
 
     def test_verify_signature_multisig(self) -> None:
         nc = self._get_nc()
@@ -333,7 +360,9 @@ class NCNanoContractTestCase(unittest.TestCase):
             sign_privkeys=[keys[0][0]],
         )
         with pytest.raises(NCInvalidSignature) as e:
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
         assert isinstance(e.value.__cause__, MissingStackItems)
         assert e.value.__cause__.args[0] == 'OP_CHECKMULTISIG: not enough signatures on the stack'
 
@@ -346,7 +375,9 @@ class NCNanoContractTestCase(unittest.TestCase):
             sign_privkeys=[KeyPair.create(b'invalid').get_private_key(b'invalid')],
         )
         with pytest.raises(NCInvalidSignature) as e:
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
         assert isinstance(e.value.__cause__, FinalStackInvalid)
         assert 'Stack left with False value' in e.value.__cause__.args[0]
 
@@ -358,13 +389,17 @@ class NCNanoContractTestCase(unittest.TestCase):
             redeem_pubkey_bytes=redeem_pubkey_bytes,
             sign_privkeys=[x[0] for x in keys[:2]],
         )
-        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+        self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+            nc, self.verification_params, ctx=VerificationContext(),
+        )
 
         # Test fails because the address was changed
         nc.clear_sighash_cache()
         nano_header.nc_address = decode_address(self.peer.wallet.get_unused_address())
         with pytest.raises(NCInvalidSignature) as e:
-            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(nc, self.verification_params)
+            self.peer.verification_service.verifiers.nano_header.verify_nc_signature(
+                nc, self.verification_params, ctx=VerificationContext(),
+            )
         assert isinstance(e.value.__cause__, EqualVerifyFailed)
 
     def test_get_related_addresses(self) -> None:

--- a/hathor_tests/poa/test_poa.py
+++ b/hathor_tests/poa/test_poa.py
@@ -27,6 +27,7 @@ from hathor.transaction.exceptions import PoaValidationError
 from hathor.transaction.poa import PoaBlock
 from hathor.transaction.static_metadata import BlockStaticMetadata
 from hathor.verification.poa_block_verifier import PoaBlockVerifier
+from hathor.verification.verification_context import VerificationContext
 
 
 def test_get_hashed_poa_data() -> None:
@@ -119,51 +120,51 @@ def test_verify_poa() -> None:
     # Test no rewards
     block.outputs = [TxOutput(123, b'')]
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'blocks must not have rewards in a PoA network'
     block.outputs = []
 
     # Test timestamp
     block.timestamp = 152
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'blocks must have at least 30 seconds between them'
     block.timestamp = 153
 
     # Test no signers
     settings.CONSENSUS_ALGORITHM = PoaSettings.model_construct(signers=())
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'invalid PoA signature'
 
     # Test no data
     settings.CONSENSUS_ALGORITHM = PoaSettings(signers=(PoaSignerSettings(public_key=public_key_bytes),))
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'invalid PoA signature'
 
     # Test invalid data
     block.data = b'some_data'
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'invalid PoA signature'
 
     # Test incorrect private key
     PoaSigner(ec.generate_private_key(ec.SECP256K1())).sign_block(block)
     block.signer_id = poa_signer._signer_id  # we set the correct signer id to test only the signature
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'invalid PoA signature'
 
     # Test valid signature
     poa_signer.sign_block(block)
-    block_verifier.verify_poa(block)
+    block_verifier.verify_poa(block, ctx=VerificationContext())
 
     # Test some random weight fails
     block.weight = 123
     poa_signer.sign_block(block)
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'block weight is 123, expected 2.0'
 
     # For this part we use two signers, so the ordering matters
@@ -176,23 +177,23 @@ def test_verify_poa() -> None:
     # Test valid signature with two signers, in turn
     block.weight = poa.BLOCK_WEIGHT_IN_TURN
     first_poa_signer.sign_block(block)
-    block_verifier.verify_poa(block)
+    block_verifier.verify_poa(block, ctx=VerificationContext())
 
     # And the other signature fails for the weight
     second_poa_signer.sign_block(block)
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'block weight is 2.0, expected 1.0'
 
     # Test valid signature with two signers, out of turn
     block.weight = poa.BLOCK_WEIGHT_OUT_OF_TURN
     second_poa_signer.sign_block(block)
-    block_verifier.verify_poa(block)
+    block_verifier.verify_poa(block, ctx=VerificationContext())
 
     # And the other signature fails for the weight
     first_poa_signer.sign_block(block)
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'block weight is 1.0, expected 2.0'
 
     # When we increment the height, the turn inverts
@@ -215,23 +216,23 @@ def test_verify_poa() -> None:
     # Test valid signature with two signers, in turn
     block.weight = poa.BLOCK_WEIGHT_IN_TURN
     second_poa_signer.sign_block(block)
-    block_verifier.verify_poa(block)
+    block_verifier.verify_poa(block, ctx=VerificationContext())
 
     # And the other signature fails for the weight
     first_poa_signer.sign_block(block)
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'block weight is 2.0, expected 1.0'
 
     # Test valid signature with two signers, out of turn
     block.weight = poa.BLOCK_WEIGHT_OUT_OF_TURN
     first_poa_signer.sign_block(block)
-    block_verifier.verify_poa(block)
+    block_verifier.verify_poa(block, ctx=VerificationContext())
 
     # And the other signature fails for the weight
     second_poa_signer.sign_block(block)
     with pytest.raises(PoaValidationError) as e:
-        block_verifier.verify_poa(block)
+        block_verifier.verify_poa(block, ctx=VerificationContext())
     assert str(e.value) == 'block weight is 1.0, expected 2.0'
 
 

--- a/hathor_tests/simulation/test_simulator.py
+++ b/hathor_tests/simulation/test_simulator.py
@@ -2,6 +2,7 @@ from hathor.feature_activation.feature_service import FeatureService
 from hathor.manager import HathorManager
 from hathor.simulator import FakeConnection
 from hathor.simulator.trigger import All as AllTriggers, StopWhenSynced, Trigger
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.vertex_verifier import VertexVerifier
 from hathor_tests.simulation.base import SimulatorTestCase
 
@@ -17,7 +18,7 @@ class RandomSimulatorTestCase(SimulatorTestCase):
             reactor=self.reactor,
             settings=self._settings,
             feature_service=feature_service
-        ).verify_pow(tx, override_weight=0.)
+        ).verify_pow(tx, override_weight=0., ctx=VerificationContext())
 
     def test_one_node(self) -> None:
         manager1 = self.create_peer()

--- a/hathor_tests/tx/test_block.py
+++ b/hathor_tests/tx/test_block.py
@@ -26,6 +26,7 @@ from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.validation_state import ValidationState
 from hathor.util import not_none
 from hathor.verification.block_verifier import BlockVerifier
+from hathor.verification.verification_context import VerificationContext
 from hathor_tests.unittest import TestBuilder
 
 
@@ -148,7 +149,7 @@ def test_verify_must_signal() -> None:
     block = Block()
 
     with pytest.raises(BlockMustSignalError) as e:
-        verifier.verify_mandatory_signaling(block)
+        verifier.verify_mandatory_signaling(block, ctx=VerificationContext())
 
     assert str(e.value) == "Block must signal support for feature 'NOP_FEATURE_1' during MUST_SIGNAL phase."
 
@@ -161,4 +162,4 @@ def test_verify_must_not_signal() -> None:
     verifier = BlockVerifier(settings=settings, feature_service=feature_service, daa=Mock(), tx_storage=Mock())
     block = Block()
 
-    verifier.verify_mandatory_signaling(block)
+    verifier.verify_mandatory_signaling(block, ctx=VerificationContext())

--- a/hathor_tests/tx/test_genesis.py
+++ b/hathor_tests/tx/test_genesis.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 from hathor.conf import HathorSettings
 from hathor.daa import DifficultyAdjustmentAlgorithm, TestMode
 from hathor.feature_activation.feature_service import FeatureService
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifier import VertexVerifier
 from hathor.verification.vertex_verifiers import VertexVerifiers
@@ -51,7 +52,7 @@ class GenesisTest(unittest.TestCase):
         genesis = self.storage.get_all_genesis()
         for g in genesis:
             self.assertEqual(g.calculate_hash(), g.hash)
-            self.assertIsNone(verifier.verify_pow(g))
+            self.assertIsNone(verifier.verify_pow(g, ctx=VerificationContext()))
 
     def test_verify(self):
         genesis = self.storage.get_all_genesis()

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -38,6 +38,7 @@ from hathor.transaction.exceptions import (
 from hathor.transaction.scripts import P2PKH, parse_address_script
 from hathor.transaction.util import int_to_bytes
 from hathor.transaction.validation_state import ValidationState
+from hathor.verification.verification_context import VerificationContext
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import Wallet
 from hathor_tests import unittest
@@ -90,8 +91,11 @@ class TransactionTest(unittest.TestCase):
 
         best_block = self.manager.tx_storage.get_best_block()
         block_storage = self.manager.get_nc_block_storage(best_block)
+        ctx = VerificationContext()
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(self._settings, tx, tx.get_complete_token_info(block_storage))
+            self._verifiers.tx.verify_sum(
+                self._settings, tx, tx.get_complete_token_info(block_storage), ctx=ctx,
+            )
 
     def test_input_output_match_more_htr(self):
         genesis_block = self.genesis_blocks[0]
@@ -111,8 +115,11 @@ class TransactionTest(unittest.TestCase):
 
         best_block = self.manager.tx_storage.get_best_block()
         block_storage = self.manager.get_nc_block_storage(best_block)
+        ctx = VerificationContext()
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(self._settings, tx, tx.get_complete_token_info(block_storage))
+            self._verifiers.tx.verify_sum(
+                self._settings, tx, tx.get_complete_token_info(block_storage), ctx=ctx,
+            )
 
     def test_validation(self):
         # add 100 blocks and check that walking through get_next_block_best_chain yields the same blocks
@@ -152,7 +159,7 @@ class TransactionTest(unittest.TestCase):
         _input.data = data_wrong
 
         with self.assertRaises(InvalidInputData):
-            self._verifiers.tx.verify_inputs(tx, params=self.verification_params)
+            self._verifiers.tx.verify_inputs(tx, params=self.verification_params, ctx=VerificationContext())
 
     def test_too_many_inputs(self):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
@@ -163,13 +170,13 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(inputs=inputs, storage=self.tx_storage)
 
         with self.assertRaises(TooManyInputs):
-            self._verifiers.tx.verify_number_of_inputs(tx)
+            self._verifiers.tx.verify_number_of_inputs(tx, ctx=VerificationContext())
 
     def test_no_inputs(self):
         tx = Transaction(inputs=[], storage=self.tx_storage)
 
         with self.assertRaises(TooFewInputs):
-            self._verifiers.tx.verify_number_of_inputs(tx)
+            self._verifiers.tx.verify_number_of_inputs(tx, ctx=VerificationContext())
 
     def test_too_many_outputs(self):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
@@ -180,7 +187,7 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(outputs=outputs, storage=self.tx_storage)
 
         with self.assertRaises(TooManyOutputs):
-            self._verifiers.vertex.verify_number_of_outputs(tx)
+            self._verifiers.vertex.verify_number_of_outputs(tx, ctx=VerificationContext())
 
     def _gen_tx_spending_genesis_block(self):
         parents = [tx.hash for tx in self.genesis_txs]
@@ -281,11 +288,11 @@ class TransactionTest(unittest.TestCase):
 
         b.init_static_metadata_from_storage(self._settings, self.tx_storage)
         with self.assertRaises(AuxPowNoMagicError):
-            self._verifiers.merge_mined_block.verify_aux_pow(b)
+            self._verifiers.merge_mined_block.verify_aux_pow(b, ctx=VerificationContext())
 
         # adding the MAGIC_NUMBER makes it work:
         b.aux_pow = b.aux_pow._replace(coinbase_head=b.aux_pow.coinbase_head + MAGIC_NUMBER)
-        self._verifiers.merge_mined_block.verify_aux_pow(b)
+        self._verifiers.merge_mined_block.verify_aux_pow(b, ctx=VerificationContext())
 
     def test_merge_mined_multiple_magic(self):
         from hathor.merged_mining import MAGIC_NUMBER
@@ -355,9 +362,9 @@ class TransactionTest(unittest.TestCase):
 
         b1.init_static_metadata_from_storage(self._settings, self.tx_storage)
         b2.init_static_metadata_from_storage(self._settings, self.tx_storage)
-        self._verifiers.merge_mined_block.verify_aux_pow(b1)  # OK
+        self._verifiers.merge_mined_block.verify_aux_pow(b1, ctx=VerificationContext())  # OK
         with self.assertRaises(AuxPowUnexpectedMagicError):
-            self._verifiers.merge_mined_block.verify_aux_pow(b2)
+            self._verifiers.merge_mined_block.verify_aux_pow(b2, ctx=VerificationContext())
 
     def test_merge_mined_long_merkle_path(self):
         from hathor.merged_mining import MAGIC_NUMBER
@@ -396,11 +403,11 @@ class TransactionTest(unittest.TestCase):
         # Test with the INCREASE_MAX_MERKLE_PATH_LENGTH feature disabled
         with patch(patch_path, is_feature_active_false):
             with self.assertRaises(AuxPowLongMerklePathError):
-                self._verifiers.merge_mined_block.verify_aux_pow(b)
+                self._verifiers.merge_mined_block.verify_aux_pow(b, ctx=VerificationContext())
 
             # removing one path makes it work
             b.aux_pow.merkle_path.pop()
-            self._verifiers.merge_mined_block.verify_aux_pow(b)
+            self._verifiers.merge_mined_block.verify_aux_pow(b, ctx=VerificationContext())
 
         b2 = MergeMinedBlock(
             timestamp=self.genesis_blocks[0].timestamp + 1,
@@ -419,11 +426,11 @@ class TransactionTest(unittest.TestCase):
         # Test with the INCREASE_MAX_MERKLE_PATH_LENGTH feature enabled
         with patch(patch_path, is_feature_active_true):
             with self.assertRaises(AuxPowLongMerklePathError):
-                self._verifiers.merge_mined_block.verify_aux_pow(b2)
+                self._verifiers.merge_mined_block.verify_aux_pow(b2, ctx=VerificationContext())
 
             # removing one path makes it work
             b2.aux_pow.merkle_path.pop()
-            self._verifiers.merge_mined_block.verify_aux_pow(b2)
+            self._verifiers.merge_mined_block.verify_aux_pow(b2, ctx=VerificationContext())
 
     def test_block_outputs(self):
         from hathor.transaction.exceptions import TooManyOutputs
@@ -443,7 +450,7 @@ class TransactionTest(unittest.TestCase):
             storage=self.tx_storage)
 
         with self.assertRaises(TooManyOutputs):
-            self._verifiers.vertex.verify_outputs(block)
+            self._verifiers.vertex.verify_outputs(block, ctx=VerificationContext())
 
     def test_tx_number_parents(self):
         genesis_block = self.genesis_blocks[0]
@@ -614,7 +621,7 @@ class TransactionTest(unittest.TestCase):
         tx.weight += self._settings.MAX_TX_WEIGHT_DIFF + 0.1
         tx.update_hash()
         with self.assertRaises(WeightError):
-            self._verifiers.tx.verify_weight(tx)
+            self._verifiers.tx.verify_weight(tx, ctx=VerificationContext())
 
     def test_weight_nan(self):
         # this should succeed
@@ -767,34 +774,34 @@ class TransactionTest(unittest.TestCase):
         self.assertFalse(tx_equal.is_genesis)
 
         # Pow error
-        self._verifiers.vertex.verify_pow(tx2)
+        self._verifiers.vertex.verify_pow(tx2, ctx=VerificationContext())
         tx2.weight = 100
         with self.assertRaises(PowError):
-            self._verifiers.vertex.verify_pow(tx2)
+            self._verifiers.vertex.verify_pow(tx2, ctx=VerificationContext())
 
         # Verify parent timestamps
-        self._verifiers.vertex.verify_parents(tx2)
+        self._verifiers.vertex.verify_parents(tx2, ctx=VerificationContext())
         tx2_timestamp = tx2.timestamp
         tx2.timestamp = 2
         with self.assertRaises(TimestampError):
-            self._verifiers.vertex.verify_parents(tx2)
+            self._verifiers.vertex.verify_parents(tx2, ctx=VerificationContext())
         tx2.timestamp = tx2_timestamp
 
         # Verify inputs timestamps
-        self._verifiers.tx.verify_inputs(tx2, params=self.verification_params)
+        self._verifiers.tx.verify_inputs(tx2, params=self.verification_params, ctx=VerificationContext())
         tx2.timestamp = 2
         with self.assertRaises(TimestampError):
-            self._verifiers.tx.verify_inputs(tx2, params=self.verification_params)
+            self._verifiers.tx.verify_inputs(tx2, params=self.verification_params, ctx=VerificationContext())
         tx2.timestamp = tx2_timestamp
 
         # Validate maximum distance between blocks
         block = blocks[0]
         block2 = blocks[1]
         block2.timestamp = block.timestamp + self._settings.MAX_DISTANCE_BETWEEN_BLOCKS
-        self._verifiers.vertex.verify_parents(block2)
+        self._verifiers.vertex.verify_parents(block2, ctx=VerificationContext())
         block2.timestamp += 1
         with self.assertRaises(TimestampError):
-            self._verifiers.vertex.verify_parents(block2)
+            self._verifiers.vertex.verify_parents(block2, ctx=VerificationContext())
 
     def test_block_big_nonce(self):
         block = self.genesis_blocks[0]
@@ -974,8 +981,8 @@ class TransactionTest(unittest.TestCase):
         _output = TxOutput(value, script)
 
         tx = Transaction(inputs=[_input], outputs=[_output], storage=self.tx_storage)
-        self._verifiers.vertex.verify_outputs(tx)
-        self._verifiers.tx.verify_output_token_indexes(tx)
+        self._verifiers.vertex.verify_outputs(tx, ctx=VerificationContext())
+        self._verifiers.tx.verify_output_token_indexes(tx, ctx=VerificationContext())
 
     def test_txout_script_limit_exceeded(self):
         with self.assertRaises(InvalidOutputScriptSize):
@@ -999,7 +1006,9 @@ class TransactionTest(unittest.TestCase):
             outputs=[_output],
             storage=self.tx_storage
         )
-        self._verifiers.tx.verify_inputs(tx, skip_script=True, params=self.verification_params)
+        self._verifiers.tx.verify_inputs(
+            tx, skip_script=True, params=self.verification_params, ctx=VerificationContext(),
+        )
 
     def test_txin_data_limit_exceeded(self):
         with self.assertRaises(InvalidInputDataSize):
@@ -1156,7 +1165,7 @@ class TransactionTest(unittest.TestCase):
         output3 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output3], storage=self.tx_storage)
         tx.update_hash()
-        self._verifiers.vertex.verify_sigops_output(tx)
+        self._verifiers.vertex.verify_sigops_output(tx, ctx=VerificationContext())
 
     def test_sigops_output_multi_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1168,7 +1177,7 @@ class TransactionTest(unittest.TestCase):
         output4 = TxOutput(value, hscript)
         tx = Transaction(inputs=[_input], outputs=[output4]*num_outputs, storage=self.tx_storage)
         tx.update_hash()
-        self._verifiers.vertex.verify_sigops_output(tx)
+        self._verifiers.vertex.verify_sigops_output(tx, ctx=VerificationContext())
 
     def test_sigops_input_single_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1210,7 +1219,7 @@ class TransactionTest(unittest.TestCase):
         input3 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input3], outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
-        self._verifiers.tx.verify_sigops_input(tx)
+        self._verifiers.tx.verify_sigops_input(tx, ctx=VerificationContext())
 
     def test_sigops_input_multi_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
@@ -1224,7 +1233,7 @@ class TransactionTest(unittest.TestCase):
         input4 = TxInput(genesis_block.hash, 0, hscript)
         tx = Transaction(inputs=[input4]*num_inputs, outputs=[_output], storage=self.tx_storage)
         tx.update_hash()
-        self._verifiers.tx.verify_sigops_input(tx)
+        self._verifiers.tx.verify_sigops_input(tx, ctx=VerificationContext())
 
     def test_compare_bytes_equal(self) -> None:
         # create some block

--- a/hathor_tests/verification/test_completeness.py
+++ b/hathor_tests/verification/test_completeness.py
@@ -1,0 +1,172 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Integration tests for the VerificationContext completeness mechanism.
+
+These tests confirm that the dispatcher records the expected VerificationCheck
+flags into metadata, and that simulating a "skipped check" bug (e.g., by
+patching a verifier to return the empty flag) fires VerificationChecksMissingError.
+"""
+
+from unittest.mock import patch
+
+from hathor.crypto.util import get_address_from_public_key
+from hathor.manager import HathorManager
+from hathor.transaction import Block, Transaction, TxInput, TxOutput
+from hathor.transaction.exceptions import VerificationChecksMissingError
+from hathor.transaction.scripts import P2PKH
+from hathor.verification.transaction_verifier import TransactionVerifier
+from hathor.verification.verification_check import VerificationCheck as VC
+from hathor_tests import unittest
+from hathor_tests.utils import add_blocks_unlock_reward, get_genesis_key
+
+
+class VerificationContextCompletenessTest(unittest.TestCase):
+    """End-to-end tests that validate_full / verify_basic + verify populate
+    meta.verification_checks and that a missing flag is caught."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager: HathorManager = self.create_peer('network')
+
+    def _get_valid_block(self) -> Block:
+        block = Block(
+            hash=b'some_hash',
+            storage=self.manager.tx_storage,
+            weight=1,
+            outputs=[TxOutput(value=6400, script=b'')],
+            parents=[
+                self._settings.GENESIS_BLOCK_HASH,
+                self._settings.GENESIS_TX1_HASH,
+                self._settings.GENESIS_TX2_HASH,
+            ],
+        )
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
+        return block
+
+    def _get_valid_tx(self) -> Transaction:
+        # Mint rewards so the genesis block is unlockable.
+        add_blocks_unlock_reward(self.manager)
+        genesis_private_key = get_genesis_key()
+        genesis_public_key = genesis_private_key.public_key()
+        genesis_block = self.manager.tx_storage.get_transaction(self._settings.GENESIS_BLOCK_HASH)
+
+        utxo = genesis_block.outputs[0]
+        address = get_address_from_public_key(genesis_public_key)
+        script = P2PKH.create_output_script(address)
+        output = TxOutput(utxo.value, script)
+        _input = TxInput(self._settings.GENESIS_BLOCK_HASH, 0, b'')
+
+        tx = Transaction(
+            hash=b'some_hash',
+            storage=self.manager.tx_storage,
+            weight=1,
+            inputs=[_input],
+            outputs=[output],
+            parents=[self._settings.GENESIS_TX1_HASH, self._settings.GENESIS_TX2_HASH],
+        )
+        tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
+
+        data_to_sign = tx.get_sighash_all()
+        assert self.manager.wallet
+        public_bytes, signature = self.manager.wallet.get_input_aux_data(data_to_sign, genesis_private_key)
+        _input.data = P2PKH.create_input_data(public_bytes, signature)
+        return tx
+
+    # --- block completeness ---
+
+    def test_block_flags_recorded_after_verify_basic(self) -> None:
+        """After verify_basic on a block, the basic-stage flags are in metadata."""
+        block = self._get_valid_block()
+        params = self.get_verification_params(self.manager)
+        self.manager.verification_service.verify_basic(block, params)
+
+        checks = block.get_metadata().verification_checks
+        assert VC.VERSION_BASIC in checks
+        assert VC.OLD_TIMESTAMP in checks
+        assert VC.BLOCK_WEIGHT in checks
+        assert VC.REWARD in checks
+        assert VC.CHECKPOINTS in checks
+
+    def test_block_flags_recorded_after_verify(self) -> None:
+        """After verify on a block, the verify-stage flags are in metadata."""
+        block = self._get_valid_block()
+        params = self.get_verification_params(self.manager)
+        self.manager.verification_service.verify(block, params)
+
+        checks = block.get_metadata().verification_checks
+        assert VC.HEADERS in checks
+        assert VC.PARENTS in checks
+        assert VC.HEIGHT in checks
+        assert VC.MANDATORY_SIGNALING in checks
+        assert VC.POW in checks
+        assert VC.NO_INPUTS in checks
+        assert VC.OUTPUTS in checks
+        assert VC.BLOCK_DATA in checks
+        assert VC.SIGOPS_OUTPUT in checks
+
+    # --- transaction completeness ---
+
+    def test_tx_balance_flag_recorded_after_verify(self) -> None:
+        """After verify on a tx, BALANCE is in metadata (the flag this mechanism
+        primarily protects — original 'skipped balance check' bug)."""
+        tx = self._get_valid_tx()
+        params = self.get_verification_params(self.manager)
+        self.manager.verification_service.verify_basic(tx, params)
+        self.manager.verification_service.verify(tx, params)
+
+        checks = tx.get_metadata().verification_checks
+        assert VC.BALANCE in checks
+        assert VC.BALANCE_POSTPONED not in checks  # non-nano: never postponed
+        assert VC.INPUTS in checks
+        assert VC.VERSION in checks
+        assert VC.SIGOPS_INPUT in checks
+        assert VC.CONFLICT in checks
+
+    # --- regression: simulated bug fires completeness error ---
+
+    def test_broken_verify_sum_triggers_completeness_error(self) -> None:
+        """Simulate a future bug where verify_sum silently returns no flag
+        (representing someone stubbing or breaking the balance check). The
+        completeness check on verify() must fire VerificationChecksMissingError."""
+        tx = self._get_valid_tx()
+        params = self.get_verification_params(self.manager)
+        self.manager.verification_service.verify_basic(tx, params)
+
+        # Patch verify_sum to be a no-op that returns no flag. The dispatcher
+        # will record VerificationCheck(0) — effectively nothing. The any_of
+        # group {BALANCE, BALANCE_POSTPONED} will be empty → error.
+        with patch.object(TransactionVerifier, 'verify_sum', return_value=VC(0)):
+            with self.assertRaises(VerificationChecksMissingError) as exc_ctx:
+                self.manager.verification_service.verify(tx, params)
+
+        message = str(exc_ctx.exception)
+        assert 'BALANCE' in message
+
+    def test_broken_verify_inputs_triggers_completeness_error(self) -> None:
+        """Simulate a broken verify_inputs that succeeds (doesn't raise) but
+        doesn't record its flag (e.g., a future refactor that removed the
+        ctx.record call). The completeness check on verify() must fire."""
+        tx = self._get_valid_tx()
+        params = self.get_verification_params(self.manager)
+        self.manager.verification_service.verify_basic(tx, params)
+
+        # Replace verify_inputs with a no-op that ignores ctx entirely.
+        # Because recording lives inside the verifier, stubbing the verifier
+        # automatically omits the flag — the stronger defense.
+        with patch.object(TransactionVerifier, 'verify_inputs', return_value=None):
+            with self.assertRaises(VerificationChecksMissingError) as exc_ctx:
+                self.manager.verification_service.verify(tx, params)
+
+        assert 'INPUTS' in str(exc_ctx.exception)

--- a/hathor_tests/verification/test_fee_header_verifier.py
+++ b/hathor_tests/verification/test_fee_header_verifier.py
@@ -5,6 +5,7 @@ from hathor.transaction.exceptions import FeeHeaderTokenNotFound, InvalidFeeAmou
 from hathor.transaction.headers.fee_header import FeeHeader, FeeHeaderEntry
 from hathor.types import TokenUid
 from hathor.verification.fee_header_verifier import MAX_FEES_LEN, FeeHeaderVerifier
+from hathor.verification.verification_context import VerificationContext
 from hathor_tests import unittest
 
 
@@ -49,7 +50,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         fees = [FeeHeaderEntry(token_index=0, amount=100)]  # HTR fee
         header = self._create_fee_header(tx, fees)
 
-        FeeHeaderVerifier.verify_fee_list(header, tx)  # +1 for HTR
+        FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())  # +1 for HTR
 
         # Multiple fee entries with different tokens
         tx = self._create_transaction_with_tokens(2)  # Custom tokens at indices 1,2
@@ -59,7 +60,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         ]
         header = self._create_fee_header(tx, fees)
 
-        FeeHeaderVerifier.verify_fee_list(header, tx)
+        FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_verify_without_storage_invalid_fee_amounts(self) -> None:
         """Test valid scenarios for verify_without_storage."""
@@ -70,20 +71,20 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         with pytest.raises(InvalidFeeAmount, match="fees should be a positive integer, got 0"):
             fees = [FeeHeaderEntry(token_index=0, amount=0)]  # HTR fee
             header = self._create_fee_header(tx, fees)
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
         # Invalid negative amount
         with pytest.raises(InvalidFeeAmount, match="fees should be a positive integer, got -50"):
             fees = [FeeHeaderEntry(token_index=0, amount=-50)]  # HTR fee
             header = self._create_fee_header(tx, fees)
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
         # Invalid non-multiple of 100
         with pytest.raises(InvalidFeeAmount,
                            match="fees using deposit custom tokens should be a multiple of 100, got 150"):
             fees = [FeeHeaderEntry(token_index=1, amount=150)]
             header = self._create_fee_header(tx, fees)
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_verify_fee_list_size_empty(self) -> None:
         """Test that empty fees list raises InvalidFeeHeader."""
@@ -91,7 +92,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         header = self._create_fee_header(tx, [])
 
         with pytest.raises(InvalidFeeHeader, match="fees cannot be empty"):
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_verify_fee_list_size_exceeds_max(self) -> None:
         """Test that fees list exceeding MAX_FEES_LEN raises InvalidFeeHeader."""
@@ -102,7 +103,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
 
         expected_msg = f"more fees than the max allowed: {MAX_FEES_LEN + 1} > {MAX_FEES_LEN}"
         with pytest.raises(InvalidFeeHeader, match=expected_msg):
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_verify_fee_list_size_at_max(self) -> None:
         """Test that fees list exactly at MAX_FEES_LEN is valid."""
@@ -112,7 +113,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         header = self._create_fee_header(tx, fees)
 
         # Should not raise any exception
-        FeeHeaderVerifier.verify_fee_list(header, tx)
+        FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_duplicate_token_indexes_in_fees(self) -> None:
         """Test that duplicate token indices in fees raise InvalidFeeHeader."""
@@ -124,7 +125,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         header = self._create_fee_header(tx, fees)
 
         with pytest.raises(InvalidFeeHeader, match="duplicate token indexes in fees list"):
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_invalid_token_indexes_out_of_bounds(self) -> None:
         """Test that token indices out of bounds raise FeeHeaderTokenNotFound."""
@@ -134,7 +135,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
 
         with pytest.raises(FeeHeaderTokenNotFound,
                            match="fees contains token index 5 which is not in tokens list"):
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())
 
     def test_invalid_token_index_greater_than_tx_tokens_len(self) -> None:
         """Test that token index greater than tx_tokens_len raises FeeHeaderTokenNotFound."""
@@ -144,4 +145,4 @@ class TestFeeHeaderVerifier(unittest.TestCase):
 
         with pytest.raises(FeeHeaderTokenNotFound,
                            match="fees contains token index 2 which is not in tokens list"):
-            FeeHeaderVerifier.verify_fee_list(header, tx)
+            FeeHeaderVerifier.verify_fee_list(header, tx, ctx=VerificationContext())

--- a/hathor_tests/verification/test_post_nano_voiding.py
+++ b/hathor_tests/verification/test_post_nano_voiding.py
@@ -1,0 +1,83 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Post-nano-execution completeness check — if a postponed balance check
+isn't re-run (or is bypassed), the tx must be voided via NCFail."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hathor.conf.settings import HathorSettings
+from hathor.nanocontracts.exception import NCFail
+from hathor.nanocontracts.execution.block_executor import NCBlockExecutor
+from hathor.verification.required_checks import required_post_nano_checks
+from hathor.verification.verification_check import VerificationCheck as VC
+
+
+def _make_executor() -> NCBlockExecutor:
+    settings = MagicMock(spec=HathorSettings)
+    settings.SKIP_VERIFICATION = set()
+    executor = NCBlockExecutor.__new__(NCBlockExecutor)
+    executor._settings = settings
+    return executor
+
+
+def _make_tx(checks: VC) -> MagicMock:
+    """Minimal Transaction mock: has_shielded_outputs=False, verification_checks=`checks`."""
+    from hathor.transaction import Transaction
+    tx = MagicMock(spec=Transaction)
+    tx.hash = b'\x01' * 32
+    tx.is_genesis = False
+    meta = MagicMock()
+    meta.verification_checks = checks
+    tx.get_metadata = MagicMock(return_value=meta)
+    return tx
+
+
+class TestPostNanoVoiding:
+    def test_balance_recorded_passes(self) -> None:
+        """Happy path: BALANCE is set post-execution → no NCFail."""
+        executor = _make_executor()
+        tx = _make_tx(VC.BALANCE)
+        executor._assert_verification_checks_complete_after_execution(tx)
+
+    def test_balance_postponed_but_never_promoted_raises_ncfail(self) -> None:
+        """Simulates: _verify_sum_after_execution was removed or failed to
+        record BALANCE. The post-nano completeness check must void the tx."""
+        executor = _make_executor()
+        tx = _make_tx(VC.BALANCE_POSTPONED)
+        with pytest.raises(NCFail) as exc:
+            executor._assert_verification_checks_complete_after_execution(tx)
+        assert 'BALANCE' in str(exc.value)
+
+    def test_no_flags_raises_ncfail(self) -> None:
+        """Pathological: no balance flag at all (neither BALANCE nor POSTPONED).
+        Must void — stronger signal that verification was bypassed entirely."""
+        executor = _make_executor()
+        tx = _make_tx(VC(0))
+        with pytest.raises(NCFail):
+            executor._assert_verification_checks_complete_after_execution(tx)
+
+    def test_required_post_nano_is_balance_for_tx(self) -> None:
+        """The post-nano contract is: BALANCE must be recorded. BALANCE_POSTPONED
+        alone is NOT sufficient (that's the whole point of this check)."""
+        from hathor.transaction import Transaction
+        settings = MagicMock(spec=HathorSettings)
+        settings.SKIP_VERIFICATION = set()
+        tx = MagicMock(spec=Transaction)
+        tx.hash = b'\x01' * 32
+        tx.is_genesis = False
+        req = required_post_nano_checks(tx, settings)
+        assert req.all_of == VC.BALANCE

--- a/hathor_tests/verification/test_required_checks_match_dispatcher.py
+++ b/hathor_tests/verification/test_required_checks_match_dispatcher.py
@@ -1,0 +1,262 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Dispatcher completeness cross-check.
+
+The VerificationContext mechanism depends on `required_checks_for(...)` staying
+in sync with what `verification_service.py` actually calls. If they drift, the
+completeness check silently rubber-stamps whatever flags happen to be set.
+
+This test enumerates (vertex type x conditional-params) combinations, runs the
+real dispatcher, and asserts `ctx.checks_run` EXACTLY equals the required flag
+set. Adding a new verifier call to the dispatcher without updating
+`required_checks.py` (or vice-versa) will fail this test immediately.
+"""
+
+import dataclasses
+from unittest.mock import patch
+
+from hathor.crypto.util import get_address_from_public_key
+from hathor.manager import HathorManager
+from hathor.transaction import BaseTransaction, BitcoinAuxPow, Block, MergeMinedBlock, Transaction, TxInput, TxOutput
+from hathor.transaction.scripts import P2PKH
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.verification.required_checks import Stage, required_checks_for
+from hathor.verification.verification_check import VerificationCheck
+from hathor.verification.verification_params import VerificationParams
+from hathor_tests import unittest
+from hathor_tests.utils import add_blocks_unlock_reward, create_tokens, get_genesis_key
+
+
+class RequiredChecksMatchDispatcherTest(unittest.TestCase):
+    """For every supported vertex shape + params combination, verify that the
+    dispatcher records EXACTLY the flag set declared by required_checks_for."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager: HathorManager = self.create_peer('network')
+        self.service = self.manager.verification_service
+
+    # --- fixtures ---
+
+    def _valid_block(self) -> Block:
+        block = Block(
+            hash=b'some_hash',
+            storage=self.manager.tx_storage,
+            weight=1,
+            outputs=[TxOutput(value=6400, script=b'')],
+            parents=[
+                self._settings.GENESIS_BLOCK_HASH,
+                self._settings.GENESIS_TX1_HASH,
+                self._settings.GENESIS_TX2_HASH,
+            ],
+        )
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
+        return block
+
+    def _valid_merge_mined_block(self) -> MergeMinedBlock:
+        block = MergeMinedBlock(
+            hash=b'some_hash',
+            storage=self.manager.tx_storage,
+            weight=1,
+            outputs=[TxOutput(value=6400, script=b'')],
+            aux_pow=BitcoinAuxPow.dummy(),
+            parents=[
+                self._settings.GENESIS_BLOCK_HASH,
+                self._settings.GENESIS_TX1_HASH,
+                self._settings.GENESIS_TX2_HASH,
+            ],
+        )
+        block.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
+        return block
+
+    def _valid_tx(self) -> Transaction:
+        add_blocks_unlock_reward(self.manager)
+        genesis_private_key = get_genesis_key()
+        genesis_public_key = genesis_private_key.public_key()
+        genesis_block = self.manager.tx_storage.get_transaction(self._settings.GENESIS_BLOCK_HASH)
+
+        utxo = genesis_block.outputs[0]
+        address = get_address_from_public_key(genesis_public_key)
+        script = P2PKH.create_output_script(address)
+        output = TxOutput(utxo.value, script)
+        _input = TxInput(self._settings.GENESIS_BLOCK_HASH, 0, b'')
+
+        tx = Transaction(
+            hash=b'some_hash',
+            storage=self.manager.tx_storage,
+            weight=1,
+            inputs=[_input],
+            outputs=[output],
+            parents=[self._settings.GENESIS_TX1_HASH, self._settings.GENESIS_TX2_HASH],
+        )
+        tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
+
+        data_to_sign = tx.get_sighash_all()
+        assert self.manager.wallet
+        public_bytes, signature = self.manager.wallet.get_input_aux_data(data_to_sign, genesis_private_key)
+        _input.data = P2PKH.create_input_data(public_bytes, signature)
+        return tx
+
+    def _valid_token_creation_tx(self) -> TokenCreationTransaction:
+        add_blocks_unlock_reward(self.manager)
+        assert self.manager.wallet
+        tx = create_tokens(self.manager, self.manager.wallet.get_unused_address())
+        tx.init_static_metadata_from_storage(self._settings, self.manager.tx_storage)
+        return tx
+
+    # --- the core assertion ---
+
+    def _assert_recorded_matches_required(
+        self,
+        vertex: BaseTransaction,
+        params: VerificationParams,
+        stage: Stage,
+        run: str,
+    ) -> None:
+        """Run the dispatcher for `stage`, capture ctx.checks_run, and compare
+        to required_checks_for(vertex, params, settings, stage).
+
+        For `all_of`: recorded MUST be a superset (may record extra for clarity).
+        For `any_of_groups`: recorded MUST intersect every group.
+        The symmetric invariant: no flag in `all_of ∪ flatten(any_of_groups)`
+        may be missing.
+        """
+        captured = {'ctx': None}
+
+        original_persist = type(self.service)._persist_context
+
+        def spy_persist(svc, v, ctx):
+            # Capture the ctx before it's merged into meta. Only capture for
+            # the vertex under test (the dispatcher may persist for sub-vertices
+            # but we only care about the top-level verify_basic/verify call).
+            if captured['ctx'] is None and v is vertex:
+                captured['ctx'] = ctx
+            return original_persist(svc, v, ctx)
+
+        with patch.object(type(self.service), '_persist_context', spy_persist):
+            if stage is Stage.VERIFY_BASIC:
+                self.service.verify_basic(vertex, params)
+            elif stage is Stage.VERIFY:
+                # verify_basic must run first — verify() is documented to
+                # require at_least_basic state. We run both and capture verify's ctx.
+                self.service.verify_basic(vertex, params)
+                captured['ctx'] = None  # reset — we want verify's ctx, not basic's
+                self.service.verify(vertex, params)
+            else:
+                self.fail(f'unsupported stage for this test: {stage}')
+
+        ctx = captured['ctx']
+        assert ctx is not None, f'{run}: dispatcher never called _persist_context'
+
+        required = required_checks_for(vertex, params, self._settings, stage)
+        recorded = ctx.checks_run
+
+        # all_of: every required flag must be recorded
+        missing_all = required.all_of & ~recorded
+        assert missing_all == VerificationCheck(0), (
+            f'{run}: required_checks declares {required.all_of!r} but dispatcher '
+            f'only recorded {recorded!r}. Missing: {missing_all!r}. '
+            f'required_checks.py and verification_service.py have drifted.'
+        )
+
+        # any_of_groups: at least one flag from each group must be recorded
+        for group in required.any_of_groups:
+            assert (recorded & group) != VerificationCheck(0), (
+                f'{run}: required_checks any-of group {group!r} has no match in '
+                f'recorded {recorded!r}. Dispatcher must record at least one of these.'
+            )
+
+        # Inverse: dispatcher should NOT record flags that aren't in the required
+        # set (neither all_of nor any group). If it does, required_checks is
+        # incomplete — declare them.
+        all_valid = required.all_of
+        for group in required.any_of_groups:
+            all_valid |= group
+        unexpected = recorded & ~all_valid
+        assert unexpected == VerificationCheck(0), (
+            f'{run}: dispatcher recorded {unexpected!r} but required_checks '
+            f'does not declare them. Add to required_checks_for, or remove '
+            f'the record call from the verifier.'
+        )
+
+    # --- verify_basic stage combinations ---
+
+    def test_block_verify_basic(self) -> None:
+        block = self._valid_block()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(block, params, Stage.VERIFY_BASIC, 'block verify_basic')
+
+    def test_block_verify_basic_skip_weight(self) -> None:
+        block = self._valid_block()
+        params = dataclasses.replace(
+            self.get_verification_params(self.manager),
+            skip_block_weight_verification=True,
+        )
+        self._assert_recorded_matches_required(
+            block, params, Stage.VERIFY_BASIC, 'block verify_basic (skip_weight)'
+        )
+
+    def test_merge_mined_block_verify_basic(self) -> None:
+        block = self._valid_merge_mined_block()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(
+            block, params, Stage.VERIFY_BASIC, 'merge_mined verify_basic'
+        )
+
+    def test_tx_verify_basic(self) -> None:
+        tx = self._valid_tx()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(tx, params, Stage.VERIFY_BASIC, 'tx verify_basic')
+
+    def test_token_creation_tx_verify_basic(self) -> None:
+        tx = self._valid_token_creation_tx()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(
+            tx, params, Stage.VERIFY_BASIC, 'token_creation_tx verify_basic'
+        )
+
+    # --- verify stage combinations ---
+
+    def test_block_verify(self) -> None:
+        block = self._valid_block()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(block, params, Stage.VERIFY, 'block verify')
+
+    def test_merge_mined_block_verify(self) -> None:
+        block = self._valid_merge_mined_block()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(block, params, Stage.VERIFY, 'merge_mined verify')
+
+    def test_tx_verify(self) -> None:
+        tx = self._valid_tx()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(tx, params, Stage.VERIFY, 'tx verify')
+
+    def test_tx_verify_without_reward_locked(self) -> None:
+        tx = self._valid_tx()
+        params = dataclasses.replace(
+            self.get_verification_params(self.manager),
+            reject_locked_reward=False,
+        )
+        self._assert_recorded_matches_required(
+            tx, params, Stage.VERIFY, 'tx verify (no reject_locked_reward)'
+        )
+
+    def test_token_creation_tx_verify(self) -> None:
+        tx = self._valid_token_creation_tx()
+        params = self.get_verification_params(self.manager)
+        self._assert_recorded_matches_required(
+            tx, params, Stage.VERIFY, 'token_creation_tx verify'
+        )

--- a/hathor_tests/verification/test_verification_context.py
+++ b/hathor_tests/verification/test_verification_context.py
@@ -1,0 +1,98 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from hathor.transaction.exceptions import VerificationChecksMissingError
+from hathor.verification.verification_check import VerificationCheck as VC
+from hathor.verification.verification_context import RequiredChecks, VerificationContext
+
+
+class TestVerificationContext:
+    def test_starts_empty(self) -> None:
+        ctx = VerificationContext()
+        assert ctx.checks_run == VC(0)
+        assert not ctx.has(VC.BALANCE)
+
+    def test_record_sets_flag(self) -> None:
+        ctx = VerificationContext()
+        ctx.record(VC.BALANCE)
+        assert ctx.has(VC.BALANCE)
+        assert not ctx.has(VC.INPUTS)
+
+    def test_record_is_idempotent(self) -> None:
+        ctx = VerificationContext()
+        ctx.record(VC.BALANCE)
+        ctx.record(VC.BALANCE)
+        assert ctx.checks_run == VC.BALANCE
+
+    def test_record_combined_flag(self) -> None:
+        ctx = VerificationContext()
+        ctx.record(VC.BALANCE | VC.INPUTS)
+        assert ctx.has(VC.BALANCE)
+        assert ctx.has(VC.INPUTS)
+
+    def test_check_passes_when_all_recorded(self) -> None:
+        ctx = VerificationContext()
+        ctx.record(VC.BALANCE)
+        ctx.record(VC.INPUTS)
+        ctx.check(RequiredChecks(all_of=VC.BALANCE | VC.INPUTS), stage='test')
+
+    def test_check_raises_when_missing_all_of(self) -> None:
+        ctx = VerificationContext(vertex_hash=b'\x01' * 32)
+        ctx.record(VC.BALANCE)
+        with pytest.raises(VerificationChecksMissingError) as exc:
+            ctx.check(RequiredChecks(all_of=VC.BALANCE | VC.INPUTS), stage='test')
+        assert 'INPUTS' in str(exc.value)
+
+    def test_any_of_group_satisfied_by_either(self) -> None:
+        # Classic BALANCE-or-BALANCE_POSTPONED invariant.
+        group = VC.BALANCE | VC.BALANCE_POSTPONED
+        req = RequiredChecks(any_of_groups=(group,))
+
+        ctx1 = VerificationContext()
+        ctx1.record(VC.BALANCE)
+        ctx1.check(req, stage='test')
+
+        ctx2 = VerificationContext()
+        ctx2.record(VC.BALANCE_POSTPONED)
+        ctx2.check(req, stage='test')
+
+    def test_any_of_group_fails_when_none_recorded(self) -> None:
+        group = VC.BALANCE | VC.BALANCE_POSTPONED
+        ctx = VerificationContext(vertex_hash=b'\x02' * 32)
+        ctx.record(VC.INPUTS)  # unrelated
+        with pytest.raises(VerificationChecksMissingError):
+            ctx.check(RequiredChecks(any_of_groups=(group,)), stage='test')
+
+    def test_combined_all_and_any_of(self) -> None:
+        req = RequiredChecks(
+            all_of=VC.INPUTS | VC.VERSION,
+            any_of_groups=(VC.BALANCE | VC.BALANCE_POSTPONED,),
+        )
+        ctx = VerificationContext()
+        ctx.record(VC.INPUTS)
+        ctx.record(VC.VERSION)
+        ctx.record(VC.BALANCE_POSTPONED)
+        ctx.check(req, stage='test')
+
+    def test_required_checks_or_combines_both(self) -> None:
+        a = RequiredChecks(all_of=VC.INPUTS, any_of_groups=(VC.BALANCE | VC.BALANCE_POSTPONED,))
+        b = RequiredChecks(all_of=VC.VERSION, any_of_groups=(VC.POA | VC.POW,))
+        combined = a | b
+        assert combined.all_of == VC.INPUTS | VC.VERSION
+        assert combined.any_of_groups == (
+            VC.BALANCE | VC.BALANCE_POSTPONED,
+            VC.POA | VC.POW,
+        )


### PR DESCRIPTION
### Motivation

Consensus verification has a silent-failure class of bug: when two dispatch gates disagree, a check can be skipped and nothing in the system notices. We hit exactly this recently on the shielded-outputs work — a tx with shielded inputs → transparent outputs was having its balance check skipped by both the transparent path (gated on `is_shielded()`) and the shielded path (gated on `has_shielded_outputs()`). Neither fired. No exception, no log, just an inflation hole.

This PR adds a defense-in-depth mechanism that makes this class of bug loud. Each verify_* method records a flag when its invariant has been enforced; at the end of each verification stage, the dispatcher asserts the recorded flag set covers the required set for the vertex's shape. Any skip — dispatcher-level OR internal to a verifier — raises `VerificationChecksMissingError`.

The mechanism is self-enforcing: a cross-check test enumerates (vertex type × params) combinations and asserts the required-flag table stays 1:1 with what the dispatcher actually records. That test already earned its keep — it caught two real drifts in the required-checks table on first run, which are fixed in this PR.

### Acceptance Criteria

- `VerificationCheck` IntFlag enum covers every verify_* invariant across all verifier classes (42 flags)
- `VerificationContext` threads through `verify_basic` and `verify`; `ctx` is a **required** keyword argument on every verifier method — no silent no-op if a caller forgets it
- Verifiers self-record at their success tail, so stubbing/early-returning/deleting a check's work will fail the completeness assertion
- Nano-contract postponement: `verify_sum` records `BALANCE_POSTPONED` when a nonexistent token defers the check; `NCBlockExecutor._verify_sum_after_execution` records `BALANCE` after re-verification; a post-nano completeness check voids the tx (via `NCFail`) if `BALANCE` wasn't promoted
- `verification_checks` persisted in `TransactionMetadata` via `to_storage_json` (internal bookkeeping, deliberately **not** exposed in public `to_json`)
- Cross-check test (`test_required_checks_match_dispatcher`) enumerates vertex shape × params combinations and asserts `ctx.checks_run` equals `required_checks_for(...)` bidirectionally. Future drift fails loudly
- Regression coverage: `test_completeness` simulates a broken verifier (stub returns no-op) and asserts `VerificationChecksMissingError` fires. `test_post_nano_voiding` simulates a bypassed post-execution re-check and asserts `NCFail` is raised
- Full test suite clean: 2530 passed, lint/mypy clean across the whole tree

### Scope note

This lands on `master`, which does not yet carry the shielded-outputs feature set. The shielded flag bundle (`SHIELDED_COMMITMENTS`, `SHIELDED_BALANCE`, `SHIELDED_SURJECTION`, etc.) is intentionally deferred to the follow-up port on `feat/ct-amount-token-privacy` — that branch has the verifiers to instrument. The framework here is additive and ready to accept them.

### Checklist

- [x] If you are requesting a merge into \`master\`, confirm this code is production-ready and can be included in future releases as soon as it gets merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)