### PR TITLE
feat(decimal): encode/decode scaffold [part 3]

### DIFF
--- a/hathor/serialization/encoding/output_value.py
+++ b/hathor/serialization/encoding/output_value.py
@@ -17,6 +17,5 @@ from hathorlib.serialization.encoding.output_value import *  # noqa: F401,F403
 from hathorlib.serialization.encoding.output_value import (  # noqa: F401
     MAX_OUTPUT_VALUE_32,
     MAX_OUTPUT_VALUE_64,
-    decode_output_value,
     encode_output_value,
 )

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -926,14 +926,6 @@ class TxInput:
         return vertex_serializer.serialize_tx_input_sighash(self)
 
     @classmethod
-    def create_from_bytes(cls, buf: bytes, *, verbose: VerboseCallback = None) -> tuple['TxInput', bytes]:
-        """ Creates a TxInput from a serialized input. Returns the input
-        and remaining bytes
-        """
-        from hathor.transaction.vertex_parser import vertex_serializer
-        return vertex_serializer.deserialize_tx_input(buf, verbose=verbose)
-
-    @classmethod
     def create_from_dict(cls, data: dict) -> 'TxInput':
         """ Creates a TxInput from a human readable dict."""
         return cls(
@@ -1000,22 +992,6 @@ class TxOutput:
             return f'{cls_name}(token_data={bin(self.token_data)}, value={value_str}, script={self.script.hex()})'
         else:
             return f'{cls_name}(value={value_str}, script={self.script.hex()})'
-
-    def __bytes__(self) -> bytes:
-        """Returns a byte representation of the output
-
-        :rtype: bytes
-        """
-        from hathor.transaction.vertex_parser import vertex_serializer
-        return vertex_serializer.serialize_tx_output_bytes(self)
-
-    @classmethod
-    def create_from_bytes(cls, buf: bytes, *, verbose: VerboseCallback = None) -> tuple['TxOutput', bytes]:
-        """ Creates a TxOutput from a serialized output. Returns the output
-        and remaining bytes
-        """
-        from hathor.transaction.vertex_parser import vertex_serializer
-        return vertex_serializer.deserialize_tx_output(buf, verbose=verbose)
 
     def get_token_index(self) -> int:
         """The token uid index in the list"""

--- a/hathor/transaction/util.py
+++ b/hathor/transaction/util.py
@@ -19,7 +19,7 @@ import struct
 from struct import error as StructError
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-from hathor.transaction.exceptions import InvalidFeeAmount, InvalidOutputValue, TransactionDataError
+from hathor.transaction.exceptions import InvalidFeeAmount, TransactionDataError
 from hathorlib.utils import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount  # noqa: F401
 
 if TYPE_CHECKING:
@@ -71,29 +71,6 @@ def decode_string_utf8(encoded: bytes, key: str) -> str:
         return decoded
     except UnicodeDecodeError:
         raise StructError('{} must be a valid utf-8 string.'.format(key))
-
-
-def bytes_to_output_value(data: bytes) -> tuple[int, bytes]:
-    from hathor.serialization import BadDataError, Deserializer
-    from hathor.serialization.encoding.output_value import decode_output_value
-    deserializer = Deserializer.build_bytes_deserializer(data)
-    try:
-        output_value = decode_output_value(deserializer)
-    except BadDataError as e:
-        raise InvalidOutputValue(*e.args)
-    remaining_data = deserializer.read_all()
-    return (output_value, remaining_data)
-
-
-def output_value_to_bytes(number: int) -> bytes:
-    from hathor.serialization import Serializer
-    from hathor.serialization.encoding.output_value import encode_output_value
-    serializer = Serializer.build_bytes_serializer()
-    try:
-        encode_output_value(serializer, number)
-    except ValueError as e:
-        raise InvalidOutputValue(*e.args)
-    return bytes(serializer.finalize())
 
 
 def validate_token_name_and_symbol(settings: HathorSettings,

--- a/hathor/transaction/vertex_parser/_block.py
+++ b/hathor/transaction/vertex_parser/_block.py
@@ -26,6 +26,7 @@ from hathor.transaction.vertex_parser._common import (
     serialize_graph_fields,
     serialize_tx_output,
 )
+from hathorlib.decimal_places import VertexDecimalVersion
 
 if TYPE_CHECKING:
     from hathor.transaction.base_transaction import TxOutput
@@ -50,7 +51,7 @@ def serialize_block_funds(
     """
     serializer.write_struct((block.signal_bits, block.version, len(block.outputs)), '!BBB')
     for tx_output in block.outputs:
-        serialize_tx_output(serializer, tx_output)
+        serialize_tx_output(serializer, tx_output, decimal_version=VertexDecimalVersion.V1)  # Blocks are always V1.
 
 
 def serialize_block_graph_fields(
@@ -103,7 +104,11 @@ def deserialize_block_funds(
 
     outputs: list[TxOutput] = []
     for _ in range(outputs_len):
-        txout = _deserialize_tx_output(deserializer, verbose=verbose)
+        txout = _deserialize_tx_output(
+            deserializer,
+            decimal_version=VertexDecimalVersion.V1,  # Blocks are always V1.
+            verbose=verbose,
+        )
         outputs.append(txout)
 
     block.signal_bits = signal_bits

--- a/hathor/transaction/vertex_parser/_common.py
+++ b/hathor/transaction/vertex_parser/_common.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from hathor.serialization import Deserializer, Serializer
-from hathor.serialization.encoding.output_value import decode_output_value
 from hathor.transaction.base_transaction import TX_HASH_SIZE
 from hathor.transaction.exceptions import SerializedSizeError
-from hathor.transaction.util import VerboseCallback, int_to_bytes, output_value_to_bytes
+from hathor.transaction.util import VerboseCallback, int_to_bytes
+from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.serialization.encoding.output_value import decode_output_value, encode_output_value
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -65,9 +66,9 @@ def serialize_tx_input_sighash(serializer: Serializer, tx_input: TxInput) -> Non
     serializer.write_bytes(int_to_bytes(0, 2))
 
 
-def serialize_tx_output(serializer: Serializer, tx_output: TxOutput) -> None:
+def serialize_tx_output(serializer: Serializer, tx_output: TxOutput, *, decimal_version: VertexDecimalVersion) -> None:
     """Serialize a TxOutput. Matches bytes(TxOutput)."""
-    serializer.write_bytes(output_value_to_bytes(tx_output.value))
+    encode_output_value(serializer, tx_output.value, decimal_version=decimal_version)
     serializer.write_bytes(int_to_bytes(tx_output.token_data, 1))
     serializer.write_bytes(int_to_bytes(len(tx_output.script), 2))
     serializer.write_bytes(tx_output.script)
@@ -142,6 +143,7 @@ def _deserialize_tx_input(
 def _deserialize_tx_output(
     deserializer: Deserializer,
     *,
+    decimal_version: VertexDecimalVersion,
     verbose: VerboseCallback = None,
 ) -> 'TxOutput':
     """Deserialize a single TxOutput. Matches TxOutput.create_from_bytes()."""
@@ -150,7 +152,7 @@ def _deserialize_tx_output(
     from hathor.transaction.exceptions import InvalidOutputValue
 
     try:
-        value = decode_output_value(deserializer)
+        value = decode_output_value(deserializer, decimal_version=decimal_version)
     except BadDataError as e:
         raise InvalidOutputValue(*e.args) from e
     if verbose:

--- a/hathor/transaction/vertex_parser/_fee_header.py
+++ b/hathor/transaction/vertex_parser/_fee_header.py
@@ -17,10 +17,11 @@
 from __future__ import annotations
 
 from hathor.serialization import Deserializer, Serializer
-from hathor.serialization.encoding.output_value import decode_output_value, encode_output_value
+from hathor.serialization.encoding.output_value import decode_output_value_v1
 from hathor.transaction.headers.fee_header import FeeHeader, FeeHeaderEntry
 from hathor.transaction.headers.types import VertexHeaderId
 from hathor.transaction.util import VerboseCallback, int_to_bytes
+from hathorlib.serialization.encoding.output_value import encode_output_value_v1
 
 # ---------------------------------------------------------------------------
 # Deserialization
@@ -44,7 +45,7 @@ def deserialize_fee_header(
         verbose('fees_len', fees_len)
     for _ in range(fees_len):
         token_index = deserializer.read_byte()
-        amount = decode_output_value(deserializer)
+        amount = decode_output_value_v1(deserializer)
         fees.append(FeeHeaderEntry(
             token_index=token_index,
             amount=amount,
@@ -65,4 +66,4 @@ def serialize_fee_header(serializer: Serializer, header: FeeHeader) -> None:
 
     for fee in header.fees:
         serializer.write_bytes(int_to_bytes(fee.token_index, 1))
-        encode_output_value(serializer, fee.amount)
+        encode_output_value_v1(serializer, fee.amount)

--- a/hathor/transaction/vertex_parser/_nano_header.py
+++ b/hathor/transaction/vertex_parser/_nano_header.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 from hathor.serialization import Deserializer, Serializer
 from hathor.serialization.encoding.leb128 import decode_leb128, encode_leb128
-from hathor.serialization.encoding.output_value import decode_output_value, encode_output_value
+from hathor.serialization.encoding.output_value import decode_output_value_v1
 from hathor.transaction.headers.nano_header import (
     _NC_SCRIPT_LEN_MAX_BYTES,
     ADDRESS_LEN_BYTES,
@@ -30,6 +30,7 @@ from hathor.transaction.headers.nano_header import (
 )
 from hathor.transaction.headers.types import VertexHeaderId
 from hathor.transaction.util import VerboseCallback, int_to_bytes
+from hathorlib.serialization.encoding.output_value import encode_output_value_v1
 
 
 @dataclass(slots=True, kw_only=True, frozen=True)
@@ -124,7 +125,7 @@ def _deserialize_nano_action(deserializer: Deserializer) -> NanoHeaderAction:
     type_bytes = bytes(deserializer.read_bytes(1))
     action_type = NCActionType.from_bytes(type_bytes)
     token_index = deserializer.read_byte()
-    amount = decode_output_value(deserializer)
+    amount = decode_output_value_v1(deserializer)
     return NanoHeaderAction(
         type=action_type,
         token_index=token_index,
@@ -171,4 +172,4 @@ def _serialize_nano_action(serializer: Serializer, action: NanoHeaderAction) -> 
     """Serialize a single NanoHeaderAction into the serializer."""
     serializer.write_bytes(action.type.to_bytes())
     serializer.write_bytes(int_to_bytes(action.token_index, 1))
-    encode_output_value(serializer, action.amount)
+    encode_output_value_v1(serializer, action.amount)

--- a/hathor/transaction/vertex_parser/_token_creation.py
+++ b/hathor/transaction/vertex_parser/_token_creation.py
@@ -55,7 +55,7 @@ def serialize_token_creation_funds(
     for tx_input in tx.inputs:
         serialize_tx_input(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output)
+        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
     serializer.write_bytes(_serialize_token_info(tx))
 
 
@@ -76,7 +76,7 @@ def serialize_token_creation_sighash(
     for tx_input in tx.inputs:
         serialize_tx_input_sighash(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output)
+        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
     serializer.write_bytes(_serialize_token_info(tx))
     for header_bytes in headers_sighash:
         serializer.write_bytes(header_bytes)
@@ -115,7 +115,11 @@ def deserialize_token_creation_funds(
 
     outputs: list[TxOutput] = []
     for _ in range(outputs_len):
-        txout = _deserialize_tx_output(deserializer, verbose=verbose)
+        txout = _deserialize_tx_output(
+            deserializer,
+            decimal_version=tx.get_decimal_version(),
+            verbose=verbose,
+        )
         outputs.append(txout)
 
     # Token info

--- a/hathor/transaction/vertex_parser/_transaction.py
+++ b/hathor/transaction/vertex_parser/_transaction.py
@@ -58,7 +58,7 @@ def serialize_tx_funds(
     for tx_input in tx.inputs:
         serialize_tx_input(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output)
+        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
 
 
 def serialize_tx_sighash(
@@ -81,7 +81,7 @@ def serialize_tx_sighash(
     for tx_input in tx.inputs:
         serialize_tx_input_sighash(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output)
+        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
     for header_bytes in headers_sighash:
         serializer.write_bytes(header_bytes)
 
@@ -125,7 +125,11 @@ def deserialize_tx_funds(
 
     outputs: list[TxOutput] = []
     for _ in range(outputs_len):
-        txout = _deserialize_tx_output(deserializer, verbose=verbose)
+        txout = _deserialize_tx_output(
+            deserializer,
+            decimal_version=tx.get_decimal_version(),
+            verbose=verbose,
+        )
         outputs.append(txout)
 
     tx.signal_bits = signal_bits

--- a/hathor/transaction/vertex_parser/vertex_serializer.py
+++ b/hathor/transaction/vertex_parser/vertex_serializer.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING
 from hathor.serialization import Serializer
 from hathor.transaction.base_transaction import TxVersion
 from hathor.transaction.util import VerboseCallback, int_to_bytes
+from hathorlib.decimal_places import VertexDecimalVersion
 
 if TYPE_CHECKING:
     from hathor.transaction.base_transaction import BaseTransaction, TxInput, TxOutput
@@ -194,11 +195,11 @@ def serialize_tx_input_sighash(txin: TxInput) -> bytes:
     return bytes(serializer.finalize())
 
 
-def serialize_tx_output_bytes(txout: TxOutput) -> bytes:
+def serialize_tx_output_bytes(txout: TxOutput, *, decimal_version: VertexDecimalVersion) -> bytes:
     """Serialize a TxOutput. Replaces bytes(txout)."""
     from hathor.transaction.vertex_parser._common import serialize_tx_output as _ser
     serializer = Serializer.build_bytes_serializer()
-    _ser(serializer, txout)
+    _ser(serializer, txout, decimal_version=decimal_version)
     return bytes(serializer.finalize())
 
 
@@ -226,13 +227,18 @@ def deserialize_tx_input(buf: bytes, *, verbose: VerboseCallback = None) -> tupl
     return txin, remaining
 
 
-def deserialize_tx_output(buf: bytes, *, verbose: VerboseCallback = None) -> tuple[TxOutput, bytes]:
+def deserialize_tx_output(
+    buf: bytes,
+    *,
+    decimal_version: VertexDecimalVersion,
+    verbose: VerboseCallback = None,
+) -> tuple[TxOutput, bytes]:
     """Deserialize a TxOutput from bytes. Replaces TxOutput.create_from_bytes()."""
     from hathor.serialization import Deserializer
     from hathor.transaction.vertex_parser._common import _deserialize_tx_output
 
     deserializer = Deserializer.build_bytes_deserializer(buf)
-    txout = _deserialize_tx_output(deserializer, verbose=verbose)
+    txout = _deserialize_tx_output(deserializer, decimal_version=decimal_version, verbose=verbose)
     remaining = bytes(deserializer.read_all())
     return txout, remaining
 

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -48,6 +48,8 @@ from hathor_tests.utils import (
     create_script_with_sigops,
     get_genesis_key,
 )
+from hathorlib.serialization import BadDataError, Deserializer, Serializer
+from hathorlib.serialization.encoding.output_value import decode_output_value_v1, encode_output_value_v1
 
 
 class TransactionTest(unittest.TestCase):
@@ -909,25 +911,31 @@ class TransactionTest(unittest.TestCase):
     def test_output_serialization(self):
         from hathor.serialization.encoding.output_value import MAX_OUTPUT_VALUE_32
         from hathor.transaction.base_transaction import MAX_OUTPUT_VALUE
-        from hathor.transaction.util import bytes_to_output_value, output_value_to_bytes
-        max_32 = output_value_to_bytes(MAX_OUTPUT_VALUE_32)
+        serializer = Serializer.build_bytes_serializer()
+        encode_output_value_v1(serializer, MAX_OUTPUT_VALUE_32)
+        max_32 = serializer.finalize()
         self.assertEqual(len(max_32), 4)
-        value, buf = bytes_to_output_value(max_32)
+        deserializer = Deserializer.build_bytes_deserializer(max_32)
+        value = decode_output_value_v1(deserializer)
         self.assertEqual(value, MAX_OUTPUT_VALUE_32)
 
-        over_32 = output_value_to_bytes(MAX_OUTPUT_VALUE_32 + 1)
+        serializer = Serializer.build_bytes_serializer()
+        encode_output_value_v1(serializer, MAX_OUTPUT_VALUE_32 + 1)
+        over_32 = serializer.finalize()
         self.assertEqual(len(over_32), 8)
-        value, buf = bytes_to_output_value(over_32)
+        deserializer = Deserializer.build_bytes_deserializer(over_32)
+        value = decode_output_value_v1(deserializer)
         self.assertEqual(value, MAX_OUTPUT_VALUE_32 + 1)
 
-        max_64 = output_value_to_bytes(MAX_OUTPUT_VALUE)
+        serializer = Serializer.build_bytes_serializer()
+        encode_output_value_v1(serializer, MAX_OUTPUT_VALUE)
+        max_64 = serializer.finalize()
         self.assertEqual(len(max_64), 8)
-        value, buf = bytes_to_output_value(max_64)
+        deserializer = Deserializer.build_bytes_deserializer(max_64)
+        value = decode_output_value_v1(deserializer)
         self.assertEqual(value, MAX_OUTPUT_VALUE)
 
     def test_output_value(self):
-        from hathor.transaction.util import bytes_to_output_value
-
         # first test using a small output value with 8 bytes. It should fail
         parents = [tx.hash for tx in self.genesis_txs]
         outputs = [TxOutput(1, b'')]
@@ -968,7 +976,7 @@ class TransactionTest(unittest.TestCase):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
         _input = TxInput(random_bytes, 0, random_bytes)
         tx = Transaction(inputs=[_input], outputs=[output], parents=parents, storage=self.tx_storage)
-        with self.assertRaises(InvalidOutputValue):
+        with self.assertRaises(ValueError):
             self.manager.cpu_mining_service.resolve(tx)
 
         # 'Manually resolving', to validate verify method
@@ -978,8 +986,9 @@ class TransactionTest(unittest.TestCase):
 
         # Invalid output value
         invalid_output = bytes.fromhex('ffffffff')
-        with self.assertRaises(InvalidOutputValue):
-            bytes_to_output_value(invalid_output)
+        deserializer = Deserializer.build_bytes_deserializer(invalid_output)
+        with self.assertRaises(BadDataError):
+            decode_output_value_v1(deserializer)
 
         # Can't instantiate an output with negative value
         with self.assertRaises(InvalidOutputValue):

--- a/hathorlib/hathorlib/decimal_places.py
+++ b/hathorlib/hathorlib/decimal_places.py
@@ -31,6 +31,7 @@ class VertexDecimalVersion(IntEnum):
     """
 
     V1 = 1
+    V2 = 2
 
     def get_decimal_places(self, settings: HathorSettings) -> int:
         """Return the number of decimal places this version maps to, according to settings."""

--- a/hathorlib/hathorlib/serialization/encoding/output_value.py
+++ b/hathorlib/hathorlib/serialization/encoding/output_value.py
@@ -26,51 +26,51 @@ Examples:
 
 >>> se = Serializer.build_bytes_serializer()
 >>> try:
-...     encode_output_value(se, 0)
+...     encode_output_value_v1(se, 0)
 ... except ValueError as e:
 ...     print(*e.args)
 Number must be strictly positive
 
 >>> try:
-...     encode_output_value(se, -1)
+...     encode_output_value_v1(se, -1)
 ... except ValueError as e:
 ...     print(*e.args)
 Number must not be negative
 
 >>> se = Serializer.build_bytes_serializer()
->>> encode_output_value(se, 0, strict=False)  # writes 00000000
->>> encode_output_value(se, 100)  # writes 00000064
->>> encode_output_value(se, 2 ** 31 - 1)  # writes 7fffffff
->>> encode_output_value(se, 2 ** 31)  # writes ffffffff80000000
->>> encode_output_value(se, 2 ** 63)  # writes 8000000000000000
+>>> encode_output_value_v1(se, 0, strict=False)  # writes 00000000
+>>> encode_output_value_v1(se, 100)  # writes 00000064
+>>> encode_output_value_v1(se, 2 ** 31 - 1)  # writes 7fffffff
+>>> encode_output_value_v1(se, 2 ** 31)  # writes ffffffff80000000
+>>> encode_output_value_v1(se, 2 ** 63)  # writes 8000000000000000
 >>> bytes(se.finalize()).hex()
 '00000000000000647fffffffffffffff800000008000000000000000'
 
 >>> se = Serializer.build_bytes_serializer()
 >>> try:
-...     encode_output_value(se, 2 ** 63 + 1)
+...     encode_output_value_v1(se, 2 ** 63 + 1)
 ... except ValueError as e:
 ...     print(*e.args)
 Number is too big; max possible value is 2**63, got: 9223372036854775809
 
 >>> de = Deserializer.build_bytes_deserializer(b'\x00\x00\x00\x00')
 >>> try:
-...     decode_output_value(de)
+...     decode_output_value_v1(de)
 ... except ValueError as e:
 ...     print(*e.args)
 Number must be strictly positive
 
 >>> data = bytes.fromhex('00000000000000647fffffffffffffff800000008000000000000000') + b'test'
 >>> de = Deserializer.build_bytes_deserializer(data)
->>> decode_output_value(de, strict=False)  # reads 00000000
+>>> decode_output_value_v1(de, strict=False)  # reads 00000000
 0
->>> decode_output_value(de)  # reads 00000064
+>>> decode_output_value_v1(de)  # reads 00000064
 100
->>> decode_output_value(de)  # reads 7fffffff
+>>> decode_output_value_v1(de)  # reads 7fffffff
 2147483647
->>> decode_output_value(de)  # reads ffffffff80000000
+>>> decode_output_value_v1(de)  # reads ffffffff80000000
 2147483648
->>> decode_output_value(de)  # reads 8000000000000000
+>>> decode_output_value_v1(de)  # reads 8000000000000000
 9223372036854775808
 >>> bytes(de.read_all())
 b'test'
@@ -79,6 +79,9 @@ b'test'
 
 import struct
 
+from typing_extensions import assert_never
+
+from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.serialization import Deserializer, Serializer
 from hathorlib.serialization.exceptions import BadDataError
 
@@ -86,7 +89,17 @@ MAX_OUTPUT_VALUE_32 = 2 ** 31 - 1  # max value (inclusive) before having to use 
 MAX_OUTPUT_VALUE_64 = 2 ** 63  # max value (inclusive) that can be encoded (with 8 bytes): 9_223_372_036_854_775_808
 
 
-def encode_output_value(serializer: Serializer, number: int, *, strict: bool = True) -> None:
+def encode_output_value(serializer: Serializer, value: int, *, decimal_version: VertexDecimalVersion) -> None:
+    match decimal_version:
+        case VertexDecimalVersion.V1:
+            encode_output_value_v1(serializer, value)
+        case VertexDecimalVersion.V2:
+            raise NotImplementedError
+        case _:
+            assert_never(decimal_version)
+
+
+def encode_output_value_v1(serializer: Serializer, number: int, *, strict: bool = True) -> None:
     """ Encodes either 4 or 8 bytes using our output-value format.
 
     This modules's docstring has more details and examples.
@@ -105,7 +118,17 @@ def encode_output_value(serializer: Serializer, number: int, *, strict: bool = T
         serializer.write_bytes(number.to_bytes(4, byteorder='big', signed=True))
 
 
-def decode_output_value(deserializer: Deserializer, *, strict: bool = True) -> int:
+def decode_output_value(deserializer: Deserializer, *, decimal_version: VertexDecimalVersion) -> int:
+    match decimal_version:
+        case VertexDecimalVersion.V1:
+            return decode_output_value_v1(deserializer)
+        case VertexDecimalVersion.V2:
+            raise NotImplementedError
+        case _:
+            assert_never(decimal_version)
+
+
+def decode_output_value_v1(deserializer: Deserializer, *, strict: bool = True) -> int:
     """ Decodes either 4 or 8 bytes using our output-value format.
 
     This modules's docstring has more details and examples.


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1697

### Motivation

Prepare the serialization and deserialization paths of `TxOutput` for the introduction of decimal places V2.

### Acceptance Criteria

- Add `VertexDecimalVersion.V2`.
- `TxOutput` encode and decode are now switched depending on the `VertexDecimalVersion`.
  - `VertexDecimalVersion.V2` simply raises `NotImplementedError`.
- Thread `VertexDecimalVersion` through the `TxOutput` encode and decode paths.
- `FeeHeader` and `NanoHeader` are currently hardcoded to V1 and do not depend on `VertexDecimalVersion`. This will be changed in future PRs.
- Remove unused methods and functions: `TxInput.create_from_bytes`, `TxOutput.__bytes__`, `TxOutput.create_from_bytes`, `bytes_to_output_value`, `output_value_to_bytes`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 