### PR TITLE
chore: rename verify_sum -> verify_transparent_balance

### DIFF
--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -288,7 +288,7 @@ class NCBlockExecutor:
 
             # after the execution we have the latest state in the storage
             # and at this point no tokens pending creation
-            self._verify_sum_after_execution(tx, block_storage)
+            self._verify_transparent_balance_after_execution(tx, block_storage)
         except NCFail as e:
             return NCTxExecutionFailure(
                 tx=tx,
@@ -299,12 +299,14 @@ class NCBlockExecutor:
 
         return NCTxExecutionSuccess(tx=tx, runner=runner)
 
-    def _verify_sum_after_execution(self, tx: Transaction, block_storage: 'NCBlockStorage') -> None:
+    def _verify_transparent_balance_after_execution(
+        self, tx: Transaction, block_storage: 'NCBlockStorage'
+    ) -> None:
         """Verify token sums after execution for dynamically created tokens."""
         from hathor.verification.transaction_verifier import TransactionVerifier
         try:
             token_dict = tx.get_complete_token_info(block_storage)
-            TransactionVerifier.verify_sum(self._settings, tx, token_dict)
+            TransactionVerifier.verify_transparent_balance(self._settings, tx, token_dict)
         except TokenNotFound as e:
             # At this point, any nonexistent token would have made a prior validation fail. For example, if there
             # was a withdrawal of a nonexistent token, it would have failed in the balance validation before.

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -125,7 +125,7 @@ class CreateTxResource(Resource):
         verifiers.vertex.verify_parents(tx)
 
         block_storage = self.manager.get_nc_block_storage(best_block)
-        verifiers.tx.verify_sum(self.manager._settings, tx, tx.get_complete_token_info(block_storage))
+        verifiers.tx.verify_transparent_balance(self.manager._settings, tx, tx.get_complete_token_info(block_storage))
 
 
 CreateTxResource.openapi = {

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -300,7 +300,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
 
         fee_header = self.get_fee_header()
         fees = fee_header.get_fees()
-        # we store the total fee amount from the header to be used in the verify_sum
+        # we store the total fee amount from the header to be used in verify_transparent_balance
         token_dict.fees_from_fee_header = fee_header.total_fee_amount()
         for fee in fees:
             token_info = token_dict.get(fee.token_uid)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -256,7 +256,7 @@ class TransactionVerifier:
                 raise InvalidToken('token uid index not available: index {}'.format(output.get_token_index()))
 
     @classmethod
-    def verify_sum(
+    def verify_transparent_balance(
         cls,
         settings: HathorSettings,
         tx: Transaction,

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -265,7 +265,7 @@ class VerificationService:
         self.verifiers.tx.verify_version(tx, params)
 
         block_storage = self._get_block_storage(params)
-        self.verifiers.tx.verify_sum(
+        self.verifiers.tx.verify_transparent_balance(
             self._settings,
             tx,
             token_dict or tx.get_complete_token_info(block_storage),
@@ -280,7 +280,7 @@ class VerificationService:
     def _verify_token_creation_tx(self, tx: TokenCreationTransaction, params: VerificationParams) -> None:
         """ Run all validations as regular transactions plus validation on token info.
 
-        We also overload verify_sum to make some different checks
+        We also overload verify_transparent_balance to make some different checks
         """
         # we should validate the token info before verifying the tx
         self.verifiers.token_creation_tx.verify_token_info(tx, params)

--- a/hathor_tests/nanocontracts/test_fee_tokens.py
+++ b/hathor_tests/nanocontracts/test_fee_tokens.py
@@ -62,7 +62,7 @@ class FeeTokensTestCase(BlueprintTestCase):
         self.dag_builder = TestDAGBuilder.from_manager(self.manager)
 
     def test_postponed_verification_success(self) -> None:
-        """Postponed verification means running verify_sum on NC execution-time instead of verification-time."""
+        """Postponed verification: run verify_transparent_balance at NC execution-time, not verification-time."""
         artifacts = self.dag_builder.build_from_str(f'''
             blockchain genesis b[1..12]
             b10 < dummy
@@ -145,7 +145,7 @@ class FeeTokensTestCase(BlueprintTestCase):
         assert tx2.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, tx2.hash}
 
         # It fails with a balance error caused by the withdrawal,
-        # because this check runs before the postponed verify_sum.
+        # because this check runs before the postponed verify_transparent_balance.
         assert_nc_failure_reason(
             manager=self.manager,
             tx_id=tx2.hash,

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -91,7 +91,9 @@ class TransactionTest(unittest.TestCase):
         best_block = self.manager.tx_storage.get_best_block()
         block_storage = self.manager.get_nc_block_storage(best_block)
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(self._settings, tx, tx.get_complete_token_info(block_storage))
+            self._verifiers.tx.verify_transparent_balance(
+                self._settings, tx, tx.get_complete_token_info(block_storage)
+            )
 
     def test_input_output_match_more_htr(self):
         genesis_block = self.genesis_blocks[0]
@@ -112,7 +114,9 @@ class TransactionTest(unittest.TestCase):
         best_block = self.manager.tx_storage.get_best_block()
         block_storage = self.manager.get_nc_block_storage(best_block)
         with self.assertRaises(InputOutputMismatch):
-            self._verifiers.tx.verify_sum(self._settings, tx, tx.get_complete_token_info(block_storage))
+            self._verifiers.tx.verify_transparent_balance(
+                self._settings, tx, tx.get_complete_token_info(block_storage)
+            )
 
     def test_validation(self):
         # add 100 blocks and check that walking through get_next_block_best_chain yields the same blocks

--- a/hathor_tests/tx/test_verification.py
+++ b/hathor_tests/tx/test_verification.py
@@ -616,7 +616,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
         verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
         verify_parents_wrapped = Mock(wraps=self.verifiers.vertex.verify_parents)
-        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_transparent_balance_wrapped = Mock(wraps=self.verifiers.tx.verify_transparent_balance)
         verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
         verify_tx_version_wrapped = Mock(wraps=self.verifiers.tx.verify_version)
 
@@ -632,7 +632,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(VertexVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_transparent_balance', verify_transparent_balance_wrapped),
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TransactionVerifier, 'verify_version', verify_tx_version_wrapped),
         ):
@@ -652,7 +652,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped.assert_called_once()
         verify_script_wrapped.assert_called_once()
         verify_parents_wrapped.assert_called_once()
-        verify_sum_wrapped.assert_called_once()
+        verify_transparent_balance_wrapped.assert_called_once()
         verify_reward_locked_wrapped.assert_called_once()
         verify_tx_version_wrapped.assert_called_once()
 
@@ -756,7 +756,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
         verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
         verify_parents_wrapped = Mock(wraps=self.verifiers.vertex.verify_parents)
-        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_transparent_balance_wrapped = Mock(wraps=self.verifiers.tx.verify_transparent_balance)
         verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
         verify_tx_version_wrapped = Mock(wraps=self.verifiers.tx.verify_version)
 
@@ -775,7 +775,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(VertexVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_transparent_balance', verify_transparent_balance_wrapped),
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TransactionVerifier, 'verify_version', verify_tx_version_wrapped),
         ):
@@ -798,7 +798,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped.assert_called_once()
         verify_script_wrapped.assert_called_once()
         verify_parents_wrapped.assert_called_once()
-        verify_sum_wrapped.assert_called_once()
+        verify_transparent_balance_wrapped.assert_called_once()
         verify_reward_locked_wrapped.assert_called_once()
         verify_headers_wrapped.assert_called_once()
 
@@ -923,7 +923,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
         verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
         verify_parents_wrapped = Mock(wraps=self.verifiers.vertex.verify_parents)
-        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_transparent_balance_wrapped = Mock(wraps=self.verifiers.tx.verify_transparent_balance)
         verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
         verify_tx_version_wrapped = Mock(wraps=self.verifiers.tx.verify_version)
 
@@ -942,7 +942,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(VertexVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_transparent_balance', verify_transparent_balance_wrapped),
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TransactionVerifier, 'verify_version', verify_tx_version_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
@@ -964,7 +964,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped.assert_called_once()
         verify_script_wrapped.assert_called_once()
         verify_parents_wrapped.assert_called_once()
-        verify_sum_wrapped.assert_called_once()
+        verify_transparent_balance_wrapped.assert_called_once()
         verify_reward_locked_wrapped.assert_called_once()
         verify_tx_version_wrapped.assert_called_once()
 
@@ -1072,7 +1072,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped = Mock(wraps=self.verifiers.tx.verify_inputs)
         verify_script_wrapped = Mock(wraps=self.verifiers.tx.verify_script)
         verify_parents_wrapped = Mock(wraps=self.verifiers.vertex.verify_parents)
-        verify_sum_wrapped = Mock(wraps=self.verifiers.tx.verify_sum)
+        verify_transparent_balance_wrapped = Mock(wraps=self.verifiers.tx.verify_transparent_balance)
         verify_reward_locked_wrapped = Mock(wraps=self.verifiers.tx.verify_reward_locked)
         verify_tx_version_wrapped = Mock(wraps=self.verifiers.tx.verify_version)
 
@@ -1094,7 +1094,7 @@ class VerificationTest(unittest.TestCase):
             patch.object(TransactionVerifier, 'verify_inputs', verify_inputs_wrapped),
             patch.object(TransactionVerifier, 'verify_script', verify_script_wrapped),
             patch.object(VertexVerifier, 'verify_parents', verify_parents_wrapped),
-            patch.object(TransactionVerifier, 'verify_sum', verify_sum_wrapped),
+            patch.object(TransactionVerifier, 'verify_transparent_balance', verify_transparent_balance_wrapped),
             patch.object(TransactionVerifier, 'verify_reward_locked', verify_reward_locked_wrapped),
             patch.object(TransactionVerifier, 'verify_version', verify_tx_version_wrapped),
             patch.object(TokenCreationTransactionVerifier, 'verify_token_info', verify_token_info_wrapped),
@@ -1119,7 +1119,7 @@ class VerificationTest(unittest.TestCase):
         verify_inputs_wrapped.assert_called_once()
         verify_script_wrapped.assert_called_once()
         verify_parents_wrapped.assert_called_once()
-        verify_sum_wrapped.assert_called_once()
+        verify_transparent_balance_wrapped.assert_called_once()
         verify_reward_locked_wrapped.assert_called_once()
         verify_tx_version_wrapped.assert_called_once()
 


### PR DESCRIPTION
## Summary

Mechanical rename of `TransactionVerifier.verify_sum` → `verify_transparent_balance`, plus the `NCBlockExecutor._verify_sum_after_execution` helper. No behavior change.

## Why this rename, in the context of shielded outputs

Today every regular transaction has exactly one balance check: `verify_sum` confirms that, per token, sum-of-inputs equals sum-of-outputs (with mint/melt authority handling the difference). It's the only such check, so the generic name fits.

The upcoming shielded-outputs feature breaks that one-to-one mapping. Shielded outputs hide their amount behind Pedersen commitments, so per-token plaintext arithmetic no longer applies to them. Instead, shielded txs are validated by a separate `verify_shielded_balance` that proves the homomorphic balance equation over the commitments (with range proofs, surjection proofs, and an `excess_blinding_factor` from `UnshieldBalanceHeader` for partial-unshield txs).

Once shielded lands, `_verify_tx` will dispatch to **exactly one** of:

- `verify_transparent_balance` — the existing plaintext per-token check (this PR's renamed function), OR
- `verify_shielded_balance` — the new commitment-based check

…based on `tx.is_shielded()`.

That makes the current name actively misleading: `verify_sum` is not "the sum check" anymore — it's "the *transparent* sum check, used when amounts are public." Renaming it now, on its own, lets the security-critical shielded verification PR (PR 5 of [the split plan](docs/plans/shielded-pr-split.md)) land with a minimal diff focused purely on the new logic — reviewers won't have to mentally separate "which lines are the rename" from "which lines are the new commitment-balance code."

## Scope

- `hathor/verification/transaction_verifier.py` — definition.
- `hathor/verification/verification_service.py` — callsite + docstring.
- `hathor/transaction/resources/create_tx.py` — callsite.
- `hathor/nanocontracts/execution/block_executor.py` — callsite + helper rename.
- `hathor/transaction/transaction.py` — comment.
- `hathor_tests/nanocontracts/test_fee_tokens.py` — comments.
- `hathor_tests/tx/test_tx.py` — 2 callsites.
- `hathor_tests/tx/test_verification.py` — Mock/`patch.object` references and local var name (4 test methods).

No signature change, no semantic change, no new behavior. The function still does exactly what it did before; only the name reflects what it actually verifies.

## Test plan

- [x] `poetry run ruff check` on the changed files
- [x] `poetry run mypy` on the changed files
- [x] `poetry run pytest hathor_tests/tx/test_tx.py hathor_tests/tx/test_verification.py hathor_tests/nanocontracts/test_fee_tokens.py` — 80/80 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)