### PR TITLE
fix(nano): remove non-Exception subclasses

### DIFF
--- a/hathor/nanocontracts/custom_builtins.py
+++ b/hathor/nanocontracts/custom_builtins.py
@@ -16,7 +16,6 @@
 from hathorlib.nanocontracts.custom_builtins import (  # noqa: F401
     AST_NAME_BLACKLIST,
     DISABLED_BUILTINS,
-    EXEC_BUILTINS,
     WRAPPER_ASSIGNMENTS,
     WRAPPER_UPDATES,
     ImportFunction,
@@ -25,4 +24,5 @@ from hathorlib.nanocontracts.custom_builtins import (  # noqa: F401
     custom_range,
     enumerate,
     filter,
+    get_exec_builtins,
 )

--- a/hathor/verification/on_chain_blueprint_verifier.py
+++ b/hathor/verification/on_chain_blueprint_verifier.py
@@ -233,7 +233,7 @@ class OnChainBlueprintVerifier:
             try:
                 rule(tx)
             except SyntaxError as e:
-                raise OCBInvalidScript('forbidden syntax') from e
+                raise OCBInvalidScript(f'forbidden syntax: {e}') from e
 
     def _verify_python_script(self, tx: OnChainBlueprint) -> None:
         """Verify that the script can be parsed at all."""

--- a/hathor_tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
+++ b/hathor_tests/nanocontracts/on_chain_blueprints/test_script_restrictions.py
@@ -57,7 +57,7 @@ class OnChainBlueprintScriptTestCase(unittest.TestCase):
             self.manager.vertex_handler.on_new_relayed_vertex(blueprint)
         assert isinstance(cm.exception.__cause__, OCBInvalidScript)
         assert isinstance(cm.exception.__cause__.__cause__, SyntaxError)
-        assert cm.exception.args[0] == 'full validation failed: forbidden syntax'
+        assert 'full validation failed: forbidden syntax' in cm.exception.args[0]
         # The first error is always the one that makes the tx fail
         assert cm.exception.__cause__.__cause__.args[0] == syntax_errors[0]
 

--- a/hathor_tests/nanocontracts/test_base_exception_escape.py
+++ b/hathor_tests/nanocontracts/test_base_exception_escape.py
@@ -14,13 +14,14 @@
 
 import pytest
 
+from hathor.exception import InvalidNewTransaction
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 
 class TestBaseExceptionEscape(BlueprintTestCase):
-    def _test_exception_escape(self, method: str) -> None:
+    def _test_exception_escape(self, exc_name: str) -> None:
         dag_builder = TestDAGBuilder.from_manager(self.manager)
         private_key = unittest.OCB_TEST_PRIVKEY.hex()
         password = unittest.OCB_TEST_PASSWORD.hex()
@@ -36,7 +37,7 @@ class TestBaseExceptionEscape(BlueprintTestCase):
             nc_init.nc_method = initialize()
 
             nc_call.nc_id = nc_init
-            nc_call.nc_method = {method}()
+            nc_call.nc_method = raise_exc()
 
             ocb <-- b11
             b11 < nc_init
@@ -52,41 +53,41 @@ class TestBlueprint(Blueprint):
         pass
 
     @public
-    def raise_system_exit(self, ctx: Context) -> None:
-        raise SystemExit
-
-    @public
-    def raise_keyboard_interrupt(self, ctx: Context) -> None:
-        raise KeyboardInterrupt
-
-    @public
-    def raise_base_exception(self, ctx: Context) -> None:
-        raise BaseException
-
-    @public
-    def raise_generator_exit(self, ctx: Context) -> None:
-        raise GeneratorExit
+    def raise_exc(self, ctx: Context) -> None:
+        raise {exc_name}
             ```
         """)
 
         artifacts.propagate_with(self.manager)
 
     def test_system_exit(self) -> None:
-        # FIXME: Shouldn't crash!
-        with pytest.raises(SystemExit, match='-1'):
-            self._test_exception_escape('raise_system_exit')
+        with pytest.raises(Exception) as e:
+            self._test_exception_escape('SystemExit')
+        assert isinstance(e.value.__cause__, InvalidNewTransaction)
+        assert e.value.__cause__.args[0] == (
+            'full validation failed: forbidden syntax: Usage or reference to SystemExit is not allowed.'
+        )
 
     def test_keyboard_interrupt(self) -> None:
-        # FIXME: Shouldn't crash!
-        with pytest.raises(SystemExit, match='-1'):
-            self._test_exception_escape('raise_keyboard_interrupt')
+        with pytest.raises(Exception) as e:
+            self._test_exception_escape('KeyboardInterrupt')
+        assert isinstance(e.value.__cause__, InvalidNewTransaction)
+        assert e.value.__cause__.args[0] == (
+            'full validation failed: forbidden syntax: Usage or reference to KeyboardInterrupt is not allowed.'
+        )
 
     def test_base_exception(self) -> None:
-        # FIXME: Shouldn't crash!
-        with pytest.raises(SystemExit, match='-1'):
-            self._test_exception_escape('raise_base_exception')
+        with pytest.raises(Exception) as e:
+            self._test_exception_escape('BaseException')
+        assert isinstance(e.value.__cause__, InvalidNewTransaction)
+        assert e.value.__cause__.args[0] == (
+            'full validation failed: forbidden syntax: Usage or reference to BaseException is not allowed.'
+        )
 
     def test_generator_exit(self) -> None:
-        # FIXME: Shouldn't crash!
-        with pytest.raises(SystemExit, match='-1'):
-            self._test_exception_escape('raise_generator_exit')
+        with pytest.raises(Exception) as e:
+            self._test_exception_escape('GeneratorExit')
+        assert isinstance(e.value.__cause__, InvalidNewTransaction)
+        assert e.value.__cause__.args[0] == (
+            'full validation failed: forbidden syntax: Usage or reference to GeneratorExit is not allowed.'
+        )

--- a/hathor_tests/nanocontracts/test_base_exception_escape.py
+++ b/hathor_tests/nanocontracts/test_base_exception_escape.py
@@ -1,0 +1,92 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+
+
+class TestBaseExceptionEscape(BlueprintTestCase):
+    def _test_exception_escape(self, method: str) -> None:
+        dag_builder = TestDAGBuilder.from_manager(self.manager)
+        private_key = unittest.OCB_TEST_PRIVKEY.hex()
+        password = unittest.OCB_TEST_PASSWORD.hex()
+
+        artifacts = dag_builder.build_from_str(f"""
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            ocb.ocb_private_key = "{private_key}"
+            ocb.ocb_password = "{password}"
+
+            nc_init.nc_id = ocb
+            nc_init.nc_method = initialize()
+
+            nc_call.nc_id = nc_init
+            nc_call.nc_method = {method}()
+
+            ocb <-- b11
+            b11 < nc_init
+            nc_init <-- nc_call <-- b12
+
+            ocb.ocb_code = ```
+from hathor import Blueprint, Context, export, public
+
+@export
+class TestBlueprint(Blueprint):
+    @public
+    def initialize(self, ctx: Context) -> None:
+        pass
+
+    @public
+    def raise_system_exit(self, ctx: Context) -> None:
+        raise SystemExit
+
+    @public
+    def raise_keyboard_interrupt(self, ctx: Context) -> None:
+        raise KeyboardInterrupt
+
+    @public
+    def raise_base_exception(self, ctx: Context) -> None:
+        raise BaseException
+
+    @public
+    def raise_generator_exit(self, ctx: Context) -> None:
+        raise GeneratorExit
+            ```
+        """)
+
+        artifacts.propagate_with(self.manager)
+
+    def test_system_exit(self) -> None:
+        # FIXME: Shouldn't crash!
+        with pytest.raises(SystemExit, match='-1'):
+            self._test_exception_escape('raise_system_exit')
+
+    def test_keyboard_interrupt(self) -> None:
+        # FIXME: Shouldn't crash!
+        with pytest.raises(SystemExit, match='-1'):
+            self._test_exception_escape('raise_keyboard_interrupt')
+
+    def test_base_exception(self) -> None:
+        # FIXME: Shouldn't crash!
+        with pytest.raises(SystemExit, match='-1'):
+            self._test_exception_escape('raise_base_exception')
+
+    def test_generator_exit(self) -> None:
+        # FIXME: Shouldn't crash!
+        with pytest.raises(SystemExit, match='-1'):
+            self._test_exception_escape('raise_generator_exit')

--- a/hathor_tests/nanocontracts/test_custom_import.py
+++ b/hathor_tests/nanocontracts/test_custom_import.py
@@ -17,7 +17,7 @@ from io import StringIO
 from textwrap import dedent
 from unittest.mock import ANY, Mock, call, patch
 
-from hathor.nanocontracts.custom_builtins import EXEC_BUILTINS
+from hathor.nanocontracts.custom_builtins import get_exec_builtins
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 
@@ -38,8 +38,9 @@ class TestCustomImport(BlueprintTestCase):
         '''
 
         # Wrap our custom builtin so we can spy its calls
-        wrapped_import_function = Mock(wraps=EXEC_BUILTINS['__import__'])
-        EXEC_BUILTINS['__import__'] = wrapped_import_function
+        exec_builtins = get_exec_builtins()
+        wrapped_import_function = Mock(wraps=exec_builtins['__import__'])
+        exec_builtins['__import__'] = wrapped_import_function
 
         # Before being used, the function is uncalled
         wrapped_import_function.assert_not_called()

--- a/hathor_tests/nanocontracts/test_exposed_properties.py
+++ b/hathor_tests/nanocontracts/test_exposed_properties.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from hathor.nanocontracts import Blueprint, Context, public
 from hathor.nanocontracts.allowed_imports import ALLOWED_IMPORTS
-from hathor.nanocontracts.custom_builtins import EXEC_BUILTINS
+from hathor.nanocontracts.custom_builtins import get_exec_builtins
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 MAX_DEPTH = 20
@@ -259,14 +259,15 @@ class MyBlueprint(Blueprint):
         mutable_props.extend(search_writeable_properties(MyBlueprint, 'MyBlueprint'))
         mutable_props.extend(search_writeable_properties(self, 'self'))
         mutable_props.extend(search_writeable_properties(ctx, 'ctx'))
-        custom_import = EXEC_BUILTINS['__import__']
+        exec_builtins = get_exec_builtins()
+        custom_import = exec_builtins['__import__']
         for module_name, import_names in ALLOWED_IMPORTS.items():
             module = custom_import(module_name, fromlist=list(import_names))
             for import_name in import_names:
                 obj = getattr(module, import_name)
                 obj_name = f'{module_name}.{import_name}'
                 mutable_props.extend(search_writeable_properties(obj, obj_name))
-        for builtin_name, builtin_obj in EXEC_BUILTINS.items():
+        for builtin_name, builtin_obj in exec_builtins.items():
             if should_skip_attr(builtin_name):
                 continue
             mutable_props.extend(search_writeable_properties(builtin_obj, builtin_name))

--- a/hathorlib/hathorlib/nanocontracts/custom_builtins.py
+++ b/hathorlib/hathorlib/nanocontracts/custom_builtins.py
@@ -461,6 +461,12 @@ DISABLED_BUILTINS: frozenset[str] = frozenset({
     # This is useless for Blueprints.
     'complex',
 
+    # non-Exception subclasses are not caught by the Nano runtime and bubble up, crashing the full node.
+    'BaseException',
+    'GeneratorExit',
+    'KeyboardInterrupt',
+    'SystemExit',
+
     # =====================================
     # These are not included in the list because they're not callables, so we should generate
     # disabled functions for them. Also, some of them shouldn't be blocked in the AST.
@@ -489,345 +495,357 @@ AST_NAME_BLACKLIST: frozenset[str] = frozenset({
 })
 
 
-# list of allowed builtins during execution of an on-chain blueprint code
-EXEC_BUILTINS: dict[str, Any] = {
-    # XXX: check https://github.com/python/mypy/blob/master/mypy/typeshed/stdlib/builtins.pyi for the full typing
-    # XXX: check https://github.com/python/cpython/blob/main/Python/bltinmodule.c for the implementation
+_EXEC_BUILTINS: dict[str, Any] | None = None
 
-    # XXX: required to declare classes
-    # O(1)
-    # (func: Callable[[], CellType | Any], name: str, /, *bases: Any, metaclass: Any = ..., **kwds: Any) -> Any
-    '__build_class__': builtins.__build_class__,
 
-    # XXX: required to do imports
-    # XXX: will trigger the execution of the imported module
-    # (name: str, globals: Mapping[str, object] | None = None, locals: Mapping[str, object] | None = None,
-    #  fromlist: Sequence[str] = (), level: int = 0) -> types.ModuleType
-    '__import__': _generate_restricted_import_function(ALLOWED_IMPORTS),
+def get_exec_builtins() -> dict[str, Any]:
+    global _EXEC_BUILTINS
+    if _EXEC_BUILTINS is not None:
+        return _EXEC_BUILTINS
 
-    # XXX: also required to declare classes
-    # XXX: this would be '__main__' for a module that is loaded as the main entrypoint, and the module name otherwise,
-    # since the blueprint code is adhoc, we could as well expose something else, like '__blueprint__' constant
-    '__name__': BLUEPRINT_EXPORT_NAME,
+    # list of allowed builtins during execution of an on-chain blueprint code
+    _EXEC_BUILTINS = {
+        # XXX: check https://github.com/python/mypy/blob/master/mypy/typeshed/stdlib/builtins.pyi for the full typing
+        # XXX: check https://github.com/python/cpython/blob/main/Python/bltinmodule.c for the implementation
 
-    # make it always True, which is how we'll normally run anyway
-    '__debug__': True,
+        # XXX: required to declare classes
+        # O(1)
+        # (func: Callable[[], CellType | Any], name: str, /, *bases: Any, metaclass: Any = ..., **kwds: Any) -> Any
+        '__build_class__': builtins.__build_class__,
 
-    # O(1)
-    # (x: SupportsAbs[T], /) -> T
-    'abs': builtins.abs,
+        # XXX: required to do imports
+        # XXX: will trigger the execution of the imported module
+        # (name: str, globals: Mapping[str, object] | None = None, locals: Mapping[str, object] | None = None,
+        #  fromlist: Sequence[str] = (), level: int = 0) -> types.ModuleType
+        '__import__': _generate_restricted_import_function(ALLOWED_IMPORTS),
 
-    # XXX: consumes an iterable when calling
-    # O(N) for N=len(iterable)
-    # (iterable: Iterable[object], /) -> bool
-    'all': custom_all,
+        # XXX: also required to declare classes
+        # XXX: this would be '__main__' for a module that is loaded as the main entrypoint, and the module name
+        # otherwise, since the blueprint code is adhoc, we could as well expose something else, like '__blueprint__'
+        # constant
+        '__name__': BLUEPRINT_EXPORT_NAME,
 
-    # XXX: consumes an iterable when calling
-    # O(N) for N=len(iterable)
-    # (iterable: Iterable[object], /) -> bool
-    'any': custom_any,
+        # make it always True, which is how we'll normally run anyway
+        '__debug__': True,
 
-    # O(1)
-    # (number: int | SupportsIndex, /) -> str
-    'bin': builtins.bin,
+        # O(1)
+        # (x: SupportsAbs[T], /) -> T
+        'abs': builtins.abs,
 
-    # O(1)
-    # type bool(int)
-    'bool': builtins.bool,
+        # XXX: consumes an iterable when calling
+        # O(N) for N=len(iterable)
+        # (iterable: Iterable[object], /) -> bool
+        'all': custom_all,
 
-    # XXX: consumes an iterable when calling
-    # O(N) for N=len(iterable)
-    # type bytearray(MutableSequence[int])
-    'bytearray': builtins.bytearray,
+        # XXX: consumes an iterable when calling
+        # O(N) for N=len(iterable)
+        # (iterable: Iterable[object], /) -> bool
+        'any': custom_any,
 
-    # XXX: consumes an iterable when calling
-    # O(N) for N=len(iterable)
-    # type bytes(Sequence[int])
-    'bytes': builtins.bytes,
+        # O(1)
+        # (number: int | SupportsIndex, /) -> str
+        'bin': builtins.bin,
 
-    # O(1)
-    # (obj: object, /) -> bool
-    'callable': builtins.callable,
+        # O(1)
+        # type bool(int)
+        'bool': builtins.bool,
 
-    # O(1)
-    # (i: int, /) -> str
-    'chr': builtins.chr,
+        # XXX: consumes an iterable when calling
+        # O(N) for N=len(iterable)
+        # type bytearray(MutableSequence[int])
+        'bytearray': builtins.bytearray,
 
-    # O(1)
-    # decorator
-    'classmethod': builtins.classmethod,
+        # XXX: consumes an iterable when calling
+        # O(N) for N=len(iterable)
+        # type bytes(Sequence[int])
+        'bytes': builtins.bytes,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterable)
-    # type dict(MutableMapping[K, V])
-    # () -> dict
-    # (**kwargs: V) -> dict[str, V]
-    # (map: SupportsKeysAndGetItem[K, V], /) -> dict[K, V]
-    # (map: SupportsKeysAndGetItem[str, V], /, **kwargs: V) -> dict[K, V]
-    # (iterable: Iterable[tuple[K, V]], /) -> dict[K, V]
-    # (iterable: Iterable[tuple[str, V]], /, **kwargs: V) -> dict[str, V]
-    # (iterable: Iterable[list[str]], /) -> dict[str, str]
-    # (iterable: Iterable[list[bytes]], /) -> dict[bytes, bytes]
-    'dict': builtins.dict,
+        # O(1)
+        # (obj: object, /) -> bool
+        'callable': builtins.callable,
 
-    # O(1)
-    # (x: SupportsDivMod[T, R], y: T, /) -> R
-    # (x: T, y: SupportsRDivMod[T, R], /) -> R
-    'divmod': builtins.divmod,
+        # O(1)
+        # (i: int, /) -> str
+        'chr': builtins.chr,
 
-    # O(1)
-    # (iterable: Iterable[T], start: int = 0) -> enumerate(Iterator[T])
-    'enumerate': enumerate,
+        # O(1)
+        # decorator
+        'classmethod': builtins.classmethod,
 
-    # O(1)
-    # (function: None, iterable: Iterable[T | None], /) -> filter(Iterator[T])
-    # (function: Callable[[S], TypeGuard[T]], iterable: Iterable[S], /) -> filter(Iterator[T])
-    # (function: Callable[[S], TypeIs[T]], iterable: Iterable[S], /) -> filter(Iterator[T])
-    # (function: Callable[[T], Any], iterable: Iterable[T], /) -> filter(Iterator[T])
-    'filter': builtins.filter,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterable)
+        # type dict(MutableMapping[K, V])
+        # () -> dict
+        # (**kwargs: V) -> dict[str, V]
+        # (map: SupportsKeysAndGetItem[K, V], /) -> dict[K, V]
+        # (map: SupportsKeysAndGetItem[str, V], /, **kwargs: V) -> dict[K, V]
+        # (iterable: Iterable[tuple[K, V]], /) -> dict[K, V]
+        # (iterable: Iterable[tuple[str, V]], /, **kwargs: V) -> dict[str, V]
+        # (iterable: Iterable[list[str]], /) -> dict[str, str]
+        # (iterable: Iterable[list[bytes]], /) -> dict[bytes, bytes]
+        'dict': builtins.dict,
 
-    # O(N) for N=len(value)
-    # (value: object, format_spec: str = "", /) -> str
-    'format': builtins.format,
+        # O(1)
+        # (x: SupportsDivMod[T, R], y: T, /) -> R
+        # (x: T, y: SupportsRDivMod[T, R], /) -> R
+        'divmod': builtins.divmod,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterable)
-    # type frozenset(AbstractSet[T])
-    # () -> frozenset
-    # (iterable: Iterable[T], /) -> frozenset[T]
-    'frozenset': builtins.frozenset,
+        # O(1)
+        # (iterable: Iterable[T], start: int = 0) -> enumerate(Iterator[T])
+        'enumerate': enumerate,
 
-    # O(1)
-    # __hash__ shortcut
-    # (obj: object, /) -> int
-    'hash': builtins.hash,
+        # O(1)
+        # (function: None, iterable: Iterable[T | None], /) -> filter(Iterator[T])
+        # (function: Callable[[S], TypeGuard[T]], iterable: Iterable[S], /) -> filter(Iterator[T])
+        # (function: Callable[[S], TypeIs[T]], iterable: Iterable[S], /) -> filter(Iterator[T])
+        # (function: Callable[[T], Any], iterable: Iterable[T], /) -> filter(Iterator[T])
+        'filter': builtins.filter,
 
-    # O(1)
-    # (number: int | SupportsIndex, /) -> str
-    'hex': builtins.hex,
+        # O(N) for N=len(value)
+        # (value: object, format_spec: str = "", /) -> str
+        'format': builtins.format,
 
-    # We allow `isinstance()` checks
-    'isinstance': builtins.isinstance,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterable)
+        # type frozenset(AbstractSet[T])
+        # () -> frozenset
+        # (iterable: Iterable[T], /) -> frozenset[T]
+        'frozenset': builtins.frozenset,
 
-    # O(1) various -> int
-    # (x: ConvertibleToInt = ..., /) -> int
-    # (x: str | bytes | bytearray, /, base: SupportsIndex) -> int
-    'int': builtins.int,
+        # O(1)
+        # __hash__ shortcut
+        # (obj: object, /) -> int
+        'hash': builtins.hash,
 
-    # O(1)
-    # __iter__ shortcut
-    # (object: SupportsIter[I], /) -> I
-    # (object: GetItemIterable[T], /) -> Iterator[T]
-    # (object: Callable[[], T | None], sentinel: None, /) -> Iterator[T]
-    # (object: Callable[[], T], sentinel: object, /) -> Iterator[T]
-    'iter': builtins.iter,
+        # O(1)
+        # (number: int | SupportsIndex, /) -> str
+        'hex': builtins.hex,
 
-    # O(1)
-    # (obj: Sized, /) -> int
-    'len': builtins.len,
+        # We allow `isinstance()` checks
+        'isinstance': builtins.isinstance,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterable)
-    # () -> list
-    # (iterable: Iterable[T], /) -> list[T]
-    'list': builtins.list,
+        # O(1) various -> int
+        # (x: ConvertibleToInt = ..., /) -> int
+        # (x: str | bytes | bytearray, /, base: SupportsIndex) -> int
+        'int': builtins.int,
 
-    # O(1)
-    # type map
-    # (func: Callable[[T], S], iter: Iterable[T], /) -> map[S]
-    # (func: Callable[[T1, T2], S], iter1: Iterable[T1], iter2: Iterable[T2], /) -> map[S]
-    # ...
-    # (func: Callable[[T1, ..., TN], S], iter1: Iterable[T1], ..., iterN: Iterable[TN],/) -> map[S]
-    'map': builtins.map,
+        # O(1)
+        # __iter__ shortcut
+        # (object: SupportsIter[I], /) -> I
+        # (object: GetItemIterable[T], /) -> Iterator[T]
+        # (object: Callable[[], T | None], sentinel: None, /) -> Iterator[T]
+        # (object: Callable[[], T], sentinel: object, /) -> Iterator[T]
+        'iter': builtins.iter,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterables)
-    # (arg1: T, arg2: T, /, *_args: T, key: None = None) -> T
-    # (arg1: T, arg2: T, /, *_args: T, key: Callable[[T], T]) -> T
-    # (iterable: Iterable[T], /, *, key: None = None) -> T
-    # (iterable: Iterable[T], /, *, key: Callable[[T], T]) -> T
-    # (iterable: Iterable[T], /, *, key: None = None, default: T) -> T
-    # (iterable: Iterable[T], /, *, key: Callable[[T], T], default: T) -> T
-    'max': builtins.max,
+        # O(1)
+        # (obj: Sized, /) -> int
+        'len': builtins.len,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterables)
-    # (arg1: T, arg2: T, /, *_args: T, key: None = None) -> T
-    # (arg1: T, arg2: T, /, *_args: T, key: Callable[[T], T]) -> T
-    # (iterable: Iterable[T], /, *, key: None = None) -> T
-    # (iterable: Iterable[T], /, *, key: Callable[[T], T]) -> T
-    # (iterable: Iterable[T], /, *, key: None = None, default: T) -> T
-    # (iterable: Iterable[T], /, *, key: Callable[[T], T], default: T) -> T
-    'min': builtins.min,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterable)
+        # () -> list
+        # (iterable: Iterable[T], /) -> list[T]
+        'list': builtins.list,
 
-    # O(1)
-    # __next__ shortcut
-    # (i: SupportsNext[T], /) -> T
-    # (i: SupportsNext[T], default: V, /) -> T | V
-    'next': builtins.next,
+        # O(1)
+        # type map
+        # (func: Callable[[T], S], iter: Iterable[T], /) -> map[S]
+        # (func: Callable[[T1, T2], S], iter1: Iterable[T1], iter2: Iterable[T2], /) -> map[S]
+        # ...
+        # (func: Callable[[T1, ..., TN], S], iter1: Iterable[T1], ..., iterN: Iterable[TN],/) -> map[S]
+        'map': builtins.map,
 
-    # O(1)
-    # (number: int | SupportsIndex, /) -> str
-    'oct': builtins.oct,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterables)
+        # (arg1: T, arg2: T, /, *_args: T, key: None = None) -> T
+        # (arg1: T, arg2: T, /, *_args: T, key: Callable[[T], T]) -> T
+        # (iterable: Iterable[T], /, *, key: None = None) -> T
+        # (iterable: Iterable[T], /, *, key: Callable[[T], T]) -> T
+        # (iterable: Iterable[T], /, *, key: None = None, default: T) -> T
+        # (iterable: Iterable[T], /, *, key: Callable[[T], T], default: T) -> T
+        'max': builtins.max,
 
-    # O(1)
-    # (c: str | bytes | bytearray, /) -> int
-    'ord': builtins.ord,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterables)
+        # (arg1: T, arg2: T, /, *_args: T, key: None = None) -> T
+        # (arg1: T, arg2: T, /, *_args: T, key: Callable[[T], T]) -> T
+        # (iterable: Iterable[T], /, *, key: None = None) -> T
+        # (iterable: Iterable[T], /, *, key: Callable[[T], T]) -> T
+        # (iterable: Iterable[T], /, *, key: None = None, default: T) -> T
+        # (iterable: Iterable[T], /, *, key: Callable[[T], T], default: T) -> T
+        'min': builtins.min,
 
-    # XXX: can be used to easily make large numbers
-    # O(1)
-    # (base: int, exp: int, mod: int) -> int
-    'pow': builtins.pow,
+        # O(1)
+        # __next__ shortcut
+        # (i: SupportsNext[T], /) -> T
+        # (i: SupportsNext[T], default: V, /) -> T | V
+        'next': builtins.next,
 
-    # XXX: generator that escapes the VM
-    # O(1)
-    # type range(Sequence[int])
-    # (stop: SupportsIndex, /) -> range
-    # (start: SupportsIndex, stop: SupportsIndex, step: SupportsIndex = ..., /) -> range
-    'range': custom_range,
+        # O(1)
+        # (number: int | SupportsIndex, /) -> str
+        'oct': builtins.oct,
 
-    # XXX: can consume an iterator when calling
-    # O(N) for N=len(sequence)
-    # type reversed(Iterator[T])
-    # (sequence: Reversible[T], /) -> reversed[T]
-    # (sequence: SupportsLenAndGetItem[T], /) -> reversed[T]
-    'reversed': builtins.reversed,
+        # O(1)
+        # (c: str | bytes | bytearray, /) -> int
+        'ord': builtins.ord,
 
-    # O(1)
-    # (number: SupportsRound1[T], ndigits: None = None) -> T
-    # (number: SupportsRound2[T], ndigits: SupportsIndex) -> T
-    'round': builtins.round,
+        # XXX: can be used to easily make large numbers
+        # O(1)
+        # (base: int, exp: int, mod: int) -> int
+        'pow': builtins.pow,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterable)
-    # type set(MutableSet[T])
-    # () -> set
-    # (iterable: Iterable[T], /) -> set[T]
-    'set': builtins.set,
+        # XXX: generator that escapes the VM
+        # O(1)
+        # type range(Sequence[int])
+        # (stop: SupportsIndex, /) -> range
+        # (start: SupportsIndex, stop: SupportsIndex, step: SupportsIndex = ..., /) -> range
+        'range': custom_range,
 
-    # O(1)
-    # type slice(Generic[A, B, C])
-    # (stop: int | None, /) -> slice[int | MaybeNone, int | MaybeNone, int | MaybeNone]
-    'slice': builtins.slice,
+        # XXX: can consume an iterator when calling
+        # O(N) for N=len(sequence)
+        # type reversed(Iterator[T])
+        # (sequence: Reversible[T], /) -> reversed[T]
+        # (sequence: SupportsLenAndGetItem[T], /) -> reversed[T]
+        'reversed': builtins.reversed,
 
-    # XXX: consumes an iterator when calling
-    # O(N*log(N)) for N=len(iterable)
-    # (iterable: Iterable[T], /, *, key: None = None, reverse: bool = False) -> list[T]
-    # (iterable: Iterable[T], /, *, key: Callable[[T], T], reverse: bool = False) -> list[T]
-    'sorted': builtins.sorted,
+        # O(1)
+        # (number: SupportsRound1[T], ndigits: None = None) -> T
+        # (number: SupportsRound2[T], ndigits: SupportsIndex) -> T
+        'round': builtins.round,
 
-    # O(1)
-    # type staticmethod(Generic[P, R])
-    # (f: Callable[P, R], /) -> staticmethod[P, R]
-    'staticmethod': builtins.staticmethod,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterable)
+        # type set(MutableSet[T])
+        # () -> set
+        # (iterable: Iterable[T], /) -> set[T]
+        'set': builtins.set,
 
-    # O(1)
-    # __str__ shortcut
-    # (object: object = ...) -> str
-    # (object: ReadableBuffer, encoding: str = ..., errors: str = ...) -> str
-    'str': builtins.str,
+        # O(1)
+        # type slice(Generic[A, B, C])
+        # (stop: int | None, /) -> slice[int | MaybeNone, int | MaybeNone, int | MaybeNone]
+        'slice': builtins.slice,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterable)
-    # (iterable: Iterable[bool], /, start: int = 0) -> int
-    # (iterable: Iterable[T], /) -> T
-    # (iterable: Iterable[T], /, start: T) -> T
-    'sum': builtins.sum,
+        # XXX: consumes an iterator when calling
+        # O(N*log(N)) for N=len(iterable)
+        # (iterable: Iterable[T], /, *, key: None = None, reverse: bool = False) -> list[T]
+        # (iterable: Iterable[T], /, *, key: Callable[[T], T], reverse: bool = False) -> list[T]
+        'sorted': builtins.sorted,
 
-    # XXX: consumes an iterator when calling
-    # O(N) for N=len(iterable)
-    # type tuple(Sequence[T])
-    # (iterable: Iterable[T] = ..., /) -> tuple[T]
-    'tuple': builtins.tuple,
+        # O(1)
+        # type staticmethod(Generic[P, R])
+        # (f: Callable[P, R], /) -> staticmethod[P, R]
+        'staticmethod': builtins.staticmethod,
 
-    # O(1)
-    # type zip(Iterator[T])
-    # (iter: Iterable[T], /, *, strict: bool = ...) -> zip[tuple[T]]
-    # (iter1: Iterable[T1], iter2: Iterable[T2], /, *, strict: bool = ...) -> zip[tuple[T1, T2]]
-    # ...
-    # (iter1: Iterable[T1], ..., iterN: Iterable[TN], /, *, strict: bool = ...) -> zip[tuple[T1, ..., TN]]
-    'zip': builtins.zip,
+        # O(1)
+        # __str__ shortcut
+        # (object: object = ...) -> str
+        # (object: ReadableBuffer, encoding: str = ..., errors: str = ...) -> str
+        'str': builtins.str,
 
-    # these exceptions aren't available in Python 3.10, so don't expose them
-    # 'BaseExceptionGroup': builtins.BaseExceptionGroup,
-    # 'ExceptionGroup': builtins.ExceptionGroup,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterable)
+        # (iterable: Iterable[bool], /, start: int = 0) -> int
+        # (iterable: Iterable[T], /) -> T
+        # (iterable: Iterable[T], /, start: T) -> T
+        'sum': builtins.sum,
 
-    # expose all other exception types:
-    'ArithmeticError': builtins.ArithmeticError,
-    'AssertionError': builtins.AssertionError,
-    'AttributeError': builtins.AttributeError,
-    'BaseException': builtins.BaseException,
-    'BlockingIOError': builtins.BlockingIOError,
-    'BrokenPipeError': builtins.BrokenPipeError,
-    'BufferError': builtins.BufferError,
-    'ChildProcessError': builtins.ChildProcessError,
-    'ConnectionAbortedError': builtins.ConnectionAbortedError,
-    'ConnectionError': builtins.ConnectionError,
-    'ConnectionRefusedError': builtins.ConnectionRefusedError,
-    'ConnectionResetError': builtins.ConnectionResetError,
-    'EOFError': builtins.EOFError,
-    'EnvironmentError': builtins.EnvironmentError,
-    'Exception': builtins.Exception,
-    'FileExistsError': builtins.FileExistsError,
-    'FileNotFoundError': builtins.FileNotFoundError,
-    'FloatingPointError': builtins.FloatingPointError,
-    'GeneratorExit': builtins.GeneratorExit,
-    'IOError': builtins.IOError,
-    'ImportError': builtins.ImportError,
-    'IndentationError': builtins.IndentationError,
-    'IndexError': builtins.IndexError,
-    'InterruptedError': builtins.InterruptedError,
-    'IsADirectoryError': builtins.IsADirectoryError,
-    'KeyError': builtins.KeyError,
-    'KeyboardInterrupt': builtins.KeyboardInterrupt,
-    'LookupError': builtins.LookupError,
-    'MemoryError': builtins.MemoryError,
-    'ModuleNotFoundError': builtins.ModuleNotFoundError,
-    'NameError': builtins.NameError,
-    'NotADirectoryError': builtins.NotADirectoryError,
-    'NotImplementedError': builtins.NotImplementedError,
-    'OSError': builtins.OSError,
-    'OverflowError': builtins.OverflowError,
-    'PermissionError': builtins.PermissionError,
-    'ProcessLookupError': builtins.ProcessLookupError,
-    'RecursionError': builtins.RecursionError,
-    'ReferenceError': builtins.ReferenceError,
-    'RuntimeError': builtins.RuntimeError,
-    'StopAsyncIteration': builtins.StopAsyncIteration,
-    'StopIteration': builtins.StopIteration,
-    'SyntaxError': builtins.SyntaxError,
-    'SystemError': builtins.SystemError,
-    'SystemExit': builtins.SystemExit,
-    'TabError': builtins.TabError,
-    'TimeoutError': builtins.TimeoutError,
-    'TypeError': builtins.TypeError,
-    'UnboundLocalError': builtins.UnboundLocalError,
-    'UnicodeDecodeError': builtins.UnicodeDecodeError,
-    'UnicodeEncodeError': builtins.UnicodeEncodeError,
-    'UnicodeError': builtins.UnicodeError,
-    'UnicodeTranslateError': builtins.UnicodeTranslateError,
-    'ValueError': builtins.ValueError,
-    'ZeroDivisionError': builtins.ZeroDivisionError,
+        # XXX: consumes an iterator when calling
+        # O(N) for N=len(iterable)
+        # type tuple(Sequence[T])
+        # (iterable: Iterable[T] = ..., /) -> tuple[T]
+        'tuple': builtins.tuple,
 
-    # expose all warning types:
-    'BytesWarning': builtins.BytesWarning,
-    'DeprecationWarning': builtins.DeprecationWarning,
-    'EncodingWarning': builtins.EncodingWarning,
-    'FutureWarning': builtins.FutureWarning,
-    'ImportWarning': builtins.ImportWarning,
-    'PendingDeprecationWarning': builtins.PendingDeprecationWarning,
-    'ResourceWarning': builtins.ResourceWarning,
-    'RuntimeWarning': builtins.RuntimeWarning,
-    'SyntaxWarning': builtins.SyntaxWarning,
-    'UnicodeWarning': builtins.UnicodeWarning,
-    'UserWarning': builtins.UserWarning,
-    'Warning': builtins.Warning,
+        # O(1)
+        # type zip(Iterator[T])
+        # (iter: Iterable[T], /, *, strict: bool = ...) -> zip[tuple[T]]
+        # (iter1: Iterable[T1], iter2: Iterable[T2], /, *, strict: bool = ...) -> zip[tuple[T1, T2]]
+        # ...
+        # (iter1: Iterable[T1], ..., iterN: Iterable[TN], /, *, strict: bool = ...) -> zip[tuple[T1, ..., TN]]
+        'zip': builtins.zip,
 
-    # All other builtins are NOT exposed:
-    # =====================================
+        # these exceptions aren't available in Python 3.10, so don't expose them
+        # 'BaseExceptionGroup': builtins.BaseExceptionGroup,
+        # 'ExceptionGroup': builtins.ExceptionGroup,
 
-    **{
-        name: _generate_disabled_builtin_func(name)
-        for name in DISABLED_BUILTINS
-    },
-}
+        # expose all other exception types:
+        'ArithmeticError': builtins.ArithmeticError,
+        'AssertionError': builtins.AssertionError,
+        'AttributeError': builtins.AttributeError,
+        'BlockingIOError': builtins.BlockingIOError,
+        'BrokenPipeError': builtins.BrokenPipeError,
+        'BufferError': builtins.BufferError,
+        'ChildProcessError': builtins.ChildProcessError,
+        'ConnectionAbortedError': builtins.ConnectionAbortedError,
+        'ConnectionError': builtins.ConnectionError,
+        'ConnectionRefusedError': builtins.ConnectionRefusedError,
+        'ConnectionResetError': builtins.ConnectionResetError,
+        'EOFError': builtins.EOFError,
+        'EnvironmentError': builtins.EnvironmentError,
+        'Exception': builtins.Exception,
+        'FileExistsError': builtins.FileExistsError,
+        'FileNotFoundError': builtins.FileNotFoundError,
+        'FloatingPointError': builtins.FloatingPointError,
+        'IOError': builtins.IOError,
+        'ImportError': builtins.ImportError,
+        'IndentationError': builtins.IndentationError,
+        'IndexError': builtins.IndexError,
+        'InterruptedError': builtins.InterruptedError,
+        'IsADirectoryError': builtins.IsADirectoryError,
+        'KeyError': builtins.KeyError,
+        'LookupError': builtins.LookupError,
+        'MemoryError': builtins.MemoryError,
+        'ModuleNotFoundError': builtins.ModuleNotFoundError,
+        'NameError': builtins.NameError,
+        'NotADirectoryError': builtins.NotADirectoryError,
+        'NotImplementedError': builtins.NotImplementedError,
+        'OSError': builtins.OSError,
+        'OverflowError': builtins.OverflowError,
+        'PermissionError': builtins.PermissionError,
+        'ProcessLookupError': builtins.ProcessLookupError,
+        'RecursionError': builtins.RecursionError,
+        'ReferenceError': builtins.ReferenceError,
+        'RuntimeError': builtins.RuntimeError,
+        'StopAsyncIteration': builtins.StopAsyncIteration,
+        'StopIteration': builtins.StopIteration,
+        'SyntaxError': builtins.SyntaxError,
+        'SystemError': builtins.SystemError,
+        'TabError': builtins.TabError,
+        'TimeoutError': builtins.TimeoutError,
+        'TypeError': builtins.TypeError,
+        'UnboundLocalError': builtins.UnboundLocalError,
+        'UnicodeDecodeError': builtins.UnicodeDecodeError,
+        'UnicodeEncodeError': builtins.UnicodeEncodeError,
+        'UnicodeError': builtins.UnicodeError,
+        'UnicodeTranslateError': builtins.UnicodeTranslateError,
+        'ValueError': builtins.ValueError,
+        'ZeroDivisionError': builtins.ZeroDivisionError,
+
+        # expose all warning types:
+        'BytesWarning': builtins.BytesWarning,
+        'DeprecationWarning': builtins.DeprecationWarning,
+        'EncodingWarning': builtins.EncodingWarning,
+        'FutureWarning': builtins.FutureWarning,
+        'ImportWarning': builtins.ImportWarning,
+        'PendingDeprecationWarning': builtins.PendingDeprecationWarning,
+        'ResourceWarning': builtins.ResourceWarning,
+        'RuntimeWarning': builtins.RuntimeWarning,
+        'SyntaxWarning': builtins.SyntaxWarning,
+        'UnicodeWarning': builtins.UnicodeWarning,
+        'UserWarning': builtins.UserWarning,
+        'Warning': builtins.Warning,
+
+        # All other builtins are NOT exposed:
+        # =====================================
+
+        **{
+            name: _generate_disabled_builtin_func(name)
+            for name in DISABLED_BUILTINS
+        },
+    }
+
+    for name, builtin in _EXEC_BUILTINS.items():
+        import inspect
+        if inspect.isclass(builtin) and issubclass(builtin, BaseException):
+            assert issubclass(builtin, Exception), f'cannot allow non-Exception subclasses: {name}'
+
+    return _EXEC_BUILTINS

--- a/hathorlib/hathorlib/nanocontracts/metered_exec.py
+++ b/hathorlib/hathorlib/nanocontracts/metered_exec.py
@@ -58,9 +58,9 @@ class MeteredExecutor:
     def exec(self, source: str, /) -> dict[str, Any]:
         """ This is equivalent to `exec(source)` but with execution metering and memory limiting.
         """
-        from hathorlib.nanocontracts.custom_builtins import EXEC_BUILTINS
+        from hathorlib.nanocontracts.custom_builtins import get_exec_builtins
         env: dict[str, object] = {
-            '__builtins__': EXEC_BUILTINS,
+            '__builtins__': get_exec_builtins(),
         }
         # XXX: calling compile now makes the exec step consume less fuel
         code = compile(
@@ -80,11 +80,11 @@ class MeteredExecutor:
     def call(self, func: Callable[[Unpack[_Ts]], _T], /, *, args: tuple[Unpack[_Ts]]) -> _T:
         """ This is equivalent to `func(*args, **kwargs)` but with execution metering and memory limiting.
         """
-        from hathorlib.nanocontracts.custom_builtins import EXEC_BUILTINS
+        from hathorlib.nanocontracts.custom_builtins import get_exec_builtins
         from hathorlib.nanocontracts.exception import NCFail
 
         env: dict[str, object] = {
-            '__builtins__': EXEC_BUILTINS,
+            '__builtins__': get_exec_builtins(),
             '__func__': func,
             '__args__': args,
             '__result__': None,
@@ -104,7 +104,7 @@ class MeteredExecutor:
             exec(code, env)
         except NCFail:
             raise
-        except Exception as e:
+        except BaseException as e:
             # Convert any other exception to NCFail.
             raise NCFail from e
 

--- a/hathorlib/tests/test_custom_builtins.py
+++ b/hathorlib/tests/test_custom_builtins.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+import unittest
+
+import pytest
+
+from hathorlib.nanocontracts.custom_builtins import DISABLED_BUILTINS, get_exec_builtins
+from hathorlib.nanocontracts.exception import NCDisabledBuiltinError
+
+
+class CustomBuiltinsTestCase(unittest.TestCase):
+    def test_get_exec_builtins_is_cached(self) -> None:
+        # Identity check pins the lazy-init contract: subsequent calls must return the same dict instance.
+        first = get_exec_builtins()
+        second = get_exec_builtins()
+        assert first is second
+
+    def test_exec_builtins_exposes_safe_callables(self) -> None:
+        exec_builtins = get_exec_builtins()
+        assert exec_builtins['abs'] is builtins.abs
+        assert exec_builtins['len'] is builtins.len
+        assert exec_builtins['isinstance'] is builtins.isinstance
+
+    def test_exec_builtins_exposes_only_exception_subclasses(self) -> None:
+        # No non-Exception BaseException subclass (BaseException, GeneratorExit, KeyboardInterrupt, SystemExit)
+        # may leak into the blueprint env — they bubble up past Nano's catch and crash the full node.
+        exec_builtins = get_exec_builtins()
+        for name, value in exec_builtins.items():
+            if isinstance(value, type) and issubclass(value, BaseException):
+                assert issubclass(value, Exception), f'non-Exception subclass leaked into exec builtins: {name}'
+
+    def test_disabled_builtins_are_replaced_with_disabled_func(self) -> None:
+        exec_builtins = get_exec_builtins()
+        for name in DISABLED_BUILTINS:
+            assert name in exec_builtins
+            assert exec_builtins[name] is not getattr(builtins, name, None)
+
+    def test_disabled_builtin_raises_when_called(self) -> None:
+        exec_builtins = get_exec_builtins()
+        with pytest.raises(NCDisabledBuiltinError):
+            exec_builtins['eval']('1 + 1')


### PR DESCRIPTION
### Motivation

- `MeteredExecutor.call()` only catches `Exception`, not `BaseException`, so non-Exception `BaseException` subclasses propagate uncaught past the nano-contract error boundary
- `custom_builtins.py` exposes `BaseException` (line 759), `GeneratorExit` (774), `KeyboardInterrupt` (782), and `SystemExit` (800) to blueprint code
- In production, the escaped exception reaches `vertex_handler` which calls `crash_and_exit`

### Acceptance Criteria

- First commit adds tests reproducing the issue.
- Second commit fixes it by removing such exceptions from allowed builtins
  - Validate allowed builtins once to make sure they do not contain non-`Exception` subclasses.
  - Update exception message so it's better to debug.
  - Update tests to assert the new restrictions.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 