### PR TITLE
chore: add basic instructions for agents

### DIFF
--- a/.claude/rules/api-endpoints.md
+++ b/.claude/rules/api-endpoints.md
@@ -1,0 +1,134 @@
+---
+globs: ["hathor/**/resources/**/*.py", "hathor/version_resource.py"]
+---
+
+# REST API Endpoint Conventions
+
+## Resource Class Pattern
+
+```python
+from hathor.api.openapi import api_endpoint
+from hathor.api.openapi.register import register_resource
+from hathor.api.schemas.base import ErrorResponse, ResponseModel
+from hathor.api_util import Resource
+from hathor.utils.api import QueryParams
+
+class MyQueryParams(QueryParams):
+    """Query parameters for the endpoint."""
+    height: int = Field(description="Height of the block")
+
+class MySuccessResponse(ResponseModel):
+    http_status_code: ClassVar[int] = 200
+    data: str
+
+@register_resource
+class MyResource(Resource):
+    isLeaf = True
+
+    def __init__(self, manager: HathorManager) -> None:
+        super().__init__()
+        self.manager = manager
+
+    @api_endpoint(
+        path='/my-endpoint',
+        method='GET',
+        operation_id='my_endpoint',
+        summary='Short description',
+        tags=['tag'],
+        visibility='public',
+        rate_limit_global=[{'rate': '50r/s', 'burst': 100, 'delay': 50}],
+        rate_limit_per_ip=[{'rate': '3r/s', 'burst': 10, 'delay': 3}],
+        query_params_model=MyQueryParams,
+        response_model=Union[MySuccessResponse, ErrorResponse],
+    )
+    def render_GET(self, request: Request, *, params: MyQueryParams) -> ResponseModel:
+        # Just return a ResponseModel — decorator handles JSON, CORS, content-type
+        return MySuccessResponse(data='hello')
+```
+
+## Key Rules
+
+- Always decorate with `@register_resource` from `hathor.api.openapi.register`
+- Set `isLeaf = True` on every resource class
+- Use `@api_endpoint(...)` decorator on `render_GET`/`render_POST` — it handles CORS, content-type, and JSON serialization automatically
+- **Do NOT** manually call `set_cors()`, `json_dumpb()`, or set content-type headers — the decorator does this
+- **Do NOT** define `.openapi` dicts on the class — OpenAPI spec is auto-generated from the decorator params and models
+- Define query params as a `QueryParams` subclass → passed as `*, params:` kwarg
+- Define request body as a model → pass as `request_model=`, received as `*, body:` kwarg
+- Return `ResponseModel` subclasses; use `Union[A, B]` for multiple possible responses
+- For async: return a `Deferred` resolving to a `ResponseModel`; decorator handles `NOT_DONE_YET`
+- Set `http_status_code: ClassVar[int]` on response models for non-200 status codes
+
+## Scaffolding a New Endpoint
+
+When creating a new resource file in a `hathor/**/resources/` directory, use this template:
+
+```python
+#  Copyright <YEAR> Hathor Labs  # Use the current year
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  ...full Apache 2.0 header...
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Union
+
+from hathor.api.openapi import api_endpoint
+from hathor.api.openapi.register import register_resource
+from hathor.api.schemas.base import ErrorResponse, ResponseModel
+from hathor.api_util import Resource
+from hathor.utils.api import QueryParams
+
+if TYPE_CHECKING:
+    from twisted.web.http import Request
+
+    from hathor.manager import HathorManager
+
+
+class MyQueryParams(QueryParams):
+    """Query parameters for the endpoint."""
+    # param_name: str = Field(description="...")
+
+
+class MySuccessResponse(ResponseModel):
+    """Success response."""
+    http_status_code: ClassVar[int] = 200
+    # field: type
+
+
+class MyErrorResponse(ResponseModel):
+    """Error response."""
+    http_status_code: ClassVar[int] = 400
+    error: str
+
+
+@register_resource
+class MyResource(Resource):
+    isLeaf = True
+
+    def __init__(self, manager: HathorManager) -> None:
+        super().__init__()
+        self.manager = manager
+
+    @api_endpoint(
+        path='/my-endpoint',
+        method='GET',
+        operation_id='my_endpoint',
+        summary='Short description',
+        description='Longer description of the endpoint.',
+        tags=['tag'],
+        visibility='public',
+        rate_limit_global=[{'rate': '50r/s', 'burst': 100, 'delay': 50}],
+        rate_limit_per_ip=[{'rate': '3r/s', 'burst': 10, 'delay': 3}],
+        query_params_model=MyQueryParams,
+        response_model=Union[MySuccessResponse, MyErrorResponse],
+    )
+    def render_GET(self, request: Request, *, params: MyQueryParams) -> ResponseModel:
+        return MySuccessResponse(...)
+```
+
+After creating the resource, create a matching test file in `hathor_tests/` mirroring the source path using `_ResourceTest` base class with `StubSite`.
+
+## Legacy Pattern (still in some files)
+
+Some older endpoints still use the manual pattern with `set_cors()`, `json_dumpb()`, and `.openapi` dicts. New endpoints should always use `@api_endpoint`. When modifying old endpoints, prefer migrating to the new pattern.

--- a/.claude/rules/dag-builder.md
+++ b/.claude/rules/dag-builder.md
@@ -1,0 +1,96 @@
+---
+globs: ["hathor_tests/**/*.py", "hathor/dag_builder/**/*.py"]
+---
+
+# DAGBuilder
+
+## DSL Syntax Reference
+
+The `build_from_str()` method accepts a string-based DSL for building DAG structures:
+
+```
+blockchain genesis b[1..50]          # create chain of 50 blocks from genesis
+a <-- b <-- c                        # parent edges (left is child, right is parent for <--)
+a --> b --> c                         # parent edges (left is parent, right is child for -->)
+a.out[0] <<< b c d                   # spending edges (b, c, d spend output 0 of a)
+b30 < dummy                          # ordering dependency (dummy created before b30)
+a.out[0] = 100 HTR                   # set output amount and token
+a.out[1] = 100 TKA                   # custom token (auto-creates TokenCreationTransaction)
+a.weight = 31.8                      # set vertex weight
+```
+
+## Nano Contract Attributes
+
+```
+tx.nc_id = "{hex}"                   # nano contract ID (hex string)
+tx.nc_id = other_tx                  # nano contract ID from another vertex
+tx.nc_method = initialize()          # method call with no args
+tx.nc_method = deposit(arg1, arg2)   # method call with args
+tx.nc_deposit = 10 HTR               # deposit tokens into contract
+tx.nc_withdrawal = 5 TKA             # withdraw tokens from contract
+```
+
+## On-Chain Blueprint Attributes
+
+```
+ocb.ocb_private_key = "{hex}"        # signing key
+ocb.ocb_password = "{hex}"           # password
+ocb.ocb_code = "{hex}"               # hex-encoded code
+ocb.ocb_code = file.py, ClassName    # code from file
+```
+
+## Fee-Based Token Attributes
+
+```
+FBT.token_version = fee              # mark as fee-based token
+FBT.fee = 1 HTR                      # set fee amount
+```
+
+## Initialization Pattern
+
+```python
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+
+# In setUp:
+builder = self.get_builder()
+self.manager = self.create_peer_from_builder(builder)
+self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+```
+
+## Build & Propagate
+
+```python
+artifacts = self.dag_builder.build_from_str('''
+    blockchain genesis b[1..50]
+    b1.out[0] <<< tx1
+    b30 < tx1
+    b40 --> tx1
+''')
+artifacts.propagate_with(self.manager)
+
+# Retrieve vertices
+tx1 = artifacts.get_typed_vertex('tx1', Transaction)
+b1, b40 = artifacts.get_typed_vertices(['b1', 'b40'], Block)
+```
+
+## Partial Propagation
+
+```python
+artifacts.propagate_with(self.manager, up_to='b10')        # propagate up to b10
+artifacts.propagate_with(self.manager, up_to_before='tx1')  # stop before tx1
+artifacts.propagate_with(self.manager)                      # finish remaining
+```
+
+## Key Rules
+
+- Always include `b{N} < dummy` where N >= REWARD_SPEND_MIN_BLOCKS to unlock block rewards
+- Custom tokens (TKA, TKB, etc.) auto-create TokenCreationTransaction vertices
+- Node names are unique identifiers — same name always refers to the same vertex
+- Blocks cannot have inputs; transactions cannot be block parents
+- DefaultFiller auto-fills missing parents, outputs, and balances
+
+## Key Files
+
+- Implementation: `hathor/dag_builder/builder.py`, `tokenizer.py`, `default_filler.py`, `artifacts.py`
+- Test helper: `hathor_tests/dag_builder/builder.py` (TestDAGBuilder)
+- Examples: `hathor_tests/dag_builder/test_dag_builder.py`

--- a/.claude/rules/nano-contracts.md
+++ b/.claude/rules/nano-contracts.md
@@ -1,0 +1,48 @@
+---
+globs: ["hathor/nanocontracts/**/*.py"]
+---
+
+# Nano Contracts Development
+
+## Blueprint Structure
+
+Blueprints inherit from `Blueprint` and use decorators to define methods:
+
+```python
+from hathor.nanocontracts.blueprint import Blueprint
+from hathor.nanocontracts.context import Context
+from hathorlib.nanocontracts.types import public, view
+
+class MyBlueprint(Blueprint):
+    balance: int  # State attributes declared as class annotations
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        self.balance = 0
+
+    @public(allow_deposit=True, allow_withdrawal=True)
+    def transfer(self, ctx: Context, amount: int) -> None:
+        self.balance += amount
+
+    @view
+    def get_balance(self) -> int:
+        return self.balance
+```
+
+## Method Decorators
+- `@public` — modifies state, receives `ctx: Context`. Optional params: `allow_deposit`, `allow_withdrawal`, `allow_grant_authority`, `allow_acquire_authority`, `allow_actions`, `allow_reentrancy`
+- `@view` — read-only, does NOT receive `ctx: Context`, cannot modify state
+- `@fallback` — handles calls to undefined methods; same params as `@public`
+- `@export` — class decorator to export a blueprint
+
+## Action Directions
+- **DEPOSIT** = tokens flow TO the contract (appears on the **output** side)
+- **WITHDRAWAL** = tokens flow FROM the contract (appears on the **input** side)
+
+This is critical for balance calculations and fee handling.
+
+## Key Components
+- `Runner` — executes blueprint methods with proper context
+- `BlockExecutor` — processes all nano actions in a block
+- Types from `hathorlib.nanocontracts.types`
+- Context from `hathor.nanocontracts.context`

--- a/.claude/rules/pydantic-models.md
+++ b/.claude/rules/pydantic-models.md
@@ -1,0 +1,52 @@
+---
+globs: ["hathor/event/**/*.py", "hathor/**/resources/**/*.py", "hathor/conf/**/*.py", "hathor/utils/pydantic.py"]
+---
+
+# Pydantic Usage
+
+## Custom BaseModel
+
+Always use the project's BaseModel, never raw pydantic:
+
+```python
+from hathor.utils.pydantic import BaseModel
+
+class MyModel(BaseModel):
+    name: str
+    value: int
+```
+
+This BaseModel enforces `extra='forbid'` (no unknown fields) and `frozen=True` (immutable instances).
+
+## Hex Serialization
+
+Use `Hex[T]` for bytes fields that should serialize as hex strings in JSON:
+
+```python
+from hathor.utils.pydantic import BaseModel, Hex
+
+class TxInfo(BaseModel):
+    tx_id: Hex[VertexId]  # bytes in Python, hex string in JSON
+```
+
+## Settings
+
+Avoid using `get_global_settings()` — inject `HathorSettings` as a dependency instead:
+
+```python
+# PREFERRED: dependency injection
+class MyClass:
+    def __init__(self, settings: HathorSettings) -> None:
+        self._settings = settings
+
+# AVOID: global singleton
+from hathor.conf.get_settings import get_global_settings
+settings = get_global_settings()
+```
+
+## Validators
+
+Use pydantic v2 style validators:
+```python
+from pydantic import field_validator, model_validator
+```

--- a/.claude/rules/python-style.md
+++ b/.claude/rules/python-style.md
@@ -1,0 +1,43 @@
+---
+globs: ["hathor/**/*.py", "hathor_cli/**/*.py", "hathor_tests/**/*.py"]
+---
+
+# Python Style Guide
+
+## Formatting
+- Line length: 119 characters
+- No trailing whitespace, single newline at EOF
+
+## Imports
+- Always include `from __future__ import annotations` as first import
+- Use `TYPE_CHECKING` blocks for imports only needed by type checkers:
+  ```python
+  from __future__ import annotations
+
+  from typing import TYPE_CHECKING
+
+  if TYPE_CHECKING:
+      from hathor.transaction import BaseTransaction
+  ```
+- No wildcard imports (`from x import *`)
+- Group: stdlib → third-party → first-party (`hathor`, `hathor_tests`)
+
+## Type Annotations
+- Strict mypy is enforced across the codebase
+- No `Any` without justification, `disallow_untyped_defs`, `disallow_any_generics`
+- Use `X | None` instead of `Optional[X]`
+
+## Naming
+- `PascalCase` for classes and type aliases
+- `snake_case` for functions, methods, variables
+- `UPPER_SNAKE_CASE` for module-level constants
+- `_` prefix for private methods/attributes
+- `__slots__` on all classes (not just performance-critical ones)
+
+## Logging
+- Use structlog: `from structlog import get_logger; logger = get_logger()` at module level
+- Instance logger: `self.log = logger.new()` in `__init__`
+- Structured kwargs, never f-strings: `self.log.debug('found output', tx=tx.hash_hex, index=index)`
+
+## License Header
+All new Python files must start with the Apache 2.0 Hathor Labs license header (see CLAUDE.md).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,57 @@
+---
+globs: ["hathor_tests/**/*.py"]
+---
+
+# Testing Conventions
+
+## Base Classes
+- `TestCase` — general tests (from `hathor_tests.unittest`)
+- `SimulatorTestCase` — DAG/consensus simulation tests
+- `BlueprintTestCase` — nano contract blueprint tests
+- `_ResourceTest` — API resource tests (uses StubSite for HTTP)
+
+## DAGBuilder (preferred for creating vertices)
+
+Use `DAGBuilder` for creating blocks and transactions in tests. It provides a declarative, deterministic way to build DAG structures:
+
+```python
+def test_something(self):
+    manager = ...  # from create_peer_from_builder
+    dag_builder = manager.dag_builder  # or construct from test helper
+    # Use DAGBuilder to create vertices — see hathor_tests/ for examples
+```
+
+Prefer DAGBuilder over manual vertex construction to avoid flaky tests and ensure determinism.
+
+## TestBuilder Pattern
+
+```python
+def test_something(self):
+    builder = self.get_builder()
+    # configure builder...
+    manager = self.create_peer_from_builder(builder)
+```
+
+- `self.get_builder(settings=None)` returns a `TestBuilder` pre-configured with `self.rng` and `self.clock`
+- Chain builder methods: `builder.set_settings(s)`, `builder.enable_sync_v2()`, etc.
+- `self.create_peer_from_builder(builder)` calls `builder.build()` and returns the `HathorManager`
+
+## Async Tests
+- Use `async def` with `await` for async test methods
+- For HTTP: use `StubSite` to wrap a resource, then `await web.get(...)` or `await web.post(...)`
+
+## Determinism
+- Use `self.rng` (seeded Random instance) for all randomness — never `random.random()`
+- Use `self.clock` as the reactor for time-dependent tests
+- Tests must be deterministic and reproducible
+
+## Naming & Structure
+- Files: `test_*.py` inside `hathor_tests/`
+- Classes: `Test*` prefix
+- Directory structure mirrors `hathor/` (e.g., `hathor/verification/` → `hathor_tests/verification/`)
+
+## Running Tests
+```bash
+pytest hathor_tests/path/to/test_file.py -n0         # single file, no parallelism
+pytest hathor_tests/path/to/test_file.py::TestClass::test_method -n0  # single test
+```

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,0 +1,37 @@
+---
+globs: ["hathor/verification/**/*.py"]
+---
+
+# Verification Pipeline
+
+## Architecture
+
+`VerificationService` dispatches to `VertexVerifiers` (a NamedTuple grouping per-type verifiers):
+
+```python
+class VertexVerifiers(NamedTuple):
+    vertex: VertexVerifier
+    block: BlockVerifier
+    merge_mined_block: MergeMinedBlockVerifier
+    poa_block: PoaBlockVerifier
+    tx: TransactionVerifier
+    token_creation_tx: TokenCreationTransactionVerifier
+    nano_header: NanoHeaderVerifier
+    on_chain_blueprint: OnChainBlueprintVerifier
+```
+
+## Two-Phase Verification
+- **verify_basic**: structural checks (timestamps, weights, scripts) — no storage needed
+- **verify** (full): semantic checks requiring storage (inputs, balances, consensus)
+
+## Key Rules
+- Verifiers **raise exceptions** on failure — never return bool
+- Use `match/case` on `vertex.version` with `assert type(vertex) is X` for dispatch
+- Use `__slots__` on verifier classes for performance
+- `ValidationState`: INITIAL(0) → BASIC(1) → FULL(3), or INVALID(-1). Also CHECKPOINT(2) and CHECKPOINT_FULL(4).
+
+## Adding New Verification Logic
+1. Add a new method to the appropriate verifier class in `hathor/verification/`
+2. Call it from `verify_basic()` or `verify()` in the verifier as appropriate
+3. Raise an exception on failure — never return bool
+4. Add tests covering both valid and invalid cases

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ keys.json
 
 # Pycharm
 .idea
+
+# Claude Code personal overrides
+CLAUDE.local.md
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# Hathor Core
+
+A full-node implementation for the Hathor Network — a DAG-based cryptocurrency with nano contracts.
+
+## Environment
+
+Always run Python commands through `poetry run` (or the equivalent `uv` command). Verify a virtual environment is active before running tests or linting. Example: `poetry run pytest ...`, `poetry run make check`.
+
+## Build & Test Commands
+
+```bash
+# Linting & type checking
+make check          # runs: flake8, isort-check, mypy, yamllint, custom checks
+make fmt            # auto-format with isort
+make mypy           # type check hathor + hathor_tests
+
+# Tests
+make tests          # full test suite (cli, lib, genesis, custom, ci)
+make tests-quick    # fast subset, skips slow tests (--maxfail=1 -m "not slow")
+make tests-nano     # nano contracts tests with coverage
+
+# Single test
+pytest hathor_tests/path/to/test_file.py -n0            # single file, no parallelism
+pytest hathor_tests/path/to/test_file.py::TestClass -n0  # single class
+pytest hathor_tests/path/to/test_file.py::TestClass::test_method -n0  # single test
+```
+
+## Hathorlib Commands
+
+Hathorlib is a separate sub-project in `hathorlib/` with its own dependencies and checks.
+
+```bash
+cd hathorlib
+poetry install -n --no-root -E client  # install deps (if not already)
+poetry run make check                   # runs: flake8, isort-check, mypy
+poetry run make tests                   # test suite with coverage (>60% threshold)
+poetry run make fmt                     # auto-format with isort
+```
+
+## Architecture Overview
+
+### DAG Structure
+The ledger is a DAG where vertices are either **blocks** (consensus/weight) or **transactions** (value transfer). Each vertex references 2+ parent vertices. Blocks form a blockchain backbone; transactions hang between blocks.
+
+### TxVersion Dispatch
+Every vertex has a `TxVersion` (IntEnum): REGULAR_BLOCK(0), REGULAR_TRANSACTION(1), TOKEN_CREATION_TRANSACTION(2), MERGE_MINED_BLOCK(3), POA_BLOCK(5), ON_CHAIN_BLUEPRINT(6). The version is primarily used for deserialization; runtime dispatch typically uses `isinstance` checks.
+
+### Verification Pipeline
+`VerificationService` dispatches to `VertexVerifiers` (NamedTuple of per-type verifiers):
+- **verify_basic**: structural checks (timestamps, weights, scripts) — no storage access
+- **verify** (full): semantic checks requiring storage (inputs exist, balances, consensus)
+- Verifiers **raise exceptions** on failure (never return bool)
+- `ValidationState`: INITIAL(0) → BASIC(1) → FULL(3), or INVALID(-1)
+
+### Nano Contracts
+Nano contracts are Hathor's smart contracts. Blueprints define on-chain logic with `@public`, `@view` decorators. The `Runner` executes methods; `BlockExecutor` processes all nano actions in a block. Actions: DEPOSIT (tokens → contract, output side), WITHDRAWAL (tokens ← contract, input side).
+
+### Feature Activation
+State machine for network upgrades: DEFINED → STARTED → MUST_SIGNAL → LOCKED_IN → ACTIVE. Controlled by `Feature` enum + per-network criteria. Use `Features.from_vertex(settings=..., feature_service=..., vertex=block)` to get all feature states, or `feature_service.is_feature_active(vertex=vertex, feature=Feature.X)` for a single check.
+
+## Project Layout
+
+```
+hathor/                  # Main package
+  consensus/             # DAG consensus algorithm
+  crypto/                # Crypto utilities + confidential tx
+  event/                 # Event framework
+  feature_activation/    # Feature flags state machine
+  nanocontracts/         # Nano contracts (blueprints, runner, executor)
+  p2p/                   # Peer-to-peer networking
+  transaction/           # Vertex types, storage, serialization
+  verification/          # Verification pipeline
+  wallet/                # Wallet + API resources
+hathor_cli/              # CLI entry points
+hathor_tests/            # Tests (mirrors hathor/ structure)
+hathorlib/               # Lightweight shared library
+```
+
+## Key Conventions
+
+See `.claude/rules/` for detailed, scoped rules on Python style, testing, API endpoints, pydantic, nano contracts, and verification. Key highlights:
+
+- **License**: Apache 2.0, Hathor Labs header on all new Python files (template below).
+- **Settings**: Prefer injecting `HathorSettings` as a dependency; avoid `get_global_settings()` singleton.
+
+## License
+
+```python
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+```


### PR DESCRIPTION
### Motivation

Currently there's no standard instructions for agents to quickly learn the project's structure.

### Acceptance Criteria

- Add `CLAUDE.md` and `.claude/rules` from #1634
- Add an `AGENTS.md` symlink to `CLAUDE.md`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 