### PR TITLE
feat(decimal): update basic APIs [part 2]

### DIFF
--- a/hathor/client.py
+++ b/hathor/client.py
@@ -392,6 +392,7 @@ def create_tx_from_dict(data: dict[str, Any], update_hash: bool = False,
 
     cls = get_cls_from_tx_version(TxVersion(data['version']))
     metadata = data.pop('metadata', None)
+    data.pop('decimal_version')
     tx = cls(**data)
     if update_hash:
         tx.update_hash()

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -29,6 +29,7 @@ from hathor.transaction.exceptions import CheckpointError
 from hathor.transaction.static_metadata import BlockStaticMetadata
 from hathor.transaction.util import VerboseCallback
 from hathor.utils.int import get_bit_list
+from hathorlib.decimal_places import VertexDecimalVersion
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -202,6 +203,7 @@ class Block(GenericVertex[BlockStaticMetadata]):
         json = super().to_json(decode_script=decode_script, include_metadata=include_metadata)
         json['tokens'] = []
         json['data'] = base64.b64encode(self.data).decode('utf-8')
+        json['decimal_version'] = VertexDecimalVersion.V1.value  # Blocks are always V1.
         return json
 
     def to_json_extended(self) -> dict[str, Any]:

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -208,6 +208,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
     def to_json(self, decode_script: bool = False, include_metadata: bool = False) -> dict[str, Any]:
         json = super().to_json(decode_script=decode_script, include_metadata=include_metadata)
         json['tokens'] = [h.hex() for h in self.tokens]
+        json['decimal_version'] = self.get_decimal_version().value
 
         if self.is_nano_contract():
             nano_header = self.get_nano_header()

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -26,6 +26,7 @@ from hathor.manager import HathorManager
 from hathor.transaction.token_info import TokenVersion
 from hathor.types import BlockId, TransactionId
 from hathor.utils.pydantic import BaseModel, Hex
+from hathorlib.decimal_places import VertexDecimalVersion
 
 
 class NativeTokenInfo(BaseModel):
@@ -48,7 +49,13 @@ class VersionResponse(ResponseModel):
     reward_spend_min_blocks: int = Field(description="Minimum blocks before reward can be spent")
     max_number_inputs: int = Field(description="Maximum number of inputs per transaction")
     max_number_outputs: int = Field(description="Maximum number of outputs per transaction")
-    decimal_places: int = Field(description="Number of decimal places for token amounts")
+    decimal_places: int = Field(description="Number of decimal places for token amounts. DEPRECATED")
+    display_decimal_places: int = Field(
+        description="Number of decimal places to be displayed for all tokens; it is simply cosmetic"
+    )
+    decimal_places_by_version: dict[VertexDecimalVersion, int] = Field(
+        description="Number of decimal places for each supported vertex decimal version"
+    )
     genesis_block_hash: Hex[BlockId] = Field(description="Genesis block hash in hex")
     genesis_tx1_hash: Hex[TransactionId] = Field(description="Genesis transaction 1 hash in hex")
     genesis_tx2_hash: Hex[TransactionId] = Field(description="Genesis transaction 2 hash in hex")
@@ -71,6 +78,8 @@ VersionResponse.openapi_examples = {
             max_number_inputs=256,
             max_number_outputs=256,
             decimal_places=2,
+            display_decimal_places=2,
+            decimal_places_by_version={VertexDecimalVersion.V1: 2},
             genesis_block_hash=BlockId(b'\x00' * 32),
             genesis_tx1_hash=TransactionId(b'\x00' * 31 + b'\x01'),
             genesis_tx2_hash=TransactionId(b'\x00' * 31 + b'\x02'),
@@ -130,7 +139,9 @@ class VersionResource(Resource):
             reward_spend_min_blocks=self._settings.REWARD_SPEND_MIN_BLOCKS,
             max_number_inputs=self._settings.MAX_NUM_INPUTS,
             max_number_outputs=self._settings.MAX_NUM_OUTPUTS,
-            decimal_places=self._settings.DISPLAY_DECIMAL_PLACES,
+            decimal_places=self._settings.DISPLAY_DECIMAL_PLACES,  # TODO: This field is deprecated and will be removed
+            display_decimal_places=self._settings.DISPLAY_DECIMAL_PLACES,
+            decimal_places_by_version=self._settings.VERTEX_DECIMAL_PLACES,
             genesis_block_hash=self._settings.GENESIS_BLOCK_HASH,
             genesis_tx1_hash=self._settings.GENESIS_TX1_HASH,
             genesis_tx2_hash=self._settings.GENESIS_TX2_HASH,

--- a/hathor_tests/resources/transaction/test_mining.py
+++ b/hathor_tests/resources/transaction/test_mining.py
@@ -48,7 +48,8 @@ class MiningApiTest(_BaseResourceTest._ResourceTest):
             },
             'tokens': [],
             'data': '',
-            'signal_bits': 0
+            'signal_bits': 0,
+            'decimal_version': 1,
         })
 
     @inlineCallbacks
@@ -88,7 +89,8 @@ class MiningApiTest(_BaseResourceTest._ResourceTest):
             },
             'tokens': [],
             'data': '',
-            'signal_bits': 0
+            'signal_bits': 0,
+            'decimal_version': 1,
         })
 
     @inlineCallbacks

--- a/hathor_tests/resources/transaction/test_tx.py
+++ b/hathor_tests/resources/transaction/test_tx.py
@@ -9,6 +9,7 @@ from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.validation_state import ValidationState
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_transactions, create_fee_tokens
+from hathorlib.decimal_places import VertexDecimalVersion
 
 
 class TransactionTest(_BaseResourceTest._ResourceTest):
@@ -182,6 +183,11 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         # First block data
         self.assertEqual(data['meta']['first_block'], None)
         self.assertEqual(data['meta']['first_block_height'], None)
+
+        # Decimal version
+        decimal_version = VertexDecimalVersion.V1
+        assert tx.get_decimal_version() == decimal_version
+        assert data['tx']['decimal_version'] == decimal_version
 
     @inlineCallbacks
     def test_get_one_known_tx_with_authority(self):

--- a/hathor_tests/tx/test_mining.py
+++ b/hathor_tests/tx/test_mining.py
@@ -111,7 +111,8 @@ class MiningTest(unittest.TestCase):
             timestamp=12344,
             tokens=[],
             version=0,
-            weight=60
+            weight=60,
+            decimal_version=1,
         )
 
         self.assertTrue(isinstance(block, Block))


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1696

### Motivation

With the upcoming upgrade of decimal places and the new distinction made in the previous PR, this PR updates the `/version` and `/transaction` APIs so they reflect that distinction.

After this is merged, clients must use `display_decimal_places` from the `/version` API to generate user-facing labels, and use `decimal_version` from the `/transaction` API to decode transaction output values.

### Acceptance Criteria

- Add `display_decimal_places` and `decimal_places_by_version` fields to `/version` API and mark `decimal_places` for deprecation.
- Add `decimal_version` field to `/transaction` API.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 