### PR TITLE
refactor(consensus): centralize vertex deserializer creation

### DIFF
--- a/hathor/nanocontracts/on_chain_blueprint.py
+++ b/hathor/nanocontracts/on_chain_blueprint.py
@@ -195,14 +195,13 @@ class OnChainBlueprint(Transaction):
     @override
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
                            *, verbose: VerboseCallback = None) -> Self:
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._common import deserialize_graph_fields
+        from hathor.transaction.vertex_parser._common import deserialize_graph_fields, make_vertex_deserializer
         from hathor.transaction.vertex_parser._headers import deserialize_headers
         from hathor.transaction.vertex_parser._on_chain_blueprint import deserialize_ocb_extra_fields
         from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
         settings = get_global_settings()
         tx = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
+        deserializer = make_vertex_deserializer(struct_bytes, settings)
         deserialize_tx_funds(deserializer, tx, verbose=verbose)
         deserialize_ocb_extra_fields(deserializer, tx, verbose=verbose)
         deserialize_graph_fields(deserializer, tx, verbose=verbose)

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -92,12 +92,12 @@ class Block(GenericVertex[BlockStaticMetadata]):
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
                            *, verbose: VerboseCallback = None) -> Self:
         from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
         from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
+        from hathor.transaction.vertex_parser._common import make_vertex_deserializer
         from hathor.transaction.vertex_parser._headers import deserialize_headers
         settings = get_global_settings()
         block = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
+        deserializer = make_vertex_deserializer(struct_bytes, settings)
         deserialize_block_funds(deserializer, block, verbose=verbose)
         deserialize_block_graph_fields(deserializer, block, verbose=verbose)
         block.nonce = int.from_bytes(deserializer.read_bytes(cls.SERIALIZATION_NONCE_SIZE), byteorder='big')

--- a/hathor/transaction/merge_mined_block.py
+++ b/hathor/transaction/merge_mined_block.py
@@ -63,10 +63,10 @@ class MergeMinedBlock(Block):
     @override
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
                            *, verbose: VerboseCallback = None) -> Self:
-        from hathor.serialization import Deserializer
         from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_block_graph_fields
+        from hathor.transaction.vertex_parser._common import make_vertex_deserializer
         block = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
+        deserializer = make_vertex_deserializer(struct_bytes)
         deserialize_block_funds(deserializer, block, verbose=verbose)
         deserialize_block_graph_fields(deserializer, block, verbose=verbose)
         block.aux_pow = BitcoinAuxPow.from_bytes(bytes(deserializer.read_all()))

--- a/hathor/transaction/poa/poa_block.py
+++ b/hathor/transaction/poa/poa_block.py
@@ -66,12 +66,12 @@ class PoaBlock(Block):
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional[TransactionStorage] = None,
                            *, verbose: VerboseCallback = None) -> Self:
         from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
         from hathor.transaction.vertex_parser._block import deserialize_block_funds, deserialize_poa_block_graph_fields
+        from hathor.transaction.vertex_parser._common import make_vertex_deserializer
         from hathor.transaction.vertex_parser._headers import deserialize_headers
         settings = get_global_settings()
         block = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
+        deserializer = make_vertex_deserializer(struct_bytes, settings)
         deserialize_block_funds(deserializer, block, verbose=verbose)
         deserialize_poa_block_graph_fields(
             deserializer, block, signer_id_len=poa.SIGNER_ID_LEN, max_signature_len=_MAX_POA_SIGNATURE_LEN,

--- a/hathor/transaction/token_creation_tx.py
+++ b/hathor/transaction/token_creation_tx.py
@@ -88,13 +88,12 @@ class TokenCreationTransaction(Transaction):
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
                            *, verbose: VerboseCallback = None) -> Self:
         from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._common import deserialize_graph_fields
+        from hathor.transaction.vertex_parser._common import deserialize_graph_fields, make_vertex_deserializer
         from hathor.transaction.vertex_parser._headers import deserialize_headers
         from hathor.transaction.vertex_parser._token_creation import deserialize_token_creation_funds
         settings = get_global_settings()
         tx = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
+        deserializer = make_vertex_deserializer(struct_bytes, settings)
         deserialize_token_creation_funds(deserializer, tx, verbose=verbose)
         deserialize_graph_fields(deserializer, tx, verbose=verbose)
         (tx.nonce,) = deserializer.read_struct('!I')

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -105,13 +105,12 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
     def create_from_struct(cls, struct_bytes: bytes, storage: Optional['TransactionStorage'] = None,
                            *, verbose: VerboseCallback = None) -> Self:
         from hathor.conf.get_settings import get_global_settings
-        from hathor.serialization import Deserializer
-        from hathor.transaction.vertex_parser._common import deserialize_graph_fields
+        from hathor.transaction.vertex_parser._common import deserialize_graph_fields, make_vertex_deserializer
         from hathor.transaction.vertex_parser._headers import deserialize_headers
         from hathor.transaction.vertex_parser._transaction import deserialize_tx_funds
         settings = get_global_settings()
         tx = cls(storage=storage)
-        deserializer = Deserializer.build_bytes_deserializer(struct_bytes)
+        deserializer = make_vertex_deserializer(struct_bytes, settings)
         deserialize_tx_funds(deserializer, tx, verbose=verbose)
         deserialize_graph_fields(deserializer, tx, verbose=verbose)
         (tx.nonce,) = deserializer.read_struct('!I')

--- a/hathor/transaction/vertex_parser/_common.py
+++ b/hathor/transaction/vertex_parser/_common.py
@@ -24,6 +24,7 @@ from hathor.transaction.base_transaction import TX_HASH_SIZE
 from hathor.transaction.util import VerboseCallback, int_to_bytes, output_value_to_bytes
 
 if TYPE_CHECKING:
+    from hathor.conf.settings import HathorSettings
     from hathor.transaction.base_transaction import BaseTransaction, TxInput, TxOutput
 
 # Weight (d=double 8 bytes), timestamp (I=uint32 4 bytes), parents_len (B=uint8 1 byte)
@@ -74,6 +75,11 @@ def serialize_tx_output(serializer: Serializer, tx_output: TxOutput) -> None:
 # ---------------------------------------------------------------------------
 # Deserialization
 # ---------------------------------------------------------------------------
+
+
+def make_vertex_deserializer(struct_bytes: bytes, _settings: 'HathorSettings | None' = None) -> Deserializer:
+    """Build a deserializer for a serialized vertex."""
+    return Deserializer.build_bytes_deserializer(struct_bytes)
 
 
 def deserialize_graph_fields(


### PR DESCRIPTION
### Motivation

Currently the deserializer does not take in a "settings" object. Future changes in the deserializer will need access to the current settings.

### Acceptance Criteria

- Centralize the creation of the deserializer object so we can easily inject the settings.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 