### PR TITLE
refactor(decimal): renames and reorganization [part 8]

### DIFF
--- a/hathor/client.py
+++ b/hathor/client.py
@@ -392,7 +392,7 @@ def create_tx_from_dict(data: dict[str, Any], update_hash: bool = False,
 
     cls = get_cls_from_tx_version(TxVersion(data['version']))
     metadata = data.pop('metadata', None)
-    data.pop('decimal_version')
+    data.pop('token_amount_version')
     tx = cls(**data)
     if update_hash:
         tx.update_hash()

--- a/hathor/daa/common.py
+++ b/hathor/daa/common.py
@@ -194,7 +194,7 @@ def _minimum_tx_weight(settings: HathorSettings, tx: 'Transaction', test_mode: T
     # We need to take into consideration the decimal places because it is inside the amount.
     # For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     # Max below is preventing division by 0 when handling authority methods that have no outputs
-    decimal_places = tx.get_decimal_version().get_decimal_places(settings)
+    decimal_places = tx.get_token_amount_version().get_decimal_places(settings)
     amount = max(1, tx.sum_outputs) / (10 ** decimal_places)
     weight = (
         + settings.MIN_TX_WEIGHT_COEFFICIENT * log(tx_size, 2)

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -69,6 +69,7 @@ from hathor.verification.verification_service import VerificationService
 from hathor.vertex_handler import VertexHandler
 from hathor.wallet import BaseWallet
 from hathorlib.base_transaction import tx_or_block_from_bytes as lib_tx_or_block_from_bytes
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor.websocket.factory import HathorAdminWebsocketFactory
@@ -410,7 +411,7 @@ class HathorManager:
         if save_to:
             self.profiler.dump_stats(save_to)
 
-    def get_nc_runner(self, block: Block) -> Runner:
+    def get_nc_runner(self, block: Block, *, token_amount_version: TokenAmountVersion) -> Runner:
         """Return a contract runner for a given block."""
         nc_storage_factory = self.consensus_algorithm.nc_storage_factory
         block_storage = get_block_storage_from_block(nc_storage_factory, block)
@@ -418,12 +419,8 @@ class HathorManager:
         return self.runner_factory.create(
             runtime_version=features.nano_runtime_version,
             block_storage=block_storage,
+            token_amount_version=token_amount_version
         )
-
-    def get_best_block_nc_runner(self) -> Runner:
-        """Return a contract runner for the best block."""
-        best_block = self.tx_storage.get_best_block()
-        return self.get_nc_runner(best_block)
 
     def get_nc_block_storage(self, block: Block) -> NCBlockStorage:
         """Return the nano block storage for a given block."""

--- a/hathor/nanocontracts/blueprint_service.py
+++ b/hathor/nanocontracts/blueprint_service.py
@@ -30,6 +30,7 @@ from hathor.nanocontracts.exception import (
 from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathorlib.nanocontracts.types import BlueprintId
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor import Blueprint
@@ -72,17 +73,28 @@ class BlueprintService:
         # XXX: maybe use N blocks confirmation, like reward-locks
         return blueprint_tx
 
-    def get_blueprint_class(self, blueprint_id: BlueprintId) -> type[Blueprint]:
-        """Returns the blueprint class associated with the given blueprint_id.
+    def get_blueprint_class_and_token_amount_version(
+        self,
+        blueprint_id: BlueprintId,
+    ) -> tuple[type[Blueprint], TokenAmountVersion]:
+        """Returns the blueprint class associated with the given blueprint_id, and its TokenAmountVersion.
 
         The blueprint class could be in the catalog (first search), or it could be the tx_id of an on-chain blueprint.
         """
         from hathor.nanocontracts import OnChainBlueprint
         blueprint = self._get_blueprint(blueprint_id)
         if isinstance(blueprint, OnChainBlueprint):
-            return blueprint.get_blueprint_class()
+            return blueprint.get_blueprint_class(), blueprint.get_token_amount_version()
         else:
-            return blueprint
+            return blueprint, TokenAmountVersion.V2
+
+    def get_blueprint_class(self, blueprint_id: BlueprintId) -> type[Blueprint]:
+        """Returns the blueprint class associated with the given blueprint_id.
+
+        The blueprint class could be in the catalog (first search), or it could be the tx_id of an on-chain blueprint.
+        """
+        blueprint_class, _ = self.get_blueprint_class_and_token_amount_version(blueprint_id)
+        return blueprint_class
 
     def get_blueprint_source(self, blueprint_id: BlueprintId) -> str:
         """Returns the source code associated with the given blueprint_id.

--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -298,6 +298,7 @@ class NCBlockExecutor:
 
         runner = self._runner_factory.create(
             runtime_version=runtime_version,
+            token_amount_version=tx.get_token_amount_version(),
             block_storage=block_storage,
             seed=rng_seed,
         )

--- a/hathor/nanocontracts/resources/state.py
+++ b/hathor/nanocontracts/resources/state.py
@@ -48,6 +48,7 @@ class NanoContractStateResource(Resource):
     def __init__(self, manager: 'HathorManager') -> None:
         super().__init__()
         self.manager = manager
+        self.nc_storage_factory = manager.consensus_algorithm.nc_storage_factory
 
     def render_GET(self, request: 'Request') -> bytes:
         request.setHeader(b'content-type', b'application/json; charset=utf-8')
@@ -135,9 +136,11 @@ class NanoContractStateResource(Resource):
         else:
             block = self.manager.tx_storage.get_best_block()
 
+        from hathor.nanocontracts.storage import get_block_storage_from_block
+        block_storage = get_block_storage_from_block(self.nc_storage_factory, block)
+
         try:
-            runner = self.manager.get_nc_runner(block)
-            nc_storage = runner.get_storage(nc_id_bytes)
+            nc_storage = block_storage.get_contract_storage(nc_id_bytes)
         except NanoContractDoesNotExist:
             # Nano contract does not exist at this block
             request.setResponseCode(404)
@@ -148,7 +151,10 @@ class NanoContractStateResource(Resource):
             return error_response.json_dumpb()
 
         blueprint_id = nc_storage.get_blueprint_id()
-        blueprint_class = self.manager.blueprint_service.get_blueprint_class(blueprint_id)
+        blueprint_class, token_amount_version = (
+            self.manager.blueprint_service.get_blueprint_class_and_token_amount_version(blueprint_id)
+        )
+        runner = self.manager.get_nc_runner(block, token_amount_version=token_amount_version)
 
         value: Any
         # Get balances.

--- a/hathor/transaction/block.py
+++ b/hathor/transaction/block.py
@@ -29,7 +29,7 @@ from hathor.transaction.exceptions import CheckpointError
 from hathor.transaction.static_metadata import BlockStaticMetadata
 from hathor.transaction.util import VerboseCallback
 from hathor.utils.int import get_bit_list
-from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -203,7 +203,7 @@ class Block(GenericVertex[BlockStaticMetadata]):
         json = super().to_json(decode_script=decode_script, include_metadata=include_metadata)
         json['tokens'] = []
         json['data'] = base64.b64encode(self.data).decode('utf-8')
-        json['decimal_version'] = VertexDecimalVersion.V1.value  # Blocks are always V1.
+        json['token_amount_version'] = TokenAmountVersion.V1.value  # Blocks are always V1.
         return json
 
     def to_json_extended(self) -> dict[str, Any]:

--- a/hathor/transaction/token_info.py
+++ b/hathor/transaction/token_info.py
@@ -67,13 +67,13 @@ class TokenInfoDict(dict[TokenUid, TokenInfo]):
 
          The fee is determined using the following rules:
          - If a token has one or more chargeable outputs, the fee is calculated
-           as `chargeable_outputs * settings.FEE_PER_OUTPUT`.
+           as `chargeable_outputs * settings.FEE_PER_OUTPUT_V1`.
          - If a token has zero chargeable outputs but one or more chargeable inputs,
-           a flat fee of `settings.FEE_PER_OUTPUT` is applied.
+           a flat fee of `settings.FEE_PER_OUTPUT_V1` is applied.
 
          Args:
              settings (HathorSettings): The configuration object containing fee-related
-                 parameters, such as `FEE_PER_OUTPUT`.
+                 parameters, such as `FEE_PER_OUTPUT_V1`.
 
          Returns:
              int: The total transaction fee
@@ -82,10 +82,10 @@ class TokenInfoDict(dict[TokenUid, TokenInfo]):
 
         for token_uid, token_info in self.items():
             if token_info.chargeable_outputs > 0:
-                fee += token_info.chargeable_outputs * settings.FEE_PER_OUTPUT
+                fee += token_info.chargeable_outputs * settings.FEE_PER_OUTPUT_V1
             else:
                 if token_info.chargeable_inputs > 0:
-                    fee += settings.FEE_PER_OUTPUT
+                    fee += settings.FEE_PER_OUTPUT_V1
         return fee
 
 

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -36,7 +36,7 @@ from hathor.transaction.static_metadata import TransactionStaticMetadata
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion, get_token_version
 from hathor.transaction.util import VerboseCallback
 from hathor.types import TokenUid, VertexId
-from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.transaction.shielded_tx_output import ShieldedOutput
 
 T = TypeVar('T', bound=AnyVertexHeader)
@@ -267,7 +267,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
     def to_json(self, decode_script: bool = False, include_metadata: bool = False) -> dict[str, Any]:
         json = super().to_json(decode_script=decode_script, include_metadata=include_metadata)
         json['tokens'] = [h.hex() for h in self.tokens]
-        json['decimal_version'] = self.get_decimal_version().value
+        json['token_amount_version'] = self.get_token_amount_version().value
 
         if self.is_nano_contract():
             nano_header = self.get_nano_header()
@@ -345,7 +345,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
         nano_header = self.get_nano_header()
 
         for action in nano_header.get_actions():
-            rules = BalanceRules.get_rules(self._settings, action)
+            rules = BalanceRules.get_rules(self._settings, action, self.get_token_amount_version())
             if action.token_uid not in token_dict:
                 # we try to load this token version from storage in case it's not in the inputs
                 token_dict[action.token_uid] = TokenInfo(
@@ -489,9 +489,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
         self.set_static_metadata(static_metadata)
 
     @final
-    def get_decimal_version(self) -> VertexDecimalVersion:
-        """
-        Return the decimal-places version under which this transaction's token amounts are interpreted.
-        """
+    def get_token_amount_version(self) -> TokenAmountVersion:
+        """Return the version under which this transaction's token amounts are interpreted."""
         # Transactions are always V1. This will be updated in the future.
-        return VertexDecimalVersion.V1
+        return TokenAmountVersion.V1

--- a/hathor/transaction/util.py
+++ b/hathor/transaction/util.py
@@ -17,14 +17,9 @@ from __future__ import annotations
 import re
 import struct
 from struct import error as StructError
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any, Callable, Optional
 
-from hathor.transaction.exceptions import InvalidFeeAmount, TransactionDataError
 from hathorlib.utils import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount  # noqa: F401
-
-if TYPE_CHECKING:
-    from hathor import TokenUid
-    from hathor.conf.settings import HathorSettings
 
 VerboseCallback = Optional[Callable[[str, Any], None]]
 
@@ -71,31 +66,3 @@ def decode_string_utf8(encoded: bytes, key: str) -> str:
         return decoded
     except UnicodeDecodeError:
         raise StructError('{} must be a valid utf-8 string.'.format(key))
-
-
-def validate_token_name_and_symbol(settings: HathorSettings,
-                                   token_name: str,
-                                   token_symbol: str) -> None:
-    """Validate token_name and token_symbol before creating a new token."""
-    name_len = len(token_name)
-    symbol_len = len(token_symbol)
-    if name_len == 0 or name_len > settings.MAX_LENGTH_TOKEN_NAME:
-        raise TransactionDataError('Invalid token name length ({})'.format(name_len))
-    if symbol_len == 0 or symbol_len > settings.MAX_LENGTH_TOKEN_SYMBOL:
-        raise TransactionDataError('Invalid token symbol length ({})'.format(symbol_len))
-
-    # Can't create token with hathor name or symbol
-    if clean_token_string(token_name) == clean_token_string(settings.HATHOR_TOKEN_NAME):
-        raise TransactionDataError('Invalid token name ({})'.format(token_name))
-    if clean_token_string(token_symbol) == clean_token_string(settings.HATHOR_TOKEN_SYMBOL):
-        raise TransactionDataError('Invalid token symbol ({})'.format(token_symbol))
-
-
-def validate_fee_amount(settings: HathorSettings, token_uid: TokenUid | bytes, amount: int) -> None:
-    """Validate the fee amount."""
-    if amount <= 0:
-        raise InvalidFeeAmount(f'fees should be a positive integer, got {amount}')
-
-    if token_uid != settings.HATHOR_TOKEN_UID and amount % settings.FEE_DIVISOR != 0:
-        raise InvalidFeeAmount(f'fees using deposit custom tokens should be a multiple of {settings.FEE_DIVISOR}, '
-                               f'got {amount}')

--- a/hathor/transaction/vertex_parser/_block.py
+++ b/hathor/transaction/vertex_parser/_block.py
@@ -26,7 +26,7 @@ from hathor.transaction.vertex_parser._common import (
     serialize_graph_fields,
     serialize_tx_output,
 )
-from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor.transaction.base_transaction import TxOutput
@@ -51,7 +51,7 @@ def serialize_block_funds(
     """
     serializer.write_struct((block.signal_bits, block.version, len(block.outputs)), '!BBB')
     for tx_output in block.outputs:
-        serialize_tx_output(serializer, tx_output, decimal_version=VertexDecimalVersion.V1)  # Blocks are always V1.
+        serialize_tx_output(serializer, tx_output, token_amount_version=TokenAmountVersion.V1)  # Blocks are always V1.
 
 
 def serialize_block_graph_fields(
@@ -106,7 +106,7 @@ def deserialize_block_funds(
     for _ in range(outputs_len):
         txout = _deserialize_tx_output(
             deserializer,
-            decimal_version=VertexDecimalVersion.V1,  # Blocks are always V1.
+            token_amount_version=TokenAmountVersion.V1,  # Blocks are always V1.
             verbose=verbose,
         )
         outputs.append(txout)

--- a/hathor/transaction/vertex_parser/_common.py
+++ b/hathor/transaction/vertex_parser/_common.py
@@ -22,8 +22,8 @@ from hathor.serialization import Deserializer, Serializer
 from hathor.transaction.base_transaction import TX_HASH_SIZE
 from hathor.transaction.exceptions import SerializedSizeError
 from hathor.transaction.util import VerboseCallback, int_to_bytes
-from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.serialization.encoding.output_value import decode_output_value, encode_output_value
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -66,9 +66,14 @@ def serialize_tx_input_sighash(serializer: Serializer, tx_input: TxInput) -> Non
     serializer.write_bytes(int_to_bytes(0, 2))
 
 
-def serialize_tx_output(serializer: Serializer, tx_output: TxOutput, *, decimal_version: VertexDecimalVersion) -> None:
+def serialize_tx_output(
+    serializer: Serializer,
+    tx_output: TxOutput,
+    *,
+    token_amount_version: TokenAmountVersion,
+) -> None:
     """Serialize a TxOutput. Matches bytes(TxOutput)."""
-    encode_output_value(serializer, tx_output.value, decimal_version=decimal_version)
+    encode_output_value(serializer, tx_output.value, token_amount_version=token_amount_version)
     serializer.write_bytes(int_to_bytes(tx_output.token_data, 1))
     serializer.write_bytes(int_to_bytes(len(tx_output.script), 2))
     serializer.write_bytes(tx_output.script)
@@ -143,7 +148,7 @@ def _deserialize_tx_input(
 def _deserialize_tx_output(
     deserializer: Deserializer,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
     verbose: VerboseCallback = None,
 ) -> 'TxOutput':
     """Deserialize a single TxOutput. Matches TxOutput.create_from_bytes()."""
@@ -152,7 +157,7 @@ def _deserialize_tx_output(
     from hathor.transaction.exceptions import InvalidOutputValue
 
     try:
-        value = decode_output_value(deserializer, decimal_version=decimal_version)
+        value = decode_output_value(deserializer, token_amount_version=token_amount_version)
     except BadDataError as e:
         raise InvalidOutputValue(*e.args) from e
     if verbose:

--- a/hathor/transaction/vertex_parser/_fee_header.py
+++ b/hathor/transaction/vertex_parser/_fee_header.py
@@ -21,8 +21,8 @@ from hathor.serialization.encoding.output_value import decode_output_value
 from hathor.transaction.headers.fee_header import FeeHeader, FeeHeaderEntry
 from hathor.transaction.headers.types import VertexHeaderId
 from hathor.transaction.util import VerboseCallback, int_to_bytes
-from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.serialization.encoding.output_value import encode_output_value
+from hathorlib.token_amount_version import TokenAmountVersion
 
 # ---------------------------------------------------------------------------
 # Deserialization
@@ -32,7 +32,7 @@ from hathorlib.serialization.encoding.output_value import encode_output_value
 def deserialize_fee_header(
     deserializer: Deserializer,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
     verbose: VerboseCallback = None,
 ) -> list[FeeHeaderEntry]:
     """Deserialize fee header data from the deserializer."""
@@ -47,7 +47,7 @@ def deserialize_fee_header(
         verbose('fees_len', fees_len)
     for _ in range(fees_len):
         token_index = deserializer.read_byte()
-        amount = decode_output_value(deserializer, decimal_version=decimal_version)
+        amount = decode_output_value(deserializer, token_amount_version=token_amount_version)
         fees.append(FeeHeaderEntry(
             token_index=token_index,
             amount=amount,
@@ -61,11 +61,16 @@ def deserialize_fee_header(
 # ---------------------------------------------------------------------------
 
 
-def serialize_fee_header(serializer: Serializer, header: FeeHeader, *, decimal_version: VertexDecimalVersion) -> None:
+def serialize_fee_header(
+    serializer: Serializer,
+    header: FeeHeader,
+    *,
+    token_amount_version: TokenAmountVersion,
+) -> None:
     """Serialize a FeeHeader into the serializer."""
     serializer.write_bytes(VertexHeaderId.FEE_HEADER.value)
     serializer.write_bytes(int_to_bytes(len(header.fees), 1))
 
     for fee in header.fees:
         serializer.write_bytes(int_to_bytes(fee.token_index, 1))
-        encode_output_value(serializer, fee.amount, decimal_version=decimal_version)
+        encode_output_value(serializer, fee.amount, token_amount_version=token_amount_version)

--- a/hathor/transaction/vertex_parser/_headers.py
+++ b/hathor/transaction/vertex_parser/_headers.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 from hathor.serialization import Serializer
 from hathor.transaction.headers.types import VertexHeaderId
 from hathor.transaction.vertex_parser._vertex_parser import VertexParser
-from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -49,14 +49,14 @@ def deserialize_headers(
                 from hathor.transaction.headers import NanoHeader
                 from hathor.transaction.vertex_parser._nano_header import deserialize_nano_header
                 assert isinstance(vertex, Transaction)
-                data = deserialize_nano_header(deserializer, decimal_version=vertex.get_decimal_version())
+                data = deserialize_nano_header(deserializer, token_amount_version=vertex.get_token_amount_version())
                 header = NanoHeader.create_from_data(vertex, data)
             case VertexHeaderId.FEE_HEADER:
                 from hathor.transaction import Transaction
                 from hathor.transaction.headers import FeeHeader
                 from hathor.transaction.vertex_parser._fee_header import deserialize_fee_header
                 assert isinstance(vertex, Transaction)
-                fees = deserialize_fee_header(deserializer, decimal_version=vertex.get_decimal_version())
+                fees = deserialize_fee_header(deserializer, token_amount_version=vertex.get_token_amount_version())
                 header = FeeHeader(settings=settings, tx=vertex, fees=fees)
             case VertexHeaderId.SHIELDED_OUTPUTS_HEADER:
                 from hathor.transaction import Transaction
@@ -88,7 +88,7 @@ def serialize_header(
     serializer: Serializer,
     header: AnyVertexHeader,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
 ) -> None:
     """Serialize a single header into the serializer."""
     from hathor.transaction.headers import (
@@ -101,10 +101,10 @@ def serialize_header(
     match header:
         case NanoHeader():
             from hathor.transaction.vertex_parser._nano_header import serialize_nano_header
-            serialize_nano_header(serializer, header, decimal_version=decimal_version)
+            serialize_nano_header(serializer, header, token_amount_version=token_amount_version)
         case FeeHeader():
             from hathor.transaction.vertex_parser._fee_header import serialize_fee_header
-            serialize_fee_header(serializer, header, decimal_version=decimal_version)
+            serialize_fee_header(serializer, header, token_amount_version=token_amount_version)
         case ShieldedOutputsHeader():
             from hathor.transaction.vertex_parser._shielded_outputs_header import (
                 serialize_shielded_outputs_header,
@@ -119,7 +119,7 @@ def serialize_header(
             raise AssertionError('unreachable')
 
 
-def get_header_sighash_bytes(header: AnyVertexHeader, *, decimal_version: VertexDecimalVersion) -> bytes:
+def get_header_sighash_bytes(header: AnyVertexHeader, *, token_amount_version: TokenAmountVersion) -> bytes:
     """Get sighash bytes for a header."""
     from hathor.transaction.headers import FeeHeader, NanoHeader
 
@@ -127,12 +127,12 @@ def get_header_sighash_bytes(header: AnyVertexHeader, *, decimal_version: Vertex
         case NanoHeader():
             from hathor.transaction.vertex_parser._nano_header import serialize_nano_header
             serializer = Serializer.build_bytes_serializer()
-            serialize_nano_header(serializer, header, skip_signature=True, decimal_version=decimal_version)
+            serialize_nano_header(serializer, header, skip_signature=True, token_amount_version=token_amount_version)
             return bytes(serializer.finalize())
         case FeeHeader():
             from hathor.transaction.vertex_parser._fee_header import serialize_fee_header
             serializer = Serializer.build_bytes_serializer()
-            serialize_fee_header(serializer, header, decimal_version=decimal_version)
+            serialize_fee_header(serializer, header, token_amount_version=token_amount_version)
             return bytes(serializer.finalize())
         case _:
             raise AssertionError('unreachable')

--- a/hathor/transaction/vertex_parser/_nano_header.py
+++ b/hathor/transaction/vertex_parser/_nano_header.py
@@ -30,8 +30,8 @@ from hathor.transaction.headers.nano_header import (
 )
 from hathor.transaction.headers.types import VertexHeaderId
 from hathor.transaction.util import VerboseCallback, int_to_bytes
-from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.serialization.encoding.output_value import encode_output_value
+from hathorlib.token_amount_version import TokenAmountVersion
 
 
 @dataclass(slots=True, kw_only=True, frozen=True)
@@ -54,7 +54,7 @@ class NanoHeaderData:
 def deserialize_nano_header(
     deserializer: Deserializer,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
     verbose: VerboseCallback = None,
 ) -> NanoHeaderData:
     """Deserialize nano header data from the deserializer."""
@@ -92,7 +92,7 @@ def deserialize_nano_header(
     if verbose:
         verbose('nc_actions_len', nc_actions_len)
     for _ in range(nc_actions_len):
-        action = _deserialize_nano_action(deserializer, decimal_version=decimal_version)
+        action = _deserialize_nano_action(deserializer, token_amount_version=token_amount_version)
         nc_actions.append(action)
 
     nc_address = bytes(deserializer.read_bytes(ADDRESS_LEN_BYTES))
@@ -120,14 +120,18 @@ def deserialize_nano_header(
     )
 
 
-def _deserialize_nano_action(deserializer: Deserializer, *, decimal_version: VertexDecimalVersion) -> NanoHeaderAction:
+def _deserialize_nano_action(
+    deserializer: Deserializer,
+    *,
+    token_amount_version: TokenAmountVersion,
+) -> NanoHeaderAction:
     """Deserialize a single NanoHeaderAction from the deserializer."""
     from hathor.nanocontracts.types import NCActionType
 
     type_bytes = bytes(deserializer.read_bytes(1))
     action_type = NCActionType.from_bytes(type_bytes)
     token_index = deserializer.read_byte()
-    amount = decode_output_value(deserializer, decimal_version=decimal_version)
+    amount = decode_output_value(deserializer, token_amount_version=token_amount_version)
     return NanoHeaderAction(
         type=action_type,
         token_index=token_index,
@@ -144,7 +148,7 @@ def serialize_nano_header(
     serializer: Serializer,
     header: NanoHeader,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
     skip_signature: bool = False,
 ) -> None:
     """Serialize a NanoHeader into the serializer."""
@@ -160,7 +164,7 @@ def serialize_nano_header(
 
     serializer.write_bytes(int_to_bytes(len(header.nc_actions), 1))
     for action in header.nc_actions:
-        _serialize_nano_action(serializer, action, decimal_version=decimal_version)
+        _serialize_nano_action(serializer, action, token_amount_version=token_amount_version)
 
     serializer.write_bytes(header.nc_address)
     if not skip_signature:
@@ -180,9 +184,9 @@ def _serialize_nano_action(
     serializer: Serializer,
     action: NanoHeaderAction,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
 ) -> None:
     """Serialize a single NanoHeaderAction into the serializer."""
     serializer.write_bytes(action.type.to_bytes())
     serializer.write_bytes(int_to_bytes(action.token_index, 1))
-    encode_output_value(serializer, action.amount, decimal_version=decimal_version)
+    encode_output_value(serializer, action.amount, token_amount_version=token_amount_version)

--- a/hathor/transaction/vertex_parser/_token_creation.py
+++ b/hathor/transaction/vertex_parser/_token_creation.py
@@ -55,7 +55,7 @@ def serialize_token_creation_funds(
     for tx_input in tx.inputs:
         serialize_tx_input(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
+        serialize_tx_output(serializer, tx_output, token_amount_version=tx.get_token_amount_version())
     serializer.write_bytes(_serialize_token_info(tx))
 
 
@@ -76,7 +76,7 @@ def serialize_token_creation_sighash(
     for tx_input in tx.inputs:
         serialize_tx_input_sighash(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
+        serialize_tx_output(serializer, tx_output, token_amount_version=tx.get_token_amount_version())
     serializer.write_bytes(_serialize_token_info(tx))
     for header_bytes in headers_sighash:
         serializer.write_bytes(header_bytes)
@@ -117,7 +117,7 @@ def deserialize_token_creation_funds(
     for _ in range(outputs_len):
         txout = _deserialize_tx_output(
             deserializer,
-            decimal_version=tx.get_decimal_version(),
+            token_amount_version=tx.get_token_amount_version(),
             verbose=verbose,
         )
         outputs.append(txout)

--- a/hathor/transaction/vertex_parser/_transaction.py
+++ b/hathor/transaction/vertex_parser/_transaction.py
@@ -58,7 +58,7 @@ def serialize_tx_funds(
     for tx_input in tx.inputs:
         serialize_tx_input(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
+        serialize_tx_output(serializer, tx_output, token_amount_version=tx.get_token_amount_version())
 
 
 def serialize_tx_sighash(
@@ -81,7 +81,7 @@ def serialize_tx_sighash(
     for tx_input in tx.inputs:
         serialize_tx_input_sighash(serializer, tx_input)
     for tx_output in tx.outputs:
-        serialize_tx_output(serializer, tx_output, decimal_version=tx.get_decimal_version())
+        serialize_tx_output(serializer, tx_output, token_amount_version=tx.get_token_amount_version())
     for header_bytes in headers_sighash:
         serializer.write_bytes(header_bytes)
 
@@ -127,7 +127,7 @@ def deserialize_tx_funds(
     for _ in range(outputs_len):
         txout = _deserialize_tx_output(
             deserializer,
-            decimal_version=tx.get_decimal_version(),
+            token_amount_version=tx.get_token_amount_version(),
             verbose=verbose,
         )
         outputs.append(txout)

--- a/hathor/transaction/vertex_parser/vertex_serializer.py
+++ b/hathor/transaction/vertex_parser/vertex_serializer.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 from hathor.serialization import Serializer
 from hathor.transaction.base_transaction import TxVersion
 from hathor.transaction.util import VerboseCallback, int_to_bytes
-from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
     from hathor.transaction.base_transaction import BaseTransaction, TxInput, TxOutput
@@ -118,13 +118,13 @@ def serialize_headers(serializer: Serializer, vertex: BaseTransaction) -> None:
     from hathor.transaction.vertex_parser._headers import serialize_header
     match vertex:
         case Transaction():
-            decimal_version = vertex.get_decimal_version()
+            token_amount_version = vertex.get_token_amount_version()
         case Block():
-            decimal_version = VertexDecimalVersion.V1  # Blocks are always V1.
+            token_amount_version = TokenAmountVersion.V1  # Blocks are always V1.
         case _:
             raise AssertionError('unreachable')
     for h in vertex.headers:
-        serialize_header(serializer, h, decimal_version=decimal_version)
+        serialize_header(serializer, h, token_amount_version=token_amount_version)
 
 
 def serialize_without_nonce(serializer: Serializer, vertex: BaseTransaction) -> None:
@@ -150,7 +150,9 @@ def serialize_sighash(tx: Transaction, *, skip_cache: bool = False) -> bytes:
         return tx._sighash_cache
 
     from hathor.transaction.vertex_parser._headers import get_header_sighash_bytes
-    headers_sighash = [get_header_sighash_bytes(h, decimal_version=tx.get_decimal_version()) for h in tx.headers]
+    headers_sighash = [
+        get_header_sighash_bytes(h, token_amount_version=tx.get_token_amount_version()) for h in tx.headers
+    ]
 
     serializer = Serializer.build_bytes_serializer()
 
@@ -203,11 +205,11 @@ def serialize_tx_input_sighash(txin: TxInput) -> bytes:
     return bytes(serializer.finalize())
 
 
-def serialize_tx_output_bytes(txout: TxOutput, *, decimal_version: VertexDecimalVersion) -> bytes:
+def serialize_tx_output_bytes(txout: TxOutput, *, token_amount_version: TokenAmountVersion) -> bytes:
     """Serialize a TxOutput. Replaces bytes(txout)."""
     from hathor.transaction.vertex_parser._common import serialize_tx_output as _ser
     serializer = Serializer.build_bytes_serializer()
-    _ser(serializer, txout, decimal_version=decimal_version)
+    _ser(serializer, txout, token_amount_version=token_amount_version)
     return bytes(serializer.finalize())
 
 
@@ -238,7 +240,7 @@ def deserialize_tx_input(buf: bytes, *, verbose: VerboseCallback = None) -> tupl
 def deserialize_tx_output(
     buf: bytes,
     *,
-    decimal_version: VertexDecimalVersion,
+    token_amount_version: TokenAmountVersion,
     verbose: VerboseCallback = None,
 ) -> tuple[TxOutput, bytes]:
     """Deserialize a TxOutput from bytes. Replaces TxOutput.create_from_bytes()."""
@@ -246,7 +248,7 @@ def deserialize_tx_output(
     from hathor.transaction.vertex_parser._common import _deserialize_tx_output
 
     deserializer = Deserializer.build_bytes_deserializer(buf)
-    txout = _deserialize_tx_output(deserializer, decimal_version=decimal_version, verbose=verbose)
+    txout = _deserialize_tx_output(deserializer, token_amount_version=token_amount_version, verbose=verbose)
     remaining = bytes(deserializer.read_all())
     return txout, remaining
 

--- a/hathor/verification/fee_header_verifier.py
+++ b/hathor/verification/fee_header_verifier.py
@@ -19,6 +19,7 @@ from typing import Sequence
 from hathor.transaction import Transaction
 from hathor.transaction.exceptions import FeeHeaderTokenNotFound, InvalidFeeHeader
 from hathor.transaction.headers import FeeHeader
+from hathorlib.utils.token_validation import validate_fee_amount
 
 MAX_FEES_LEN: int = 16
 
@@ -35,7 +36,6 @@ class FeeHeaderVerifier:
         token_indices = [fee.token_index for fee in fees]
         FeeHeaderVerifier._verify_duplicate_indexes('fees', token_indices)
 
-        from hathor.transaction.util import validate_fee_amount
         for fee in fees:
             FeeHeaderVerifier._verify_token_index('fees', fee.token_index, len(tx.tokens))
             validate_fee_amount(fee_header.settings, tx.get_token_uid(fee.token_index), fee.amount)

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -16,9 +16,9 @@ from hathor.conf.settings import HathorSettings
 from hathor.transaction.exceptions import InvalidToken, TransactionDataError
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenInfo, TokenVersion
-from hathor.transaction.util import validate_token_name_and_symbol
 from hathor.types import TokenUid
 from hathor.verification.verification_params import VerificationParams
+from hathorlib.utils.token_validation import validate_token_name_and_symbol
 
 
 class TokenCreationTransactionVerifier:

--- a/hathor/version_resource.py
+++ b/hathor/version_resource.py
@@ -26,7 +26,6 @@ from hathor.manager import HathorManager
 from hathor.transaction.token_info import TokenVersion
 from hathor.types import BlockId, TransactionId
 from hathor.utils.pydantic import BaseModel, Hex
-from hathorlib.decimal_places import VertexDecimalVersion
 
 
 class NativeTokenInfo(BaseModel):
@@ -55,9 +54,8 @@ class VersionResponse(ResponseModel):
     display_decimal_places: int = Field(
         description="Number of decimal places to be displayed for all tokens; it is simply cosmetic"
     )
-    decimal_places_by_version: dict[VertexDecimalVersion, int] = Field(
-        description="Number of decimal places for each supported vertex decimal version"
-    )
+    token_amount_v1_decimal_places: int = Field(description="Number of decimal places for V1")
+    token_amount_v2_decimal_places: int = Field(description="Number of decimal places for V2")
     genesis_block_hash: Hex[BlockId] = Field(description="Genesis block hash in hex")
     genesis_tx1_hash: Hex[TransactionId] = Field(description="Genesis transaction 1 hash in hex")
     genesis_tx2_hash: Hex[TransactionId] = Field(description="Genesis transaction 2 hash in hex")
@@ -83,7 +81,8 @@ VersionResponse.openapi_examples = {
             max_number_outputs=256,
             decimal_places=2,
             display_decimal_places=2,
-            decimal_places_by_version={VertexDecimalVersion.V1: 2},
+            token_amount_v1_decimal_places=2,
+            token_amount_v2_decimal_places=18,
             genesis_block_hash=BlockId(b'\x00' * 32),
             genesis_tx1_hash=TransactionId(b'\x00' * 31 + b'\x01'),
             genesis_tx2_hash=TransactionId(b'\x00' * 31 + b'\x02'),
@@ -149,7 +148,8 @@ class VersionResource(Resource):
             max_number_outputs=self._settings.MAX_NUM_OUTPUTS,
             decimal_places=self._settings.DISPLAY_DECIMAL_PLACES,  # TODO: This field is deprecated and will be removed
             display_decimal_places=self._settings.DISPLAY_DECIMAL_PLACES,
-            decimal_places_by_version=self._settings.VERTEX_DECIMAL_PLACES,
+            token_amount_v1_decimal_places=self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES,
+            token_amount_v2_decimal_places=self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES,
             genesis_block_hash=self._settings.GENESIS_BLOCK_HASH,
             genesis_tx1_hash=self._settings.GENESIS_TX1_HASH,
             genesis_tx2_hash=self._settings.GENESIS_TX2_HASH,

--- a/hathor_tests/nanocontracts/blueprints/unittest.py
+++ b/hathor_tests/nanocontracts/blueprints/unittest.py
@@ -18,6 +18,7 @@ from hathor.verification.on_chain_blueprint_verifier import OnChainBlueprintVeri
 from hathor.wallet import KeyPair
 from hathor_tests import unittest
 from hathor_tests.nanocontracts.utils import TestRunner
+from hathorlib.token_amount_version import TokenAmountVersion
 
 
 class BlueprintTestCase(unittest.TestCase):
@@ -121,7 +122,11 @@ class BlueprintTestCase(unittest.TestCase):
 
         return self._register_blueprint_class(blueprint_class, blueprint_id)
 
-    def build_runner(self, runtime_version: NanoRuntimeVersion = NanoRuntimeVersion.V2) -> TestRunner:
+    def build_runner(
+        self,
+        runtime_version: NanoRuntimeVersion = NanoRuntimeVersion.V2,
+        token_amount_version: TokenAmountVersion = TokenAmountVersion.V1,
+    ) -> TestRunner:
         """Create a test runner."""
         return TestRunner(
             tx_storage=self.manager.tx_storage,
@@ -129,6 +134,7 @@ class BlueprintTestCase(unittest.TestCase):
             settings=self._settings,
             reactor=self.reactor,
             runtime_version=runtime_version,
+            token_amount_version=token_amount_version,
         )
 
     def gen_random_token_uid(self) -> TokenUid:

--- a/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
+++ b/hathor_tests/nanocontracts/on_chain_blueprints/test_bet.py
@@ -25,6 +25,7 @@ from hathor.transaction import Transaction
 from hathor.transaction.scripts import P2PKH
 from hathor.util import initialize_hd_wallet, not_none
 from hathor.wallet import KeyPair
+from hathorlib.token_amount_version import TokenAmountVersion
 
 from ...utils import DEFAULT_WORDS
 from .. import test_blueprints
@@ -175,7 +176,9 @@ class OnChainBetBlueprintTestCase(BlueprintTestCase):
 
         # set expected self objects:
         self.nc_id = ContractId(VertexId(nc_init_tx.hash))
-        self.runner = TestRunner.from_runner(self.manager.get_nc_runner(block))
+        self.runner = TestRunner.from_runner(
+            self.manager.get_nc_runner(block, token_amount_version=TokenAmountVersion.V1)
+        )
         self.nc_storage = self.runner.get_storage(self.nc_id)
 
     def test_blueprint_initialization(self) -> None:

--- a/hathor_tests/nanocontracts/test_address_example.py
+++ b/hathor_tests/nanocontracts/test_address_example.py
@@ -18,6 +18,7 @@ from hathor.transaction import Block, Transaction
 from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.token_amount_version import TokenAmountVersion
 
 
 class TestAllFields(unittest.TestCase):
@@ -54,7 +55,7 @@ class TestAllFields(unittest.TestCase):
         assert nc1.get_metadata().first_block == b12.hash
         assert nc1.get_metadata().nc_execution == NCExecutionState.SUCCESS
 
-        runner = manager.get_nc_runner(b12)
+        runner = manager.get_nc_runner(b12, token_amount_version=TokenAmountVersion.V1)
         method_address = runner.call_view_method(nc1.hash, 'get_last_address_str')
         expected_address = get_address_b58_from_bytes(nc1.get_nano_header().nc_address)
         assert method_address == expected_address

--- a/hathor_tests/nanocontracts/test_contract_create_contract.py
+++ b/hathor_tests/nanocontracts/test_contract_create_contract.py
@@ -20,6 +20,7 @@ from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathorlib.token_amount_version import TokenAmountVersion
 
 INT_NC_TYPE = make_nc_type(int)
 CONTRACT_NC_TYPE: NCType[ContractId | None] = make_nc_type(ContractId | None)  # type: ignore[arg-type]
@@ -255,7 +256,8 @@ class NCBlueprintTestCase(BlueprintTestCase):
         # Confirm that contract ids are different.
         assert len(set(contracts)) == len(contracts)
 
-        runner = self.manager.get_best_block_nc_runner()
+        best_block = self.manager.tx_storage.get_best_block()
+        runner = self.manager.get_nc_runner(best_block, token_amount_version=TokenAmountVersion.V1)
         for idx, nc_id in enumerate(contracts):
             assert runner.has_contract_been_initialized(nc_id), f'index={idx}'
 
@@ -316,7 +318,8 @@ class NCBlueprintTestCase(BlueprintTestCase):
         # Reorg!
         artifacts.propagate_with(self.manager)
 
-        runner = self.manager.get_best_block_nc_runner()
+        best_block = self.manager.tx_storage.get_best_block()
+        runner = self.manager.get_nc_runner(best_block, token_amount_version=TokenAmountVersion.V1)
         for nc_id in contracts:
             assert not runner.has_contract_been_initialized(nc_id)
 

--- a/hathor_tests/nanocontracts/test_exposed_properties.py
+++ b/hathor_tests/nanocontracts/test_exposed_properties.py
@@ -89,7 +89,6 @@ KNOWN_CASES = [
     'hathor.NCFail.some_new_attribute',
     'hathor.NCFail.with_traceback',
     'hathor.NCFee.amount',
-    'hathor.NCFee.get_htr_value',
     'hathor.NCFee.some_new_attribute',
     'hathor.NCFee.token_uid',
     'hathor.NCGrantAuthorityAction.melt',

--- a/hathor_tests/nanocontracts/test_nanocontract.py
+++ b/hathor_tests/nanocontracts/test_nanocontract.py
@@ -161,11 +161,14 @@ class NCNanoContractTestCase(unittest.TestCase):
     def test_serialization_skip_signature(self) -> None:
         nc = self._get_nc()
         nano_header = nc.get_nano_header()
-        sighash_bytes = get_header_sighash_bytes(nano_header, decimal_version=nano_header.tx.get_decimal_version())
+        sighash_bytes = get_header_sighash_bytes(
+            nano_header,
+            token_amount_version=nano_header.tx.get_token_amount_version(),
+        )
 
         tx = Transaction()
         deserializer = Deserializer.build_bytes_deserializer(sighash_bytes)
-        data = deserialize_nano_header(deserializer, decimal_version=tx.get_decimal_version())
+        data = deserialize_nano_header(deserializer, token_amount_version=tx.get_token_amount_version())
         deserialized = NanoHeader.create_from_data(tx, data)
         buf = bytes(deserializer.read_all())
 

--- a/hathor_tests/nanocontracts/test_runtime_v2.py
+++ b/hathor_tests/nanocontracts/test_runtime_v2.py
@@ -52,7 +52,7 @@ class TestRuntimeV2(BlueprintTestCase):
     def test_syscall_get_settings_v2(self) -> None:
         self.runner = self.build_runner(NanoRuntimeVersion.V2)
         result = self.runner.create_contract(self.contract_id, self.blueprint_id, self.create_context())
-        assert result == self._settings.FEE_PER_OUTPUT
+        assert result == self._settings.FEE_PER_OUTPUT_V1
 
     def test_activation(self) -> None:
         feature_settings = FeatureSettings(

--- a/hathor_tests/nanocontracts/utils.py
+++ b/hathor_tests/nanocontracts/utils.py
@@ -22,6 +22,7 @@ from hathor.types import VertexId
 from hathor.util import not_none
 from hathor.wallet import HDWallet
 from hathorlib.nanocontracts.tx_storage_protocol import NCTransactionStorageProtocol
+from hathorlib.token_amount_version import TokenAmountVersion
 
 
 class TestRunner:
@@ -42,6 +43,7 @@ class TestRunner:
         self,
         *,
         runtime_version: NanoRuntimeVersion,
+        token_amount_version: TokenAmountVersion,
         tx_storage: NCTransactionStorageProtocol,
         blueprint_service: BlueprintService,
         settings: HathorSettings,
@@ -57,6 +59,7 @@ class TestRunner:
         block_storage = NCBlockStorage(block_trie)
         self._runner: Runner = Runner(
             runtime_version=runtime_version,
+            token_amount_version=token_amount_version,
             tx_storage=tx_storage,
             blueprint_service=blueprint_service,
             storage_factory=storage_factory,

--- a/hathor_tests/others/test_hathor_settings.py
+++ b/hathor_tests/others/test_hathor_settings.py
@@ -24,7 +24,6 @@ from hathor.conf.mainnet import SETTINGS as MAINNET_SETTINGS
 from hathor.conf.settings import HathorSettings
 from hathorlib.conf import MAINNET_SETTINGS_FILEPATH
 from hathorlib.conf.utils import load_yaml_settings
-from hathorlib.decimal_places import VertexDecimalVersion
 
 
 @pytest.mark.parametrize('filepath', ['fixtures/valid_hathor_settings_fixture.yml'])
@@ -208,14 +207,6 @@ def test_consensus_algorithm() -> None:
         assert 'PoA networks do not support block rewards' in str(e.value)
 
 
-def test_get_decimal_places_unsupported_version_raises() -> None:
-    from types import SimpleNamespace
-    settings = SimpleNamespace(VERTEX_DECIMAL_PLACES={})
-    with pytest.raises(ValueError) as e:
-        VertexDecimalVersion.V1.get_decimal_places(settings)  # type: ignore[arg-type]
-    assert str(e.value) == 'unsupported decimal places version V1'
-
-
 def test_vertex_decimal_places() -> None:
     yaml_mock = Mock()
     required_settings = dict(P2PKH_VERSION_BYTE='x01', MULTISIG_VERSION_BYTE='x02', NETWORK_NAME='test')
@@ -225,22 +216,19 @@ def test_vertex_decimal_places() -> None:
 
     with patch('hathorlib.utils.yaml.dict_from_extended_yaml', yaml_mock):
         # Default mapping (V1 -> 2) loads and drives the genesis atomic amount.
-        mock_settings(yaml_mock, dict(VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 2}))
+        mock_settings(yaml_mock, dict(TOKEN_AMOUNT_V1_DECIMAL_PLACES=2))
         settings = load_yaml_settings(HathorSettings, filepath='some_path')
-        assert VertexDecimalVersion.V1.get_decimal_places(settings) == 2
         assert settings.GENESIS_TOKEN_ATOMIC_UNITS == settings.GENESIS_TOKEN_MAIN_UNITS * (10 ** 2)
 
         # Custom decimal places propagate to the computed genesis amount.
-        mock_settings(yaml_mock, dict(VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 5}))
+        mock_settings(yaml_mock, dict(TOKEN_AMOUNT_V1_DECIMAL_PLACES=5))
         settings = load_yaml_settings(HathorSettings, filepath='some_path')
-        assert VertexDecimalVersion.V1.get_decimal_places(settings) == 5
         assert settings.GENESIS_TOKEN_ATOMIC_UNITS == settings.GENESIS_TOKEN_MAIN_UNITS * (10 ** 5)
 
-        # A mapping without V1 is rejected
-        mock_settings(yaml_mock, dict(VERTEX_DECIMAL_PLACES={}))
-        with pytest.raises(ValidationError) as e:
+        mock_settings(yaml_mock, dict(TOKEN_AMOUNT_V1_DECIMAL_PLACES=5, TOKEN_AMOUNT_V2_DECIMAL_PLACES=2))
+        msg = 'TOKEN_AMOUNT_V2_DECIMAL_PLACES must be greater than or equal to TOKEN_AMOUNT_V1_DECIMAL_PLACES'
+        with pytest.raises(ValidationError, match=msg):
             load_yaml_settings(HathorSettings, filepath='some_path')
-        assert 'VERTEX_DECIMAL_PLACES must define V1.' in str(e.value)
 
 
 # TODO: Tests below are temporary while settings via python coexist with settings via yaml, just to make sure

--- a/hathor_tests/poa/test_poa_simulation.py
+++ b/hathor_tests/poa/test_poa_simulation.py
@@ -38,7 +38,6 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.util import not_none
 from hathor_tests.poa.utils import get_settings, get_signer
 from hathor_tests.simulation.base import SimulatorTestCase
-from hathorlib.decimal_places import VertexDecimalVersion
 
 
 def _get_blocks_by_height(manager: HathorManager) -> defaultdict[int, list[PoaBlock]]:
@@ -507,7 +506,8 @@ class PoaSimulationTest(SimulatorTestCase):
             GENESIS_TX1_NONCE=0,
             GENESIS_TX2_NONCE=0,
             DISPLAY_DECIMAL_PLACES=0,
-            VERTEX_DECIMAL_PLACES={VertexDecimalVersion.V1: 0},
+            TOKEN_AMOUNT_V1_DECIMAL_PLACES=0,
+            TOKEN_AMOUNT_V2_DECIMAL_PLACES=0,
             GENESIS_TOKEN_MAIN_UNITS=tokens,
             TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR=100,
             BLOCKS_PER_HALVING=None,

--- a/hathor_tests/resources/transaction/test_mining.py
+++ b/hathor_tests/resources/transaction/test_mining.py
@@ -49,7 +49,7 @@ class MiningApiTest(_BaseResourceTest._ResourceTest):
             'tokens': [],
             'data': '',
             'signal_bits': 0,
-            'decimal_version': 1,
+            'token_amount_version': 1,
         })
 
     @inlineCallbacks
@@ -90,7 +90,7 @@ class MiningApiTest(_BaseResourceTest._ResourceTest):
             'tokens': [],
             'data': '',
             'signal_bits': 0,
-            'decimal_version': 1,
+            'token_amount_version': 1,
         })
 
     @inlineCallbacks

--- a/hathor_tests/resources/transaction/test_tx.py
+++ b/hathor_tests/resources/transaction/test_tx.py
@@ -9,7 +9,7 @@ from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.validation_state import ValidationState
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_transactions, create_fee_tokens
-from hathorlib.decimal_places import VertexDecimalVersion
+from hathorlib.token_amount_version import TokenAmountVersion
 
 
 class TransactionTest(_BaseResourceTest._ResourceTest):
@@ -184,10 +184,10 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(data['meta']['first_block'], None)
         self.assertEqual(data['meta']['first_block_height'], None)
 
-        # Decimal version
-        decimal_version = VertexDecimalVersion.V1
-        assert tx.get_decimal_version() == decimal_version
-        assert data['tx']['decimal_version'] == decimal_version
+        # Token amount version
+        token_amount_version = TokenAmountVersion.V1
+        assert tx.get_token_amount_version() == token_amount_version
+        assert data['tx']['token_amount_version'] == token_amount_version
 
     @inlineCallbacks
     def test_get_one_known_tx_with_authority(self):
@@ -560,7 +560,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
 
         # The fee is paid in HTR (token_index=0)
         self.assertEqual(fee_entry['token_uid'], self._settings.HATHOR_TOKEN_UID.hex())
-        self.assertEqual(fee_entry['amount'], self._settings.FEE_PER_OUTPUT)
+        self.assertEqual(fee_entry['amount'], self._settings.FEE_PER_OUTPUT_V1)
 
     @inlineCallbacks
     def test_get_transaction_without_fee_header(self):

--- a/hathor_tests/tx/test_fee_header.py
+++ b/hathor_tests/tx/test_fee_header.py
@@ -12,7 +12,7 @@ from hathor_tests import unittest
 
 def _serialize_fee_header(header: FeeHeader) -> bytes:
     serializer = Serializer.build_bytes_serializer()
-    serialize_fee_header(serializer, header, decimal_version=header.tx.get_decimal_version())
+    serialize_fee_header(serializer, header, token_amount_version=header.tx.get_token_amount_version())
     return bytes(serializer.finalize())
 
 
@@ -23,7 +23,7 @@ def _deserialize_fee_header(
     verbose: VerboseCallback = None,
 ) -> tuple[FeeHeader, bytes]:
     deserializer = Deserializer.build_bytes_deserializer(buf)
-    fees = deserialize_fee_header(deserializer, decimal_version=tx.get_decimal_version(), verbose=verbose)
+    fees = deserialize_fee_header(deserializer, token_amount_version=tx.get_token_amount_version(), verbose=verbose)
     header = FeeHeader(settings=tx._settings, tx=tx, fees=fees)
     return header, bytes(deserializer.read_all())
 
@@ -78,7 +78,7 @@ class FeeHeaderTest(unittest.TestCase):
             tx=tx,
             fees=[FeeHeaderEntry(token_index=0, amount=500)],  # HTR paying
         )
-        sighash_bytes = get_header_sighash_bytes(header_sighash, decimal_version=tx.get_decimal_version())
+        sighash_bytes = get_header_sighash_bytes(header_sighash, token_amount_version=tx.get_token_amount_version())
         serialized_bytes = _serialize_fee_header(header_sighash)
 
         # The fee header sighash bytes are identical to its full serialization.

--- a/hathor_tests/tx/test_mining.py
+++ b/hathor_tests/tx/test_mining.py
@@ -112,7 +112,7 @@ class MiningTest(unittest.TestCase):
             tokens=[],
             version=0,
             weight=60,
-            decimal_version=1,
+            token_amount_version=1,
         )
 
         self.assertTrue(isinstance(block, Block))

--- a/hathor_tests/tx/test_nano_header.py
+++ b/hathor_tests/tx/test_nano_header.py
@@ -16,13 +16,13 @@ from hathor_tests.dag_builder.builder import TestDAGBuilder
 
 def _serialize_nano_header(header: NanoHeader) -> bytes:
     serializer = Serializer.build_bytes_serializer()
-    serialize_nano_header(serializer, header, decimal_version=header.tx.get_decimal_version())
+    serialize_nano_header(serializer, header, token_amount_version=header.tx.get_token_amount_version())
     return bytes(serializer.finalize())
 
 
 def _deserialize_nano_header(tx: Transaction, buf: bytes) -> tuple[NanoHeader, bytes]:
     deserializer = Deserializer.build_bytes_deserializer(buf)
-    data = deserialize_nano_header(deserializer, decimal_version=tx.get_decimal_version())
+    data = deserialize_nano_header(deserializer, token_amount_version=tx.get_token_amount_version())
     header = NanoHeader.create_from_data(tx, data)
     return header, bytes(deserializer.read_all())
 

--- a/hathor_tests/tx/test_token_validation.py
+++ b/hathor_tests/tx/test_token_validation.py
@@ -3,7 +3,7 @@ import pytest
 
 from hathor.conf.get_settings import get_global_settings
 from hathor.transaction.exceptions import TransactionDataError
-from hathor.transaction.util import validate_token_name_and_symbol
+from hathorlib.utils.token_validation import validate_token_name_and_symbol
 
 
 def test_token_name():

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -596,7 +596,7 @@ def create_fee_tokens(
     outputs.append(TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001))
 
     # fee
-    fee = settings.FEE_PER_OUTPUT
+    fee = settings.FEE_PER_OUTPUT_V1
 
     # fee output
     outputs.append(TxOutput(genesis_block.outputs[0].value - fee - (genesis_output_amount or 0), script, 0))

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, field_validator, mo
 from typing_extensions import Self
 
 from hathorlib.conf.utils import parse_hex_str
-from hathorlib.decimal_places import VertexDecimalVersion
 
 HATHOR_TOKEN_UID: bytes = b'\x00'
 
@@ -87,9 +86,8 @@ class HathorSettings(BaseModel):
 
     # Number of decimal places for each supported vertex decimal version.
     # A version absent from this mapping is not supported on this network.
-    VERTEX_DECIMAL_PLACES: dict[VertexDecimalVersion, int] = {
-        VertexDecimalVersion.V1: 2,
-    }
+    TOKEN_AMOUNT_V1_DECIMAL_PLACES: int = 2
+    TOKEN_AMOUNT_V2_DECIMAL_PLACES: int = 18
 
     # Minimum weight of a tx
     MIN_TX_WEIGHT: int = 14
@@ -125,11 +123,10 @@ class HathorSettings(BaseModel):
     def GENESIS_TOKEN_ATOMIC_UNITS(self) -> int:
         """Genesis pre-mined tokens in atomic units, that is, the on-chain integer amount."""
         # Blocks are always V1.
-        decimal_places = VertexDecimalVersion.V1.get_decimal_places(self)
-        return int(self.GENESIS_TOKEN_MAIN_UNITS * (10 ** decimal_places))
+        return int(self.GENESIS_TOKEN_MAIN_UNITS * (10 ** self.TOKEN_AMOUNT_V1_DECIMAL_PLACES))
 
-    # Fee rate settings
-    FEE_PER_OUTPUT: int = 1
+    # Fee rate settings in V1 decimals (that is, 0.01 HTR)
+    FEE_PER_OUTPUT_V1: int = 1
 
     @property
     def FEE_DIVISOR(self) -> int:
@@ -147,14 +144,12 @@ class HathorSettings(BaseModel):
     @property
     def INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK(self) -> int:
         # Blocks are always V1.
-        decimal_places = VertexDecimalVersion.V1.get_decimal_places(self)
-        return int(self.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * (10 ** decimal_places))
+        return int(self.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * (10 ** self.TOKEN_AMOUNT_V1_DECIMAL_PLACES))
 
     @property
     def MINIMUM_TOKEN_ATOMIC_UNITS_PER_BLOCK(self) -> int:
         # Blocks are always V1.
-        decimal_places = VertexDecimalVersion.V1.get_decimal_places(self)
-        return int(self.MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK * (10 ** decimal_places))
+        return int(self.MINIMUM_TOKEN_MAIN_UNITS_PER_BLOCK * (10 ** self.TOKEN_AMOUNT_V1_DECIMAL_PLACES))
 
     # Assume that: amount < minimum
     # But, amount = initial / (2**n), where n = number_of_halvings. Thus:
@@ -588,8 +583,9 @@ class HathorSettings(BaseModel):
         return self
 
     @model_validator(mode='after')
-    def _validate_vertex_decimal_places(self) -> Self:
-        """Validate that V1 is mapped."""
-        if VertexDecimalVersion.V1 not in self.VERTEX_DECIMAL_PLACES:
-            raise ValueError('VERTEX_DECIMAL_PLACES must define V1.')
+    def _validate_token_amount_decimal_places(self) -> Self:
+        if self.TOKEN_AMOUNT_V2_DECIMAL_PLACES < self.TOKEN_AMOUNT_V1_DECIMAL_PLACES:
+            raise ValueError(
+                'TOKEN_AMOUNT_V2_DECIMAL_PLACES must be greater than or equal to TOKEN_AMOUNT_V1_DECIMAL_PLACES'
+            )
         return self

--- a/hathorlib/hathorlib/daa.py
+++ b/hathorlib/hathorlib/daa.py
@@ -42,7 +42,7 @@ def minimum_tx_weight(tx: 'Transaction', *, fix_parents: bool = True) -> float:
     # We need to take into consideration the decimal places because it is inside the amount.
     # For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     # Max below is preventing division by 0 when handling authority methods that have no outputs
-    decimal_places = tx.get_decimal_version().get_decimal_places(settings)
+    decimal_places = tx.get_token_amount_version().get_decimal_places(settings)
     amount = max(1, tx.sum_outputs) / (10 ** decimal_places)
 
     weight: float = (

--- a/hathorlib/hathorlib/nanocontracts/balance_rules.py
+++ b/hathorlib/hathorlib/nanocontracts/balance_rules.py
@@ -30,6 +30,7 @@ from hathorlib.nanocontracts.types import (
     NCGrantAuthorityAction,
     NCWithdrawalAction,
 )
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.token_info import TokenVersion
 
 if TYPE_CHECKING:
@@ -46,11 +47,12 @@ class BalanceRules(ABC, Generic[T]):
     which is always a contract, and one for the caller, which may be a transaction or another contract.
     """
 
-    __slots__ = ('settings', 'action')
+    __slots__ = ('settings', 'action', 'token_amount_version')
 
-    def __init__(self, settings: HathorSettings, action: T) -> None:
+    def __init__(self, settings: HathorSettings, action: T, token_amount_version: TokenAmountVersion) -> None:
         self.settings = settings
         self.action = action
+        self.token_amount_version = token_amount_version
 
     @abstractmethod
     def verification_rule(self, token_dict: TokenInfoDict) -> None:
@@ -77,17 +79,21 @@ class BalanceRules(ABC, Generic[T]):
         raise NotImplementedError
 
     @staticmethod
-    def get_rules(settings: HathorSettings, action: NCAction) -> BalanceRules:
+    def get_rules(
+        settings: HathorSettings,
+        action: NCAction,
+        token_amount_version: TokenAmountVersion,
+    ) -> BalanceRules:
         """Get the balance rules instance for the provided action."""
         match action:
             case NCDepositAction():
-                return _DepositRules(settings, action)
+                return _DepositRules(settings, action, token_amount_version)
             case NCWithdrawalAction():
-                return _WithdrawalRules(settings, action)
+                return _WithdrawalRules(settings, action, token_amount_version)
             case NCGrantAuthorityAction():
-                return _GrantAuthorityRules(settings, action)
+                return _GrantAuthorityRules(settings, action, token_amount_version)
             case NCAcquireAuthorityAction():
-                return _AcquireAuthorityRules(settings, action)
+                return _AcquireAuthorityRules(settings, action, token_amount_version)
             case _:
                 assert_never(action)
 
@@ -100,6 +106,7 @@ class _DepositRules(BalanceRules[NCDepositAction]):
     - In the execution-phase (callee), the amount is added to the nano contract balance.
     - In the execution-phase (caller), the amount is removed from the nano contract balance.
     """
+    __slots__ = ()
 
     @override
     def verification_rule(self, token_dict: TokenInfoDict) -> None:
@@ -127,6 +134,7 @@ class _WithdrawalRules(BalanceRules[NCWithdrawalAction]):
     - In the execution-phase (callee), the amount is removed from the nano contract balance.
     - In the execution-phase (caller), the amount is added to the nano contract balance.
     """
+    __slots__ = ()
 
     @override
     def verification_rule(self, token_dict: TokenInfoDict) -> None:
@@ -154,6 +162,7 @@ class _GrantAuthorityRules(BalanceRules[NCGrantAuthorityAction]):
     - In the execution phase (callee), the authorities are granted to the nano contract.
     - In the execution phase (caller), we check whether the balance can grant the authorities to the called contract.
     """
+    __slots__ = ()
 
     @override
     def verification_rule(self, token_dict: TokenInfoDict) -> None:
@@ -206,6 +215,7 @@ class _AcquireAuthorityRules(BalanceRules[NCAcquireAuthorityAction]):
     - In the execution phase (callee), we check whether the nano contract balance can grant those authorities.
     - In the execution phase (caller), we grant the authorities to the caller.
     """
+    __slots__ = ()
 
     @override
     def verification_rule(self, token_dict: TokenInfoDict) -> None:

--- a/hathorlib/hathorlib/nanocontracts/runner/runner.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/runner.py
@@ -90,6 +90,7 @@ from hathorlib.nanocontracts.utils import (
     is_nc_public_method,
     is_nc_view_method,
 )
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.token_info import TokenDescription, TokenVersion
 from hathorlib.utils import clean_token_string
 from hathorlib.utils.token_validation import validate_fee_amount, validate_token_name_and_symbol
@@ -126,6 +127,7 @@ class Runner:
         reactor: ClockProtocol,
         settings: HathorSettings,
         runtime_version: NanoRuntimeVersion,
+        token_amount_version: TokenAmountVersion,
         tx_storage: NCTransactionStorageProtocol,
         blueprint_service: BlueprintServiceProtocol,
         storage_factory: NCStorageFactory,
@@ -140,6 +142,7 @@ class Runner:
         self._settings = settings
         self.reactor = reactor
         self._runtime_version = runtime_version
+        self.token_amount_version = token_amount_version
 
         # For tracking fuel and memory usage
         self._initial_fuel = self._settings.NC_INITIAL_FUEL_TO_CALL_METHOD
@@ -470,7 +473,7 @@ class Runner:
         # call below, if it succeeds.
         previous_changes_tracker = last_call_record.changes_tracker
         for action in actions:
-            rules = BalanceRules.get_rules(self._settings, action)
+            rules = BalanceRules.get_rules(self._settings, action, self.token_amount_version)
             rules.nc_caller_execution_rule(previous_changes_tracker)
 
         # All calls must begin with non-negative balance.
@@ -673,7 +676,7 @@ class Runner:
 
         self._validate_actions(method, called_method_name, ctx)
         for action in ctx.__all_actions__:
-            rules = BalanceRules.get_rules(self._settings, action)
+            rules = BalanceRules.get_rules(self._settings, action, self.token_amount_version)
             rules.nc_callee_execution_rule(changes_tracker)
             self._handle_index_update(action)
 
@@ -1285,7 +1288,7 @@ class Runner:
                 raise NCFail('syscall `get_settings` is not yet supported')
             case NanoRuntimeVersion.V2:
                 return NanoSettings(
-                    fee_per_output=self._settings.FEE_PER_OUTPUT,
+                    fee_per_output=self._settings.FEE_PER_OUTPUT_V1,
                 )
             case _:
                 assert_never(self._runtime_version)
@@ -1421,7 +1424,7 @@ class Runner:
             # because we registered all fee tokens in the paid fees dict, it should contain at
             # least the length of fees
             assert fee.token_uid in self._paid_actions_fees
-            fee_sum += fee.get_htr_value(self._settings)
+            fee_sum += fee.__get_htr_value__(self._settings, self.token_amount_version)
 
         chargeable_actions = {NCActionType.DEPOSIT, NCActionType.WITHDRAWAL}
         for token_uid, actions in ctx_actions.items():
@@ -1470,6 +1473,7 @@ class RunnerFactory:
         self,
         *,
         runtime_version: NanoRuntimeVersion,
+        token_amount_version: TokenAmountVersion,
         block_storage: NCBlockStorage,
         seed: bytes | None = None,
     ) -> Runner:
@@ -1477,6 +1481,7 @@ class RunnerFactory:
             reactor=self.reactor,
             settings=self.settings,
             runtime_version=runtime_version,
+            token_amount_version=token_amount_version,
             tx_storage=self.tx_storage,
             storage_factory=self.nc_storage_factory,
             blueprint_service=self.blueprint_service,

--- a/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
@@ -82,7 +82,7 @@ def _validate_fee_based_payment_token(fee_payment_token: TokenDescription) -> No
 def _calculate_unit_fee_token_fee(settings: HathorSettings, fee_payment_token: TokenDescription) -> int:
     """Calculate the fee for handling a fee-based token"""
     if fee_payment_token.token_id == HATHOR_TOKEN_UID:
-        return settings.FEE_PER_OUTPUT
-    numerator = settings.FEE_PER_OUTPUT * settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+        return settings.FEE_PER_OUTPUT_V1
+    numerator = settings.FEE_PER_OUTPUT_V1 * settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
     assert numerator % settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR == 0
     return numerator // settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR

--- a/hathorlib/hathorlib/nanocontracts/simulator/simulator.py
+++ b/hathorlib/hathorlib/nanocontracts/simulator/simulator.py
@@ -59,6 +59,7 @@ from hathorlib.nanocontracts.types import (
 )
 from hathorlib.nanocontracts.vertex_data import BlockData
 from hathorlib.scripts import P2PKH
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.token_info import TokenDescription, TokenVersion
 
 
@@ -404,6 +405,7 @@ class NanoSimulator:
 
         return self._runner_factory.create(
             runtime_version=self._runtime_version,
+            token_amount_version=TokenAmountVersion.V1,
             block_storage=self._current_block_storage,
             seed=rng_seed,
         )

--- a/hathorlib/hathorlib/nanocontracts/types.py
+++ b/hathorlib/hathorlib/nanocontracts/types.py
@@ -33,6 +33,7 @@ from hathorlib.nanocontracts.blueprint_syntax_validation import (
 from hathorlib.nanocontracts.exception import BlueprintSyntaxError, NCSerializationError
 from hathorlib.nanocontracts.faux_immutable import FauxImmutableMeta
 from hathorlib.serialization import SerializationError
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.utils import get_deposit_token_withdraw_amount
 from hathorlib.utils.address import decode_address, get_address_b58_from_bytes
 from hathorlib.utils.typing import InnerTypeMixin
@@ -559,7 +560,7 @@ class NCFee:
     token_uid: TokenUid
     amount: int
 
-    def get_htr_value(self, settings: HathorSettings) -> int:
+    def __get_htr_value__(self, settings: HathorSettings, token_amount_version: TokenAmountVersion) -> int:
         """
         Get the amount converted to HTR
         """

--- a/hathorlib/hathorlib/serialization/encoding/output_value.py
+++ b/hathorlib/hathorlib/serialization/encoding/output_value.py
@@ -108,9 +108,9 @@ import struct
 
 from typing_extensions import assert_never
 
-from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.serialization import Deserializer, Serializer
 from hathorlib.serialization.exceptions import BadDataError
+from hathorlib.token_amount_version import TokenAmountVersion
 
 MAX_OUTPUT_VALUE_32 = 2 ** 31 - 1  # max value (inclusive) before having to use 8 bytes: 2_147_483_647
 MAX_OUTPUT_VALUE_64 = 2 ** 63  # max value (inclusive) that can be encoded (with 8 bytes): 9_223_372_036_854_775_808
@@ -119,14 +119,14 @@ MAX_OUTPUT_VALUE_V2: int = MAX_OUTPUT_VALUE_64 * 10**16
 MAX_OUTPUT_VALUE_V2_LENGTH: int = (MAX_OUTPUT_VALUE_V2.bit_length() + 7) // 8
 
 
-def encode_output_value(serializer: Serializer, value: int, *, decimal_version: VertexDecimalVersion) -> None:
-    match decimal_version:
-        case VertexDecimalVersion.V1:
+def encode_output_value(serializer: Serializer, value: int, *, token_amount_version: TokenAmountVersion) -> None:
+    match token_amount_version:
+        case TokenAmountVersion.V1:
             encode_output_value_v1(serializer, value)
-        case VertexDecimalVersion.V2:
+        case TokenAmountVersion.V2:
             encode_output_value_v2(serializer, value)
         case _:
-            assert_never(decimal_version)
+            assert_never(token_amount_version)
 
 
 def encode_output_value_v1(serializer: Serializer, number: int, *, strict: bool = True) -> None:
@@ -212,14 +212,14 @@ def encode_output_value_v2(serializer: Serializer, value: int, *, strict: bool =
     serializer.write_bytes(payload)
 
 
-def decode_output_value(deserializer: Deserializer, *, decimal_version: VertexDecimalVersion) -> int:
-    match decimal_version:
-        case VertexDecimalVersion.V1:
+def decode_output_value(deserializer: Deserializer, *, token_amount_version: TokenAmountVersion) -> int:
+    match token_amount_version:
+        case TokenAmountVersion.V1:
             return decode_output_value_v1(deserializer)
-        case VertexDecimalVersion.V2:
+        case TokenAmountVersion.V2:
             return decode_output_value_v2(deserializer)
         case _:
-            assert_never(decimal_version)
+            assert_never(token_amount_version)
 
 
 def decode_output_value_v1(deserializer: Deserializer, *, strict: bool = True) -> int:

--- a/hathorlib/hathorlib/token_amount_version.py
+++ b/hathorlib/hathorlib/token_amount_version.py
@@ -17,14 +17,16 @@ from __future__ import annotations
 from enum import IntEnum, unique
 from typing import TYPE_CHECKING
 
+from typing_extensions import assert_never
+
 if TYPE_CHECKING:
     from hathorlib.conf.settings import HathorSettings
 
 
 @unique
-class VertexDecimalVersion(IntEnum):
+class TokenAmountVersion(IntEnum):
     """
-    The decimal-places version under which a vertex's token amounts must be interpreted.
+    The version under which a vertex's token amounts must be interpreted, according to the version's decimal places.
 
     The integer value is the raw version as encoded in the vertex, so it is part of the
     serialization contract and must remain stable.
@@ -35,7 +37,10 @@ class VertexDecimalVersion(IntEnum):
 
     def get_decimal_places(self, settings: HathorSettings) -> int:
         """Return the number of decimal places this version maps to, according to settings."""
-        decimal_places = settings.VERTEX_DECIMAL_PLACES.get(self)
-        if decimal_places is None:
-            raise ValueError(f'unsupported decimal places version {self.name}')
-        return decimal_places
+        match self:
+            case TokenAmountVersion.V1:
+                return settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+            case TokenAmountVersion.V2:
+                return settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES
+            case _:
+                assert_never(self)

--- a/hathorlib/hathorlib/transaction/__init__.py
+++ b/hathorlib/hathorlib/transaction/__init__.py
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING, List, TypeVar, final
 
 from hathorlib.base_transaction import TX_HASH_SIZE, BaseTransaction, TxInput, TxOutput
 from hathorlib.conf import HathorSettings
-from hathorlib.decimal_places import VertexDecimalVersion
 from hathorlib.exceptions import InvalidOutputValue, InvalidToken
 from hathorlib.headers import VertexBaseHeader
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.utils import unpack, unpack_len
 
 if TYPE_CHECKING:
@@ -281,9 +281,7 @@ class Transaction(BaseTransaction):
                     output.value, index))
 
     @final
-    def get_decimal_version(self) -> VertexDecimalVersion:
-        """
-        Return the decimal-places version under which this transaction's token amounts are interpreted.
-        """
+    def get_token_amount_version(self) -> TokenAmountVersion:
+        """Return the version under which this transaction's token amounts are interpreted."""
         # Transactions are always V1. This will be updated in the future.
-        return VertexDecimalVersion.V1
+        return TokenAmountVersion.V1

--- a/hathorlib/tests/test_nc_address_type.py
+++ b/hathorlib/tests/test_nc_address_type.py
@@ -16,6 +16,7 @@ import unittest
 
 from hathorlib.exceptions import InvalidAddress
 from hathorlib.nanocontracts.types import NC_HTR_TOKEN_UID, Address, NCFee, TokenUid
+from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.utils.address import get_address_b58_from_public_key, get_public_key_from_bytes_compressed
 
 
@@ -57,13 +58,13 @@ class TestNCFee(unittest.TestCase):
         from hathorlib.conf import HathorSettings
         settings = HathorSettings()
         fee = NCFee(token_uid=NC_HTR_TOKEN_UID, amount=100)
-        self.assertEqual(fee.get_htr_value(settings), 100)
+        self.assertEqual(fee.__get_htr_value__(settings, TokenAmountVersion.V1), 100)
 
     def test_custom_token_fee_value(self) -> None:
         from hathorlib.conf import HathorSettings
         settings = HathorSettings()
         fee = NCFee(token_uid=TokenUid(b'\x01' * 32), amount=1000)
         # For custom token, it converts using deposit percentage
-        result = fee.get_htr_value(settings)
+        result = fee.__get_htr_value__(settings, TokenAmountVersion.V1)
         self.assertIsInstance(result, int)
         self.assertGreater(result, 0)

--- a/htr-rs/justfile
+++ b/htr-rs/justfile
@@ -5,16 +5,20 @@ export RUSTFLAGS := "-D warnings"
 help:
   @just --list
 
-# Run the full local check suite: check, fmt, clippy, test, sort, audit.
-all: check fmt clippy test sort audit
+# Run the full local check suite: check, fmt-check, clippy, test, sort, audit.
+all: check fmt-check clippy test sort audit
 
 # Type-check all workspace crates, including tests/benches/examples, with every feature enabled.
 check:
   cargo check --workspace --all-targets --all-features
 
 # Verify formatting of all workspace crates without modifying files.
-fmt:
+fmt-check:
   cargo fmt --all -- --check
+
+# Format all workspace crates.
+fmt:
+  cargo fmt --all
 
 # Lint all workspace crates, including tests/benches/examples, with every feature enabled; warnings fail the build.
 clippy:


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1722

### Motivation

In preparation for the main project PR to implement the new decimals place version, this PR does a few refactors, clean ups, and improvements so we can decrease the diff in the main PR. There's no change in any behavior, and the versioning system is just scaffolded — it's completely unused right now.

### Acceptance Criteria

- Rename `DecimalsVersion` to `TokenAmountVersion`.
- Thread the transaction's `TokenAmountVersion` through the `Runner`. It will be used in the future.
- Thread the transaction's `TokenAmountVersion` through the `BalanceRules`. It will be used in the future.
- Add new `get_blueprint_class_and_token_amount_version` method to `BlueprintService`, and use it in the nano state API.
- Remove duplicate functions `validate_token_name_and_symbol` and `validate_fee_amount` from `hathor`, use their counterparts from `hathorlib` instead.
- Remove `HathorManager.get_best_block_nc_runner` (it was only used in one test).
- Rename `NCFee.get_htr_value` to `__get_htr_value__`, moving it out of the user API for Blueprints.
- Refactors in `HathorSettings`:
  - Replace `VERTEX_DECIMAL_PLACES` by `TOKEN_AMOUNT_V1_DECIMAL_PLACES` and `TOKEN_AMOUNT_V2_DECIMAL_PLACES` (and refactor the `/version` API accordingly).
  - Rename `FEE_PER_OUTPUT` to `FEE_PER_OUTPUT_V1`.
- Remove support for Python 3.9 and 3.10 from hathorlib and add `htr_lib` as a dependency (currently unused).
- Update `htr-rs/justfile` to include a `fmt` command.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 