### PR TITLE
feat(indexes): fast mempool-tips initialization

### DIFF
--- a/hathor/indexes/base_index.py
+++ b/hathor/indexes/base_index.py
@@ -25,6 +25,7 @@ from hathor.transaction.base_transaction import BaseTransaction
 if TYPE_CHECKING:  # pragma: no cover
     from hathor.conf.settings import HathorSettings
     from hathor.indexes.manager import IndexesManager
+    from hathor.transaction.storage import TransactionStorage
 
 logger = get_logger()
 
@@ -44,6 +45,18 @@ class BaseIndex(ABC):
 
         It comes with a no-op implementation by default because usually indexes will not need this.
         """
+        pass
+
+    def still_needs_initialization(self, tx_storage: 'TransactionStorage') -> bool:
+        """Return whether this index still needs to receive transactions during initialization.
+
+        This is called after ``init_start`` and after the index has been cleared, so indexes can use persisted
+        metadata to skip a known unnecessary rebuild.
+        """
+        return True
+
+    def init_finish(self, tx_storage: 'TransactionStorage') -> None:
+        """Called after initialization finishes for indexes selected at the beginning of initialization."""
         pass
 
     @abstractmethod

--- a/hathor/indexes/manager.py
+++ b/hathor/indexes/manager.py
@@ -142,14 +142,16 @@ class IndexesManager(ABC):
             if db_last_started_at != index_last_started_at:
                 indexes_to_init.append(index)
 
-        if indexes_to_init:
-            indexes_names = [type(index).__name__ for index in indexes_to_init]
+        initial_indexes_to_init = indexes_to_init.copy()
+
+        if initial_indexes_to_init:
+            indexes_names = [type(index).__name__ for index in initial_indexes_to_init]
             self.log.info('there are indexes that need initialization', indexes_to_init=indexes_names)
         else:
             self.log.info('there are no indexes that need initialization')
 
         # make sure that all the indexes that we're rebuilding are cleared
-        for index in indexes_to_init:
+        for index in initial_indexes_to_init:
             index_db_name = index.get_db_name()
             if index_db_name:
                 tx_storage.set_index_last_started_at(index_db_name, NULL_INDEX_LAST_STARTED_AT)
@@ -165,6 +167,12 @@ class IndexesManager(ABC):
         self.log.debug('indexes pre-init')
         for index in self.iter_all_indexes():
             index.init_start(self)
+
+        indexes_to_init = [index for index in initial_indexes_to_init if index.still_needs_initialization(tx_storage)]
+        skipped_indexes = [index for index in initial_indexes_to_init if index not in indexes_to_init]
+        if skipped_indexes:
+            indexes_names = [type(index).__name__ for index in skipped_indexes]
+            self.log.info('some indexes do not need initialization anymore', indexes=indexes_names)
 
         if indexes_to_init:
             overall_scope: Scope = reduce(operator.__or__, map(lambda i: i.get_scope(), indexes_to_init))
@@ -186,6 +194,9 @@ class IndexesManager(ABC):
             for index in indexes_to_init:
                 if index.get_scope().matches(tx):
                     index.init_loop_step(tx)
+
+        for index in indexes_to_init:
+            index.init_finish(tx_storage)
 
         # Restore cache capacity.
         assert cache_capacity is not None
@@ -420,9 +431,9 @@ class IndexesManager(ABC):
 
 class RocksDBIndexesManager(IndexesManager):
     def __init__(self, rocksdb_storage: 'RocksDBStorage', *, settings: HathorSettings) -> None:
-        from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
         from hathor.indexes.rocksdb_height_index import RocksDBHeightIndex
         from hathor.indexes.rocksdb_info_index import RocksDBInfoIndex
+        from hathor.indexes.rocksdb_mempool_tips_index import SimpleRocksDBMempoolTipsIndex
         from hathor.indexes.rocksdb_timestamp_index import RocksDBTimestampIndex
 
         self.settings = settings
@@ -430,8 +441,7 @@ class RocksDBIndexesManager(IndexesManager):
 
         self.info = RocksDBInfoIndex(self._db, settings=settings)
         self.height = RocksDBHeightIndex(self._db, settings=settings)
-        # XXX: use of RocksDBMempoolTipsIndex is very slow and was suspended
-        self.mempool_tips = MemoryMempoolTipsIndex(settings=self.settings)
+        self.mempool_tips = SimpleRocksDBMempoolTipsIndex(rocksdb_storage, settings=self.settings)
 
         self.sorted_all = RocksDBTimestampIndex(self._db, scope_type=TimestampScopeType.ALL, settings=settings)
         self.sorted_blocks = RocksDBTimestampIndex(self._db, scope_type=TimestampScopeType.BLOCKS, settings=settings)

--- a/hathor/indexes/rocksdb_mempool_tips_index.py
+++ b/hathor/indexes/rocksdb_mempool_tips_index.py
@@ -17,16 +17,58 @@ from typing import TYPE_CHECKING, Iterable, Optional
 from structlog import get_logger
 
 from hathor.conf.settings import HathorSettings
+from hathor.indexes.memory_mempool_tips_index import MemoryMempoolTipsIndex
 from hathor.indexes.mempool_tips_index import ByteCollectionMempoolTipsIndex
 from hathor.indexes.rocksdb_utils import RocksDBSimpleSet
+from hathor.transaction import BaseTransaction
 
 if TYPE_CHECKING:  # pragma: no cover
     import rocksdb
 
+    from hathor.storage import RocksDBStorage
+    from hathor.transaction.storage import TransactionStorage
+
 logger = get_logger()
 
 _CF_NAME_MEMPOOL_TIPS_INDEX = b'mempool-tips-index'
+_CF_NAME_MEMPOOL_TIPS_INDEX_META = b'mempool-tips-index-meta'
 _DB_NAME: str = 'mempool_tips'
+_DB_EMPTY_KEY = b'empty'
+_DB_EMPTY_VALUE = b'1'
+
+
+class SimpleRocksDBMempoolTipsIndex(MemoryMempoolTipsIndex):
+    """Memory-backed mempool tips index with a persistent marker for the known-empty case."""
+
+    def __init__(self, rocksdb_storage: 'RocksDBStorage', *, settings: HathorSettings) -> None:
+        super().__init__(settings=settings)
+        self._db = rocksdb_storage.get_db()
+        self._cf_meta = rocksdb_storage.get_or_create_column_family(_CF_NAME_MEMPOOL_TIPS_INDEX_META)
+
+    def still_needs_initialization(self, tx_storage: 'TransactionStorage') -> bool:
+        return not self.is_empty_marker_set()
+
+    def init_finish(self, tx_storage: 'TransactionStorage') -> None:
+        self._sync_empty_marker()
+
+    def update(self, tx: BaseTransaction, *, force_remove: bool = False) -> None:
+        super().update(tx, force_remove=force_remove)
+        self._sync_empty_marker()
+
+    def is_empty_marker_set(self) -> bool:
+        return self._db.get((self._cf_meta, _DB_EMPTY_KEY)) == _DB_EMPTY_VALUE
+
+    def _sync_empty_marker(self) -> None:
+        if self._index:
+            self._clear_empty_marker()
+        else:
+            self._set_empty_marker()
+
+    def _set_empty_marker(self) -> None:
+        self._db.put((self._cf_meta, _DB_EMPTY_KEY), _DB_EMPTY_VALUE)
+
+    def _clear_empty_marker(self) -> None:
+        self._db.delete((self._cf_meta, _DB_EMPTY_KEY))
 
 
 class RocksDBMempoolTipsIndex(ByteCollectionMempoolTipsIndex):

--- a/hathor_tests/others/test_metrics.py
+++ b/hathor_tests/others/test_metrics.py
@@ -119,6 +119,7 @@ class MetricsTest(unittest.TestCase):
             b'timestamp-sorted-txs': 0.0,
             b'nc-state': 0.0,
             b'vertex-children': 0.0,
+            b'mempool-tips-index-meta': 0.0,
         })
 
         manager.tx_storage.pre_init()
@@ -176,6 +177,7 @@ class MetricsTest(unittest.TestCase):
             b'timestamp-sorted-txs': 0.0,
             b'nc-state': 0.0,
             b'vertex-children': 0.0,
+            b'mempool-tips-index-meta': 0.0,
         })
 
         manager.tx_storage.pre_init()

--- a/hathor_tests/tx/test_mempool_tips_index.py
+++ b/hathor_tests/tx/test_mempool_tips_index.py
@@ -12,11 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from unittest.mock import patch
+
+from hathor.crypto.util import decode_address
 from hathor.daa import DAAFactory, TestMode
 from hathor.graphviz import GraphvizVisualizer
+from hathor.indexes.rocksdb_mempool_tips_index import SimpleRocksDBMempoolTipsIndex
+from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Block, Transaction
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.utils import add_new_transactions
 
 DEBUG: bool = False
 
@@ -34,6 +40,138 @@ class TestMempoolTipsIndex(unittest.TestCase):
         self.mempool_tips = self.tx_storage.indexes.mempool_tips
 
         self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def test_empty_marker_is_written_and_skips_next_initialization(self) -> None:
+        path = self.mkdtemp()
+        settings = self._settings.model_copy(update={'REWARD_SPEND_MIN_BLOCKS': 1})
+        artifacts = self.get_builder(settings).set_rocksdb_path(path).build()
+        manager = artifacts.manager
+        manager.start()
+        self.clock.run()
+        self.clock.advance(5)
+
+        dag_builder = TestDAGBuilder.from_manager(manager)
+        dag_artifacts = dag_builder.build_from_str('''
+            blockchain genesis b[1..1]
+        ''')
+        dag_artifacts.propagate_with(manager, up_to='b1')
+
+        tx_storage = manager.tx_storage
+        mempool_tips = tx_storage.indexes.mempool_tips
+        assert isinstance(mempool_tips, SimpleRocksDBMempoolTipsIndex)
+        assert mempool_tips.get() == set()
+        assert mempool_tips.is_empty_marker_set()
+
+        mempool_tips._clear_empty_marker()
+        assert not mempool_tips.is_empty_marker_set()
+
+        manager.stop()
+        assert artifacts.rocksdb_storage is not None
+        artifacts.rocksdb_storage.close()
+
+        artifacts = self.get_builder(settings).set_rocksdb_path(path).build()
+        tx_storage = artifacts.tx_storage
+        mempool_tips = tx_storage.indexes.mempool_tips
+        assert isinstance(mempool_tips, SimpleRocksDBMempoolTipsIndex)
+
+        with patch.object(mempool_tips, 'init_loop_step', wraps=mempool_tips.init_loop_step) as init_loop_step:
+            tx_storage.indexes._manually_initialize(tx_storage)
+
+        assert init_loop_step.call_count > 0
+        assert mempool_tips.get() == set()
+        assert mempool_tips.is_empty_marker_set()
+
+        assert artifacts.rocksdb_storage is not None
+        artifacts.rocksdb_storage.close()
+
+        artifacts = self.get_builder(settings).set_rocksdb_path(path).build()
+        tx_storage = artifacts.tx_storage
+        mempool_tips = tx_storage.indexes.mempool_tips
+        assert isinstance(mempool_tips, SimpleRocksDBMempoolTipsIndex)
+
+        assert mempool_tips.is_empty_marker_set()
+        with (
+            patch.object(mempool_tips, 'init_loop_step', side_effect=AssertionError('unexpected init loop step')),
+            patch.object(tx_storage, 'get_all_transactions', side_effect=AssertionError('unexpected tx iteration')),
+        ):
+            tx_storage.indexes._manually_initialize(tx_storage)
+
+        assert mempool_tips.get() == set()
+        assert mempool_tips.is_empty_marker_set()
+
+        assert artifacts.rocksdb_storage is not None
+        artifacts.rocksdb_storage.close()
+
+    def test_missing_empty_marker_rebuilds_non_empty_mempool(self) -> None:
+        path = self.mkdtemp()
+        settings = self._settings.model_copy(update={'REWARD_SPEND_MIN_BLOCKS': 1})
+        daa_factory = DAAFactory(settings=settings, test_mode=TestMode.TEST_ALL_WEIGHT)
+        wallet = self._create_test_wallet(unlocked=True)
+        wallet.settings = settings
+        artifacts = self.get_builder(settings) \
+            .set_daa_factory(daa_factory) \
+            .set_rocksdb_path(path) \
+            .set_wallet(wallet) \
+            .enable_wallet_index() \
+            .build()
+        manager = artifacts.manager
+        manager.start()
+        self.clock.run()
+        self.clock.advance(5)
+
+        address = decode_address(wallet.get_unused_address())
+        add_new_blocks(manager, settings.REWARD_SPEND_MIN_BLOCKS + 1, address=address)
+        self.clock.run()
+        tx, = add_new_transactions(manager, 1)
+
+        mempool_tips = manager.tx_storage.indexes.mempool_tips
+        assert isinstance(mempool_tips, SimpleRocksDBMempoolTipsIndex)
+        assert mempool_tips.get() == {tx.hash}
+        assert not mempool_tips.is_empty_marker_set()
+
+        manager.stop()
+        assert artifacts.rocksdb_storage is not None
+        artifacts.rocksdb_storage.close()
+
+        artifacts = self.get_builder(settings).set_rocksdb_path(path).build()
+        tx_storage = artifacts.tx_storage
+        mempool_tips = tx_storage.indexes.mempool_tips
+        assert isinstance(mempool_tips, SimpleRocksDBMempoolTipsIndex)
+
+        assert not mempool_tips.is_empty_marker_set()
+        with patch.object(mempool_tips, 'init_loop_step', wraps=mempool_tips.init_loop_step) as init_loop_step:
+            tx_storage.indexes._manually_initialize(tx_storage)
+
+        assert init_loop_step.call_count > 0
+        assert mempool_tips.get() == {tx.hash}
+        assert not mempool_tips.is_empty_marker_set()
+
+        assert artifacts.rocksdb_storage is not None
+        artifacts.rocksdb_storage.close()
+
+    def test_empty_marker_runtime_updates(self) -> None:
+        mempool_tips = self.mempool_tips
+        assert isinstance(mempool_tips, SimpleRocksDBMempoolTipsIndex)
+
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..3]
+            b2 < dummy
+            b2 < tx1
+            tx1 <-- b3
+        ''')
+        tx1, = artifacts.get_typed_vertices(['tx1'], Transaction)
+
+        artifacts.propagate_with(self.manager, up_to='b2')
+        assert mempool_tips.get() == set()
+        assert mempool_tips.is_empty_marker_set()
+
+        artifacts.propagate_with(self.manager, up_to='tx1')
+        assert mempool_tips.get() == {tx1.hash}
+        assert not mempool_tips.is_empty_marker_set()
+
+        artifacts.propagate_with(self.manager, up_to='b3')
+        assert mempool_tips.get() == set()
+        assert mempool_tips.is_empty_marker_set()
 
     def test_mempool_tip_spender_became_valid(self) -> None:
         """


### PR DESCRIPTION
### Motivation

The mempool tips index is kept in memory because the original RocksDB-backed implementation was too slow, but the in-memory variant has to be rebuilt at every startup by iterating over all transactions. In practice the mempool is empty most of the time (notably right after a clean shutdown when sync has caught up), so that rebuild is pure wasted work.

This PR adds a lightweight persisted "empty" marker for the mempool tips index so that, when it applies, initialization can be skipped entirely. To support this it also introduces a generic mechanism on `BaseIndex` that lets any index opt out of rebuild based on persisted metadata, keeping the change reusable for future indexes.

### Acceptance Criteria

- `BaseIndex` exposes two new optional hooks — `still_needs_initialization(tx_storage)` and `init_finish(tx_storage)` — defaulting to "always rebuild" and a no-op respectively, so existing indexes are unaffected.
- `IndexesManager` consults `still_needs_initialization` after `init_start` to drop indexes from the rebuild set, logs which ones were skipped, and calls `init_finish` on every index that was initially selected for initialization.
- A new `SimpleRocksDBMempoolTipsIndex` replaces `MemoryMempoolTipsIndex` in `RocksDBIndexesManager`: it stays memory-backed for reads/writes but persists an "empty" marker in a dedicated column family whenever the in-memory set transitions to/from empty.
- On startup, if the empty marker is present, the mempool tips index skips the full transaction scan; if the marker is absent, the normal rebuild still runs and the marker is re-synced at the end of initialization.
- Tests cover the three relevant cases: marker is written and lets a subsequent startup skip iteration entirely, a missing marker correctly rebuilds a non-empty mempool, and the marker is kept in sync as transactions enter and leave the mempool at runtime.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 