### PR TITLE
feat(p2p): introduce WhitelistManager and `# policy:` directive

### DIFF
--- a/hathor/builder/builder.py
+++ b/hathor/builder/builder.py
@@ -476,7 +476,6 @@ class Builder:
             my_peer=my_peer,
             pubsub=self._get_or_create_pubsub(),
             ssl=enable_ssl,
-            whitelist_only=False,
             rng=self._rng,
             enable_ipv6=self._enable_ipv6,
             disable_ipv4=self._disable_ipv4,

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -52,7 +52,6 @@ from hathor.nanocontracts.runner.runner import RunnerFactory
 from hathor.nanocontracts.storage import NCBlockStorage, NCContractStorage, get_block_storage_from_block
 from hathor.p2p.manager import ConnectionsManager
 from hathor.p2p.peer import PrivatePeer
-from hathor.p2p.peer_id import PeerId
 from hathor.pubsub import EventArguments, HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
 from hathor.reward_lock import is_spent_reward_locked
@@ -236,9 +235,6 @@ class HathorManager:
 
         # Thread pool used to resolve pow when sending tokens
         self.pow_thread_pool = ThreadPool(minthreads=0, maxthreads=settings.MAX_POW_THREADS, name='Pow thread pool')
-
-        # List of whitelisted peers
-        self.peers_whitelist: list[PeerId] = []
 
         # List of capabilities of the peer
         if capabilities is not None:
@@ -896,24 +892,6 @@ class HathorManager:
 
     def has_sync_version_capability(self) -> bool:
         return self._settings.CAPABILITY_SYNC_VERSION in self.capabilities
-
-    def add_peer_to_whitelist(self, peer_id: PeerId) -> None:
-        if not self._settings.ENABLE_PEER_WHITELIST:
-            return
-
-        if peer_id in self.peers_whitelist:
-            self.log.info('peer already in whitelist', peer_id=peer_id)
-        else:
-            self.peers_whitelist.append(peer_id)
-
-    def remove_peer_from_whitelist_and_disconnect(self, peer_id: PeerId) -> None:
-        if not self._settings.ENABLE_PEER_WHITELIST:
-            return
-
-        if peer_id in self.peers_whitelist:
-            self.peers_whitelist.remove(peer_id)
-            # disconnect from node
-            self.connections.drop_connection_by_peer_id(peer_id)
 
     def has_recent_activity(self) -> bool:
         current_timestamp = time.time()

--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -23,7 +23,6 @@ from twisted.internet.interfaces import IListeningPort, IProtocol, IProtocolFact
 from twisted.internet.task import LoopingCall
 from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
 from twisted.python.failure import Failure
-from twisted.web.client import Agent
 
 from hathor.conf.settings import HathorSettings
 from hathor.p2p.netfilter.factory import NetfilterFactory
@@ -37,7 +36,7 @@ from hathor.p2p.rate_limiter import RateLimiter
 from hathor.p2p.states.ready import ReadyState
 from hathor.p2p.sync_factory import SyncAgentFactory
 from hathor.p2p.sync_version import SyncVersion
-from hathor.p2p.utils import parse_whitelist
+from hathor.p2p.whitelist_manager import WhitelistManager
 from hathor.pubsub import HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor
 from hathor.transaction import BaseTransaction
@@ -47,9 +46,6 @@ if TYPE_CHECKING:
     from hathor.manager import HathorManager
 
 logger = get_logger()
-
-# The timeout in seconds for the whitelist GET request
-WHITELIST_REQUEST_TIMEOUT = 45
 
 
 class _SyncRotateInfo(NamedTuple):
@@ -85,7 +81,7 @@ class ConnectionsManager:
     new_connection_from_queue: deque[PeerId]
     connecting_peers: dict[IStreamClientEndpoint, _ConnectingPeer]
     handshaking_peers: set[HathorProtocol]
-    whitelist_only: bool
+    whitelist: WhitelistManager
     verified_peer_storage: VerifiedPeerStorage
     _sync_factories: dict[SyncVersion, SyncAgentFactory]
     _enabled_sync_versions: set[SyncVersion]
@@ -100,7 +96,6 @@ class ConnectionsManager:
         pubsub: PubSubManager,
         ssl: bool,
         rng: Random,
-        whitelist_only: bool,
         enable_ipv6: bool,
         disable_ipv4: bool,
     ) -> None:
@@ -187,16 +182,15 @@ class ConnectionsManager:
         self.lc_connect.clock = self.reactor
         self.lc_connect_interval = 0.2  # seconds
 
-        # A timer to try to reconnect to the disconnect known peers.
-        if self._settings.ENABLE_PEER_WHITELIST:
-            self.wl_reconnect = LoopingCall(self.update_whitelist)
-            self.wl_reconnect.clock = self.reactor
-
         # Pubsub object to publish events
         self.pubsub = pubsub
 
-        # Parameter to explicitly enable whitelist-only mode, when False it will still check the whitelist for sync-v1
-        self.whitelist_only = whitelist_only
+        # Whitelist manager: owns enabled flag, active policy, peer list, refresh loop and gating decision.
+        self.whitelist = WhitelistManager(
+            settings=self._settings,
+            reactor=self.reactor,
+            drop_connection=self.drop_connection_by_peer_id,
+        )
 
         # Parameter to enable IPv6 connections
         self.enable_ipv6 = enable_ipv6
@@ -210,9 +204,6 @@ class ConnectionsManager:
         # sync-manager factories
         self._sync_factories = {}
         self._enabled_sync_versions = set()
-
-        # agent to perform HTTP requests
-        self._http_agent = Agent(self.reactor)
 
     def add_sync_factory(self, sync_version: SyncVersion, sync_factory: SyncAgentFactory) -> None:
         """Add factory for the given sync version, must use a sync version that does not already exist."""
@@ -298,28 +289,12 @@ class ConnectionsManager:
         self.lc_reconnect.start(5, now=False)
         self.lc_sync_update.start(self.lc_sync_update_interval, now=False)
 
-        if self._settings.ENABLE_PEER_WHITELIST:
-            self._start_whitelist_reconnect()
+        self.whitelist.start()
 
         for description in self.listen_address_descriptions:
             self.listen(description)
 
         self.do_discovery()
-
-    def _start_whitelist_reconnect(self) -> None:
-        # The deferred returned by the LoopingCall start method
-        # executes when the looping call stops running
-        # https://docs.twistedmatrix.com/en/stable/api/twisted.internet.task.LoopingCall.html
-        d = self.wl_reconnect.start(30)
-        d.addErrback(self._handle_whitelist_reconnect_err)
-
-    def _handle_whitelist_reconnect_err(self, *args: Any, **kwargs: Any) -> None:
-        """ This method will be called when an exception happens inside the whitelist update
-            and ends up stopping the looping call.
-            We log the error and start the looping call again.
-        """
-        self.log.error('whitelist reconnect had an exception. Start looping call again.', args=args, kwargs=kwargs)
-        self.reactor.callLater(30, self._start_whitelist_reconnect)
 
     def _start_peer_connect_loop(self) -> None:
         # The deferred returned by the LoopingCall start method
@@ -596,47 +571,6 @@ class ConnectionsManager:
         # when the peer is disconnected and without entrypoint
         for peer in list(self.verified_peer_storage.values()):
             self.connect_to_peer(peer, int(now))
-
-    def update_whitelist(self) -> Deferred[None]:
-        from twisted.web.client import readBody
-        from twisted.web.http_headers import Headers
-        assert self._settings.WHITELIST_URL is not None
-        self.log.info('update whitelist')
-        d = self._http_agent.request(
-            b'GET',
-            self._settings.WHITELIST_URL.encode(),
-            Headers({'User-Agent': ['hathor-core']}),
-            None)
-        d.addCallback(readBody)
-        d.addTimeout(WHITELIST_REQUEST_TIMEOUT, self.reactor)
-        d.addCallback(self._update_whitelist_cb)
-        d.addErrback(self._update_whitelist_err)
-
-        return d
-
-    def _update_whitelist_err(self, *args: Any, **kwargs: Any) -> None:
-        self.log.error('update whitelist failed', args=args, kwargs=kwargs)
-
-    def _update_whitelist_cb(self, body: bytes) -> None:
-        assert self.manager is not None
-        self.log.info('update whitelist got response')
-        try:
-            text = body.decode()
-            new_whitelist = parse_whitelist(text)
-        except Exception:
-            self.log.exception('failed to parse whitelist')
-            return
-        current_whitelist = set(self.manager.peers_whitelist)
-        peers_to_add = new_whitelist - current_whitelist
-        if peers_to_add:
-            self.log.info('add new peers to whitelist', peers=peers_to_add)
-        peers_to_remove = current_whitelist - new_whitelist
-        if peers_to_remove:
-            self.log.info('remove peers peers from whitelist', peers=peers_to_remove)
-        for peer_id in peers_to_add:
-            self.manager.add_peer_to_whitelist(peer_id)
-        for peer_id in peers_to_remove:
-            self.manager.remove_peer_from_whitelist_and_disconnect(peer_id)
 
     def connect_to_peer(self, peer: UnverifiedPeer | PublicPeer, now: int) -> None:
         """ Attempts to connect if it is not connected to the peer.

--- a/hathor/p2p/resources/status.py
+++ b/hathor/p2p/resources/status.py
@@ -104,7 +104,7 @@ class StatusResource(Resource):
                 'uptime': now - self.manager.start_time,
                 'entrypoints': self.manager.connections.my_peer.info.entrypoints_as_str(),
             },
-            'peers_whitelist': [str(peer_id) for peer_id in self.manager.peers_whitelist],
+            'peers_whitelist': [str(peer_id) for peer_id in self.manager.connections.whitelist.peers],
             'known_peers': known_peers,
             'connections': {
                 'connected_peers': connected_peers,

--- a/hathor/p2p/states/peer_id.py
+++ b/hathor/p2p/states/peer_id.py
@@ -162,29 +162,10 @@ class PeerIdState(BaseState):
         self.send_ready()
 
     def _should_block_peer(self, peer_id: PeerId) -> bool:
-        """ Determine if peer should not be allowed to connect.
+        """Determine whether the peer should be denied admission.
 
-        Currently this is only because the peer is not in a whitelist and whitelist blocking is active.
+        The decision is delegated to the connection's WhitelistManager, which knows the
+        active policy, the whitelist contents, and the local enforcement flags.
         """
-        peer_is_whitelisted = peer_id in self.protocol.node.peers_whitelist
-        # never block whitelisted peers
-        if peer_is_whitelisted:
-            return False
-
-        # when ENABLE_PEER_WHITELIST is set, we check if we're on sync-v1 to block non-whitelisted peers
-        if self._settings.ENABLE_PEER_WHITELIST:
-            assert self.protocol.sync_version is not None
-            if not peer_is_whitelisted:
-                if self.protocol.sync_version.is_v1():
-                    return True
-                elif self._settings.USE_PEER_WHITELIST_ON_SYNC_V2:
-                    return True
-
-        # otherwise we block non-whitelisted peers when on "whitelist-only mode"
-        if self.protocol.connections is not None:
-            protocol_is_whitelist_only = self.protocol.connections.whitelist_only
-            if protocol_is_whitelist_only and not peer_is_whitelisted:
-                return True
-
-        # default is not blocking, this will be sync-v2 peers not on whitelist when not on whitelist-only mode
-        return False
+        assert self.protocol.connections is not None
+        return not self.protocol.connections.whitelist.is_connection_allowed(peer_id)

--- a/hathor/p2p/utils.py
+++ b/hathor/p2p/utils.py
@@ -14,6 +14,7 @@
 
 import re
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from typing import Any, Optional
 
 import requests
@@ -24,6 +25,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.x509 import Certificate
 from cryptography.x509.oid import NameOID
+from structlog import get_logger
 from twisted.internet.interfaces import IAddress
 
 from hathor.conf.get_settings import get_global_settings
@@ -33,6 +35,10 @@ from hathor.p2p.peer_discovery import DNSPeerDiscovery
 from hathor.p2p.peer_endpoint import PeerEndpoint
 from hathor.p2p.peer_id import PeerId
 from hathor.transaction.genesis import get_representation_for_all_genesis
+
+logger = get_logger()
+
+WHITELIST_HEADER = 'hathor-whitelist'
 
 
 def discover_hostname(timeout: float | None = None) -> Optional[str]:
@@ -130,39 +136,91 @@ def generate_certificate(private_key: RSAPrivateKey, ca_file: str, ca_pkey_file:
     return certificate
 
 
+class WhitelistPolicy(StrEnum):
+    """Policy types declared in the whitelist content.
+
+    Values are case-insensitive when parsed from the file.
+    """
+    ALLOW_ALL = 'allow-all'
+    ONLY_WHITELISTED_PEERS = 'only-whitelisted-peers'
+
+
+def _pop_header(text: str, expected: str) -> list[str]:
+    """Validate the file header and return the remaining lines."""
+    lines = text.splitlines()
+    if not lines or lines.pop(0) != expected:
+        raise ValueError('invalid header')
+    return lines
+
+
 def parse_file(text: str, *, header: Optional[str] = None) -> list[str]:
     """Parses a list of strings."""
     if header is None:
-        header = 'hathor-whitelist'
-    lines = text.splitlines()
-    _header = lines.pop(0)
-    if _header != header:
-        raise ValueError('invalid header')
+        header = WHITELIST_HEADER
+    lines = _pop_header(text, header)
     stripped_lines = (line.strip() for line in lines)
     nonblank_lines = filter(lambda line: line and not line.startswith('#'), stripped_lines)
     return list(nonblank_lines)
 
 
-def parse_whitelist(text: str, *, header: Optional[str] = None) -> set[PeerId]:
-    """ Parses the list of whitelist peer ids
+def parse_whitelist(text: str) -> tuple[set[PeerId], WhitelistPolicy]:
+    """Parses the whitelist content and returns peers and active policy.
 
-    Example:
+    The optional ``# policy: <value>`` directive MUST appear before any
+    peer-ID line. It is written as a commented line so older parsers (which
+    strip ``#`` lines) remain compatible. If absent, the policy defaults to
+    ``ONLY_WHITELISTED_PEERS``. ``ALLOW_ALL`` requires an empty peer list.
 
-    parse_whitelist('''hathor-whitelist
-# node1
- 2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367
+    Malformed peer IDs are logged and skipped so a single bad line does not
+    abort the whitelist refresh.
 
-2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367
+    >>> peers, policy = parse_whitelist(
+    ...     'hathor-whitelist\\n'
+    ...     '# node1\\n'
+    ...     ' 2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367\\n'
+    ... )
+    >>> [str(p) for p in peers]
+    ['2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367']
+    >>> policy == WhitelistPolicy.ONLY_WHITELISTED_PEERS
+    True
 
-# node3
-G2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367
-2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367
-''')
-    {'2ffdfbbfd6d869a0742cff2b054af1cf364ae4298660c0e42fa8b00a66a30367'}
-
+    >>> parse_whitelist('hathor-whitelist\\n# policy: allow-all\\n')
+    (set(), <WhitelistPolicy.ALLOW_ALL: 'allow-all'>)
     """
-    lines = parse_file(text, header=header)
-    return {PeerId(line.split()[0]) for line in lines}
+    lines = _pop_header(text, WHITELIST_HEADER)
+
+    policy = WhitelistPolicy.ONLY_WHITELISTED_PEERS
+    policy_seen = False
+    peers: set[PeerId] = set()
+
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith('#'):
+            comment = line[1:].strip()
+            if comment.lower().startswith('policy:'):
+                if peers:
+                    raise ValueError('policy directive must appear before any peer ID')
+                if policy_seen:
+                    raise ValueError('duplicate policy directive')
+                value = comment.split(':', 1)[1].strip().lower()
+                try:
+                    policy = WhitelistPolicy(value)
+                except ValueError:
+                    raise ValueError(f'invalid whitelist policy: {value}')
+                policy_seen = True
+            continue
+        token = line.split()[0]
+        try:
+            peers.add(PeerId(token))
+        except (ValueError, TypeError) as exc:
+            logger.warn('skipping malformed peer ID in whitelist', peer=token, error=str(exc))
+
+    if policy == WhitelistPolicy.ALLOW_ALL and peers:
+        raise ValueError('peer list must be empty when policy is allow-all')
+
+    return peers, policy
 
 
 def format_address(addr: IAddress) -> str:

--- a/hathor/p2p/whitelist_manager.py
+++ b/hathor/p2p/whitelist_manager.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Callable, Optional
+
+from structlog import get_logger
+from twisted.internet.defer import Deferred
+from twisted.internet.task import LoopingCall
+from twisted.web.client import Agent
+
+from hathor.conf.settings import HathorSettings
+from hathor.p2p.peer_id import PeerId
+from hathor.p2p.utils import WhitelistPolicy, parse_whitelist
+from hathor.reactor import ReactorProtocol as Reactor
+
+logger = get_logger()
+
+# The timeout in seconds for the whitelist GET request
+WHITELIST_REQUEST_TIMEOUT = 45
+
+
+class WhitelistManager:
+    """Owns the peer whitelist: enabled flag, active policy, peer list, and
+    the periodic refresh loop. Centralizes the connection-admission decision
+    so that other modules only consult `is_connection_allowed`.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: HathorSettings,
+        reactor: Reactor,
+        drop_connection: Callable[[PeerId], None],
+    ) -> None:
+        self.log = logger.new()
+        self._settings = settings
+        self._reactor = reactor
+        self._drop_connection = drop_connection
+
+        # When True, the protocol-level whitelist mechanism is active and the manager
+        # periodically fetches and applies updates from WHITELIST_URL.
+        self.enabled = settings.ENABLE_PEER_WHITELIST
+
+        self.policy: WhitelistPolicy = WhitelistPolicy.ONLY_WHITELISTED_PEERS
+        self.peers: set[PeerId] = set()
+
+        self._http_agent: Optional[Agent] = None
+        self._loop: Optional[LoopingCall] = None
+        if self.enabled:
+            self._loop = LoopingCall(self.update)
+            self._loop.clock = reactor
+
+    def start(self) -> None:
+        """Start the periodic refresh loop. No-op when the whitelist is disabled."""
+        if not self.enabled:
+            return
+        self._http_agent = Agent(self._reactor)
+        self._start_loop()
+
+    def _start_loop(self) -> None:
+        assert self._loop is not None
+        d = self._loop.start(30)
+        d.addErrback(self._handle_loop_err)
+
+    def _handle_loop_err(self, *args: Any, **kwargs: Any) -> None:
+        """Called when the LoopingCall stops due to an exception. Restart it."""
+        self.log.error('whitelist reconnect had an exception. Start looping call again.',
+                       args=args, kwargs=kwargs)
+        self._reactor.callLater(30, self._start_loop)
+
+    def add_peer(self, peer_id: PeerId) -> None:
+        assert self.enabled
+        if peer_id in self.peers:
+            self.log.info('peer already in whitelist', peer_id=peer_id)
+            return
+        self.peers.add(peer_id)
+
+    def remove_peer_and_disconnect(self, peer_id: PeerId) -> None:
+        assert self.enabled
+        if peer_id not in self.peers:
+            return
+        self.peers.remove(peer_id)
+        self._drop_connection(peer_id)
+
+    def is_connection_allowed(self, peer_id: PeerId) -> bool:
+        """Return True if the peer is allowed to connect under the current policy."""
+        if peer_id in self.peers:
+            return True
+        if self.policy == WhitelistPolicy.ALLOW_ALL:
+            return True
+        if self.enabled:
+            return False
+        return True
+
+    def update(self) -> Deferred[None]:
+        from twisted.web.client import readBody
+        from twisted.web.http_headers import Headers
+        assert self._settings.WHITELIST_URL is not None
+        assert self._http_agent is not None
+        self.log.info('update whitelist')
+        d = self._http_agent.request(
+            b'GET',
+            self._settings.WHITELIST_URL.encode(),
+            Headers({'User-Agent': ['hathor-core']}),
+            None)
+        d.addCallback(readBody)
+        d.addTimeout(WHITELIST_REQUEST_TIMEOUT, self._reactor)
+        d.addCallback(self._update_cb)
+        d.addErrback(self._update_err)
+        return d
+
+    def _update_err(self, *args: Any, **kwargs: Any) -> None:
+        self.log.error('update whitelist failed', args=args, kwargs=kwargs)
+
+    def _update_cb(self, body: bytes) -> None:
+        self.log.info('update whitelist got response')
+        try:
+            new_whitelist, new_policy = parse_whitelist(body.decode())
+        except Exception:
+            self.log.exception('failed to parse whitelist')
+            return
+        if new_policy != self.policy:
+            self.log.info('whitelist policy changed', old=self.policy, new=new_policy)
+            self.policy = new_policy
+        to_add = new_whitelist - self.peers
+        to_remove = self.peers - new_whitelist
+        if to_add:
+            self.log.info('add new peers to whitelist', peers=to_add)
+        if to_remove:
+            self.log.info('remove peers from whitelist', peers=to_remove)
+        for peer_id in to_add:
+            self.add_peer(peer_id)
+        for peer_id in to_remove:
+            self.remove_peer_and_disconnect(peer_id)

--- a/hathor_cli/builder.py
+++ b/hathor_cli/builder.py
@@ -316,7 +316,6 @@ class CliBuilder:
             my_peer=peer,
             pubsub=pubsub,
             ssl=True,
-            whitelist_only=False,
             rng=Random(),
             enable_ipv6=self._args.x_enable_ipv6,
             disable_ipv4=self._args.x_disable_ipv4,

--- a/hathor_tests/p2p/test_bootstrap.py
+++ b/hathor_tests/p2p/test_bootstrap.py
@@ -57,7 +57,6 @@ class BootstrapTestCase(unittest.TestCase):
             pubsub,
             True,
             self.rng,
-            True,
             enable_ipv6=False,
             disable_ipv4=False
         )
@@ -92,7 +91,6 @@ class BootstrapTestCase(unittest.TestCase):
             pubsub,
             True,
             self.rng,
-            True,
             enable_ipv6=False,
             disable_ipv4=False
         )

--- a/hathor_tests/p2p/test_whitelist.py
+++ b/hathor_tests/p2p/test_whitelist.py
@@ -1,15 +1,94 @@
 from unittest.mock import Mock, patch
 
+import pytest
 from twisted.internet.defer import Deferred, TimeoutError
 from twisted.python.failure import Failure
 from twisted.web.client import Agent
 
 from hathor.conf.get_settings import get_global_settings
 from hathor.manager import HathorManager
-from hathor.p2p.manager import WHITELIST_REQUEST_TIMEOUT
+from hathor.p2p.peer_id import PeerId
 from hathor.p2p.sync_version import SyncVersion
+from hathor.p2p.utils import WhitelistPolicy, parse_whitelist
+from hathor.p2p.whitelist_manager import WHITELIST_REQUEST_TIMEOUT
 from hathor.simulator import FakeConnection
 from hathor_tests import unittest
+
+PEER_A_HEX = '00' * 32
+PEER_B_HEX = '11' * 32
+PEER_A = PeerId(PEER_A_HEX)
+PEER_B = PeerId(PEER_B_HEX)
+
+
+def test_parse_whitelist_default_policy() -> None:
+    text = f'hathor-whitelist\n{PEER_A_HEX}\n'
+    peers, policy = parse_whitelist(text)
+    assert peers == {PEER_A}
+    assert policy == WhitelistPolicy.ONLY_WHITELISTED_PEERS
+
+
+def test_parse_whitelist_allow_all_policy() -> None:
+    text = 'hathor-whitelist\n# policy: allow-all\n'
+    peers, policy = parse_whitelist(text)
+    assert peers == set()
+    assert policy == WhitelistPolicy.ALLOW_ALL
+
+
+def test_parse_whitelist_only_whitelisted_policy_with_peers() -> None:
+    text = f'hathor-whitelist\n# policy: only-whitelisted-peers\n{PEER_A_HEX}\n{PEER_B_HEX}\n'
+    peers, policy = parse_whitelist(text)
+    assert peers == {PEER_A, PEER_B}
+    assert policy == WhitelistPolicy.ONLY_WHITELISTED_PEERS
+
+
+def test_parse_whitelist_policy_is_case_insensitive() -> None:
+    text = 'hathor-whitelist\n# Policy: ALLOW-ALL\n'
+    peers, policy = parse_whitelist(text)
+    assert peers == set()
+    assert policy == WhitelistPolicy.ALLOW_ALL
+
+
+def test_parse_whitelist_policy_after_peer_id_is_rejected() -> None:
+    text = f'hathor-whitelist\n{PEER_A_HEX}\n# policy: allow-all\n'
+    with pytest.raises(ValueError, match='before any peer ID'):
+        parse_whitelist(text)
+
+
+def test_parse_whitelist_duplicate_policy_is_rejected() -> None:
+    text = 'hathor-whitelist\n# policy: allow-all\n# policy: only-whitelisted-peers\n'
+    with pytest.raises(ValueError, match='duplicate policy directive'):
+        parse_whitelist(text)
+
+
+def test_parse_whitelist_invalid_policy_value_is_rejected() -> None:
+    text = 'hathor-whitelist\n# policy: bogus\n'
+    with pytest.raises(ValueError, match='invalid whitelist policy'):
+        parse_whitelist(text)
+
+
+def test_parse_whitelist_invalid_header_is_rejected() -> None:
+    with pytest.raises(ValueError, match='invalid header'):
+        parse_whitelist('not-the-header\n')
+
+
+def test_parse_whitelist_unrelated_comments_do_not_set_policy() -> None:
+    text = f'hathor-whitelist\n# node A\n{PEER_A_HEX}\n'
+    peers, policy = parse_whitelist(text)
+    assert peers == {PEER_A}
+    assert policy == WhitelistPolicy.ONLY_WHITELISTED_PEERS
+
+
+def test_parse_whitelist_allow_all_with_peers_is_rejected() -> None:
+    text = f'hathor-whitelist\n# policy: allow-all\n{PEER_A_HEX}\n'
+    with pytest.raises(ValueError, match='peer list must be empty'):
+        parse_whitelist(text)
+
+
+def test_parse_whitelist_skips_malformed_peer_ids() -> None:
+    text = f'hathor-whitelist\n{PEER_A_HEX}\nnot-a-valid-peer-id\n{PEER_B_HEX}\n'
+    peers, policy = parse_whitelist(text)
+    assert peers == {PEER_A, PEER_B}
+    assert policy == WhitelistPolicy.ONLY_WHITELISTED_PEERS
 
 
 class WhitelistTestCase(unittest.TestCase):
@@ -45,7 +124,7 @@ class WhitelistTestCase(unittest.TestCase):
         manager2 = self.create_peer(network)
         self.assertEqual(manager2.connections.get_enabled_sync_versions(), {SyncVersion.V2})
 
-        manager1.peers_whitelist.append(manager2.my_peer.id)
+        manager1.connections.whitelist.add_peer(manager2.my_peer.id)
 
         conn = FakeConnection(manager1, manager2)
         self.assertFalse(conn.tr1.disconnecting)
@@ -59,18 +138,16 @@ class WhitelistTestCase(unittest.TestCase):
         self.assertFalse(conn.tr1.disconnecting)
         self.assertTrue(conn.tr2.disconnecting)
 
-    def test_whitelist_yes_yes(self) -> None:
+    def test_whitelist_allow_all_policy_admits_unlisted_peers(self) -> None:
         network = 'testnet'
         self._settings = get_global_settings().model_copy(update={'ENABLE_PEER_WHITELIST': True})
 
         manager1 = self.create_peer(network)
-        self.assertEqual(manager1.connections.get_enabled_sync_versions(), {SyncVersion.V2})
-
         manager2 = self.create_peer(network)
-        self.assertEqual(manager2.connections.get_enabled_sync_versions(), {SyncVersion.V2})
 
-        manager1.peers_whitelist.append(manager2.my_peer.id)
-        manager2.peers_whitelist.append(manager1.my_peer.id)
+        # Neither peer is in the other's whitelist, but both have ALLOW_ALL active.
+        manager1.connections.whitelist.policy = WhitelistPolicy.ALLOW_ALL
+        manager2.connections.whitelist.policy = WhitelistPolicy.ALLOW_ALL
 
         conn = FakeConnection(manager1, manager2)
         self.assertFalse(conn.tr1.disconnecting)
@@ -84,60 +161,95 @@ class WhitelistTestCase(unittest.TestCase):
         self.assertFalse(conn.tr1.disconnecting)
         self.assertFalse(conn.tr2.disconnecting)
 
-    def test_update_whitelist(self) -> None:
+    def test_update_cb_updates_policy(self) -> None:
         network = 'testnet'
         manager: HathorManager = self.create_peer(network)
-        connections_manager = manager.connections
+        whitelist = manager.connections.whitelist
+
+        body = b'hathor-whitelist\n# policy: allow-all\n'
+        whitelist._update_cb(body)
+
+        assert whitelist.policy == WhitelistPolicy.ALLOW_ALL
+
+    def test_whitelist_yes_yes(self) -> None:
+        network = 'testnet'
+        self._settings = get_global_settings().model_copy(update={'ENABLE_PEER_WHITELIST': True})
+
+        manager1 = self.create_peer(network)
+        self.assertEqual(manager1.connections.get_enabled_sync_versions(), {SyncVersion.V2})
+
+        manager2 = self.create_peer(network)
+        self.assertEqual(manager2.connections.get_enabled_sync_versions(), {SyncVersion.V2})
+
+        manager1.connections.whitelist.add_peer(manager2.my_peer.id)
+        manager2.connections.whitelist.add_peer(manager1.my_peer.id)
+
+        conn = FakeConnection(manager1, manager2)
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertFalse(conn.tr2.disconnecting)
+
+        # Run the p2p protocol.
+        for _ in range(100):
+            conn.run_one_step(debug=True)
+            self.clock.advance(0.1)
+
+        self.assertFalse(conn.tr1.disconnecting)
+        self.assertFalse(conn.tr2.disconnecting)
+
+    def test_update(self) -> None:
+        network = 'testnet'
+        manager: HathorManager = self.create_peer(network)
+        whitelist = manager.connections.whitelist
 
         settings_mock = Mock()
         settings_mock.WHITELIST_URL = 'some_url'
-        connections_manager._settings = settings_mock
+        whitelist._settings = settings_mock
 
         agent_mock = Mock(spec_set=Agent)
         agent_mock.request = Mock()
-        connections_manager._http_agent = agent_mock
+        whitelist._http_agent = agent_mock
 
         with (
-            patch.object(connections_manager, '_update_whitelist_cb') as _update_whitelist_cb_mock,
-            patch.object(connections_manager, '_update_whitelist_err') as _update_whitelist_err_mock,
+            patch.object(whitelist, '_update_cb') as _update_cb_mock,
+            patch.object(whitelist, '_update_err') as _update_err_mock,
             patch('twisted.web.client.readBody') as read_body_mock
         ):
             # Test success
             agent_mock.request.return_value = Deferred()
             read_body_mock.return_value = b'body'
-            d = connections_manager.update_whitelist()
+            d = whitelist.update()
             d.callback(None)
 
             read_body_mock.assert_called_once_with(None)
-            _update_whitelist_cb_mock.assert_called_once_with(b'body')
-            _update_whitelist_err_mock.assert_not_called()
+            _update_cb_mock.assert_called_once_with(b'body')
+            _update_err_mock.assert_not_called()
 
             read_body_mock.reset_mock()
-            _update_whitelist_cb_mock.reset_mock()
-            _update_whitelist_err_mock.reset_mock()
+            _update_cb_mock.reset_mock()
+            _update_err_mock.reset_mock()
 
             # Test request error
             agent_mock.request.return_value = Deferred()
-            d = connections_manager.update_whitelist()
+            d = whitelist.update()
             error = Failure('some_error')
             d.errback(error)
 
             read_body_mock.assert_not_called()
-            _update_whitelist_cb_mock.assert_not_called()
-            _update_whitelist_err_mock.assert_called_once_with(error)
+            _update_cb_mock.assert_not_called()
+            _update_err_mock.assert_called_once_with(error)
 
             read_body_mock.reset_mock()
-            _update_whitelist_cb_mock.reset_mock()
-            _update_whitelist_err_mock.reset_mock()
+            _update_cb_mock.reset_mock()
+            _update_err_mock.reset_mock()
 
             # Test timeout
             agent_mock.request.return_value = Deferred()
             read_body_mock.return_value = b'body'
-            connections_manager.update_whitelist()
+            whitelist.update()
 
             self.clock.advance(WHITELIST_REQUEST_TIMEOUT + 1)
 
             read_body_mock.assert_not_called()
-            _update_whitelist_cb_mock.assert_not_called()
-            _update_whitelist_err_mock.assert_called_once()
-            assert isinstance(_update_whitelist_err_mock.call_args.args[0].value, TimeoutError)
+            _update_cb_mock.assert_not_called()
+            _update_err_mock.assert_called_once()
+            assert isinstance(_update_err_mock.call_args.args[0].value, TimeoutError)

--- a/hathor_tests/resources/p2p/test_status.py
+++ b/hathor_tests/resources/p2p/test_status.py
@@ -15,8 +15,10 @@ class StatusTest(_BaseResourceTest._ResourceTest):
         self.web = StubSite(StatusResource(self.manager))
         address1 = IPv4Address('TCP', '192.168.1.1', 54321)
         self.manager.connections.my_peer.info.entrypoints.add(PeerAddress.from_address(address1))
-        self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
-        self.manager.peers_whitelist.append(self.get_random_peer_from_pool().id)
+        # add_peer asserts enabled, so populate the set directly to keep this fixture working
+        # when ENABLE_PEER_WHITELIST is False.
+        self.manager.connections.whitelist.peers.add(self.get_random_peer_from_pool().id)
+        self.manager.connections.whitelist.peers.add(self.get_random_peer_from_pool().id)
 
         self.manager2 = self.create_peer('testnet')
         address2 = IPv4Address('TCP', '192.168.1.1', 54322)

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -111,10 +111,6 @@ class HathorSettings(BaseModel):
     # enable peer whitelist
     ENABLE_PEER_WHITELIST: bool = False
 
-    # weather to use the whitelist with sync-v2 peers, does not affect whether the whitelist is enabled or not, it will
-    # always be enabled for sync-v1 if it is enabled
-    USE_PEER_WHITELIST_ON_SYNC_V2: bool = True
-
     # Genesis pre-mined tokens
     GENESIS_TOKEN_UNITS: int = 1 * (10 ** 9)  # 1B
 


### PR DESCRIPTION
### Motivation

The peer-whitelist mechanism on `master` mixes operational state (peer list, fetch loop) with admission policy and pulls those concerns across `ConnectionsManager`, `HathorManager`, and `PeerIdState`. There is no way for the *whitelist content itself* to declare a policy, so operators cannot opt the network into an `allow-all` mode at runtime without a code/config change.

This PR introduces:

1. A `# policy: <value>` directive in the whitelist content. It is written as a comment so older parsers ignore it. Accepted values: `only-whitelisted-peers` (default; preserves current behavior) and `allow-all` (admits peers regardless of list membership). The directive must appear before any peer ID; duplicates and unknown values are rejected (case-insensitive).
2. A new `WhitelistManager` (`hathor/p2p/whitelist_manager.py`) that owns the enabled flag, the active policy, the peer list, the periodic refresh loop, and the connection-admission decision. It is loose-coupled to the connections layer via a `drop_connection: Callable[[PeerId], None]` predicate received at construction.

The admission rule is reduced to: peer in the list → allow; `allow-all` policy → allow; otherwise `enabled or whitelist_only` → block. The sync-v1 special case and the `USE_PEER_WHITELIST_ON_SYNC_V2` setting (also removed from `hathorlib/conf/settings.py`) are gone.

`ConnectionsManager` loses the old fields/methods (`whitelist_only`, `whitelist_policy`, `update_whitelist`, `_update_whitelist_*`, `wl_reconnect`, the whitelist HTTP agent). `HathorManager` loses `peers_whitelist`, `add_peer_to_whitelist`, and `remove_peer_from_whitelist_and_disconnect`. The status resource and tests read the peer list off `manager.connections.whitelist`.

### Acceptance Criteria

- [x] Whitelist parser recognizes the optional `# policy: <value>` directive and validates it (precedence, no duplicates, known values, case-insensitive).
- [x] `allow-all` admits peers that are not on the list; `only-whitelisted-peers` preserves the existing behavior.
- [x] `WhitelistManager` owns the enabled flag, active policy, peer list, refresh loop, and admission decision; `ConnectionsManager` and `HathorManager` no longer host whitelist state or methods.
- [x] `PeerIdState._should_block_peer` is a thin delegation to `whitelist.is_connection_allowed(peer_id)`.
- [x] `USE_PEER_WHITELIST_ON_SYNC_V2` and the sync-v1 branch are removed.
- [x] Unit tests cover parser cases (default, allow-all, only-whitelisted, case-insensitive, policy-after-peer rejection, duplicate rejection, invalid value, invalid header, unrelated comments) and policy enforcement (`allow-all` admits unlisted peers; `_update_cb` updates the active policy).
- [x] `pytest hathor_tests/{p2p,resources/p2p,others}` passes (205/205).
- [x] `mypy` and `ruff check` clean on changed files.
- [ ] CI green on the PR.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged.