### PR TITLE
refactor: introduce GenericVertex.resolve_spent_output and migrate callsites

### DIFF
--- a/hathor/indexes/utxo_index.py
+++ b/hathor/indexes/utxo_index.py
@@ -143,7 +143,7 @@ class UtxoIndex(BaseIndex):
         # remove all inputs
         for tx_input in tx.inputs:
             spent_tx = tx.get_spent_tx(tx_input)
-            spent_tx_output = spent_tx.outputs[tx_input.index]
+            spent_tx_output = spent_tx.resolve_spent_output(tx_input.index)
             log_it = log.new(tx_id=spent_tx.hash_hex, index=tx_input.index)
             if _should_skip_output(spent_tx_output):
                 log_it.debug('ignore input')
@@ -184,7 +184,7 @@ class UtxoIndex(BaseIndex):
         # re-add inputs that aren't voided
         for tx_input in tx.inputs:
             spent_tx = tx.get_spent_tx(tx_input)
-            spent_tx_output = spent_tx.outputs[tx_input.index]
+            spent_tx_output = spent_tx.resolve_spent_output(tx_input.index)
             log_it = log.new(tx_id=spent_tx.hash_hex, index=tx_input.index)
             if _should_skip_output(spent_tx_output):
                 log_it.debug('ignore input')

--- a/hathor/nanocontracts/vertex_data.py
+++ b/hathor/nanocontracts/vertex_data.py
@@ -53,7 +53,7 @@ def _get_txin_output(vertex: BaseTransaction, txin: TxInput) -> TxOutput | None:
 
     assert len(vertex2.outputs) > txin.index, 'invalid output index'
 
-    txin_output = vertex2.outputs[txin.index]
+    txin_output = vertex2.resolve_spent_output(txin.index)
     return txin_output
 
 

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -297,6 +297,15 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
         """Sum of the value of the outputs"""
         return sum(output.value for output in self.outputs if not output.is_token_authority())
 
+    def resolve_spent_output(self, index: int) -> 'TxOutput':
+        """Return the output at `index` that an input may spend.
+
+        Default implementation indexes `self.outputs` directly. Subclasses with
+        additional output spaces (e.g. shielded outputs) override this to make
+        the lookup aware of those spaces.
+        """
+        return self.outputs[index]
+
     def get_target(self, override_weight: Optional[float] = None) -> int:
         """Target to be achieved in the mining process"""
         if not isfinite(self.weight):
@@ -426,7 +435,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         for txin in self.inputs:
             tx2 = self.storage.get_transaction(txin.tx_id)
-            txout = tx2.outputs[txin.index]
+            txout = tx2.resolve_spent_output(txin.index)
             add_address_from_output(txout)
 
         for txout in self.outputs:
@@ -775,7 +784,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
 
         for index, tx_in in enumerate(self.inputs):
             tx2 = self.storage.get_transaction(tx_in.tx_id)
-            tx2_out = tx2.outputs[tx_in.index]
+            tx2_out = tx2.resolve_spent_output(tx_in.index)
             output = serialize_output(tx2, tx2_out)
             output['tx_id'] = tx2.hash_hex
             output['index'] = tx_in.index

--- a/hathor/transaction/resources/transaction.py
+++ b/hathor/transaction/resources/transaction.py
@@ -93,7 +93,7 @@ def get_tx_extra_data(
     for index, tx_in in enumerate(tx.inputs):
         if tx.storage:
             tx2 = tx.storage.get_transaction(tx_in.tx_id)
-            tx2_out = tx2.outputs[tx_in.index]
+            tx2_out = tx2.resolve_spent_output(tx_in.index)
             output = tx2_out.to_json(decode_script=True)
             output['tx_id'] = tx2.hash_hex
             output['index'] = tx_in.index

--- a/hathor/transaction/scripts/execute.py
+++ b/hathor/transaction/scripts/execute.py
@@ -117,7 +117,7 @@ def script_eval(tx: Transaction, txin: TxInput, spent_tx: BaseTransaction, versi
     """
     raw_script_eval(
         input_data=txin.data,
-        output_script=spent_tx.outputs[txin.index].script,
+        output_script=spent_tx.resolve_spent_output(txin.index).script,
         extras=UtxoScriptExtras(tx=tx, txin=txin, spent_tx=spent_tx, version=version),
     )
 

--- a/hathor/transaction/scripts/opcode.py
+++ b/hathor/transaction/scripts/opcode.py
@@ -515,7 +515,7 @@ def op_find_p2pkh(context: ScriptContext) -> None:
     spent_tx = context.extras.spent_tx
     txin = context.extras.txin
     tx = context.extras.tx
-    contract_value = spent_tx.outputs[txin.index].value
+    contract_value = spent_tx.resolve_spent_output(txin.index).value
 
     address = context.stack.pop()
     if not isinstance(address, bytes):

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -328,7 +328,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
 
         for tx_input in self.inputs:
             spent_tx = self.get_spent_tx(tx_input)
-            spent_output = spent_tx.outputs[tx_input.index]
+            spent_output = spent_tx.resolve_spent_output(tx_input.index)
 
             token_uid = spent_tx.get_token_uid(spent_output.get_token_index())
             token_version = get_token_version(self.storage, nc_block_storage, token_uid)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -123,7 +123,7 @@ class TransactionVerifier:
             if tx_input.index >= len(spent_tx.outputs):
                 raise InexistentInput('Output spent by this input does not exist: {} index {}'.format(
                     tx_input.tx_id.hex(), tx_input.index))
-            n_txops += counter.get_sigops_count(tx_input.data, spent_tx.outputs[tx_input.index].script)
+            n_txops += counter.get_sigops_count(tx_input.data, spent_tx.resolve_spent_output(tx_input.index).script)
 
         if n_txops > self._settings.MAX_TX_SIGOPS_INPUT:
             raise TooManySigOps(


### PR DESCRIPTION
> Stacked on top of #1668 (PR 1 — `verify_sum` rename). Merge that one first; this PR's diff against `master` will then shrink to just this refactor.

## Summary

Adds `resolve_spent_output(index) -> TxOutput` to `GenericVertex`, and migrates every in-scope direct `spent_tx.outputs[txin.index]` read to use it. **No behavior change.** The default implementation indexes `self.outputs` directly, which is exactly what the old code did inline.

## Why this refactor, in the context of shielded outputs

Today, a `TxInput.index` always refers to a transparent output, so every callsite that resolves a spent output writes the same line:

```python
spent_tx.outputs[txin.index]
```

Once shielded outputs land, that assumption breaks. Shielded outputs live in a separate list on `Transaction` (`shielded_outputs`), and an input's `index` will be a flat lookup over the combined `outputs + shielded_outputs` space — transparent first, then shielded, then raise. The shielded-aware `Transaction.resolve_spent_output` does that 3-way lookup; non-`Transaction` vertices keep the trivial transparent-only default from `GenericVertex`.

If we add the override without first migrating the callsites, then the security-critical shielded verification PR (PR 5 of [the split plan](docs/plans/shielded-pr-split.md)) has to touch every one of the lines listed below — interleaving "this is a mechanical replacement of `outputs[idx]` with a method call" with "this is the new homomorphic balance equation." Reviewers shouldn't have to mentally separate the two. By landing the migration as its own no-op refactor now, PR 5's diff at each of these callsites becomes zero — only the new `Transaction.resolve_spent_output` override is added there, and these existing lines stay put.

## Scope

New method on `GenericVertex`:

```python
def resolve_spent_output(self, index: int) -> 'TxOutput':
    return self.outputs[index]
```

Migrated callsites (all formerly `something.outputs[idx]`):

- `hathor/transaction/base_transaction.py` — `get_related_addresses`, `to_json_extended`
- `hathor/transaction/scripts/execute.py` — `script_eval`
- `hathor/transaction/scripts/opcode.py` — `op_find_p2pkh`
- `hathor/verification/transaction_verifier.py` — sigops counting in `verify_sigops_input`
- `hathor/indexes/utxo_index.py` — `_update_executed`, `_update_voided`
- `hathor/transaction/resources/transaction.py` — `/transaction` API serializer
- `hathor/transaction/transaction.py` — `_get_token_info_from_inputs`
- `hathor/nanocontracts/vertex_data.py` — `_resolve_input_output`

### Not migrated, intentionally

- `hathor/simulator/utils.py`, `hathor/wallet/resources/thin_wallet/{address_balance,address_search}.py`, `hathor_tests/**` — these aren't on the shielded-aware path in subsequent PRs (wallet support is PR 6, simulator/test helpers stay transparent-only). Migrating them now would just churn lines for no PR-5 win.
- `hathor/indexes/rocksdb_tokens_index.py` — the plan listed this, but on `master` it only reads `tx.outputs[index]` (its own outputs), never `spent_tx.outputs[index]`. Its shielded-aware logic (`is_shielded_output`-gated branches) is added in a later PR alongside the new code paths, so there's no master callsite to migrate here.

### Why only `resolve_spent_output`, not also `shielded_outputs` / `is_shielded_output`

The split plan also lists `shielded_outputs` (default `[]`) and `is_shielded_output(index)` (default `False`) as part of the new `GenericVertex` API. I deliberately deferred those two to PR 4 (the data-model PR that introduces `ShieldedOutput`):

- Neither has any caller in PR 2's transparent-only scope. The migrated callsites listed above don't use them — they only need `resolve_spent_output`, which can be precisely typed as `-> TxOutput` today.
- Typing `shielded_outputs` requires the `ShieldedOutput` class, which doesn't exist until PR 4. Adding it now would either need a placeholder type (dead scaffolding) or `Any` (banned).
- PR 4 introduces `ShieldedOutput` anyway, so adding both methods there alongside the type is the natural place — they cost two lines each and have a real type to return.

This keeps PR 2 a true no-op refactor: every change is provably equivalent to the line it replaced.

## Test plan

- [x] `poetry run ruff check` on the changed files
- [x] `poetry run mypy` on the changed files
- [x] `poetry run pytest hathor_tests/tx hathor_tests/verification hathor_tests/resources/transaction hathor_tests/nanocontracts` — 991 passed, 6 skipped, 2 xfailed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)