### PR TITLE
refactor(decimals): swap int for TokenAmount/TokenBalance on the static surface [part 10]

### DIFF
--- a/hathor/daa/daa.py
+++ b/hathor/daa/daa.py
@@ -28,6 +28,7 @@ from hathor.daa.common import (
 )
 from hathor.profiler import get_cpu_profiler
 from hathor.types import VertexId
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -102,12 +103,12 @@ class DifficultyAdjustmentAlgorithm:
         """Return the ids of the required blocks to call calculate_block_difficulty."""
         return _get_block_dependencies(self._settings, block, parent_block_getter)
 
-    def get_tokens_issued_per_block(self, height: int) -> int:
+    def get_tokens_issued_per_block(self, height: int) -> UnsignedAmount:
         """Return the number of tokens issued (aka reward) per block of a given height."""
         amount = _get_base_tokens_issued_per_block(self._settings, height)
         return amount // self._config.reward_reduction_factor
 
-    def get_reward_for_next_block(self, parent_block: Block) -> int:
+    def get_reward_for_next_block(self, parent_block: Block) -> UnsignedAmount:
         """Return the reward for the next block after parent_block."""
         return self.get_tokens_issued_per_block(parent_block.get_height() + 1)
 

--- a/hathor/dag_builder/builder.py
+++ b/hathor/dag_builder/builder.py
@@ -40,6 +40,7 @@ from hathor.manager import HathorManager
 from hathor.nanocontracts.catalog import NCBlueprintCatalog
 from hathor.util import initialize_hd_wallet
 from hathor.wallet import BaseWallet
+from hathorlib.token_amount import SignedAmount
 
 logger = get_logger()
 
@@ -151,7 +152,7 @@ class DAGBuilder:
         from_node.deps.add(_to)
         return self
 
-    def update_balance(self, name: str, token: str, value: int) -> Self:
+    def update_balance(self, name: str, token: str, value: SignedAmount) -> Self:
         """Update the expected balance for a given token, where balance = sum(outputs) - sum(inputs).
 
         =0 means sum(txouts) = sum(txins)
@@ -159,7 +160,7 @@ class DAGBuilder:
         <0 means sum(txouts) < sum(txins), e.g., deposit
         """
         node = self._get_or_create_node(name)
-        node.balances[token] = node.balances.get(token, 0) + value
+        node.balances[token] = node.balances.get(token, SignedAmount(0)) + value
         if token != 'HTR':
             self._get_or_create_node(token, default_type=DAGNodeType.Token)
             self.add_deps(name, token)

--- a/hathor/dag_builder/default_filler.py
+++ b/hathor/dag_builder/default_filler.py
@@ -21,6 +21,7 @@ from hathor.daa import DAAFactory
 from hathor.dag_builder.builder import DAGBuilder, DAGInput, DAGNode, DAGNodeType, DAGOutput
 from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 
 
 class DefaultFiller:
@@ -86,7 +87,7 @@ class DefaultFiller:
                 break
             node.parents.add(pi)
 
-    def find_txin(self, amount: int, token: str) -> DAGInput:
+    def find_txin(self, amount: UnsignedAmount, token: str) -> DAGInput:
         """Create a DAGInput for an amount of tokens."""
         if token == 'HTR':
             dummy = self._get_node('dummy')
@@ -104,19 +105,19 @@ class DefaultFiller:
             token_node.outputs[index] = DAGOutput(amount, token, {'_origin': 'f2'})
             return DAGInput(token, index)
 
-    def calculate_balance(self, node: DAGNode) -> dict[str, int]:
+    def calculate_balance(self, node: DAGNode) -> dict[str, SignedAmount]:
         """Calculate the balance for each token in a node.
 
         balance = sum(outputs) - sum(inputs)
         """
-        ins: defaultdict[str, int] = defaultdict(int)
+        ins: defaultdict[str, UnsignedAmount] = defaultdict(int)
         for tx_name, index in node.inputs:
             node2 = self._get_or_create_node(tx_name)
             txout = node2.outputs[index]
             assert txout is not None
             ins[txout.token] += txout.amount
 
-        outs: defaultdict[str, int] = defaultdict(int)
+        outs: defaultdict[str, UnsignedAmount] = defaultdict(int)
         for txout in node.outputs:
             assert txout is not None
             outs[txout.token] += txout.amount
@@ -133,12 +134,12 @@ class DefaultFiller:
         balance = self.calculate_balance(node)
 
         for key, diff in balance.items():
-            target = node.balances.get(key, 0)
+            target = node.balances.get(key, SignedAmount(0))
             diff -= target
-            if diff < 0:
+            if diff < SignedAmount(0):
                 index = self.get_next_index(node.outputs)
                 node.outputs[index] = DAGOutput(abs(diff), key, {'_origin': 'f3'})
-            elif diff > 0:
+            elif diff > SignedAmount(0):
                 txin = self.find_txin(diff, key)
                 node.inputs.add(txin)
 
@@ -208,11 +209,11 @@ class DefaultFiller:
 
                     balance = self.calculate_balance(node)
                     assert set(balance.keys()).issubset({'HTR'})
-                    diff = balance.get('HTR', 0)
+                    diff = balance.get('HTR', SignedAmount(0))
 
                     # TODO Use the actual height. DAG construction has no chain context, so V1.
                     target = self._daa_factory.create_v1().get_tokens_issued_per_block(1)
-                    assert diff >= 0
+                    assert diff >= SignedAmount(0)
                     assert diff <= target
 
                     if diff < target:
@@ -247,7 +248,7 @@ class DefaultFiller:
             assert set(balance.keys()).issubset({'HTR', token})
 
             token_version = node.get_attr_token_version()
-            htr_deposit: int
+            htr_deposit: UnsignedAmount
 
             match token_version:
                 case TokenVersion.NATIVE:
@@ -257,7 +258,7 @@ class DefaultFiller:
                 case TokenVersion.FEE:
                     htr_deposit = 0
 
-            htr_balance = balance.get('HTR', 0)
+            htr_balance = balance.get('HTR', SignedAmount(0))
 
             # target = sum(outputs) - sum(inputs)
             # <0 means deposit
@@ -266,11 +267,11 @@ class DefaultFiller:
 
             diff = htr_balance - htr_target
 
-            if diff < 0:
+            if diff < SignedAmount(0):
                 index = self.get_next_index(node.outputs)
                 node.outputs[index] = DAGOutput(-diff, 'HTR', {'_origin': 'f8'})
 
-            elif diff > 0:
+            elif diff > SignedAmount(0):
                 txin = self.find_txin(diff, 'HTR')
                 node.inputs.add(txin)
 
@@ -281,11 +282,11 @@ class DefaultFiller:
                 del self._builder._nodes['dummy']
             else:
                 assert set(balance.keys()) == {'HTR'}
-                diff = balance.get('HTR', 0)
+                diff = balance.get('HTR', SignedAmount(0))
 
-                assert diff <= 0
+                assert diff <= SignedAmount(0)
 
-                if diff < 0:
+                if diff < SignedAmount(0):
                     index = self.get_next_index(node.outputs)
                     node.outputs[index] = DAGOutput(-diff, 'HTR', {})
 

--- a/hathor/dag_builder/types.py
+++ b/hathor/dag_builder/types.py
@@ -24,6 +24,7 @@ from hathor.dag_builder.utils import get_literal
 from hathor.transaction import BaseTransaction
 from hathor.transaction.token_info import TokenVersion
 from hathor.wallet import BaseWallet
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 
 AttributeType: TypeAlias = dict[str, str | int]
 VertexResolverType: TypeAlias = Callable[[BaseTransaction], Any]
@@ -54,7 +55,7 @@ class DAGNode:
     #   =0 means sum(txouts) = sum(txins)
     #   >0 means sum(txouts) > sum(txins), e.g., withdrawal
     #   <0 means sum(txouts) < sum(txins), e.g., deposit
-    balances: dict[str, int] = field(default_factory=dict)
+    balances: dict[str, SignedAmount] = field(default_factory=dict)
 
     def get_all_dependencies(self) -> Iterator[str]:
         yield from self.parents
@@ -102,6 +103,6 @@ class DAGInput(NamedTuple):
 
 
 class DAGOutput(NamedTuple):
-    amount: int
+    amount: UnsignedAmount
     token: str
     attrs: AttributeType

--- a/hathor/dag_builder/vertex_exporter.py
+++ b/hathor/dag_builder/vertex_exporter.py
@@ -45,6 +45,7 @@ from hathor.transaction.headers.nano_header import ADDRESS_LEN_BYTES
 from hathor.transaction.scripts.p2pkh import P2PKH
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.wallet import BaseWallet, HDWallet, KeyPair
+from hathorlib.token_amount import UnsignedAmount
 
 _TEMPLATE_PATTERN = re.compile(r'`(\w+)`')
 
@@ -387,7 +388,7 @@ class VertexExporter:
             actions = node.get_attr_list(key, default=[])
             for token_name, value in actions:
                 assert isinstance(token_name, str)
-                assert isinstance(value, int)
+                assert isinstance(value, UnsignedAmount)
                 token_index = 0
                 if token_name != 'HTR':
                     assert isinstance(vertex, Transaction)

--- a/hathor/indexes/rocksdb_tokens_index.py
+++ b/hathor/indexes/rocksdb_tokens_index.py
@@ -40,6 +40,7 @@ from hathor.transaction.base_transaction import TxVersion
 from hathor.transaction.token_info import TokenVersion
 from hathor.types import TokenUid
 from hathor.util import collect_n, json_dumpb, json_loadb
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 
 if TYPE_CHECKING:  # pragma: no cover
     import rocksdb
@@ -235,7 +236,7 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         name: str | None,
         symbol: str | None,
         version: TokenVersion | None,
-        total: int = 0,
+        total: UnsignedAmount = 0,
         n_contracts_can_mint: int = 0,
         n_contracts_can_melt: int = 0,
     ) -> None:
@@ -270,7 +271,7 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         name: str,
         symbol: str,
         version: TokenVersion,
-        total: int,
+        total: UnsignedAmount,
     ) -> None:
         self.create_token_info(
             token_uid=token_uid,
@@ -352,7 +353,7 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         return dict_info
 
     @override
-    def add_to_total(self, token_uid: bytes, amount: int) -> None:
+    def add_to_total(self, token_uid: bytes, amount: SignedAmount) -> None:
         dict_info = self._get_value_info(token_uid, create_default=True)
         dict_info.total += amount
         key_info = self._to_key_info(token_uid)
@@ -610,8 +611,8 @@ class RocksDBTokenIndexInfo(TokenIndexInfo):
         assert self._info.version is not None
         return self._info.version
 
-    def get_total(self) -> int:
-        return self._info.total
+    def get_total(self) -> UnsignedAmount:
+        return UnsignedAmount(self._info.total)
 
     def _iter_authority_utxos(self, *, is_mint: bool) -> Iterator[TokenUtxoInfo]:
         it = self._index._db.iterkeys(self._index._cf)

--- a/hathor/indexes/rocksdb_utxo_index.py
+++ b/hathor/indexes/rocksdb_utxo_index.py
@@ -23,6 +23,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.crypto.util import decode_address, get_address_b58_from_bytes
 from hathor.indexes.rocksdb_utils import InternalUid, RocksDBIndexUtils, from_internal_token_uid, to_internal_token_uid
 from hathor.indexes.utxo_index import UtxoIndex, UtxoIndexItem
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:  # pragma: no cover
     import rocksdb
@@ -340,7 +341,7 @@ class RocksDBUtxoIndex(UtxoIndex, RocksDBIndexUtils):
             assert key.address == seek.address
             yield key.to_index_item()
 
-    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: int,
+    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: UnsignedAmount,
                              target_timestamp: Optional[int] = None) -> Iterator[UtxoIndexItem]:
         seek = _SeekKeyTimeLock(token_uid_internal=to_internal_token_uid(token_uid), address=decode_address(address),
                                 amount=target_amount, timelock=(target_timestamp or 0xffffffff))
@@ -354,7 +355,7 @@ class RocksDBUtxoIndex(UtxoIndex, RocksDBIndexUtils):
                 continue
             yield i
 
-    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: int,
+    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: UnsignedAmount,
                                target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
         seek = _SeekKeyHeightLock(token_uid_internal=to_internal_token_uid(token_uid), address=decode_address(address),
                                   amount=target_amount, heightlock=(target_height or 0xffffffff))

--- a/hathor/indexes/tokens_index.py
+++ b/hathor/indexes/tokens_index.py
@@ -21,6 +21,7 @@ from hathor.indexes.base_index import BaseIndex
 from hathor.indexes.scope import Scope
 from hathor.transaction import BaseTransaction
 from hathor.transaction.token_info import TokenVersion
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.nanocontracts.runner.index_records import UpdateAuthoritiesRecord
@@ -61,7 +62,7 @@ class TokenIndexInfo(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_total(self) -> int:
+    def get_total(self) -> UnsignedAmount:
         """The token's total supply"""
         raise NotImplementedError
 
@@ -143,7 +144,7 @@ class TokensIndex(BaseIndex):
         name: str,
         symbol: str,
         version: TokenVersion,
-        total: int = 0,
+        total: UnsignedAmount = 0,
         n_contracts_can_mint: int = 0,
         n_contracts_can_melt: int = 0,
     ) -> None:
@@ -157,7 +158,7 @@ class TokensIndex(BaseIndex):
         name: str,
         symbol: str,
         version: TokenVersion,
-        total: int,
+        total: UnsignedAmount,
     ) -> None:
         """Create a token info for a new token created in a contract."""
         raise NotImplementedError
@@ -201,6 +202,6 @@ class TokensIndex(BaseIndex):
         raise NotImplementedError
 
     @abstractmethod
-    def add_to_total(self, token_uid: bytes, amount: int) -> None:
+    def add_to_total(self, token_uid: bytes, amount: SignedAmount) -> None:
         """Add an amount to the total of `token_uid`. The amount may be negative."""
         raise NotImplementedError

--- a/hathor/indexes/utxo_index.py
+++ b/hathor/indexes/utxo_index.py
@@ -25,6 +25,7 @@ from hathor.indexes.scope import Scope
 from hathor.transaction import BaseTransaction, Block, TxOutput
 from hathor.transaction.scripts import parse_address_script
 from hathor.util import sorted_merger
+from hathorlib.token_amount import UnsignedAmount
 
 logger = get_logger()
 
@@ -41,7 +42,7 @@ class UtxoIndexItem:
     tx_id: bytes
     index: int
     address: str
-    amount: int
+    amount: UnsignedAmount
     timelock: Optional[int]
     heightlock: Optional[int]
 
@@ -208,7 +209,7 @@ class UtxoIndex(BaseIndex):
             log_it.debug('re-add input that became unspent')
             self._add_utxo(UtxoIndexItem.from_tx_output(spent_tx, tx_input.index, spent_tx_output))
 
-    def iter_utxos(self, *, address: str, target_amount: int, token_uid: Optional[bytes] = None,
+    def iter_utxos(self, *, address: str, target_amount: UnsignedAmount, token_uid: Optional[bytes] = None,
                    target_timestamp: Optional[int] = None,
                    target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
         """ Search UTXOs for a given token_uid+address+target_value, if no token_uid is given, HTR is assumed.
@@ -291,13 +292,13 @@ class UtxoIndex(BaseIndex):
         raise NotImplementedError
 
     @abstractmethod
-    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: int,
+    def _iter_utxos_timelock(self, *, token_uid: bytes, address: str, target_amount: UnsignedAmount,
                              target_timestamp: Optional[int] = None) -> Iterator[UtxoIndexItem]:
         """Iterate over all UTXOs that ONLY HAVE timelocks that will be unlocked at target_timestamp."""
         raise NotImplementedError
 
     @abstractmethod
-    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: int,
+    def _iter_utxos_heightlock(self, *, token_uid: bytes, address: str, target_amount: UnsignedAmount,
                                target_height: Optional[int] = None) -> Iterator[UtxoIndexItem]:
         """Iterate over all UTXOs that ONLY HAVE heightlocks that will be unlocked at target_height."""
         raise NotImplementedError

--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -69,6 +69,7 @@ from hathor.verification.verification_service import VerificationService
 from hathor.vertex_handler import VertexHandler
 from hathor.wallet import BaseWallet
 from hathorlib.base_transaction import tx_or_block_from_bytes as lib_tx_or_block_from_bytes
+from hathorlib.token_amount import UnsignedAmount
 from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
@@ -793,7 +794,7 @@ class HathorManager:
         )
         return block
 
-    def get_tokens_issued_per_block(self, height: int) -> int:
+    def get_tokens_issued_per_block(self, height: int) -> UnsignedAmount:
         """Return the number of tokens issued (aka reward) per block of a given height."""
         best_block = self.tx_storage.get_best_block()
         return self.daa_factory.create_from_parent(best_block).get_tokens_issued_per_block(height)

--- a/hathor/mining/block_template.py
+++ b/hathor/mining/block_template.py
@@ -22,13 +22,14 @@ from hathor.transaction.base_transaction import get_cls_from_tx_version
 from hathor.transaction.poa import PoaBlock
 from hathor.transaction.storage import TransactionStorage
 from hathor.util import Random
+from hathorlib.token_amount import UnsignedAmount
 
 T = TypeVar('T', bound=Block)
 
 
 class BlockTemplate(NamedTuple):
     versions: set[int]
-    reward: int  # reward unit value, 64.00 HTR is 6400
+    reward: UnsignedAmount  # reward unit value, 64.00 HTR is 6400
     weight: float  # calculated from the DAA
     timestamp_now: int  # the reference timestamp the template was generated for
     timestamp_min: int  # min valid timestamp

--- a/hathor/mining/ws.py
+++ b/hathor/mining/ws.py
@@ -58,7 +58,7 @@ JSON_RPC_INTERNAL_ERROR = JsonRpcError(-32603, 'Internal error', fatal=True)
 
 class JsonRpcWebsocketServerProtocol(WebSocketServerProtocol):
     """Small JSONRPC 2.0 abstraction over WebSocket, will forward method calls to do_<method>"""
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.info: dict[str, Any] = {}
 

--- a/hathor/simulator/trigger.py
+++ b/hathor/simulator/trigger.py
@@ -15,6 +15,8 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable
 
+from hathorlib.token_amount import UnsignedAmount
+
 if TYPE_CHECKING:
     from re import Match, Pattern
 
@@ -56,7 +58,7 @@ class StopAfterNMinedBlocks(Trigger):
 
 class StopAfterMinimumBalance(Trigger):
     """Stop the simulation after `wallet` reaches a minimum unlocked balance."""
-    def __init__(self, wallet: 'BaseWallet', token_uid: bytes, minimum_balance: int) -> None:
+    def __init__(self, wallet: 'BaseWallet', token_uid: bytes, minimum_balance: UnsignedAmount) -> None:
         self.wallet = wallet
         self.token_uid = token_uid
         self.minimum_balance = minimum_balance

--- a/hathor/simulator/tx_generator.py
+++ b/hathor/simulator/tx_generator.py
@@ -24,13 +24,14 @@ from hathor.transaction.exceptions import RewardLocked
 from hathor.types import VertexId
 from hathor.util import Random
 from hathor.wallet.exceptions import InsufficientFunds
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.manager import HathorManager
 
 logger = get_logger()
 
-GenTxFunction: TypeAlias = Callable[['HathorManager', str, int], Transaction]
+GenTxFunction: TypeAlias = Callable[['HathorManager', str, UnsignedAmount], Transaction]
 
 
 class RandomTransactionGenerator:

--- a/hathor/simulator/utils.py
+++ b/hathor/simulator/utils.py
@@ -19,9 +19,10 @@ from hathor.dag_builder import DAGBuilder
 from hathor.manager import HathorManager
 from hathor.transaction import Block, Transaction
 from hathor.types import Address, VertexId
+from hathorlib.token_amount import UnsignedAmount
 
 
-def gen_new_tx(manager: HathorManager, address: str, value: int) -> Transaction:
+def gen_new_tx(manager: HathorManager, address: str, value: UnsignedAmount) -> Transaction:
     """
     Generate and return a new transaction.
 

--- a/hathor/transaction/base_transaction.py
+++ b/hathor/transaction/base_transaction.py
@@ -39,6 +39,7 @@ from hathor.types import TokenUid, TxOutputScript, VertexId
 from hathor.util import classproperty
 from hathor.utils.weight import weight_to_work
 from hathorlib.base_transaction import TxVersion  # noqa: F401
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from _hashlib import HASH
@@ -323,7 +324,7 @@ class GenericVertex(ABC, Generic[StaticMetadataT]):
             return ''
 
     @property
-    def sum_outputs(self) -> int:
+    def sum_outputs(self) -> UnsignedAmount:
         """Sum of the value of the outputs"""
         return sum(output.value for output in self.outputs if not output.is_token_authority())
 
@@ -987,19 +988,19 @@ class TxOutput:
 
     ALL_AUTHORITIES = TOKEN_MINT_MASK | TOKEN_MELT_MASK
 
-    def __init__(self, value: int, script: TxOutputScript, token_data: int = 0) -> None:
+    def __init__(self, value: UnsignedAmount, script: TxOutputScript, token_data: int = 0) -> None:
         """
             value: amount spent (4 bytes)
             script: script in bytes
             token_data: index of the token uid in the uid list
         """
-        assert isinstance(value, int), 'value is %s, type %s' % (str(value), type(value))
+        assert isinstance(value, UnsignedAmount), 'value is %s, type %s' % (str(value), type(value))
         assert isinstance(script, TxOutputScript), 'script is %s, type %s' % (str(script), type(script))
         assert isinstance(token_data, int), 'token_data is %s, type %s' % (str(token_data), type(token_data))
         if value <= 0 or value > MAX_OUTPUT_VALUE:
             raise InvalidOutputValue
 
-        self.value = value  # int
+        self.value = value  # UnsignedAmount
         self.script = script  # bytes
         self.token_data = token_data  # int
 

--- a/hathor/transaction/exceptions.py
+++ b/hathor/transaction/exceptions.py
@@ -74,7 +74,7 @@ from hathorlib.exceptions import (  # noqa: F401
     VerifyFailed,
     WeightError,
 )
-from hathorlib.token_amount import SignedAmount
+from hathorlib.token_amount import UnsignedAmount
 
 
 class ForbiddenMint(InputOutputMismatch):
@@ -82,8 +82,8 @@ class ForbiddenMint(InputOutputMismatch):
 
     from hathor.types import TokenUid
 
-    def __init__(self, amount: SignedAmount, token_uid: TokenUid) -> None:
-        super().__init__(f'{-amount} {token_uid.hex()} tokens minted, but there is no mint authority input')
+    def __init__(self, amount: UnsignedAmount, token_uid: TokenUid) -> None:
+        super().__init__(f'{amount} {token_uid.hex()} tokens minted, but there is no mint authority input')
 
 
 class ForbiddenMelt(InputOutputMismatch):
@@ -95,8 +95,8 @@ class ForbiddenMelt(InputOutputMismatch):
         super().__init__(msg)
 
     @classmethod
-    def from_token(cls, amount: SignedAmount, token_uid: TokenUid) -> 'ForbiddenMelt':
-        return cls(f'{-amount} {token_uid.hex()} tokens melted, but there is no melt authority input')
+    def from_token(cls, amount: UnsignedAmount, token_uid: TokenUid) -> 'ForbiddenMelt':
+        return cls(f'{amount} {token_uid.hex()} tokens melted, but there is no melt authority input')
 
 
 class InvalidRangeProofError(TxValidationError):

--- a/hathor/transaction/exceptions.py
+++ b/hathor/transaction/exceptions.py
@@ -74,6 +74,7 @@ from hathorlib.exceptions import (  # noqa: F401
     VerifyFailed,
     WeightError,
 )
+from hathorlib.token_amount import SignedAmount
 
 
 class ForbiddenMint(InputOutputMismatch):
@@ -81,9 +82,8 @@ class ForbiddenMint(InputOutputMismatch):
 
     from hathor.types import TokenUid
 
-    def __init__(self, amount: int, token_uid: TokenUid) -> None:
-        super().__init__('{} {} tokens minted, but there is no mint authority input'.format(
-            (-1) * amount, token_uid.hex()))
+    def __init__(self, amount: SignedAmount, token_uid: TokenUid) -> None:
+        super().__init__(f'{-amount} {token_uid.hex()} tokens minted, but there is no mint authority input')
 
 
 class ForbiddenMelt(InputOutputMismatch):
@@ -95,9 +95,8 @@ class ForbiddenMelt(InputOutputMismatch):
         super().__init__(msg)
 
     @classmethod
-    def from_token(cls, amount: int, token_uid: TokenUid) -> 'ForbiddenMelt':
-        return cls('{} {} tokens melted, but there is no melt authority input'.format(
-            (-1) * amount, token_uid.hex()))
+    def from_token(cls, amount: SignedAmount, token_uid: TokenUid) -> 'ForbiddenMelt':
+        return cls(f'{-amount} {token_uid.hex()} tokens melted, but there is no melt authority input')
 
 
 class InvalidRangeProofError(TxValidationError):

--- a/hathor/transaction/headers/fee_header.py
+++ b/hathor/transaction/headers/fee_header.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from hathor.transaction.util import get_deposit_token_withdraw_amount
 from hathor.types import TokenUid
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -28,13 +29,13 @@ if TYPE_CHECKING:
 @dataclass(slots=True, kw_only=True, frozen=True)
 class FeeHeaderEntry:
     token_index: int
-    amount: int
+    amount: UnsignedAmount
 
 
 @dataclass(slots=True, kw_only=True, frozen=True)
 class FeeEntry:
     token_uid: TokenUid
-    amount: int
+    amount: UnsignedAmount
 
 
 @dataclass(slots=True, kw_only=True)
@@ -59,7 +60,7 @@ class FeeHeader:
             for fee in self.fees
         ]
 
-    def total_fee_amount(self) -> int:
+    def total_fee_amount(self) -> UnsignedAmount:
         """Sum fees amounts in this header and return as HTR"""
         total_fee = 0
         for fee in self.get_fees():

--- a/hathor/transaction/headers/nano_header.py
+++ b/hathor/transaction/headers/nano_header.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from typing_extensions import assert_never
 
 from hathor.types import VertexId
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.nanocontracts.context import Context
@@ -37,7 +38,7 @@ _NC_SCRIPT_LEN_MAX_BYTES: int = 2
 class NanoHeaderAction:
     type: NCActionType
     token_index: int
-    amount: int
+    amount: UnsignedAmount
 
     def to_nc_action(self, tx: Transaction) -> NCAction:
         """Create a NCAction from this NanoHeaderAction"""

--- a/hathor/transaction/token_info.py
+++ b/hathor/transaction/token_info.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from hathor.types import TokenUid
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion  # noqa: F401
 
 if TYPE_CHECKING:
@@ -41,14 +42,14 @@ class TokenInfo:
         Check if this token has been melted.
         A token is considered melted if its amount is negative.
         """
-        return self.amount < 0
+        return self.amount < SignedAmount(0)
 
     def has_been_minted(self) -> bool:
         """
         Check if this token has been minted.
         A token is considered minted if its amount is positive.
         """
-        return self.amount > 0
+        return self.amount > SignedAmount(0)
 
 
 class TokenInfoDict(dict[TokenUid, TokenInfo]):
@@ -58,7 +59,7 @@ class TokenInfoDict(dict[TokenUid, TokenInfo]):
         super().__init__(*args, **kwargs)
         self.fees_from_fee_header: int = 0
 
-    def calculate_fee(self, settings: 'HathorSettings') -> int:
+    def calculate_fee(self, settings: 'HathorSettings') -> UnsignedAmount:
         """
          Calculate the total fee based on the number of chargeable
          outputs and inputs for each token in the transaction.

--- a/hathor/verification/token_creation_transaction_verifier.py
+++ b/hathor/verification/token_creation_transaction_verifier.py
@@ -18,6 +18,7 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenInfo, TokenVersion
 from hathor.types import TokenUid
 from hathor.verification.verification_params import VerificationParams
+from hathorlib.token_amount import SignedAmount
 from hathorlib.utils.token_validation import validate_token_name_and_symbol
 
 
@@ -37,7 +38,7 @@ class TokenCreationTransactionVerifier:
         """
         # make sure tokens are being minted
         token_info = token_dict[tx.hash]
-        if token_info.amount <= 0:
+        if token_info.amount <= SignedAmount(0):
             raise InvalidToken('Token creation transaction must mint new tokens')
 
     def verify_token_info(self, tx: TokenCreationTransaction, params: VerificationParams) -> None:

--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -33,9 +33,10 @@ from hathor.transaction.scripts import P2PKH, create_output_script, parse_addres
 from hathor.transaction.storage import TransactionStorage
 from hathor.transaction.transaction import Transaction
 from hathor.transaction.util import int_to_bytes
-from hathor.types import AddressB58, Amount, TokenUid
+from hathor.types import AddressB58, TokenUid
 from hathor.wallet.exceptions import InputDuplicated, InsufficientFunds, PrivateKeyNotFound
 from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
+from hathorlib.token_amount import UnsignedAmount
 
 logger = get_logger()
 
@@ -53,14 +54,14 @@ class WalletInputInfo(NamedTuple):
 
 class WalletOutputInfo(NamedTuple):
     address: bytes
-    value: int
+    value: UnsignedAmount
     timelock: Optional[int]
     token_uid: str = HATHOR_TOKEN_UID.hex()
 
 
 class WalletBalance(NamedTuple):
-    locked: int = 0
-    available: int = 0
+    locked: UnsignedAmount = 0
+    available: UnsignedAmount = 0
 
 
 class WalletBalanceUpdate(NamedTuple):
@@ -173,9 +174,9 @@ class BaseWallet:
     def _manually_initialize(self) -> None:
         pass
 
-    def get_balance_per_address(self, token_uid: TokenUid) -> dict[AddressB58, Amount]:
+    def get_balance_per_address(self, token_uid: TokenUid) -> dict[AddressB58, UnsignedAmount]:
         """Return balance per address for a given token. This method ignores locks."""
-        balances: defaultdict[AddressB58, Amount] = defaultdict(Amount)
+        balances: defaultdict[AddressB58, UnsignedAmount] = defaultdict(int)
         for utxo_info, unspent_tx in self.unspent_txs[token_uid].items():
             balances[unspent_tx.address] += unspent_tx.value
         return dict(balances)
@@ -427,7 +428,7 @@ class BaseWallet:
         :param timestamp: the tx timestamp
         :type timestamp: int
         """
-        token_dict: dict[bytes, int] = defaultdict(int)
+        token_dict: dict[bytes, UnsignedAmount] = defaultdict(int)
         for output in outputs:
             token_uid = bytes.fromhex(output.token_uid)
             token_dict[token_uid] += output.value
@@ -490,7 +491,7 @@ class BaseWallet:
                 public_key_bytes, signature = self.get_input_aux_data(data_to_sign, self.get_private_key(address58))
                 _input.data = P2PKH.create_input_data(public_key_bytes, signature)
 
-    def handle_change_tx(self, sum_inputs: int, sum_outputs: int,
+    def handle_change_tx(self, sum_inputs: UnsignedAmount, sum_outputs: UnsignedAmount,
                          token_uid: bytes = HATHOR_TOKEN_UID) -> Optional[WalletOutputInfo]:
         """Creates an output transaction with the change value
 
@@ -516,9 +517,9 @@ class BaseWallet:
         return None
 
     def get_inputs_from_amount(
-        self, amount: int, tx_storage: 'TransactionStorage',
+        self, amount: UnsignedAmount, tx_storage: 'TransactionStorage',
         token_uid: bytes = HATHOR_TOKEN_UID, max_ts: Optional[int] = None
-    ) -> tuple[list[WalletInputInfo], int]:
+    ) -> tuple[list[WalletInputInfo], UnsignedAmount]:
         """Creates inputs from our pool of unspent tx given a value
 
         This is a very simple algorithm, so it does not try to find the best combination
@@ -1190,7 +1191,7 @@ class BaseWallet:
 
 
 class UnspentTx:
-    def __init__(self, tx_id: bytes, index: int, value: int, timestamp: int, address: str, token_data: int,
+    def __init__(self, tx_id: bytes, index: int, value: UnsignedAmount, timestamp: int, address: str, token_data: int,
                  voided: bool = False, timelock: Optional[int] = None) -> None:
         self.tx_id = tx_id
         self.index = index
@@ -1240,7 +1241,7 @@ class UnspentTx:
 
 
 class SpentTx:
-    def __init__(self, tx_id: bytes, from_tx_id: bytes, from_index: int, value: int, timestamp: int,
+    def __init__(self, tx_id: bytes, from_tx_id: bytes, from_index: int, value: UnsignedAmount, timestamp: int,
                  voided: bool = False) -> None:
         """tx_id: the tx spending the output
         from_tx_id: tx where we received the tokens

--- a/hathor/wallet/resources/thin_wallet/address_balance.py
+++ b/hathor/wallet/resources/thin_wallet/address_balance.py
@@ -24,14 +24,15 @@ from hathor.crypto.util import decode_address
 from hathor.transaction.scripts import parse_address_script
 from hathor.util import json_dumpb
 from hathor.wallet.exceptions import InvalidAddress
+from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.transaction import TxOutput
 
 
 class TokenData:
-    received: int = 0
-    spent: int = 0
+    received: UnsignedAmount = 0
+    spent: UnsignedAmount = 0
     name: str = ''
     symbol: str = ''
 

--- a/hathor_tests/nanocontracts/test_actions.py
+++ b/hathor_tests/nanocontracts/test_actions.py
@@ -35,6 +35,7 @@ from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.utils import assert_nc_failure_reason, set_nano_header
 from hathorlib.nanocontracts.verification import MAX_ACTIONS_LEN
+from hathorlib.token_amount import SignedAmount
 
 
 class MyBlueprint(Blueprint):
@@ -162,8 +163,8 @@ class TestActions(unittest.TestCase):
         self,
         *,
         tx: Transaction,
-        update_htr_output: int | None = None,
-        update_tka_output: int | None = None,
+        update_htr_output: SignedAmount | None = None,
+        update_tka_output: SignedAmount | None = None,
         add_inputs: list[TxInput] | None = None,
         add_outputs: list[TxOutput] | None = None,
     ) -> None:

--- a/hathor_tests/nanocontracts/test_reentrancy.py
+++ b/hathor_tests/nanocontracts/test_reentrancy.py
@@ -2,6 +2,7 @@ from hathor.nanocontracts import Blueprint, Context, NCFail, public
 from hathor.nanocontracts.exception import NCForbiddenReentrancy
 from hathor.nanocontracts.types import Amount, CallerId, ContractId, NCAction, NCDepositAction, TokenUid
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathorlib.token_amount import SignedAmount
 
 HTR_TOKEN_UID = TokenUid(b'\0')
 
@@ -167,7 +168,7 @@ class NCReentrancyTestCase(BlueprintTestCase):
         self.attacker_storage = self.runner.get_storage(self.nc_attacker_id)
 
         assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150
-        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == 0
+        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == SignedAmount(0)
 
     def test_basics(self) -> None:
         # Address1 sends 0.30 HTR to attacker contract.
@@ -225,7 +226,7 @@ class NCReentrancyTestCase(BlueprintTestCase):
             )
 
         assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150
-        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == 0
+        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == SignedAmount(0)
 
     def test_attack_fail_protected(self) -> None:
         # Attacker contract has a balance of 0.50 HTR in the target contract.
@@ -239,4 +240,4 @@ class NCReentrancyTestCase(BlueprintTestCase):
             )
 
         assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150
-        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == 0
+        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == SignedAmount(0)

--- a/hathorlib/hathorlib/nanocontracts/runner/index_records.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/index_records.py
@@ -19,6 +19,7 @@ from typing import Any, Self, TypeAlias
 from typing_extensions import Literal, assert_never
 
 from hathorlib.nanocontracts.types import BlueprintId, ContractId, TokenUid, VertexId
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.token_info import TokenVersion
 
 
@@ -61,7 +62,7 @@ class CreateTokenRecord:
     """Record for token creation."""
     type: Literal[IndexRecordType.CREATE_TOKEN] = field(default=IndexRecordType.CREATE_TOKEN, init=False)
     token_uid: TokenUid
-    amount: int
+    amount: UnsignedAmount
     token_symbol: str
     token_name: str
     token_version: Literal[TokenVersion.DEPOSIT] | Literal[TokenVersion.FEE]
@@ -102,7 +103,7 @@ class UpdateTokenBalanceRecord:
         init=False,
     )
     token_uid: TokenUid
-    amount: int
+    amount: SignedAmount
 
     def __post_init__(self) -> None:
         assert self.type == IndexRecordType.UPDATE_TOKEN_BALANCE
@@ -114,7 +115,7 @@ class UpdateTokenBalanceRecord:
     def from_json(cls, json_dict: dict[str, Any]) -> Self:
         return cls(
             token_uid=TokenUid(VertexId(bytes.fromhex(json_dict['token_uid']))),
-            amount=json_dict['amount'],
+            amount=SignedAmount(json_dict['amount']),
         )
 
 

--- a/hathorlib/hathorlib/nanocontracts/runner/runner.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/runner.py
@@ -90,6 +90,7 @@ from hathorlib.nanocontracts.utils import (
     is_nc_public_method,
     is_nc_view_method,
 )
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.token_info import TokenDescription, TokenVersion
 from hathorlib.utils import clean_token_string
@@ -162,10 +163,10 @@ class Runner:
         self._rng_per_contract: dict[ContractId, NanoRNG] = {}
 
         # Information about updated tokens in the current call via syscalls.
-        self._updated_tokens_totals: defaultdict[TokenUid, int] = defaultdict(int)
+        self._updated_tokens_totals: defaultdict[TokenUid, SignedAmount] = defaultdict(SignedAmount)
 
         # Information about fees paid during execution inter-contract calls.
-        self._paid_actions_fees: defaultdict[TokenUid, int] = defaultdict(int)
+        self._paid_actions_fees: defaultdict[TokenUid, UnsignedAmount] = defaultdict(int)
 
     def disable_call_trace(self) -> None:
         """Disable call trace. Useful when the runner is only used to call view methods, for example in APIs."""
@@ -522,7 +523,7 @@ class Runner:
         self._call_info = None
 
         # Reset the tokens counters so this Runner can be reused (in blueprint tests, for example).
-        self._updated_tokens_totals = defaultdict(int)
+        self._updated_tokens_totals = defaultdict(SignedAmount)
         self._paid_actions_fees = defaultdict(int)
 
     def _validate_balances(self, ctx: Context) -> None:
@@ -534,7 +535,7 @@ class Runner:
         assert self._call_info.calls is not None
 
         # total_diffs accumulates the balance differences for all contracts called during this execution.
-        total_diffs: defaultdict[TokenUid, int] = defaultdict(int)
+        total_diffs: defaultdict[TokenUid, SignedAmount] = defaultdict(SignedAmount)
 
         # Each list of change trackers account for a single call in a contract.
         for change_trackers in self._call_info.change_trackers.values():
@@ -547,7 +548,7 @@ class Runner:
                 total_diffs[TokenUid(balance_key.token_uid)] += balance
 
         # Accumulate tokens totals from syscalls to compare with the totals from this runner.
-        calculated_tokens_totals: defaultdict[TokenUid, int] = defaultdict(int)
+        calculated_tokens_totals: defaultdict[TokenUid, SignedAmount] = defaultdict(SignedAmount)
         for call in self._call_info.calls:
             if call.index_updates is None:
                 assert call.type == CallType.VIEW
@@ -587,7 +588,7 @@ class Runner:
                 case _:  # pragma: no cover
                     assert_never(action)
 
-        assert all(diff == 0 for diff in total_diffs.values()), (
+        assert all(diff == SignedAmount(0) for diff in total_diffs.values()), (
             f'change tracker diffs do not match actions: {total_diffs}'
         )
 
@@ -1106,9 +1107,9 @@ class Runner:
             case TokenVersion.NATIVE:
                 raise AssertionError
             case TokenVersion.DEPOSIT:
-                assert fee_amount > 0
+                assert fee_amount > SignedAmount(0)
             case TokenVersion.FEE:
-                assert fee_amount < 0
+                assert fee_amount < SignedAmount(0)
             case _:  # pragma: no cover
                 assert_never(token_info.token_version)
 
@@ -1393,7 +1394,7 @@ class Runner:
             self._updated_tokens_totals[record.token_uid] += record.amount
             call_record.index_updates.append(record)
 
-    def _register_paid_fee(self, token_uid: TokenUid, amount: int) -> None:
+    def _register_paid_fee(self, token_uid: TokenUid, amount: UnsignedAmount) -> None:
         """ Register a fee payment in the current call."""
         self._paid_actions_fees[token_uid] += amount
 

--- a/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
@@ -16,6 +16,7 @@ from typing_extensions import assert_never
 
 from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 from hathorlib.nanocontracts.exception import NCInvalidFeePaymentToken
+from hathorlib.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion
 from hathorlib.utils import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount
 
@@ -24,9 +25,9 @@ def calculate_mint_fee(
     *,
     settings: HathorSettings,
     token_version: TokenVersion,
-    amount: int,
+    amount: UnsignedAmount,
     fee_payment_token: TokenDescription,
-) -> int:
+) -> SignedAmount:
     """Calculate the fee for a mint operation."""
     match token_version:
         case TokenVersion.NATIVE:
@@ -45,9 +46,9 @@ def calculate_melt_fee(
     *,
     settings: HathorSettings,
     token_version: TokenVersion,
-    amount: int,
+    amount: UnsignedAmount,
     fee_payment_token: TokenDescription,
-) -> int:
+) -> SignedAmount:
     """Calculate the fee for a melt operation."""
     match token_version:
         case TokenVersion.NATIVE:
@@ -79,7 +80,7 @@ def _validate_fee_based_payment_token(fee_payment_token: TokenDescription) -> No
             assert_never(fee_payment_token.token_version)
 
 
-def _calculate_unit_fee_token_fee(settings: HathorSettings, fee_payment_token: TokenDescription) -> int:
+def _calculate_unit_fee_token_fee(settings: HathorSettings, fee_payment_token: TokenDescription) -> UnsignedAmount:
     """Calculate the fee for handling a fee-based token"""
     if fee_payment_token.token_id == HATHOR_TOKEN_UID:
         return settings.FEE_PER_OUTPUT_V1

--- a/hathorlib/hathorlib/nanocontracts/storage/changes_tracker.py
+++ b/hathorlib/hathorlib/nanocontracts/storage/changes_tracker.py
@@ -32,6 +32,7 @@ from hathorlib.nanocontracts.storage.contract_storage import (
 )
 from hathorlib.nanocontracts.storage.types import _NOT_PROVIDED, DeletedKey, DeletedKeyType
 from hathorlib.nanocontracts.types import BlueprintId, ContractId, TokenUid
+from hathorlib.token_amount import SignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion
 
 T = TypeVar('T')
@@ -78,7 +79,7 @@ class NCChangesTracker(NCContractStorage):
         self.nc_id = nc_id
 
         self.data: dict[AttrKey, tuple[Any, NCType | None]] = {}
-        self._balance_diff: dict[BalanceKey, int] = {}
+        self._balance_diff: dict[BalanceKey, SignedAmount] = {}
         self._authorities_diff: dict[BalanceKey, _NCAuthorityDiff] = {}
         self._created_tokens: dict[TokenUid, TokenDescription] = {}
         self._blueprint_id: BlueprintId | None = None
@@ -117,7 +118,7 @@ class NCChangesTracker(NCContractStorage):
             return token_description
         return self.storage.get_token(token_id)
 
-    def get_balance_diff(self) -> MappingProxyType[BalanceKey, int]:
+    def get_balance_diff(self) -> MappingProxyType[BalanceKey, SignedAmount]:
         """Return the balance diff of this change tracker."""
         return MappingProxyType(self._balance_diff)
 
@@ -217,7 +218,7 @@ class NCChangesTracker(NCContractStorage):
     def _get_mutable_balance(self, token_uid: bytes) -> MutableBalance:
         internal_key = BalanceKey(self.nc_id, token_uid)
         balance = self.storage._get_mutable_balance(token_uid)
-        balance_diff = self._balance_diff.get(internal_key, 0)
+        balance_diff = self._balance_diff.get(internal_key, SignedAmount(0))
         authorities_diff = self._authorities_diff.get(internal_key, _NCAuthorityDiff())
 
         balance.value += balance_diff
@@ -236,7 +237,7 @@ class NCChangesTracker(NCContractStorage):
         """Check that all final balances are positive. If not, it raises NCInsufficientFunds."""
         for balance_key in self._balance_diff.keys():
             balance = self.get_balance(balance_key.token_uid)
-            if balance.value < 0:
+            if balance.value < SignedAmount(0):
                 raise NCInsufficientFunds(
                     f'negative balance for contract {self.nc_id.hex()} '
                     f'(balance={balance} token_uid={balance_key.token_uid.hex()})'
@@ -258,7 +259,7 @@ class NCChangesTracker(NCContractStorage):
     def add_balance(self, token_uid: bytes, amount: int) -> None:
         self.check_if_locked()
         internal_key = BalanceKey(self.nc_id, token_uid)
-        old = self._balance_diff.get(internal_key, 0)
+        old = self._balance_diff.get(internal_key, SignedAmount(0))
         new = old + amount
         self._balance_diff[internal_key] = new
 

--- a/hathorlib/hathorlib/nanocontracts/storage/contract_storage.py
+++ b/hathorlib/hathorlib/nanocontracts/storage/contract_storage.py
@@ -29,6 +29,7 @@ from hathorlib.nanocontracts.storage.token_proxy import TokenProxy
 from hathorlib.nanocontracts.storage.types import _NOT_PROVIDED, DeletedKey, DeletedKeyType
 from hathorlib.nanocontracts.types import BlueprintId, TokenUid, VertexId
 from hathorlib.serialization import Deserializer, Serializer
+from hathorlib.token_amount import SignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion
 
 T = TypeVar('T')
@@ -73,7 +74,7 @@ class Balance:
     The balance of a token in the storage, which includes its value (amount of tokens), and the
     stored authorities. This class is immutable and therefore suitable to be used externally.
     """
-    value: int
+    value: SignedAmount
     can_mint: bool
     can_melt: bool
 
@@ -113,7 +114,7 @@ class MutableBalance:
 
     def to_immutable(self) -> Balance:
         return Balance(
-            value=self.value,
+            value=SignedAmount(self.value),
             can_mint=self.can_mint,
             can_melt=self.can_melt,
         )

--- a/hathorlib/hathorlib/nanocontracts/types.py
+++ b/hathorlib/hathorlib/nanocontracts/types.py
@@ -33,6 +33,7 @@ from hathorlib.nanocontracts.blueprint_syntax_validation import (
 from hathorlib.nanocontracts.exception import BlueprintSyntaxError, NCSerializationError
 from hathorlib.nanocontracts.faux_immutable import FauxImmutableMeta
 from hathorlib.serialization import SerializationError
+from hathorlib.token_amount import UnsignedAmount
 from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.utils import get_deposit_token_withdraw_amount
 from hathorlib.utils.address import decode_address, get_address_b58_from_bytes
@@ -560,7 +561,7 @@ class NCFee:
     token_uid: TokenUid
     amount: int
 
-    def __get_htr_value__(self, settings: HathorSettings, token_amount_version: TokenAmountVersion) -> int:
+    def __get_htr_value__(self, settings: HathorSettings, token_amount_version: TokenAmountVersion) -> UnsignedAmount:
         """
         Get the amount converted to HTR
         """

--- a/hathorlib/hathorlib/serialization/encoding/output_value.py
+++ b/hathorlib/hathorlib/serialization/encoding/output_value.py
@@ -110,6 +110,7 @@ from typing_extensions import assert_never
 
 from hathorlib.serialization import Deserializer, Serializer
 from hathorlib.serialization.exceptions import BadDataError
+from hathorlib.token_amount import UnsignedAmount
 from hathorlib.token_amount_version import TokenAmountVersion
 
 MAX_OUTPUT_VALUE_32 = 2 ** 31 - 1  # max value (inclusive) before having to use 8 bytes: 2_147_483_647
@@ -212,7 +213,7 @@ def encode_output_value_v2(serializer: Serializer, value: int, *, strict: bool =
     serializer.write_bytes(payload)
 
 
-def decode_output_value(deserializer: Deserializer, *, token_amount_version: TokenAmountVersion) -> int:
+def decode_output_value(deserializer: Deserializer, *, token_amount_version: TokenAmountVersion) -> UnsignedAmount:
     match token_amount_version:
         case TokenAmountVersion.V1:
             return decode_output_value_v1(deserializer)
@@ -222,7 +223,7 @@ def decode_output_value(deserializer: Deserializer, *, token_amount_version: Tok
             assert_never(token_amount_version)
 
 
-def decode_output_value_v1(deserializer: Deserializer, *, strict: bool = True) -> int:
+def decode_output_value_v1(deserializer: Deserializer, *, strict: bool = True) -> UnsignedAmount:
     """ Decodes either 4 or 8 bytes using our output-value format.
 
     This modules's docstring has more details and examples.
@@ -244,7 +245,7 @@ def decode_output_value_v1(deserializer: Deserializer, *, strict: bool = True) -
     return value
 
 
-def decode_output_value_v2(deserializer: Deserializer, *, strict: bool = True) -> int:
+def decode_output_value_v2(deserializer: Deserializer, *, strict: bool = True) -> UnsignedAmount:
     """
     Decode and output value for decimal version V2, using length-prefix encoding.
 

--- a/hathorlib/hathorlib/token_amount.py
+++ b/hathorlib/hathorlib/token_amount.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TypeAlias
+
+# Temporary aliases.
+SignedAmount: TypeAlias = int
+UnsignedAmount: TypeAlias = int

--- a/hathorlib/hathorlib/utils/__init__.py
+++ b/hathorlib/hathorlib/utils/__init__.py
@@ -16,6 +16,8 @@ import re
 import struct
 from typing import TYPE_CHECKING, Any, Optional, Tuple, TypeVar
 
+from hathorlib.token_amount import UnsignedAmount
+
 if TYPE_CHECKING:
     from hathorlib.conf.settings import HathorSettings
 
@@ -80,13 +82,13 @@ def not_none(optional: Optional[_T], message: str = 'Unexpected `None`') -> _T:
     return optional
 
 
-def get_deposit_token_deposit_amount(settings: 'HathorSettings', mint_amount: int) -> int:
+def get_deposit_token_deposit_amount(settings: 'HathorSettings', mint_amount: UnsignedAmount) -> UnsignedAmount:
     numerator = settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR * abs(mint_amount)
     denominator = settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
     return ceil_div(numerator, denominator)
 
 
-def get_deposit_token_withdraw_amount(settings: 'HathorSettings', melt_amount: int) -> int:
+def get_deposit_token_withdraw_amount(settings: 'HathorSettings', melt_amount: UnsignedAmount) -> UnsignedAmount:
     numerator = settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR * abs(melt_amount)
     denominator = settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
     return numerator // denominator

--- a/hathorlib/hathorlib/utils/token_validation.py
+++ b/hathorlib/hathorlib/utils/token_validation.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from hathorlib.exceptions import InvalidFeeAmount, TransactionDataError
+from hathorlib.token_amount import UnsignedAmount
 from hathorlib.utils import clean_token_string
 
 if TYPE_CHECKING:
@@ -41,7 +42,7 @@ def validate_token_name_and_symbol(settings: HathorSettings,
         raise TransactionDataError('Invalid token symbol ({})'.format(token_symbol))
 
 
-def validate_fee_amount(settings: HathorSettings, token_uid: bytes, amount: int) -> None:
+def validate_fee_amount(settings: HathorSettings, token_uid: bytes, amount: UnsignedAmount) -> None:
     """Validate the fee amount."""
     if amount <= 0:
         raise InvalidFeeAmount(f'fees should be a positive integer, got {amount}')

--- a/hathorlib/tests/test_nc_address_type.py
+++ b/hathorlib/tests/test_nc_address_type.py
@@ -16,6 +16,7 @@ import unittest
 
 from hathorlib.exceptions import InvalidAddress
 from hathorlib.nanocontracts.types import NC_HTR_TOKEN_UID, Address, NCFee, TokenUid
+from hathorlib.token_amount import UnsignedAmount
 from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.utils.address import get_address_b58_from_public_key, get_public_key_from_bytes_compressed
 
@@ -66,5 +67,5 @@ class TestNCFee(unittest.TestCase):
         fee = NCFee(token_uid=TokenUid(b'\x01' * 32), amount=1000)
         # For custom token, it converts using deposit percentage
         result = fee.__get_htr_value__(settings, TokenAmountVersion.V1)
-        self.assertIsInstance(result, int)
+        self.assertIsInstance(result, UnsignedAmount)
         self.assertGreater(result, 0)


### PR DESCRIPTION
### Motivation

The previous PR introduced the new token amount model types, `UnsignedAmount` and `SignedAmount`. In preparation to use those types across the codebase, this PR creates types with the same names that are just aliases to `int`. This means we can change all function, method, and attribute type signatures to the new types, without actually changing any logic.

To be clear, this PR **does not** use the types introduced in the previous PR. It's simply a typing trick to allows us to remove some lines from the diff of the main PR, which is coming next. What must be reviewed with attention is the deliberate choice of which type to use in each situation. `UnsignedAmount` is used whenever an value cannot be negative, and `SignedAmount` is used when it can.

### Acceptance Criteria

- Add temporary `int` aliases on `hathorlib`: `UnsignedAmount` and `SignedAmount`.
- Change all usages of `int` that represent token amounts (unsigned) to the `UnsignedAmount` alias.
- Change all usages of `int` that represent token balances (signed) to the `SignedAmount` alias.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 