### PR TITLE
chore: bump hathorlib v0.15.0

### DIFF
--- a/hathorlib/pyproject.toml
+++ b/hathorlib/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathorlib"
-version = "0.14.1"
+version = "0.15.0"
 description = "Hathor Network base objects library"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Motivation

Start release of hathorlib v0.15.0

### Acceptance Criteria

- bump python-hathorlib version to v0.15.0

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 