### PR TITLE
refactor(decimal): cleanup and prepare scaffolding [part 1]

### DIFF
--- a/hathor/conf/settings.py
+++ b/hathor/conf/settings.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Any, Union
 
 from pydantic import ConfigDict, field_validator, model_validator
@@ -20,13 +21,6 @@ from hathor.checkpoint import Checkpoint
 from hathor.consensus.consensus_settings import ConsensusSettings, PowSettings
 from hathor.feature_activation.settings import Settings as FeatureActivationSettings
 from hathorlib.conf.settings import FeatureSetting, HathorSettings as LibSettings
-
-DECIMAL_PLACES = 2
-
-GENESIS_TOKEN_UNITS = 1 * (10 ** 9)  # 1B
-GENESIS_TOKENS = GENESIS_TOKEN_UNITS * (10 ** DECIMAL_PLACES)  # 100B
-
-HATHOR_TOKEN_UID: bytes = b'\x00'
 
 
 class HathorSettings(LibSettings):
@@ -72,8 +66,8 @@ class HathorSettings(LibSettings):
             return self
 
         if (self.BLOCKS_PER_HALVING is not None or
-            self.INITIAL_TOKEN_UNITS_PER_BLOCK != 0 or
-                self.MINIMUM_TOKEN_UNITS_PER_BLOCK != 0):
+            self.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK != 0 or
+                self.MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK != 0):
             raise ValueError('PoA networks do not support block rewards')
         return self
 

--- a/hathor/daa/common.py
+++ b/hathor/daa/common.py
@@ -194,7 +194,8 @@ def _minimum_tx_weight(settings: HathorSettings, tx: 'Transaction', test_mode: T
     # We need to take into consideration the decimal places because it is inside the amount.
     # For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     # Max below is preventing division by 0 when handling authority methods that have no outputs
-    amount = max(1, tx.sum_outputs) / (10 ** settings.DECIMAL_PLACES)
+    decimal_places = tx.get_decimal_version().get_decimal_places(settings)
+    amount = max(1, tx.sum_outputs) / (10 ** decimal_places)
     weight = (
         + settings.MIN_TX_WEIGHT_COEFFICIENT * log(tx_size, 2)
         + 4 / (1 + settings.MIN_TX_WEIGHT_K / amount) + 4
@@ -209,17 +210,17 @@ def _minimum_tx_weight(settings: HathorSettings, tx: 'Transaction', test_mode: T
 def _get_base_tokens_issued_per_block(settings: HathorSettings, height: int) -> int:
     """Return the base number of tokens issued per block (before any reduction)."""
     if settings.BLOCKS_PER_HALVING is None:
-        assert settings.MINIMUM_TOKENS_PER_BLOCK == settings.INITIAL_TOKENS_PER_BLOCK
-        return settings.MINIMUM_TOKENS_PER_BLOCK
+        assert settings.MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        return settings.MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK
 
     number_of_halvings = (height - 1) // settings.BLOCKS_PER_HALVING
     number_of_halvings = max(0, number_of_halvings)
 
     if number_of_halvings > settings.MAXIMUM_NUMBER_OF_HALVINGS:
-        return settings.MINIMUM_TOKENS_PER_BLOCK
+        return settings.MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK
 
-    amount = settings.INITIAL_TOKENS_PER_BLOCK // (2**number_of_halvings)
-    return max(amount, settings.MINIMUM_TOKENS_PER_BLOCK)
+    amount = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // (2**number_of_halvings)
+    return max(amount, settings.MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK)
 
 
 def _sum_block_rewards_in_range(
@@ -241,8 +242,8 @@ def _sum_block_rewards_in_range(
     h = start_height
     while h <= end_height:
         halving = max(0, (h - 1) // settings.BLOCKS_PER_HALVING)
-        tokens_per_block = settings.INITIAL_TOKENS_PER_BLOCK // (2 ** halving)
-        tokens_per_block = max(tokens_per_block, settings.MINIMUM_TOKENS_PER_BLOCK)
+        tokens_per_block = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // (2 ** halving)
+        tokens_per_block = max(tokens_per_block, settings.MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK)
 
         next_halving_first_height = (halving + 1) * settings.BLOCKS_PER_HALVING + 1
         chunk_end = min(end_height, next_halving_first_height - 1)

--- a/hathor/dag_builder/default_filler.py
+++ b/hathor/dag_builder/default_filler.py
@@ -41,7 +41,7 @@ class DefaultFiller:
         # create the dummy and genesis nodes before builder.build() is called
         genesis_block = self._get_or_create_node('genesis_block', default_type=DAGNodeType.Genesis)
         if len(genesis_block.outputs) == 0:
-            genesis_block.outputs.append(DAGOutput(self._settings.GENESIS_TOKENS, 'HTR', {}))
+            genesis_block.outputs.append(DAGOutput(self._settings.GENESIS_TOKEN_ATOMIC_UNITS, 'HTR', {}))
         self._get_or_create_node('genesis_1', default_type=DAGNodeType.Genesis)
         self._get_or_create_node('genesis_2', default_type=DAGNodeType.Genesis)
         self._get_or_create_node('dummy', default_type=DAGNodeType.Transaction)

--- a/hathor/dag_builder/vertex_exporter.py
+++ b/hathor/dag_builder/vertex_exporter.py
@@ -536,7 +536,7 @@ class VertexExporter:
             vertex.hash = self._settings.GENESIS_BLOCK_HASH
             vertex.timestamp = self._settings.GENESIS_BLOCK_TIMESTAMP
             txout = TxOutput(
-                value=self._settings.GENESIS_TOKENS,
+                value=self._settings.GENESIS_TOKEN_ATOMIC_UNITS,
                 token_data=0,
                 script=self._settings.GENESIS_OUTPUT_SCRIPT
             )

--- a/hathor/indexes/rocksdb_tokens_index.py
+++ b/hathor/indexes/rocksdb_tokens_index.py
@@ -335,7 +335,7 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
             name=self._settings.HATHOR_TOKEN_NAME,
             symbol=self._settings.HATHOR_TOKEN_SYMBOL,
             version=TokenVersion.NATIVE,
-            total=self._settings.GENESIS_TOKENS,
+            total=self._settings.GENESIS_TOKEN_ATOMIC_UNITS,
         )
 
     def _get_value_info(self, token_uid: bytes, *, create_default: bool = True) -> _InfoDict:

--- a/hathor/nanocontracts/__init__.py
+++ b/hathor/nanocontracts/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hathor.conf import settings
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCFail
@@ -20,6 +19,7 @@ from hathor.nanocontracts.on_chain_blueprint import OnChainBlueprint
 from hathor.nanocontracts.runner import Runner
 from hathor.nanocontracts.storage import NCRocksDBStorageFactory, NCStorageFactory
 from hathor.nanocontracts.types import TokenUid, VertexId, export, fallback, public, view
+from hathorlib.conf import settings
 
 # Identifier used in metadata's voided_by when a Nano Contract method fails.
 NC_EXECUTION_FAIL_ID: bytes = b'nc-fail'

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -950,7 +950,7 @@ class TransactionStorage(ABC):
             timestamp=self._settings.GENESIS_BLOCK_TIMESTAMP,
             weight=self._settings.MIN_BLOCK_WEIGHT,
             outputs=[
-                TxOutput(self._settings.GENESIS_TOKENS, self._settings.GENESIS_OUTPUT_SCRIPT),
+                TxOutput(self._settings.GENESIS_TOKEN_ATOMIC_UNITS, self._settings.GENESIS_OUTPUT_SCRIPT),
             ],
         )
         block.update_hash()

--- a/hathor/transaction/token_info.py
+++ b/hathor/transaction/token_info.py
@@ -98,7 +98,7 @@ def get_token_version(
     Get the token version for a given token uid.
     It searches first in the tx storage and then in the block storage.
     """
-    from hathor.conf.settings import HATHOR_TOKEN_UID
+    from hathorlib.conf.settings import HATHOR_TOKEN_UID
     if token_uid == HATHOR_TOKEN_UID:
         return TokenVersion.NATIVE
     from hathor.transaction.storage.exceptions import TransactionDoesNotExist

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypeVar
 
-from typing_extensions import Self, override
+from typing_extensions import Self, final, override
 
 from hathor.checkpoint import Checkpoint
 from hathor.crypto.util import get_address_b58_from_bytes
@@ -31,6 +31,7 @@ from hathor.transaction.static_metadata import TransactionStaticMetadata
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion, get_token_version
 from hathor.transaction.util import VerboseCallback
 from hathor.types import TokenUid, VertexId
+from hathorlib.decimal_places import VertexDecimalVersion
 
 T = TypeVar('T', bound=VertexBaseHeader)
 
@@ -411,3 +412,11 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
     def init_static_metadata_from_storage(self, settings: HathorSettings, storage: 'TransactionStorage') -> None:
         static_metadata = TransactionStaticMetadata.create_from_storage(self, settings, storage)
         self.set_static_metadata(static_metadata)
+
+    @final
+    def get_decimal_version(self) -> VertexDecimalVersion:
+        """
+        Return the decimal-places version under which this transaction's token amounts are interpreted.
+        """
+        # Transactions are always V1. This will be updated in the future.
+        return VertexDecimalVersion.V1

--- a/hathor/verification/nano_header_verifier.py
+++ b/hathor/verification/nano_header_verifier.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from hathor.conf.settings import HATHOR_TOKEN_UID, HathorSettings
+from hathor.conf.settings import HathorSettings
 from hathor.nanocontracts.blueprint_service import BlueprintService
 from hathor.nanocontracts.exception import (
     NanoContractDoesNotExist,
@@ -47,6 +47,7 @@ from hathor.transaction.scripts.execute import ScriptExtras, raw_script_eval
 from hathor.transaction.scripts.opcode import OpcodesVersion
 from hathor.transaction.storage import TransactionStorage
 from hathor.verification.verification_params import VerificationParams
+from hathorlib.conf.settings import HATHOR_TOKEN_UID
 from hathorlib.nanocontracts.verification import verify_action_list
 
 MAX_SEQNUM_DIFF_MEMPOOL = MAX_SEQNUM_JUMP_SIZE + 30

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -338,7 +338,7 @@ class TransactionVerifier:
     @staticmethod
     def _check_token_permissions(token_uid: TokenUid, token_info: TokenInfo) -> None:
         """Verify whether token can be minted/melted based on its authority."""
-        from hathor.conf.settings import HATHOR_TOKEN_UID
+        from hathorlib.conf.settings import HATHOR_TOKEN_UID
         if token_info.version == TokenVersion.NATIVE:
             assert token_uid == HATHOR_TOKEN_UID
             assert not token_info.can_mint

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -130,7 +130,7 @@ class VersionResource(Resource):
             reward_spend_min_blocks=self._settings.REWARD_SPEND_MIN_BLOCKS,
             max_number_inputs=self._settings.MAX_NUM_INPUTS,
             max_number_outputs=self._settings.MAX_NUM_OUTPUTS,
-            decimal_places=self._settings.DECIMAL_PLACES,
+            decimal_places=self._settings.DISPLAY_DECIMAL_PLACES,
             genesis_block_hash=self._settings.GENESIS_BLOCK_HASH,
             genesis_tx1_hash=self._settings.GENESIS_TX1_HASH,
             genesis_tx2_hash=self._settings.GENESIS_TX2_HASH,

--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -25,7 +25,6 @@ from structlog import get_logger
 from twisted.internet.interfaces import IDelayedCall
 
 from hathor.conf.get_settings import get_global_settings
-from hathor.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 from hathor.crypto.util import decode_address
 from hathor.pubsub import EventArguments, HathorEvents, PubSubManager
 from hathor.reactor import ReactorProtocol as Reactor, get_global_reactor
@@ -36,6 +35,7 @@ from hathor.transaction.transaction import Transaction
 from hathor.transaction.util import int_to_bytes
 from hathor.types import AddressB58, Amount, TokenUid
 from hathor.wallet.exceptions import InputDuplicated, InsufficientFunds, PrivateKeyNotFound
+from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 
 logger = get_logger()
 

--- a/hathor_tests/dag_builder/test_dag_builder.py
+++ b/hathor_tests/dag_builder/test_dag_builder.py
@@ -1,6 +1,5 @@
 import pytest
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
 from hathor.nanocontracts import Blueprint, Context, OnChainBlueprint, public
 from hathor.nanocontracts.types import NCDepositAction, NCWithdrawalAction, TokenUid
 from hathor.nanocontracts.utils import load_builtin_blueprint_for_ocb
@@ -13,6 +12,7 @@ from hathor.transaction.token_info import TokenVersion
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts import test_blueprints
+from hathorlib.conf.settings import HATHOR_TOKEN_UID
 
 
 class MyBlueprint(Blueprint):

--- a/hathor_tests/feature_activation/test_reduce_daa_target.py
+++ b/hathor_tests/feature_activation/test_reduce_daa_target.py
@@ -90,7 +90,7 @@ class TestAlgorithmV1:
     def test_get_tokens_issued_per_block_normal_reward(self) -> None:
         settings = _get_settings()
         v1 = _make_v1(settings)
-        assert v1.get_tokens_issued_per_block(1) == settings.INITIAL_TOKENS_PER_BLOCK
+        assert v1.get_tokens_issued_per_block(1) == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
 
     def test_get_mined_tokens_matches_per_block_sum(self) -> None:
         settings = _get_settings()
@@ -113,7 +113,7 @@ class TestAlgorithmV2:
         settings = _get_settings()
         v2 = _make_v2(settings)
         # AVG_TIME=30, REDUCED_10X=75 (7.5s), factor=300//75=4
-        expected = settings.INITIAL_TOKENS_PER_BLOCK // 4
+        expected = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
         assert v2.get_tokens_issued_per_block(1) == expected
 
     def test_get_mined_tokens_uses_reduced_reward(self) -> None:
@@ -283,7 +283,7 @@ class TestDAAFactoryCreateFromBlock:
         block = self._mock_non_genesis_block()
 
         reward = factory.create_from_block(block).get_tokens_issued_per_block(1)
-        assert reward == settings.INITIAL_TOKENS_PER_BLOCK
+        assert reward == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
 
     def test_with_block_parent_feature_active_reduces_reward(self) -> None:
         settings = _get_settings()
@@ -295,7 +295,7 @@ class TestDAAFactoryCreateFromBlock:
 
         reward = factory.create_from_block(block).get_tokens_issued_per_block(1)
         # AVG_TIME=30, REDUCED_10X=75 (7.5s), factor=300//75=4
-        expected = settings.INITIAL_TOKENS_PER_BLOCK // 4
+        expected = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
         assert reward == expected
 
     def test_create_from_block_asserts_without_feature_service(self) -> None:
@@ -315,7 +315,7 @@ class TestDAAFactoryCreateFromBlock:
         block.is_genesis = True
 
         reward = factory.create_from_block(block).get_tokens_issued_per_block(1)
-        assert reward == settings.INITIAL_TOKENS_PER_BLOCK
+        assert reward == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
 
 
 class TestDAAFactoryRewardForNextBlock:
@@ -330,7 +330,7 @@ class TestDAAFactoryRewardForNextBlock:
         parent_block.get_height.return_value = 10
 
         reward = factory.create_from_parent(parent_block).get_reward_for_next_block(parent_block)
-        assert reward == settings.INITIAL_TOKENS_PER_BLOCK
+        assert reward == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
 
     def test_feature_active_reduces_reward(self) -> None:
         settings = _get_settings()
@@ -342,7 +342,7 @@ class TestDAAFactoryRewardForNextBlock:
         parent_block.get_height.return_value = 10
 
         reward = factory.create_from_parent(parent_block).get_reward_for_next_block(parent_block)
-        expected = settings.INITIAL_TOKENS_PER_BLOCK // 4
+        expected = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
         assert reward == expected
 
     def test_create_from_parent_asserts_without_feature_service(self) -> None:
@@ -620,8 +620,8 @@ class ActivationBoundaryTest(SimulatorTestCase):
         assert feature_service.get_state(
             block=activation_block, feature=Feature.REDUCE_DAA_TARGET
         ) == FeatureState.ACTIVE
-        v1_reward = settings.INITIAL_TOKENS_PER_BLOCK
-        v2_reward = settings.INITIAL_TOKENS_PER_BLOCK // 4
+        v1_reward = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        v2_reward = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
         assert activation_block.sum_outputs == v1_reward, (
             f'activation block (height 16) should still be V1 under Shape B '
             f'(parent at 15 is LOCKED_IN). got {activation_block.sum_outputs}, '

--- a/hathor_tests/nanocontracts/test_actions.py
+++ b/hathor_tests/nanocontracts/test_actions.py
@@ -129,7 +129,9 @@ class TestActions(unittest.TestCase):
         self.tka_balance_key = BalanceKey(nc_id=self.tx0.hash, token_uid=self.tka.hash)
 
         # Initial state sanity check. 30 HTR are used to mint 3000 TKA.
-        self.initial_htr_total = self._settings.GENESIS_TOKENS + 10 * self._settings.INITIAL_TOKENS_PER_BLOCK - 30
+        self.initial_htr_total = (
+            self._settings.GENESIS_TOKEN_ATOMIC_UNITS + 10 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 30
+        )
         self.initial_tka_total = 3000
         self._assert_token_index(htr_total=self.initial_htr_total, tka_total=self.initial_tka_total)
 
@@ -239,7 +241,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + self._settings.INITIAL_TOKENS_PER_BLOCK,
+            htr_total=self.initial_htr_total + self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK,
             tka_total=self.initial_tka_total,
         )
 
@@ -264,7 +266,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + self._settings.INITIAL_TOKENS_PER_BLOCK,
+            htr_total=self.initial_htr_total + self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK,
             tka_total=self.initial_tka_total,
         )
 
@@ -508,7 +510,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKENS_PER_BLOCK - 200,
+            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 200,
             tka_total=self.initial_tka_total + 20000,
         )
 
@@ -574,7 +576,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKENS_PER_BLOCK - 200,
+            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 200,
             tka_total=self.initial_tka_total + 20000,
         )
 
@@ -615,7 +617,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKENS_PER_BLOCK - 200,
+            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 200,
             tka_total=self.initial_tka_total + 20000,
         )
 
@@ -663,7 +665,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKENS_PER_BLOCK + 5,
+            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK + 5,
             tka_total=self.initial_tka_total - 500,
         )
 
@@ -704,7 +706,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKENS_PER_BLOCK + 5,
+            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK + 5,
             tka_total=self.initial_tka_total - 500,
         )
 
@@ -745,7 +747,7 @@ class TestActions(unittest.TestCase):
 
         # Check the token index.
         self._assert_token_index(
-            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKENS_PER_BLOCK + 5,
+            htr_total=self.initial_htr_total + 2 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK + 5,
             tka_total=self.initial_tka_total - 500,
         )
 

--- a/hathor_tests/nanocontracts/test_actions_fee.py
+++ b/hathor_tests/nanocontracts/test_actions_fee.py
@@ -1,6 +1,5 @@
 import pytest
 
-from hathor.conf.settings import HATHOR_TOKEN_UID
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import NCInvalidFee, NCInvalidFeePaymentToken
@@ -11,6 +10,7 @@ from hathor.transaction import Transaction
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.test_reentrancy import HTR_TOKEN_UID
+from hathorlib.conf.settings import HATHOR_TOKEN_UID
 
 
 class MyBlueprint(Blueprint):
@@ -470,8 +470,8 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         # Total HTR fees: 12 + 1 + 1 = 14 HTR
         htr_token_info = tokens_index.get_token_info(HATHOR_TOKEN_UID)
         expected_htr_total = (
-            self._settings.GENESIS_TOKENS
-            + 15 * self._settings.INITIAL_TOKENS_PER_BLOCK
+            self._settings.GENESIS_TOKEN_ATOMIC_UNITS
+            + 15 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
             - 12  # 12 HTR fee for initialize (1 FBT + 1 FTT + 10 DBT)
             - 1   # 1 HTR fee for tx3 (move_tokens_to_nc)
             - 1   # 1 HTR fee for tx5 (move_tokens_to_nc_paying_with_htr_and_dbt)

--- a/hathor_tests/nanocontracts/test_contract_create_contract.py
+++ b/hathor_tests/nanocontracts/test_contract_create_contract.py
@@ -285,7 +285,11 @@ class NCBlueprintTestCase(BlueprintTestCase):
         # -2 from the TKA mint in nc1.out[0]
         # -5 from the mint in nc5.nc_method
         # +1 from the melt in nc6.nc_method
-        assert htr_total == self._settings.GENESIS_TOKENS + 34 * self._settings.INITIAL_TOKENS_PER_BLOCK - 2 - 5 + 1
+        assert htr_total == (
+            self._settings.GENESIS_TOKEN_ATOMIC_UNITS
+            + 34 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+            - 2 - 5 + 1
+        )
         # 200 from nc1.out[0]
         # +456 from nc5.nc_method
         # -123 from nc6.nc_method
@@ -334,7 +338,9 @@ class NCBlueprintTestCase(BlueprintTestCase):
         assert self.manager.tx_storage.get_height_best_block() == 50
         # TODO: Is there a bug in the token index? It should be 50, not 52 blocks
         # genesis + 50 blocks - 2 from the TKA mint in nc1.out[0]
-        assert htr_total == self._settings.GENESIS_TOKENS + 52 * self._settings.INITIAL_TOKENS_PER_BLOCK - 2
+        assert htr_total == (
+            self._settings.GENESIS_TOKEN_ATOMIC_UNITS + 52 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 2
+        )
         # 200 from nc1.out[0]
         assert tka_total == 200
 

--- a/hathor_tests/nanocontracts/test_indexes2.py
+++ b/hathor_tests/nanocontracts/test_indexes2.py
@@ -62,7 +62,7 @@ class TestIndexes2(BlueprintTestCase):
         assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
         assert tka_token_info.get_total() == amount
         assert htr_token_info.get_total() == (
-            self._settings.GENESIS_TOKENS
-            + 11 * self._settings.INITIAL_TOKENS_PER_BLOCK
+            self._settings.GENESIS_TOKEN_ATOMIC_UNITS
+            + 11 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
             - get_deposit_token_deposit_amount(self._settings, amount)
         )

--- a/hathor_tests/nanocontracts/test_token_creation.py
+++ b/hathor_tests/nanocontracts/test_token_creation.py
@@ -263,7 +263,7 @@ class NCNanoContractTestCase(unittest.TestCase):
 
         tokens_index = self.manager.tx_storage.indexes.tokens
         assert tokens_index.get_token_info(settings.HATHOR_TOKEN_UID).get_total() == (
-            settings.GENESIS_TOKENS + 40 * settings.INITIAL_TOKENS_PER_BLOCK - 2
+            settings.GENESIS_TOKEN_ATOMIC_UNITS + 40 * settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 2
         )
         assert tokens_index.get_token_info(child_token_id0).get_total() == 100
         assert tokens_index.get_token_info(child_token_id1).get_total() == 30

--- a/hathor_tests/others/test_hathor_settings.py
+++ b/hathor_tests/others/test_hathor_settings.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -20,9 +21,10 @@ from pydantic import ValidationError
 
 from hathor.checkpoint import Checkpoint
 from hathor.conf.mainnet import SETTINGS as MAINNET_SETTINGS
-from hathor.conf.settings import DECIMAL_PLACES, GENESIS_TOKEN_UNITS, GENESIS_TOKENS, HathorSettings
+from hathor.conf.settings import HathorSettings
 from hathorlib.conf import MAINNET_SETTINGS_FILEPATH
 from hathorlib.conf.utils import load_yaml_settings
+from hathorlib.decimal_places import VertexDecimalVersion
 
 
 @pytest.mark.parametrize('filepath', ['fixtures/valid_hathor_settings_fixture.yml'])
@@ -101,57 +103,6 @@ def test_missing_hathor_settings_from_yaml(filepath):
     assert "validation error for HathorSettings\nNETWORK_NAME" in str(e.value)
 
 
-def test_tokens() -> None:
-    yaml_mock = Mock()
-    required_settings = dict(P2PKH_VERSION_BYTE='x01', MULTISIG_VERSION_BYTE='x02', NETWORK_NAME='test')
-
-    def mock_settings(mock: Mock, settings_: dict[str, Any]) -> None:
-        mock.return_value = required_settings | settings_
-
-    with patch('hathorlib.utils.yaml.dict_from_extended_yaml', yaml_mock):
-        # Test default values passes
-        mock_settings(yaml_mock, dict(
-            GENESIS_TOKENS=GENESIS_TOKENS,
-            GENESIS_TOKEN_UNITS=GENESIS_TOKEN_UNITS,
-            DECIMAL_PLACES=DECIMAL_PLACES,
-        ))
-        load_yaml_settings(HathorSettings, filepath='some_path')
-
-        # Test failures
-        mock_settings(yaml_mock, dict(
-            GENESIS_TOKENS=GENESIS_TOKENS + 1,
-            GENESIS_TOKEN_UNITS=GENESIS_TOKEN_UNITS,
-            DECIMAL_PLACES=DECIMAL_PLACES,
-        ))
-        with pytest.raises(ValidationError) as e:
-            load_yaml_settings(HathorSettings, filepath='some_path')
-        assert (
-            'invalid tokens: GENESIS_TOKENS=100000000001, GENESIS_TOKEN_UNITS=1000000000, DECIMAL_PLACES=2'
-        ) in str(e.value)
-
-        mock_settings(yaml_mock, dict(
-            GENESIS_TOKENS=GENESIS_TOKENS,
-            GENESIS_TOKEN_UNITS=GENESIS_TOKEN_UNITS + 1,
-            DECIMAL_PLACES=DECIMAL_PLACES,
-        ))
-        with pytest.raises(ValidationError) as e:
-            load_yaml_settings(HathorSettings, filepath='some_path')
-        assert (
-            'invalid tokens: GENESIS_TOKENS=100000000000, GENESIS_TOKEN_UNITS=1000000001, DECIMAL_PLACES=2'
-        ) in str(e.value)
-
-        mock_settings(yaml_mock, dict(
-            GENESIS_TOKENS=GENESIS_TOKENS,
-            GENESIS_TOKEN_UNITS=GENESIS_TOKEN_UNITS,
-            DECIMAL_PLACES=DECIMAL_PLACES + 1,
-        ))
-        with pytest.raises(ValidationError) as e:
-            load_yaml_settings(HathorSettings, filepath='some_path')
-        assert (
-            'invalid tokens: GENESIS_TOKENS=100000000000, GENESIS_TOKEN_UNITS=1000000000, DECIMAL_PLACES=3'
-        ) in str(e.value)
-
-
 def test_token_deposit_percentage() -> None:
     yaml_mock = Mock()
     required_settings = dict(P2PKH_VERSION_BYTE='x01', MULTISIG_VERSION_BYTE='x02', NETWORK_NAME='test')
@@ -206,8 +157,8 @@ def test_consensus_algorithm() -> None:
         # Test passes when PoA is enabled without block rewards
         mock_settings(yaml_mock, dict(
             BLOCKS_PER_HALVING=None,
-            INITIAL_TOKEN_UNITS_PER_BLOCK=0,
-            MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
+            INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
+            MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         load_yaml_settings(HathorSettings, filepath='some_path')
@@ -215,8 +166,8 @@ def test_consensus_algorithm() -> None:
         # Test fails when no signer is provided
         mock_settings(yaml_mock, dict(
             BLOCKS_PER_HALVING=None,
-            INITIAL_TOKEN_UNITS_PER_BLOCK=0,
-            MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
+            INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
+            MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=()),
         ))
         with pytest.raises(ValidationError) as e:
@@ -226,35 +177,70 @@ def test_consensus_algorithm() -> None:
         # Test fails when PoA is enabled with BLOCKS_PER_HALVING
         mock_settings(yaml_mock, dict(
             BLOCKS_PER_HALVING=123,
-            INITIAL_TOKEN_UNITS_PER_BLOCK=0,
-            MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
+            INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
+            MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
         assert 'PoA networks do not support block rewards' in str(e.value)
 
-        # Test fails when PoA is enabled with INITIAL_TOKEN_UNITS_PER_BLOCK
+        # Test fails when PoA is enabled with INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK
         mock_settings(yaml_mock, dict(
             BLOCKS_PER_HALVING=None,
-            INITIAL_TOKEN_UNITS_PER_BLOCK=123,
-            MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
+            INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=123,
+            MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
         assert 'PoA networks do not support block rewards' in str(e.value)
 
-        # Test fails when PoA is enabled with MINIMUM_TOKEN_UNITS_PER_BLOCK
+        # Test fails when PoA is enabled with MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK
         mock_settings(yaml_mock, dict(
             BLOCKS_PER_HALVING=None,
-            INITIAL_TOKEN_UNITS_PER_BLOCK=0,
-            MINIMUM_TOKEN_UNITS_PER_BLOCK=123,
+            INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
+            MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=123,
             CONSENSUS_ALGORITHM=dict(type='PROOF_OF_AUTHORITY', signers=(dict(public_key=b'some_signer'),)),
         ))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
         assert 'PoA networks do not support block rewards' in str(e.value)
+
+
+def test_get_decimal_places_unsupported_version_raises() -> None:
+    from types import SimpleNamespace
+    settings = SimpleNamespace(VERTEX_DECIMAL_PLACES={})
+    with pytest.raises(ValueError) as e:
+        VertexDecimalVersion.V1.get_decimal_places(settings)  # type: ignore[arg-type]
+    assert str(e.value) == 'unsupported decimal places version V1'
+
+
+def test_vertex_decimal_places() -> None:
+    yaml_mock = Mock()
+    required_settings = dict(P2PKH_VERSION_BYTE='x01', MULTISIG_VERSION_BYTE='x02', NETWORK_NAME='test')
+
+    def mock_settings(mock: Mock, settings_: dict[str, Any]) -> None:
+        mock.return_value = required_settings | settings_
+
+    with patch('hathorlib.utils.yaml.dict_from_extended_yaml', yaml_mock):
+        # Default mapping (V1 -> 2) loads and drives the genesis atomic amount.
+        mock_settings(yaml_mock, dict(VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 2}))
+        settings = load_yaml_settings(HathorSettings, filepath='some_path')
+        assert VertexDecimalVersion.V1.get_decimal_places(settings) == 2
+        assert settings.GENESIS_TOKEN_ATOMIC_UNITS == settings.GENESIS_TOKEN_MAIN_UNITS * (10 ** 2)
+
+        # Custom decimal places propagate to the computed genesis amount.
+        mock_settings(yaml_mock, dict(VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 5}))
+        settings = load_yaml_settings(HathorSettings, filepath='some_path')
+        assert VertexDecimalVersion.V1.get_decimal_places(settings) == 5
+        assert settings.GENESIS_TOKEN_ATOMIC_UNITS == settings.GENESIS_TOKEN_MAIN_UNITS * (10 ** 5)
+
+        # A mapping without V1 is rejected
+        mock_settings(yaml_mock, dict(VERTEX_DECIMAL_PLACES={}))
+        with pytest.raises(ValidationError) as e:
+            load_yaml_settings(HathorSettings, filepath='some_path')
+        assert 'VERTEX_DECIMAL_PLACES must define V1.' in str(e.value)
 
 
 # TODO: Tests below are temporary while settings via python coexist with settings via yaml, just to make sure

--- a/hathor_tests/poa/test_poa_simulation.py
+++ b/hathor_tests/poa/test_poa_simulation.py
@@ -38,6 +38,7 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.util import not_none
 from hathor_tests.poa.utils import get_settings, get_signer
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathorlib.decimal_places import VertexDecimalVersion
 
 
 def _get_blocks_by_height(manager: HathorManager) -> defaultdict[int, list[PoaBlock]]:
@@ -505,13 +506,13 @@ class PoaSimulationTest(SimulatorTestCase):
             GENESIS_BLOCK_NONCE=0,
             GENESIS_TX1_NONCE=0,
             GENESIS_TX2_NONCE=0,
-            DECIMAL_PLACES=0,
-            GENESIS_TOKENS=tokens,
-            GENESIS_TOKEN_UNITS=tokens,
+            DISPLAY_DECIMAL_PLACES=0,
+            VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 0},
+            GENESIS_TOKEN_MAIN_UNITS=tokens,
             TOKEN_DEPOSIT_PERCENTAGE=0.0000001,
             BLOCKS_PER_HALVING=None,
-            INITIAL_TOKEN_UNITS_PER_BLOCK=0,
-            MINIMUM_TOKEN_UNITS_PER_BLOCK=0,
+            INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
+            MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             MIN_BLOCK_WEIGHT=min_block_weight,
             MIN_TX_WEIGHT_K=0,
             MIN_TX_WEIGHT_COEFFICIENT=0,

--- a/hathor_tests/poa/test_poa_verification.py
+++ b/hathor_tests/poa/test_poa_verification.py
@@ -38,8 +38,8 @@ class PoaVerificationTest(unittest.TestCase):
         settings = self._settings.model_copy(
             update={
                 'BLOCKS_PER_HALVING': None,
-                'INITIAL_TOKEN_UNITS_PER_BLOCK': 0,
-                'MINIMUM_TOKEN_UNITS_PER_BLOCK': 0,
+                'INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK': 0,
+                'MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK': 0,
                 'CONSENSUS_ALGORITHM': PoaSettings(
                     type=ConsensusType.PROOF_OF_AUTHORITY,
                     signers=(PoaSignerSettings(public_key=public_key_bytes),),

--- a/hathor_tests/poa/utils.py
+++ b/hathor_tests/poa/utils.py
@@ -43,8 +43,8 @@ def get_settings(
     settings = settings.model_copy(update={
         'AVG_TIME_BETWEEN_BLOCKS': time_between_blocks or settings.AVG_TIME_BETWEEN_BLOCKS,
         'BLOCKS_PER_HALVING': None,
-        'INITIAL_TOKEN_UNITS_PER_BLOCK': 0,
-        'MINIMUM_TOKEN_UNITS_PER_BLOCK': 0,
+        'INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK': 0,
+        'MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK': 0,
         'CONSENSUS_ALGORITHM': PoaSettings(
             type=ConsensusType.PROOF_OF_AUTHORITY,
             signers=tuple(signers),

--- a/hathor_tests/resources/test_mining_info.py
+++ b/hathor_tests/resources/test_mining_info.py
@@ -48,11 +48,11 @@ class GetMiningInfoTest(_BaseResourceTest._ResourceTest):
         response = yield self.web.get("mined_tokens")
         data = response.json_value()
         self.assertEqual(data['blocks'], 5)
-        self.assertEqual(data['mined_tokens'], 5*self._settings.INITIAL_TOKENS_PER_BLOCK)
+        self.assertEqual(data['mined_tokens'], 5*self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
 
         add_new_blocks(self.manager, self._settings.BLOCKS_PER_HALVING + 15, advance_clock=1)
-        mined_tokens = (self._settings.BLOCKS_PER_HALVING * self._settings.INITIAL_TOKENS_PER_BLOCK +
-                        20 * self._settings.INITIAL_TOKENS_PER_BLOCK // 2)
+        mined_tokens = (self._settings.BLOCKS_PER_HALVING * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK +
+                        20 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 2)
 
         response = yield self.web.get("mined_tokens")
         data = response.json_value()

--- a/hathor_tests/resources/wallet/test_search_address.py
+++ b/hathor_tests/resources/wallet/test_search_address.py
@@ -102,7 +102,9 @@ class SearchAddressTest(_BaseResourceTest._ResourceTest):
         data = response.json_value()
         self.assertTrue(data['success'])
         # Genesis - token deposit + blocks mined
-        HTR_value = self._settings.GENESIS_TOKENS - 1 + (self._settings.INITIAL_TOKENS_PER_BLOCK * 5)
+        HTR_value = (
+            self._settings.GENESIS_TOKEN_ATOMIC_UNITS - 1 + (self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK * 5)
+        )
         self.assertEqual(data['total_transactions'], 6)  # 5 blocks mined + token creation tx
         self.assertIn(self._settings.HATHOR_TOKEN_UID.hex(), data['tokens_data'])
         self.assertIn(self.token_uid.hex(), data['tokens_data'])

--- a/hathor_tests/tx/test_blockchain.py
+++ b/hathor_tests/tx/test_blockchain.py
@@ -349,8 +349,8 @@ class BlockchainTestCase(unittest.TestCase):
     def test_tokens_issued_per_block(self):
         manager = self.create_peer('testnet', tx_storage=self.tx_storage)
         # this test is pretty dumb in that it test every possible height until halving has long stopped
-        initial_reward = self._settings.INITIAL_TOKENS_PER_BLOCK
-        final_reward = self._settings.MINIMUM_TOKENS_PER_BLOCK
+        initial_reward = self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        final_reward = self._settings.MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK
         expected_reward = initial_reward
         height = 1
         # check that there are BLOCKS_PER_HALVING with each reward, starting at the first rewardable block (height=1)

--- a/hathor_tests/tx/test_genesis.py
+++ b/hathor_tests/tx/test_genesis.py
@@ -71,7 +71,7 @@ class GenesisTest(unittest.TestCase):
         genesis_blocks = [tx for tx in genesis if tx.is_block]
         genesis_block = genesis_blocks[0]
 
-        self.assertEqual(settings.GENESIS_TOKENS, sum([output.value for output in genesis_block.outputs]))
+        self.assertEqual(settings.GENESIS_TOKEN_ATOMIC_UNITS, sum([output.value for output in genesis_block.outputs]))
 
     def test_genesis_weight(self):
         genesis = self.storage.get_all_genesis()

--- a/hathor_tests/tx/test_indexes.py
+++ b/hathor_tests/tx/test_indexes.py
@@ -139,7 +139,7 @@ class BaseIndexesTest(unittest.TestCase):
                 tx_id=self._settings.GENESIS_BLOCK_HASH,
                 index=0,
                 address=GENESIS_ADDRESS_B58,
-                amount=self._settings.GENESIS_TOKENS,
+                amount=self._settings.GENESIS_TOKEN_ATOMIC_UNITS,
                 timelock=None,
                 heightlock=self._settings.REWARD_SPEND_MIN_BLOCKS,
             ),
@@ -148,7 +148,7 @@ class BaseIndexesTest(unittest.TestCase):
         # height just not enough should be empty
         self.assertEqual(
             list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
-                                       target_amount=self._settings.GENESIS_TOKEN_UNITS,
+                                       target_amount=self._settings.GENESIS_TOKEN_MAIN_UNITS,
                                        target_height=self._settings.REWARD_SPEND_MIN_BLOCKS - 1)),
             [],
         )
@@ -156,7 +156,7 @@ class BaseIndexesTest(unittest.TestCase):
         # height is now enough
         self.assertEqual(
             list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
-                                       target_amount=self._settings.GENESIS_TOKEN_UNITS,
+                                       target_amount=self._settings.GENESIS_TOKEN_MAIN_UNITS,
                                        target_height=self._settings.REWARD_SPEND_MIN_BLOCKS)),
             expected_genesis_utxos,
         )
@@ -164,7 +164,7 @@ class BaseIndexesTest(unittest.TestCase):
         # otherwise we can leave out the height and it should give the utxos
         self.assertEqual(
             list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
-                                       target_amount=self._settings.GENESIS_TOKEN_UNITS)),
+                                       target_amount=self._settings.GENESIS_TOKEN_MAIN_UNITS)),
             expected_genesis_utxos,
         )
 

--- a/hathor_tests/tx/test_mining.py
+++ b/hathor_tests/tx/test_mining.py
@@ -40,7 +40,7 @@ class MiningTest(unittest.TestCase):
 
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
-            reward=self._settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
+            reward=self._settings.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * 100,
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=self._settings.GENESIS_BLOCK_TIMESTAMP + 3,
@@ -69,7 +69,7 @@ class MiningTest(unittest.TestCase):
 
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
-            reward=self._settings.INITIAL_TOKEN_UNITS_PER_BLOCK * 100,
+            reward=self._settings.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * 100,
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=blocks[-1].timestamp + 1,

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -17,10 +17,11 @@ from enum import StrEnum, auto, unique
 from math import log
 from typing import Annotated, Optional
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, computed_field, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, field_validator, model_validator
 from typing_extensions import Self
 
 from hathorlib.conf.utils import parse_hex_str
+from hathorlib.decimal_places import VertexDecimalVersion
 
 HATHOR_TOKEN_UID: bytes = b'\x00'
 
@@ -81,8 +82,14 @@ class HathorSettings(BaseModel):
     NATIVE_TOKEN_NAME: str = 'Hathor'
     NATIVE_TOKEN_SYMBOL: str = 'HTR'
 
-    # Number of decimal places for the Hathor token
-    DECIMAL_PLACES: int = 2
+    # Number of decimal places to be displayed for all tokens; it is simply cosmetic.
+    DISPLAY_DECIMAL_PLACES: int = 2
+
+    # Number of decimal places for each supported vertex decimal version.
+    # A version absent from this mapping is not supported on this network.
+    VERTEX_DECIMAL_PLACES: dict[VertexDecimalVersion, int] = {
+        VertexDecimalVersion.V1: 2,
+    }
 
     # Minimum weight of a tx
     MIN_TX_WEIGHT: int = 14
@@ -111,15 +118,19 @@ class HathorSettings(BaseModel):
     # enable peer whitelist
     ENABLE_PEER_WHITELIST: bool = False
 
-    # Genesis pre-mined tokens
-    GENESIS_TOKEN_UNITS: int = 1 * (10 ** 9)  # 1B
+    # Genesis pre-mined tokens in main units, that is, whole tokens without decimal places.
+    GENESIS_TOKEN_MAIN_UNITS: int = 1 * (10 ** 9)  # 1B
 
-    GENESIS_TOKENS: int = 1 * (10 ** 9) * (10 ** 2)  # 100B = GENESIS_TOKEN_UNITS * (10 ** DECIMAL_PLACES)
+    @property
+    def GENESIS_TOKEN_ATOMIC_UNITS(self) -> int:
+        """Genesis pre-mined tokens in atomic units, that is, the on-chain integer amount."""
+        # Blocks are always V1.
+        decimal_places = VertexDecimalVersion.V1.get_decimal_places(self)
+        return int(self.GENESIS_TOKEN_MAIN_UNITS * (10 ** decimal_places))
 
     # Fee rate settings
     FEE_PER_OUTPUT: int = 1
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
     def FEE_DIVISOR(self) -> int:
         """Divisor used for evaluating fee amounts"""
@@ -127,22 +138,24 @@ class HathorSettings(BaseModel):
         assert result.is_integer()
         return int(result)
 
-    # To disable reward halving, just set this to `None` and make sure that INITIAL_TOKEN_UNITS_PER_BLOCK is equal to
-    # MINIMUM_TOKEN_UNITS_PER_BLOCK.
+    # To disable reward halving, just set this to `None` and make sure that INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+    # is equal to MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK.
     BLOCKS_PER_HALVING: Optional[int] = 2 * 60 * 24 * 365  # 1051200, every 365 days
 
-    INITIAL_TOKEN_UNITS_PER_BLOCK: int = 64
-    MINIMUM_TOKEN_UNITS_PER_BLOCK: int = 8
+    INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK: int = 64
+    MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK: int = 8
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
-    def INITIAL_TOKENS_PER_BLOCK(self) -> int:
-        return int(self.INITIAL_TOKEN_UNITS_PER_BLOCK * (10 ** self.DECIMAL_PLACES))
+    def INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK(self) -> int:
+        # Blocks are always V1.
+        decimal_places = VertexDecimalVersion.V1.get_decimal_places(self)
+        return int(self.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * (10 ** decimal_places))
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
-    def MINIMUM_TOKENS_PER_BLOCK(self) -> int:
-        return int(self.MINIMUM_TOKEN_UNITS_PER_BLOCK * (10 ** self.DECIMAL_PLACES))
+    def MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK(self) -> int:
+        # Blocks are always V1.
+        decimal_places = VertexDecimalVersion.V1.get_decimal_places(self)
+        return int(self.MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK * (10 ** decimal_places))
 
     # Assume that: amount < minimum
     # But, amount = initial / (2**n), where n = number_of_halvings. Thus:
@@ -152,10 +165,9 @@ class HathorSettings(BaseModel):
     # Applying log to both sides:
     #   n > log2(initial / minimum)
     #   n > log2(initial) - log2(minimum)
-    @computed_field  # type: ignore[prop-decorator]
     @property
     def MAXIMUM_NUMBER_OF_HALVINGS(self) -> int:
-        return int(log(self.INITIAL_TOKEN_UNITS_PER_BLOCK, 2) - log(self.MINIMUM_TOKEN_UNITS_PER_BLOCK, 2))
+        return int(log(self.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK, 2) - log(self.MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK, 2))
 
     # Average time between blocks.
     AVG_TIME_BETWEEN_BLOCKS: int = 30  # in seconds
@@ -180,13 +192,11 @@ class HathorSettings(BaseModel):
     # Timestamp used for the genesis block
     GENESIS_BLOCK_TIMESTAMP: int = 1572636343
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
     def GENESIS_TX1_TIMESTAMP(self) -> int:
         """Timestamp used for the first genesis transaction."""
         return self.GENESIS_BLOCK_TIMESTAMP + 1
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
     def GENESIS_TX2_TIMESTAMP(self) -> int:
         """Timestamp used for the second genesis transaction."""
@@ -561,20 +571,6 @@ class HathorSettings(BaseModel):
     NC_MEMORY_LIMIT_TO_CALL_METHOD: int = 1024 * 1024 * 1024  # 1GiB
 
     @model_validator(mode='after')
-    def _validate_genesis_tokens(self) -> Self:
-        """Validate genesis tokens."""
-        genesis_tokens = self.GENESIS_TOKENS
-        genesis_token_units = self.GENESIS_TOKEN_UNITS
-        decimal_places = self.DECIMAL_PLACES
-
-        if genesis_tokens != genesis_token_units * (10 ** decimal_places):
-            raise ValueError(
-                f'invalid tokens: GENESIS_TOKENS={genesis_tokens}, '
-                f'GENESIS_TOKEN_UNITS={genesis_token_units}, DECIMAL_PLACES={decimal_places}'
-            )
-        return self
-
-    @model_validator(mode='after')
     def _validate_peer_connection_slots(self) -> Self:
         slot_total = (
             self.P2P_PEER_MAX_INCOMING_CONNECTIONS
@@ -589,4 +585,11 @@ class HathorSettings(BaseModel):
                 f'P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS '
                 f'({self.P2P_PEER_MAX_BOOTSTRAP_PEERS_CONNECTIONS}) = {slot_total}'
             )
+        return self
+
+    @model_validator(mode='after')
+    def _validate_vertex_decimal_places(self) -> Self:
+        """Validate that V1 is mapped."""
+        if VertexDecimalVersion.V1 not in self.VERTEX_DECIMAL_PLACES:
+            raise ValueError('VERTEX_DECIMAL_PLACES must define V1.')
         return self

--- a/hathorlib/hathorlib/daa.py
+++ b/hathorlib/hathorlib/daa.py
@@ -42,7 +42,8 @@ def minimum_tx_weight(tx: 'Transaction', *, fix_parents: bool = True) -> float:
     # We need to take into consideration the decimal places because it is inside the amount.
     # For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     # Max below is preventing division by 0 when handling authority methods that have no outputs
-    amount = max(1, tx.sum_outputs) / (10 ** settings.DECIMAL_PLACES)
+    decimal_places = tx.get_decimal_version().get_decimal_places(settings)
+    amount = max(1, tx.sum_outputs) / (10 ** decimal_places)
 
     weight: float = (
         + settings.MIN_TX_WEIGHT_COEFFICIENT * log(tx_size, 2)

--- a/hathorlib/hathorlib/decimal_places.py
+++ b/hathorlib/hathorlib/decimal_places.py
@@ -1,0 +1,40 @@
+#  Copyright 2026 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+from enum import IntEnum, unique
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hathorlib.conf.settings import HathorSettings
+
+
+@unique
+class VertexDecimalVersion(IntEnum):
+    """
+    The decimal-places version under which a vertex's token amounts must be interpreted.
+
+    The integer value is the raw version as encoded in the vertex, so it is part of the
+    serialization contract and must remain stable.
+    """
+
+    V1 = 1
+
+    def get_decimal_places(self, settings: HathorSettings) -> int:
+        """Return the number of decimal places this version maps to, according to settings."""
+        decimal_places = settings.VERTEX_DECIMAL_PLACES.get(self)
+        if decimal_places is None:
+            raise ValueError(f'unsupported decimal places version {self.name}')
+        return decimal_places

--- a/hathorlib/hathorlib/transaction.py
+++ b/hathorlib/hathorlib/transaction.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import struct
 from collections import namedtuple
 from struct import pack
-from typing import TYPE_CHECKING, List, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar, final
 
 from hathorlib.base_transaction import TX_HASH_SIZE, BaseTransaction, TxInput, TxOutput
 from hathorlib.conf import HathorSettings
+from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.exceptions import InvalidOutputValue, InvalidToken
 from hathorlib.headers import VertexBaseHeader
 from hathorlib.utils import unpack, unpack_len
@@ -250,3 +251,11 @@ class Transaction(BaseTransaction):
             if output.value <= 0:
                 raise InvalidOutputValue('Output value must be a positive integer. Value: {} and index: {}'.format(
                     output.value, index))
+
+    @final
+    def get_decimal_version(self) -> VertexDecimalVersion:
+        """
+        Return the decimal-places version under which this transaction's token amounts are interpreted.
+        """
+        # Transactions are always V1. This will be updated in the future.
+        return VertexDecimalVersion.V1


### PR DESCRIPTION
### Motivation

Decimal places describe two separate concerns that are currently coupled in the codebase. One is the display decimal places used to display values for users in the explorer, wallets, etc. Another is the actual number of decimal places used to encode values in data, such as in the serialization of output values of vertices. Today, both of these have the value of 2 — we use 2 decimal places on display, and all vertices encode output values with 2 decimal places.

In preparation for the upgrade of the number of decimal places supported on Hathor, this PR decouples those two concerns. It is simply a refactor — the `DECIMAL_PLACES = 2` setting is renamed to `DISPLAY_DECIMAL_PLACES = 2`, and a new `VERTEX_DECIMAL_VERSION` maps versions to values, currently only with `V1` which is also mapped to 2, keeping current behavior intact. In the future, new versions may be added and this separation will be important. Then, clients will have to implement the same distinction.

Other smaller improvements to related code is also implemented.

### Acceptance Criteria

- Remove constants from `hathor` settings so they're unified in `hathorlib` settings: `DECIMAL_PLACES, GENESIS_TOKEN_UNITS, GENESIS_TOKENS, HATHOR_TOKEN_UID`.
- Nomenclature improved for clarity:
  - Settings field `DECIMAL_PLACES` renamed to `DISPLAY_DECIMAL_PLACES`.
  - Settings fields like `*_TOKEN_UNITS` are renamed to `*_TOKEN_MAIN_UNITS`.
  - Settings fields like `*_TOKENS` are renamed to `*_TOKEN_ATOMIC_UNITS`. 
    - `GENESIS_TOKEN_ATOMIC_UNITS` is now a computed property instead of a field. With this change, the `_validate_genesis_tokens` validation is not needed anymore.
- Add new `VertexDecimalVersion` enum, currently only with `V1`.
  - A new settings field `VERTEX_DECIMAL_VERSION` maps `V1` to 2 decimal places.
  - Block versions are and will always be `V1`.
  - Transaction versions are retrieved from a new `Transaction.get_decimal_version` method, which currently always returns `V1`. Usages are updated accordingly.
- Remove usages of `@computed_field` from `HathorSettings`. Those were unnecessary.
- No change in behavior.


### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 