### PR TITLE
refactor(decimal): integer math in deposit calculations [part 6]

### DIFF
--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -45,7 +45,8 @@ class VersionResponse(ResponseModel):
     min_tx_weight: int = Field(description="Minimum transaction weight")
     min_tx_weight_coefficient: float = Field(description="Minimum transaction weight coefficient")
     min_tx_weight_k: float = Field(description="Minimum transaction weight k constant")
-    token_deposit_percentage: float = Field(description="Token deposit percentage")
+    token_deposit_percentage: float = Field(description="Token deposit percentage. DEPRECATED")
+    token_deposit_percentage_ppb: int = Field(description="Token deposit percentage in ppb (parts per billion)")
     reward_spend_min_blocks: int = Field(description="Minimum blocks before reward can be spent")
     max_number_inputs: int = Field(description="Maximum number of inputs per transaction")
     max_number_outputs: int = Field(description="Maximum number of outputs per transaction")
@@ -74,6 +75,7 @@ VersionResponse.openapi_examples = {
             min_tx_weight_coefficient=1.6,
             min_tx_weight_k=100,
             token_deposit_percentage=0.01,
+            token_deposit_percentage_ppb=10**7,
             reward_spend_min_blocks=300,
             max_number_inputs=256,
             max_number_outputs=256,
@@ -135,7 +137,8 @@ class VersionResource(Resource):
             min_tx_weight=self._settings.MIN_TX_WEIGHT,
             min_tx_weight_coefficient=self._settings.MIN_TX_WEIGHT_COEFFICIENT,
             min_tx_weight_k=self._settings.MIN_TX_WEIGHT_K,
-            token_deposit_percentage=self._settings.TOKEN_DEPOSIT_PERCENTAGE,
+            token_deposit_percentage=self._settings.TOKEN_DEPOSIT_PERCENTAGE_PPB / 10**9,
+            token_deposit_percentage_ppb=self._settings.TOKEN_DEPOSIT_PERCENTAGE_PPB,
             reward_spend_min_blocks=self._settings.REWARD_SPEND_MIN_BLOCKS,
             max_number_inputs=self._settings.MAX_NUM_INPUTS,
             max_number_outputs=self._settings.MAX_NUM_OUTPUTS,

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -46,7 +46,8 @@ class VersionResponse(ResponseModel):
     min_tx_weight_coefficient: float = Field(description="Minimum transaction weight coefficient")
     min_tx_weight_k: float = Field(description="Minimum transaction weight k constant")
     token_deposit_percentage: float = Field(description="Token deposit percentage. DEPRECATED")
-    token_deposit_percentage_ppb: int = Field(description="Token deposit percentage in ppb (parts per billion)")
+    token_deposit_percentage_numerator: int = Field(description="Token deposit percentage numerator")
+    token_deposit_percentage_denominator: int = Field(description="Token deposit percentage denominator")
     reward_spend_min_blocks: int = Field(description="Minimum blocks before reward can be spent")
     max_number_inputs: int = Field(description="Maximum number of inputs per transaction")
     max_number_outputs: int = Field(description="Maximum number of outputs per transaction")
@@ -75,7 +76,8 @@ VersionResponse.openapi_examples = {
             min_tx_weight_coefficient=1.6,
             min_tx_weight_k=100,
             token_deposit_percentage=0.01,
-            token_deposit_percentage_ppb=10**7,
+            token_deposit_percentage_numerator=10**7,
+            token_deposit_percentage_denominator=10**9,
             reward_spend_min_blocks=300,
             max_number_inputs=256,
             max_number_outputs=256,
@@ -140,7 +142,8 @@ class VersionResource(Resource):
             token_deposit_percentage=(
                 self._settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR / self._settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
             ),
-            token_deposit_percentage_ppb=self._settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR,
+            token_deposit_percentage_numerator=self._settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR,
+            token_deposit_percentage_denominator=self._settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR,
             reward_spend_min_blocks=self._settings.REWARD_SPEND_MIN_BLOCKS,
             max_number_inputs=self._settings.MAX_NUM_INPUTS,
             max_number_outputs=self._settings.MAX_NUM_OUTPUTS,

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -137,8 +137,10 @@ class VersionResource(Resource):
             min_tx_weight=self._settings.MIN_TX_WEIGHT,
             min_tx_weight_coefficient=self._settings.MIN_TX_WEIGHT_COEFFICIENT,
             min_tx_weight_k=self._settings.MIN_TX_WEIGHT_K,
-            token_deposit_percentage=self._settings.TOKEN_DEPOSIT_PERCENTAGE_PPB / 10**9,
-            token_deposit_percentage_ppb=self._settings.TOKEN_DEPOSIT_PERCENTAGE_PPB,
+            token_deposit_percentage=(
+                self._settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR / self._settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+            ),
+            token_deposit_percentage_ppb=self._settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR,
             reward_spend_min_blocks=self._settings.REWARD_SPEND_MIN_BLOCKS,
             max_number_inputs=self._settings.MAX_NUM_INPUTS,
             max_number_outputs=self._settings.MAX_NUM_OUTPUTS,

--- a/hathor_tests/others/test_hathor_settings.py
+++ b/hathor_tests/others/test_hathor_settings.py
@@ -112,22 +112,22 @@ def test_token_deposit_percentage_ppb() -> None:
 
     with patch('hathorlib.utils.yaml.dict_from_extended_yaml', yaml_mock):
         # Test default value passes (1% results in FEE_DIVISOR=100)
-        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_PPB=10**7))
+        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR=10**7))
         load_yaml_settings(HathorSettings, filepath='some_path')
 
-        # Test fails when TOKEN_DEPOSIT_PERCENTAGE_PPB results in non-integer FEE_DIVISOR (3% -> 33.333...)
-        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_PPB=3 * 10**7))
+        # Test fails when TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR results in non-integer FEE_DIVISOR (3% -> 33.333...)
+        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR=3 * 10**7))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
-        assert 'TOKEN_DEPOSIT_PERCENTAGE_PPB must result in an integer FEE_DIVISOR' in str(e.value)
-        assert f'TOKEN_DEPOSIT_PERCENTAGE_PPB={3 * 10**7}' in str(e.value)
+        assert 'TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR must result in an integer FEE_DIVISOR' in str(e.value)
+        assert f'TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR={3 * 10**7}' in str(e.value)
 
-        # Test fails when TOKEN_DEPOSIT_PERCENTAGE_PPB results in non-integer FEE_DIVISOR (7% -> 14.285...)
-        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_PPB=7 * 10**7))
+        # Test fails when TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR results in non-integer FEE_DIVISOR (7% -> 14.285...)
+        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR=7 * 10**7))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
-        assert 'TOKEN_DEPOSIT_PERCENTAGE_PPB must result in an integer FEE_DIVISOR' in str(e.value)
-        assert f'TOKEN_DEPOSIT_PERCENTAGE_PPB={7 * 10**7}' in str(e.value)
+        assert 'TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR must result in an integer FEE_DIVISOR' in str(e.value)
+        assert f'TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR={7 * 10**7}' in str(e.value)
 
 
 def test_consensus_algorithm() -> None:

--- a/hathor_tests/others/test_hathor_settings.py
+++ b/hathor_tests/others/test_hathor_settings.py
@@ -103,7 +103,7 @@ def test_missing_hathor_settings_from_yaml(filepath):
     assert "validation error for HathorSettings\nNETWORK_NAME" in str(e.value)
 
 
-def test_token_deposit_percentage() -> None:
+def test_token_deposit_percentage_ppb() -> None:
     yaml_mock = Mock()
     required_settings = dict(P2PKH_VERSION_BYTE='x01', MULTISIG_VERSION_BYTE='x02', NETWORK_NAME='test')
 
@@ -111,23 +111,23 @@ def test_token_deposit_percentage() -> None:
         mock.return_value = required_settings | settings_
 
     with patch('hathorlib.utils.yaml.dict_from_extended_yaml', yaml_mock):
-        # Test default value passes (0.01 results in FEE_DIVISOR=100)
-        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE=0.01))
+        # Test default value passes (1% results in FEE_DIVISOR=100)
+        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_PPB=10**7))
         load_yaml_settings(HathorSettings, filepath='some_path')
 
-        # Test fails when TOKEN_DEPOSIT_PERCENTAGE results in non-integer FEE_DIVISOR (0.03 -> 33.333...)
-        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE=0.03))
+        # Test fails when TOKEN_DEPOSIT_PERCENTAGE_PPB results in non-integer FEE_DIVISOR (3% -> 33.333...)
+        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_PPB=3 * 10**7))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
-        assert 'TOKEN_DEPOSIT_PERCENTAGE must result in an integer FEE_DIVISOR' in str(e.value)
-        assert 'TOKEN_DEPOSIT_PERCENTAGE=0.03' in str(e.value)
+        assert 'TOKEN_DEPOSIT_PERCENTAGE_PPB must result in an integer FEE_DIVISOR' in str(e.value)
+        assert f'TOKEN_DEPOSIT_PERCENTAGE_PPB={3 * 10**7}' in str(e.value)
 
-        # Test fails when TOKEN_DEPOSIT_PERCENTAGE results in non-integer FEE_DIVISOR (0.07 -> 14.285...)
-        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE=0.07))
+        # Test fails when TOKEN_DEPOSIT_PERCENTAGE_PPB results in non-integer FEE_DIVISOR (7% -> 14.285...)
+        mock_settings(yaml_mock, dict(TOKEN_DEPOSIT_PERCENTAGE_PPB=7 * 10**7))
         with pytest.raises(ValidationError) as e:
             load_yaml_settings(HathorSettings, filepath='some_path')
-        assert 'TOKEN_DEPOSIT_PERCENTAGE must result in an integer FEE_DIVISOR' in str(e.value)
-        assert 'TOKEN_DEPOSIT_PERCENTAGE=0.07' in str(e.value)
+        assert 'TOKEN_DEPOSIT_PERCENTAGE_PPB must result in an integer FEE_DIVISOR' in str(e.value)
+        assert f'TOKEN_DEPOSIT_PERCENTAGE_PPB={7 * 10**7}' in str(e.value)
 
 
 def test_consensus_algorithm() -> None:

--- a/hathor_tests/poa/test_poa_simulation.py
+++ b/hathor_tests/poa/test_poa_simulation.py
@@ -509,7 +509,7 @@ class PoaSimulationTest(SimulatorTestCase):
             DISPLAY_DECIMAL_PLACES=0,
             VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 0},
             GENESIS_TOKEN_MAIN_UNITS=tokens,
-            TOKEN_DEPOSIT_PERCENTAGE_PPB=100,
+            TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR=100,
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,

--- a/hathor_tests/poa/test_poa_simulation.py
+++ b/hathor_tests/poa/test_poa_simulation.py
@@ -509,7 +509,7 @@ class PoaSimulationTest(SimulatorTestCase):
             DISPLAY_DECIMAL_PLACES=0,
             VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 0},
             GENESIS_TOKEN_MAIN_UNITS=tokens,
-            TOKEN_DEPOSIT_PERCENTAGE=0.0000001,
+            TOKEN_DEPOSIT_PERCENTAGE_PPB=100,
             BLOCKS_PER_HALVING=None,
             INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK=0,
             MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK=0,

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -637,26 +637,6 @@ def create_fee_tokens(
     return tx
 
 
-def get_deposit_token_amount_from_htr(htr_amount: int) -> int:
-    """
-    Calculate how many tokens correspond to a given HTR amount based on the
-    configured TOKEN_DEPOSIT_PERCENTAGE.
-
-    Returns
-    -------
-    int
-        The smallest integer number of tokens that covers the given HTR amount.
-    Raises
-    ------
-    AssertionError
-        If the computed token amount is not an integer (this should not occur
-        when TOKEN_DEPOSIT_PERCENTAGE is a positive divisor).
-    """
-    token_amount = abs(htr_amount / settings.TOKEN_DEPOSIT_PERCENTAGE)
-    assert token_amount.is_integer()
-    return int(token_amount)
-
-
 def create_script_with_sigops(nops: int) -> bytes:
     """ Generate a script with multiple OP_CHECKMULTISIG that amounts to `nops` sigops
     """

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -134,9 +134,8 @@ class HathorSettings(BaseModel):
     @property
     def FEE_DIVISOR(self) -> int:
         """Divisor used for evaluating fee amounts"""
-        result = 1 / self.TOKEN_DEPOSIT_PERCENTAGE
-        assert result.is_integer()
-        return int(result)
+        assert 10**9 % self.TOKEN_DEPOSIT_PERCENTAGE_PPB == 0
+        return 10**9 // self.TOKEN_DEPOSIT_PERCENTAGE_PPB
 
     # To disable reward halving, just set this to `None` and make sure that INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
     # is equal to MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK.
@@ -350,22 +349,23 @@ class HathorSettings(BaseModel):
     # Whether miners are assumed to mine txs by default
     STRATUM_MINE_TXS_DEFAULT: bool = True
 
-    # Percentage used to calculate the number of HTR that must be deposited when minting new tokens
-    # The same percentage is used to calculate the number of HTR that must be withdraw when melting tokens
+    # Percentage used to calculate the amount of HTR that must be deposited when minting new tokens,
+    # expressed in ppb (parts per billion), where 10**7 ppb = 0.01 = 1%.
+    # The same percentage is used to calculate the number of HTR that must be withdrawn when melting tokens
     # See for further information, see [rfc 0011-token-deposit].
-    TOKEN_DEPOSIT_PERCENTAGE: float = 0.01
+    TOKEN_DEPOSIT_PERCENTAGE_PPB: int = 10 ** 7
 
-    @field_validator('TOKEN_DEPOSIT_PERCENTAGE', mode='after')
+    @field_validator('TOKEN_DEPOSIT_PERCENTAGE_PPB', mode='after')
     @classmethod
-    def _validate_token_deposit_percentage(cls, token_deposit_percentage: float) -> float:
-        """Validate that TOKEN_DEPOSIT_PERCENTAGE results in an integer FEE_DIVISOR."""
-        result = 1 / token_deposit_percentage
-        if not result.is_integer():
+    def _validate_token_deposit_percentage_ppb(cls, token_deposit_percentage_ppb: int) -> int:
+        """Validate that TOKEN_DEPOSIT_PERCENTAGE_PPB results in an integer FEE_DIVISOR."""
+        if 10**9 % token_deposit_percentage_ppb != 0:
             raise ValueError(
-                f'TOKEN_DEPOSIT_PERCENTAGE must result in an integer FEE_DIVISOR. '
-                f'Got TOKEN_DEPOSIT_PERCENTAGE={token_deposit_percentage}, FEE_DIVISOR={result}'
+                f'TOKEN_DEPOSIT_PERCENTAGE_PPB must result in an integer FEE_DIVISOR. '
+                f'Got TOKEN_DEPOSIT_PERCENTAGE_PPB={token_deposit_percentage_ppb}, '
+                f'FEE_DIVISOR={10**9 / token_deposit_percentage_ppb}'
             )
-        return token_deposit_percentage
+        return token_deposit_percentage_ppb
 
     # Array with the settings parameters that are used when calculating the settings hash
     P2P_SETTINGS_HASH_FIELDS: list[str] = [

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -134,8 +134,8 @@ class HathorSettings(BaseModel):
     @property
     def FEE_DIVISOR(self) -> int:
         """Divisor used for evaluating fee amounts"""
-        assert 10**9 % self.TOKEN_DEPOSIT_PERCENTAGE_PPB == 0
-        return 10**9 // self.TOKEN_DEPOSIT_PERCENTAGE_PPB
+        assert self.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR % self.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR == 0
+        return self.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR // self.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR
 
     # To disable reward halving, just set this to `None` and make sure that INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
     # is equal to MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK.
@@ -350,22 +350,22 @@ class HathorSettings(BaseModel):
     STRATUM_MINE_TXS_DEFAULT: bool = True
 
     # Percentage used to calculate the amount of HTR that must be deposited when minting new tokens,
-    # expressed in ppb (parts per billion), where 10**7 ppb = 0.01 = 1%.
+    # expressed with a numerator and denominator in parts per billion, where 10**7 / 10**9 = 0.01 = 1%.
     # The same percentage is used to calculate the number of HTR that must be withdrawn when melting tokens
     # See for further information, see [rfc 0011-token-deposit].
-    TOKEN_DEPOSIT_PERCENTAGE_PPB: int = 10 ** 7
+    TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR: int = 10 ** 7
+    TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR: int = 10 ** 9
 
-    @field_validator('TOKEN_DEPOSIT_PERCENTAGE_PPB', mode='after')
-    @classmethod
-    def _validate_token_deposit_percentage_ppb(cls, token_deposit_percentage_ppb: int) -> int:
-        """Validate that TOKEN_DEPOSIT_PERCENTAGE_PPB results in an integer FEE_DIVISOR."""
-        if 10**9 % token_deposit_percentage_ppb != 0:
+    @model_validator(mode='after')
+    def _validate_token_deposit_percentage(self) -> Self:
+        """Validate that TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR results in an integer FEE_DIVISOR."""
+        if self.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR % self.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR != 0:
             raise ValueError(
-                f'TOKEN_DEPOSIT_PERCENTAGE_PPB must result in an integer FEE_DIVISOR. '
-                f'Got TOKEN_DEPOSIT_PERCENTAGE_PPB={token_deposit_percentage_ppb}, '
-                f'FEE_DIVISOR={10**9 / token_deposit_percentage_ppb}'
+                f'TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR must result in an integer FEE_DIVISOR. '
+                f'Got TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR={self.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR}, '
+                f'FEE_DIVISOR={self.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR / self.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR}'
             )
-        return token_deposit_percentage_ppb
+        return self
 
     # Array with the settings parameters that are used when calculating the settings hash
     P2P_SETTINGS_HASH_FIELDS: list[str] = [

--- a/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
@@ -83,4 +83,6 @@ def _calculate_unit_fee_token_fee(settings: HathorSettings, fee_payment_token: T
     """Calculate the fee for handling a fee-based token"""
     if fee_payment_token.token_id == HATHOR_TOKEN_UID:
         return settings.FEE_PER_OUTPUT
-    return int(settings.FEE_PER_OUTPUT / settings.TOKEN_DEPOSIT_PERCENTAGE)
+    numerator = settings.FEE_PER_OUTPUT * 10**9
+    assert numerator % settings.TOKEN_DEPOSIT_PERCENTAGE_PPB == 0
+    return numerator // settings.TOKEN_DEPOSIT_PERCENTAGE_PPB

--- a/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
@@ -83,6 +83,6 @@ def _calculate_unit_fee_token_fee(settings: HathorSettings, fee_payment_token: T
     """Calculate the fee for handling a fee-based token"""
     if fee_payment_token.token_id == HATHOR_TOKEN_UID:
         return settings.FEE_PER_OUTPUT
-    numerator = settings.FEE_PER_OUTPUT * 10**9
-    assert numerator % settings.TOKEN_DEPOSIT_PERCENTAGE_PPB == 0
-    return numerator // settings.TOKEN_DEPOSIT_PERCENTAGE_PPB
+    numerator = settings.FEE_PER_OUTPUT * settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+    assert numerator % settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR == 0
+    return numerator // settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR

--- a/hathorlib/hathorlib/utils/__init__.py
+++ b/hathorlib/hathorlib/utils/__init__.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import re
 import struct
-from math import ceil, floor
 from typing import TYPE_CHECKING, Any, Optional, Tuple, TypeVar
 
 if TYPE_CHECKING:
@@ -81,8 +81,14 @@ def not_none(optional: Optional[_T], message: str = 'Unexpected `None`') -> _T:
 
 
 def get_deposit_token_deposit_amount(settings: 'HathorSettings', mint_amount: int) -> int:
-    return ceil(abs(settings.TOKEN_DEPOSIT_PERCENTAGE * mint_amount))
+    return ceil_div(settings.TOKEN_DEPOSIT_PERCENTAGE_PPB * abs(mint_amount), 10**9)
 
 
 def get_deposit_token_withdraw_amount(settings: 'HathorSettings', melt_amount: int) -> int:
-    return floor(abs(settings.TOKEN_DEPOSIT_PERCENTAGE * melt_amount))
+    return settings.TOKEN_DEPOSIT_PERCENTAGE_PPB * abs(melt_amount) // 10**9
+
+
+def ceil_div(a: int, b: int) -> int:
+    """Calculate ceil division using integer math for non-negative operands."""
+    assert a >= 0 and b >= 0
+    return (a + b - 1) // b

--- a/hathorlib/hathorlib/utils/__init__.py
+++ b/hathorlib/hathorlib/utils/__init__.py
@@ -81,14 +81,20 @@ def not_none(optional: Optional[_T], message: str = 'Unexpected `None`') -> _T:
 
 
 def get_deposit_token_deposit_amount(settings: 'HathorSettings', mint_amount: int) -> int:
-    return ceil_div(settings.TOKEN_DEPOSIT_PERCENTAGE_PPB * abs(mint_amount), 10**9)
+    numerator = settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR * abs(mint_amount)
+    denominator = settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+    return ceil_div(numerator, denominator)
 
 
 def get_deposit_token_withdraw_amount(settings: 'HathorSettings', melt_amount: int) -> int:
-    return settings.TOKEN_DEPOSIT_PERCENTAGE_PPB * abs(melt_amount) // 10**9
+    numerator = settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR * abs(melt_amount)
+    denominator = settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+    return numerator // denominator
 
 
 def ceil_div(a: int, b: int) -> int:
-    """Calculate ceil division using integer math for non-negative operands."""
+    """
+    Calculate ceil division using integer math for non-negative operands, equivalent to `ceil(a / b)` for integers.
+    """
     assert a >= 0 and b >= 0
     return (a + b - 1) // b


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1708

### Motivation

HTR deposit/withdraw calculations for deposit-based tokens currently use float math to calculate percentages. This is problematic for integers with a high amount of decimal places, because float math starts losing precision for the percentage multiplication.

This PR refactors those calculations so they use integer math instead, with no change in behavior in relation to current code. The new representation of the percentage uses ppb, parts per billion, so we're able to represent the `10^-7` value used in the Ekvilibro network.

### Acceptance Criteria

- Refactor `HathorSettings.TOKEN_DEPOSIT_PERCENTAGE` to `HathorSettings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR` and `TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR`, representing the percentage in parts per billion instead of a float.
- Refactor `get_deposit_token_deposit_amount` and `get_deposit_token_withdraw_amount` to use integer math, that is, ceil div and floor div, instead of multiplication by a float.
- Update `/version` API to include new fields `token_deposit_percentage_numerator` and `token_deposit_percentage_denominator`, and deprecate `token_deposit_percentage`.
- Remove unused `get_deposit_token_amount_from_htr`.
- No change in behavior.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 