### PR TITLE
chore(ci): update all workflows to use full SHA version for actions

### DIFF
--- a/.github/actions/setup-hathor-env/action.yml
+++ b/.github/actions/setup-hathor-env/action.yml
@@ -13,7 +13,8 @@ runs:
       run: pipx install poetry
 
     - name: Set up Python ${{ inputs.python }}
-      uses: actions/setup-python@v5
+      # https://github.com/actions/setup-python/releases/tag/v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: ${{ inputs.python }}
         cache: 'poetry'
@@ -23,7 +24,8 @@ runs:
       run: poetry config virtualenvs.in-project true
 
     - name: Cache virtualenv
-      uses: actions/cache@v4
+      # https://github.com/actions/cache/releases/tag/v5.0.5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
       with:
         path: .venv
         key: venv-${{ runner.os }}-py${{ inputs.python }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -13,8 +13,10 @@ jobs:
     name: Continuous Benchmarking base branch
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: bencherdev/bencher@main
+      # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # https://github.com/bencherdev/bencher/releases/tag/v0.6.3
+      - uses: bencherdev/bencher@46d007c103827da37db1a25b705dc73d3aaff7e6
       - name: Install hyperfine
         run: |
           wget https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine_1.12.0_amd64.deb

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,8 @@ jobs:
           - '3.12'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Prepare base version
         id: prep
         run: |
@@ -48,28 +49,33 @@ jobs:
           VERSION: ${{ steps.prep.outputs.check-version }}
         run: make check-custom
       - name: Set up QEMU  # arm64 is not available natively
-        uses: docker/setup-qemu-action@v3
+        # https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        # https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
         with:
           version: latest
           install: true
           driver-opts: network=host
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        # https://github.com/docker/login-action/releases/tag/v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         if: steps.prep.outputs.login-dockerhub == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        # https://github.com/docker/login-action/releases/tag/v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         if: steps.prep.outputs.login-ghcr == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        # https://github.com/actions/cache/releases/tag/v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         if: steps.prep_base_version.outputs.is-nightly == 'false'
         with:
           path: /tmp/.buildx-cache
@@ -78,7 +84,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-refs/heads/master-
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        # https://github.com/docker/build-push-action/releases/tag/v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ${{ steps.prep.outputs.dockerfile }}
@@ -91,7 +98,8 @@ jobs:
       - name: Test image
         run: docker run --rm ${{ env.TEST_TAG }} quick_test --data / --testnet
       - name: Build and push
-        uses: docker/build-push-action@v6
+        # https://github.com/docker/build-push-action/releases/tag/v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         if: ${{ !env.ACT }}  # Skip this step when testing locally with https://github.com/nektos/act
         with:
           context: .

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -30,9 +30,11 @@ jobs:
           # - macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        # https://github.com/actions/setup-python/releases/tag/v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python }}
       - name: Install Poetry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,14 +64,16 @@ jobs:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-hathor-env
         name: Setup Hathor node environment
         with:
           python: ${{ matrix.python }}
           os: ${{ matrix.os }}
       - name: Cache mypy
-        uses: actions/cache@v4
+        # https://github.com/actions/cache/releases/tag/v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: .mypy_cache
           # this key is setup such that every branch has its cache and new branches can reuse dev's cache, but not the other way around
@@ -91,7 +93,8 @@ jobs:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+      # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-hathor-env
         name: Setup Hathor node environment
         with:
@@ -100,7 +103,8 @@ jobs:
       - name: Run CLI tests
         run: poetry run make tests-cli
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        # https://github.com/codecov/codecov-action/releases/tag/v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         if: matrix.python == 3.12 && startsWith(matrix.os, 'ubuntu')
         with:
           flags: test-cli
@@ -116,7 +120,8 @@ jobs:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+      # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-hathor-env
         name: Setup Hathor node environment
         with:
@@ -125,7 +130,8 @@ jobs:
       - name: Run lib tests
         run: poetry run make tests-lib
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: matrix.python == 3.12 && startsWith(matrix.os, 'ubuntu')
         with:
           flags: test-lib
@@ -141,7 +147,8 @@ jobs:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+      # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-hathor-env
         name: Setup Hathor node environment
         with:
@@ -157,7 +164,8 @@ jobs:
       - name: Run CI tests
         run: poetry run pytest --cov=hathor --cov-append extras/github/
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        # https://github.com/codecov/codecov-action/releases/tag/v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         if: matrix.python == 3.12 && startsWith(matrix.os, 'ubuntu')
         with:
           flags: test-other

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -17,8 +17,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: bencherdev/bencher@main
+      # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # https://github.com/bencherdev/bencher/releases/tag/v0.6.3
+      - uses: bencherdev/bencher@46d007c103827da37db1a25b705dc73d3aaff7e6
       - name: Install hyperfine
         run: |
           wget https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine_1.12.0_amd64.deb


### PR DESCRIPTION
### Motivation

Update all actions in all GitHub workflows to use full SHA versions instead of tags.

### Acceptance Criteria

- Update all actions versions to the most recent.
- Update actions to use full SHA versions instead of tags.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 