### PR TITLE
feat(decimals): update indexes [part 11]

### DIFF
--- a/hathor/indexes/rocksdb_tokens_index.py
+++ b/hathor/indexes/rocksdb_tokens_index.py
@@ -18,17 +18,12 @@ from hathor.indexes.rocksdb_utils import (
 )
 from hathor.indexes.tokens_index import TokenIndexInfo, TokensIndex, TokenUtxoInfo
 from hathor.nanocontracts.runner.index_records import IndexRecordType, UpdateAuthoritiesRecord
-from hathor.nanocontracts.types import (
-    NCAcquireAuthorityAction,
-    NCDepositAction,
-    NCGrantAuthorityAction,
-    NCWithdrawalAction,
-)
 from hathor.transaction import BaseTransaction, Transaction
 from hathor.transaction.base_transaction import TxVersion
 from hathor.transaction.token_info import TokenVersion
 from hathor.types import TokenUid
 from hathor.util import collect_n, json_dumpb, json_loadb
+from hathorlib.nanocontracts.types import NCActionType
 from hathorlib.token_amount import SignedAmount, UnsignedAmount
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -420,20 +415,20 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         if tx.is_nano_contract():
             assert isinstance(tx, Transaction)
             nano_header = tx.get_nano_header()
-            ctx = nano_header.get_context()
-            for action in ctx.__all_actions__:
-                match action:
-                    case NCDepositAction():
-                        self.add_to_total(action.token_uid, action.amount)
-                    case NCWithdrawalAction():
-                        self.add_to_total(action.token_uid, -action.amount)
-                    case NCGrantAuthorityAction() | NCAcquireAuthorityAction():
+            for action in nano_header.nc_actions:
+                token_uid = tx.get_token_uid(action.token_index)
+                match action.type:
+                    case NCActionType.DEPOSIT:
+                        self.add_to_total(token_uid, action.amount)
+                    case NCActionType.WITHDRAWAL:
+                        self.add_to_total(token_uid, -action.amount)
+                    case NCActionType.GRANT_AUTHORITY | NCActionType.ACQUIRE_AUTHORITY:
                         # These actions don't affect the token balance but do affect the counters
                         # of contracts holding token authorities. They are handled directly by
                         # the IndexesManager via index update records created by the Runner.
                         pass
                     case _:
-                        assert_never(action)
+                        assert_never(action.type)
 
     def remove_tx(self, tx: BaseTransaction) -> None:
         for tx_input in tx.inputs:
@@ -457,19 +452,19 @@ class RocksDBTokensIndex(TokensIndex, RocksDBIndexUtils):
         if tx.is_nano_contract():
             assert isinstance(tx, Transaction)
             nano_header = tx.get_nano_header()
-            ctx = nano_header.get_context()
-            for action in ctx.__all_actions__:
-                match action:
-                    case NCDepositAction():
-                        self.add_to_total(action.token_uid, -action.amount)
-                    case NCWithdrawalAction():
-                        self.add_to_total(action.token_uid, action.amount)
-                    case NCGrantAuthorityAction() | NCAcquireAuthorityAction():
+            for action in nano_header.nc_actions:
+                token_uid = tx.get_token_uid(action.token_index)
+                match action.type:
+                    case NCActionType.DEPOSIT:
+                        self.add_to_total(token_uid, -action.amount)
+                    case NCActionType.WITHDRAWAL:
+                        self.add_to_total(token_uid, action.amount)
+                    case NCActionType.GRANT_AUTHORITY | NCActionType.ACQUIRE_AUTHORITY:
                         # These actions don't affect the nc token balance,
                         # so no need for any special handling on the index.
                         pass
                     case _:
-                        assert_never(action)
+                        assert_never(action.type)
 
     def iter_all_tokens(self) -> Iterator[tuple[bytes, TokenIndexInfo]]:
         self.log.debug('seek to start')

--- a/hathor/indexes/rocksdb_utxo_index.py
+++ b/hathor/indexes/rocksdb_utxo_index.py
@@ -12,6 +12,8 @@ from hathor.conf.settings import HathorSettings
 from hathor.crypto.util import decode_address, get_address_b58_from_bytes
 from hathor.indexes.rocksdb_utils import InternalUid, RocksDBIndexUtils, from_internal_token_uid, to_internal_token_uid
 from hathor.indexes.utxo_index import UtxoIndex, UtxoIndexItem
+from hathorlib.serialization import Deserializer, Serializer
+from hathorlib.serialization.encoding.output_value import decode_length_prefix_varint, encode_length_prefix_varint
 from hathorlib.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -89,8 +91,10 @@ class _SeekKeyNoLock(_SeekKeyBase):
 
     def _bytes(self, array: bytearray) -> None:
         super()._bytes(array)
-        array.extend(struct.pack('>Q', self.amount))
-        assert len(array) == 1 + 32 + 25 + 8
+        serializer = Serializer.build_bytes_serializer()
+        length = encode_length_prefix_varint(serializer, self.amount, strict=False)
+        array.extend(serializer.finalize())
+        assert len(array) == 1 + 32 + 25 + length + 1
 
 
 @dataclass(frozen=True)
@@ -105,9 +109,10 @@ class _KeyNoLock(_SeekKeyNoLock):
 
     def _bytes(self, array: bytearray) -> None:
         super()._bytes(array)
+        len_before = len(array)
         array.extend(self.tx_id)
         array.append(self.index)
-        assert len(array) == 1 + 32 + 25 + 8 + 32 + 1
+        assert len(array) == len_before + 32 + 1
 
     def to_index_item(self) -> UtxoIndexItem:
         return UtxoIndexItem(
@@ -135,8 +140,10 @@ class _SeekKeyTimeLock(_SeekKeyBase):
     def _bytes(self, array: bytearray) -> None:
         super()._bytes(array)
         array.extend(struct.pack('>I', self.timelock))
-        array.extend(struct.pack('>Q', self.amount))
-        assert len(array) == 1 + 32 + 25 + 4 + 8
+        serializer = Serializer.build_bytes_serializer()
+        length = encode_length_prefix_varint(serializer, self.amount, strict=False)
+        array.extend(serializer.finalize())
+        assert len(array) == 1 + 32 + 25 + 4 + length + 1
 
 
 @dataclass(frozen=True)
@@ -151,9 +158,10 @@ class _KeyTimeLock(_SeekKeyTimeLock):
 
     def _bytes(self, array: bytearray) -> None:
         super()._bytes(array)
+        len_before = len(array)
         array.extend(self.tx_id)
         array.append(self.index)
-        assert len(array) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+        assert len(array) == len_before + 32 + 1
 
     def to_index_item(self) -> UtxoIndexItem:
         return UtxoIndexItem(
@@ -182,8 +190,10 @@ class _SeekKeyHeightLock(_SeekKeyBase):
     def _bytes(self, array: bytearray) -> None:
         super()._bytes(array)
         array.extend(struct.pack('>I', self.heightlock))
-        array.extend(struct.pack('>Q', self.amount))
-        assert len(array) == 1 + 32 + 25 + 4 + 8
+        serializer = Serializer.build_bytes_serializer()
+        length = encode_length_prefix_varint(serializer, self.amount, strict=False)
+        array.extend(serializer.finalize())
+        assert len(array) == 1 + 32 + 25 + 4 + length + 1
 
 
 @dataclass(frozen=True)
@@ -198,9 +208,10 @@ class _KeyHeightLock(_SeekKeyHeightLock):
 
     def _bytes(self, array: bytearray) -> None:
         super()._bytes(array)
+        len_before = len(array)
         array.extend(self.tx_id)
         array.append(self.index)
-        assert len(array) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+        assert len(array) == len_before + 32 + 1
 
     def to_index_item(self) -> UtxoIndexItem:
         return UtxoIndexItem(
@@ -216,40 +227,58 @@ class _KeyHeightLock(_SeekKeyHeightLock):
 
 def _parse_key(key: bytes) -> _KeyBase:
     assert len(key) >= 1
-    tag = _Tag(key[0])
+    deserializer = Deserializer.build_bytes_deserializer(key)
+    tag = _Tag(deserializer.read_byte())
     if tag == _Tag.INVALID:
         raise ValueError('invalid tag found')
     elif tag == _Tag.NOLOCK:
-        assert len(key) == 1 + 32 + 25 + 8 + 32 + 1
+        token_uid_internal = InternalUid(bytes(deserializer.read_bytes(32)))
+        address = bytes(deserializer.read_bytes(25))
+        amount = decode_length_prefix_varint(deserializer, strict=False)
+        tx_id = bytes(deserializer.read_bytes(32))
+        index = deserializer.read_byte()
+        deserializer.finalize()
         return _KeyNoLock(
             tag=tag,
-            token_uid_internal=InternalUid(key[1:33]),
-            address=key[33:58],
-            amount=struct.unpack('>Q', key[58:66])[0],
-            tx_id=key[66:98],
-            index=key[98],
+            token_uid_internal=token_uid_internal,
+            address=address,
+            amount=amount,
+            tx_id=tx_id,
+            index=index,
         )
     elif tag == _Tag.TIMELOCK:
-        assert len(key) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+        token_uid_internal = InternalUid(bytes(deserializer.read_bytes(32)))
+        address = bytes(deserializer.read_bytes(25))
+        timelock = deserializer.read_struct('>I')[0]
+        amount = decode_length_prefix_varint(deserializer, strict=False)
+        tx_id = bytes(deserializer.read_bytes(32))
+        index = deserializer.read_byte()
+        deserializer.finalize()
         return _KeyTimeLock(
             tag=tag,
-            token_uid_internal=InternalUid(key[1:33]),
-            address=key[33:58],
-            timelock=struct.unpack('>I', key[58:62])[0],
-            amount=struct.unpack('>Q', key[62:70])[0],
-            tx_id=key[70:102],
-            index=key[102],
+            token_uid_internal=token_uid_internal,
+            address=address,
+            timelock=timelock,
+            amount=amount,
+            tx_id=tx_id,
+            index=index,
         )
     elif tag == _Tag.HEIGHTLOCK:
-        assert len(key) == 1 + 32 + 25 + 4 + 8 + 32 + 1
+        token_uid_internal = InternalUid(bytes(deserializer.read_bytes(32)))
+        address = bytes(deserializer.read_bytes(25))
+        heightlock = deserializer.read_struct('>I')[0]
+        amount = decode_length_prefix_varint(deserializer, strict=False)
+        tx_id = bytes(deserializer.read_bytes(32))
+        index = deserializer.read_byte()
+        deserializer.finalize()
         return _KeyHeightLock(
             tag=tag,
-            token_uid_internal=InternalUid(key[1:33]),
-            address=key[33:58],
-            heightlock=struct.unpack('>I', key[58:62])[0],
-            amount=struct.unpack('>Q', key[62:70])[0],
-            tx_id=key[70:102],
-            index=key[102],
+            token_uid_internal=token_uid_internal,
+            address=address,
+            heightlock=heightlock,
+            amount=amount,
+            tx_id=tx_id,
+            index=index,
         )
     else:
         # XXX: if/elif is exhaustive for all possible tags and invalid tag value will fail sooner
@@ -291,13 +320,13 @@ class RocksDBUtxoIndex(UtxoIndex, RocksDBIndexUtils):
     This index uses the following key formats:
 
         key_nolock     = [tag][token_uid][address][amount][tx_id][index] tag=NOLOCK
-                         |1b-||--32b----||--25b--||--8b--||-32b-||-1b--|
+                         |1b-||--32b----||--25b--||varint||-32b-||-1b--|
 
         key_timelock   = [tag][token_uid][address][timelock][amount][tx_id][index] tag=TIMELOCK
-                         |1b-||--32b----||--25b--||--4b----||--8b--||-32b-||-1b--|
+                         |1b-||--32b----||--25b--||--4b----||varint||-32b-||-1b--|
 
         key_heightlock = [tag][token_uid][address][heightlock][amount][tx_id][index] tag=HEIGHTLOCK
-                         |1b-||--32b----||--25b--||--4b------||--8b--||-32b-||-1b--|
+                         |1b-||--32b----||--25b--||--4b------||varint||-32b-||-1b--|
 
     It works nicely because rocksdb uses a tree sorted by key under the hood.
     """

--- a/hathor/transaction/storage/migrations/token_amount_v2.py
+++ b/hathor/transaction/storage/migrations/token_amount_v2.py
@@ -1,16 +1,5 @@
-#  Copyright 2023 Hathor Labs
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING
 

--- a/hathor/transaction/storage/migrations/token_amount_v2.py
+++ b/hathor/transaction/storage/migrations/token_amount_v2.py
@@ -1,0 +1,39 @@
+#  Copyright 2023 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from structlog import get_logger
+
+from hathor.transaction.storage.migrations import BaseMigration
+
+if TYPE_CHECKING:
+    from hathor.transaction.storage import TransactionStorage
+
+logger = get_logger()
+
+
+class Migration(BaseMigration):
+    def skip_empty_db(self) -> bool:
+        return True
+
+    def get_db_name(self) -> str:
+        return 'token_amount_v2'
+
+    def run(self, storage: 'TransactionStorage') -> None:
+        raise Exception(
+            'Cannot migrate your database due to an incompatible change. '
+            'Please, delete your data folder and use the latest available snapshot or sync '
+            'from beginning.'
+        )

--- a/hathor/transaction/storage/transaction_storage.py
+++ b/hathor/transaction/storage/transaction_storage.py
@@ -37,6 +37,7 @@ from hathor.transaction.storage.migrations import (
     migrate_vertex_children,
     nc_storage_compat2,
     reset_feature_state_cache,
+    token_amount_v2,
 )
 from hathor.transaction.storage.tx_allow_scope import TxAllowScope, tx_allow_context
 from hathor.transaction.transaction import Transaction
@@ -107,6 +108,7 @@ class TransactionStorage(ABC):
         nc_storage_compat2.Migration,
         migrate_vertex_children.Migration,
         reset_feature_state_cache.Migration,
+        token_amount_v2.Migration,
     ]
 
     _migrations: list[BaseMigration]

--- a/hathorlib/hathorlib/serialization/encoding/output_value.py
+++ b/hathorlib/hathorlib/serialization/encoding/output_value.py
@@ -123,7 +123,6 @@ MAX_OUTPUT_VALUE_32 = 2 ** 31 - 1  # max value (inclusive) before having to use 
 MAX_OUTPUT_VALUE_64 = 2 ** 63  # max value (inclusive) that can be encoded (with 8 bytes): 9_223_372_036_854_775_808
 
 MAX_OUTPUT_VALUE_V2: int = MAX_OUTPUT_VALUE_64 * 10**16
-MAX_OUTPUT_VALUE_V2_LENGTH: int = (MAX_OUTPUT_VALUE_V2.bit_length() + 7) // 8
 
 
 def encode_output_value(serializer: Serializer, value: int, *, token_amount_version: TokenAmountVersion) -> None:
@@ -196,6 +195,16 @@ def encode_output_value_v2(serializer: Serializer, value: int, *, strict: bool =
     >>> encode(0xc0ffee)
     '03c0ffee'
     """
+    encode_length_prefix_varint(serializer, value, strict=strict, max_value=MAX_OUTPUT_VALUE_V2)
+
+
+def encode_length_prefix_varint(
+    serializer: Serializer,
+    value: int,
+    *,
+    strict: bool,
+    max_value: int | None = None,
+) -> int:
     if value < 0:
         raise ValueError('value must be not be negative')
 
@@ -203,20 +212,21 @@ def encode_output_value_v2(serializer: Serializer, value: int, *, strict: bool =
         if strict:
             raise ValueError('value must not be zero')
         serializer.write_byte(0)
-        return
+        return 0
 
-    if value > MAX_OUTPUT_VALUE_V2:
-        raise ValueError(f'value is too big; max is {MAX_OUTPUT_VALUE_V2}, got: {value}')
+    if max_value is not None and value > max_value:
+        raise ValueError(f'value is too big; max is {max_value}, got: {value}')
 
     length = (value.bit_length() + 7) // 8
     payload = value.to_bytes(length, byteorder='big')
 
     assert len(payload) == length
-    assert length <= MAX_OUTPUT_VALUE_V2_LENGTH
     assert payload[0] != 0
 
     serializer.write_byte(length)
     serializer.write_bytes(payload)
+
+    return length
 
 
 def decode_output_value(deserializer: Deserializer, *, token_amount_version: TokenAmountVersion) -> UnsignedAmount:
@@ -309,21 +319,27 @@ def decode_output_value_v2(deserializer: Deserializer, *, strict: bool = True) -
     >>> decode_output_value_v2(build('03 c0ffee')) == 0xc0ffee
     True
     """
+    return decode_length_prefix_varint(deserializer, strict=strict, max_value=MAX_OUTPUT_VALUE_V2)
+
+
+def decode_length_prefix_varint(deserializer: Deserializer, *, strict: bool, max_value: int | None = None) -> int:
     length = deserializer.read_byte()
     if length == 0:
         if strict:
             raise ValueError('value must not be zero')
         return 0
 
-    if length > MAX_OUTPUT_VALUE_V2_LENGTH:
-        raise ValueError(f'length is too big; max is {MAX_OUTPUT_VALUE_V2_LENGTH}, got: {length}')
+    if max_value is not None:
+        max_length = (max_value.bit_length() + 7) // 8
+        if length > max_length:
+            raise ValueError(f'length is too big; max is {max_length}, got: {length}')
 
     payload = deserializer.read_bytes(length)
     if payload[0] == 0:
         raise ValueError(f'non-canonical encoding, leading zero byte: {payload.hex()}')
 
     value = int.from_bytes(payload, byteorder='big')
-    if value > MAX_OUTPUT_VALUE_V2:
-        raise ValueError(f'value is too big; max is {MAX_OUTPUT_VALUE_V2}, got: {value}')
+    if max_value is not None and value > max_value:
+        raise ValueError(f'value is too big; max is {max_value}, got: {value}')
 
     return value


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1718

### Motivation

Perform small updates on indexes for the Token Amounts V2 project.

### Acceptance Criteria

- Refactor tokens index implementation to use `nano_header.nc_actions` instead of `ctx.__all_actions__`, so it doesn't need to create a context.
- Update UTXO index implementation so it serializes amounts internally using length-prefix varints instead of fixed 8 bytes, so it supports V2 amounts in the future.
- Add fail-only migration for the token amount V2 project.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 