### PR TITLE
refactor(decimals): drop redundant verifier output check, add v2 API fields

### DIFF
--- a/hathor/nanocontracts/resources/state.py
+++ b/hathor/nanocontracts/resources/state.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, set_cors
+from hathor.conf.get_settings import get_global_settings
 from hathor.crypto.util import decode_address
 from hathor.nanocontracts.api_arguments_parser import parse_nc_method_call
 from hathor.nanocontracts.exception import NanoContractDoesNotExist
@@ -48,6 +49,7 @@ class NanoContractStateResource(Resource):
 
     def __init__(self, manager: 'HathorManager') -> None:
         super().__init__()
+        self._settings = get_global_settings()
         self.manager = manager
 
     def render_GET(self, request: 'Request') -> bytes:
@@ -158,6 +160,9 @@ class NanoContractStateResource(Resource):
         runner.token_amount_version = token_amount_version
 
         value: Any
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
         # Get balances.
         balances: dict[str, NCBalanceSuccessResponse | NCValueErrorResponse] = {}
         for token_uid_hex in params.balances:
@@ -167,6 +172,7 @@ class NanoContractStateResource(Resource):
                 for key_balance, balance in all_balances.items():
                     balances[key_balance.token_uid.hex()] = NCBalanceSuccessResponse(
                         value=str(balance.value),
+                        value_v2=str(balance.value * v1_to_v2),
                         can_mint=balance.can_mint,
                         can_melt=balance.can_melt,
                     )
@@ -181,6 +187,7 @@ class NanoContractStateResource(Resource):
             balance = nc_storage.get_balance(token_uid)
             balances[token_uid_hex] = NCBalanceSuccessResponse(
                 value=str(balance.value),
+                value_v2=str(balance.value * v1_to_v2),
                 can_mint=balance.can_mint,
                 can_melt=balance.can_melt,
             )
@@ -280,7 +287,14 @@ class NCValueSuccessResponse(Response):
 
 
 class NCBalanceSuccessResponse(Response):
+    """A contract's balance for a single token.
+
+    `value` is the V1-atomic-unit string representation (1 = 0.01 HTR); `value_v2` is the
+    same balance as V2 atomic units (1 = 10**-18 HTR), as a string to avoid JSON-number
+    precision loss for large balances.
+    """
     value: str
+    value_v2: str
     can_mint: bool
     can_melt: bool
 

--- a/hathor/transaction/resources/utxo_search.py
+++ b/hathor/transaction/resources/utxo_search.py
@@ -122,10 +122,15 @@ class UtxoSearchResource(Resource):
         iter_utxos = utxo_index.iter_utxos(token_uid=token_uid, address=address, target_amount=target_amount,
                                            target_timestamp=target_timestamp, target_height=target_height)
 
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
+        # `amount` is in V1 atomic units; `amount_v2` is the same value in V2 atomic units.
         utxo_list = [{
             'txid': utxo.tx_id.hex(),
             'index': utxo.index,
             'amount': utxo.amount,
+            'amount_v2': utxo.amount * v1_to_v2,
             'timelock': utxo.timelock,
             'heightlock': utxo.heightlock,
         } for utxo in iter_utxos]
@@ -232,6 +237,7 @@ UtxoSearchResource.openapi = {
                                                 ),
                                                 'index': 0,
                                                 'amount': 1_000_000_000,
+                                                'amount_v2': 1_000_000_000 * 10**16,
                                                 'timelock': None,
                                                 'heightlock': 10,
                                             },

--- a/hathor/verification/vertex_verifier.py
+++ b/hathor/verification/vertex_verifier.py
@@ -25,7 +25,6 @@ from hathor.transaction.exceptions import (
     HeaderNotSupported,
     IncorrectParents,
     InvalidOutputScriptSize,
-    InvalidOutputValue,
     InvalidToken,
     InvalidVersionError,
     ParentDoesNotExist,
@@ -140,10 +139,13 @@ class VertexVerifier:
             raise PowError(f'Transaction has invalid data ({numeric_hash} < {minimum_target})')
 
     def verify_outputs(self, vertex: BaseTransaction) -> None:
-        """Verify there are no hathor authority UTXOs and outputs are all positive
+        """Verify there are no hathor authority UTXOs and outputs respect script-size limits.
+
+        Output-value bounds (non-positive and overflow) are enforced by `TxOutput.__init__`
+        for constructed outputs and by the output-value decoder for deserialized ones, so they
+        are guaranteed to hold here.
 
         :raises InvalidToken: when there's a hathor authority utxo
-        :raises InvalidOutputValue: output has negative value
         :raises TooManyOutputs: when there are too many outputs
         """
         self.verify_number_of_outputs(vertex)
@@ -152,11 +154,6 @@ class VertexVerifier:
             if (output.get_token_index() == 0) and output.is_token_authority():
                 raise InvalidToken('Cannot have authority UTXO for hathor tokens: {}'.format(
                     output.to_human_readable()))
-
-            # output value must be positive
-            if output.value <= 0:
-                raise InvalidOutputValue('Output value must be a positive integer. Value: {} and index: {}'.format(
-                    output.value, index))
 
             if len(output.script) > self._settings.MAX_OUTPUT_SCRIPT_SIZE:
                 raise InvalidOutputScriptSize('size: {} and max-size: {}'.format(

--- a/hathor/wallet/resources/balance.py
+++ b/hathor/wallet/resources/balance.py
@@ -33,7 +33,9 @@ class BalanceResource(Resource):
 
     def render_GET(self, request):
         """ GET request for /wallet/balance/
-            Returns the int balance of the wallet
+            Returns the wallet balance for HTR in both decimal versions: the legacy `available`
+            and `locked` fields are V1 atomic units (1 = 0.01 HTR); the `available_v2` and
+            `locked_v2` fields are V2 atomic units (1 = 10**-18 HTR).
 
             :rtype: string (json)
         """
@@ -43,7 +45,19 @@ class BalanceResource(Resource):
         if not self.manager.wallet:
             return {'success': False, 'message': 'No wallet started on node'}
 
-        data = {'success': True, 'balance': self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID]._asdict()}
+        wallet_balance = self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID]
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
+        data = {
+            'success': True,
+            'balance': {
+                'available': wallet_balance.available,
+                'locked': wallet_balance.locked,
+                'available_v2': wallet_balance.available * v1_to_v2,
+                'locked_v2': wallet_balance.locked * v1_to_v2,
+            },
+        }
         return json_dumpb(data)
 
 
@@ -66,7 +80,9 @@ BalanceResource.openapi = {
                                     'value': {
                                         'balance': {
                                             'available': 5000,
-                                            'locked': 1000
+                                            'locked': 1000,
+                                            'available_v2': 5000 * 10**16,
+                                            'locked_v2': 1000 * 10**16,
                                         }
                                     }
                                 }

--- a/hathor/wallet/resources/thin_wallet/address_balance.py
+++ b/hathor/wallet/resources/thin_wallet/address_balance.py
@@ -36,10 +36,17 @@ class TokenData:
     name: str = ''
     symbol: str = ''
 
-    def to_dict(self):
+    def to_dict(self, *, v1_to_v2: int) -> dict[str, Any]:
+        """Return the per-token totals in both decimal versions.
+
+        `received` and `spent` are V1 atomic units (1 = 0.01 HTR); `received_v2` and
+        `spent_v2` are V2 atomic units, scaled by `v1_to_v2`.
+        """
         return {
             'received': self.received,
             'spent': self.spent,
+            'received_v2': self.received * v1_to_v2,
+            'spent_v2': self.spent * v1_to_v2,
             'name': self.name,
             'symbol': self.symbol,
         }
@@ -121,6 +128,9 @@ class AddressBalanceResource(Resource):
                         token_uid = tx.get_token_uid(tx_output.get_token_index())
                         tokens_data[token_uid].received += tx_output.value
 
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
         return_tokens_data: dict[str, dict[str, Any]] = {}
         for token_uid in tokens_data.keys():
             if token_uid == self._settings.HATHOR_TOKEN_UID:
@@ -136,7 +146,7 @@ class AddressBalanceResource(Resource):
                     # But better than get a 500 error
                     tokens_data[token_uid].name = '- (unable to fetch token information)'
                     tokens_data[token_uid].symbol = '- (unable to fetch token information)'
-            return_tokens_data[token_uid.hex()] = tokens_data[token_uid].to_dict()
+            return_tokens_data[token_uid.hex()] = tokens_data[token_uid].to_dict(v1_to_v2=v1_to_v2)
 
         data = {
             'success': True,
@@ -197,12 +207,16 @@ AddressBalanceResource.openapi = {
                                                 'symbol': 'HTR',
                                                 'received': 1000,
                                                 'spent': 800,
+                                                'received_v2': 1000 * 10**16,
+                                                'spent_v2': 800 * 10**16,
                                             },
                                             '00000828d80dd4cd809c959139f7b4261df41152f4cce65a8777eb1c3a1f9702': {
                                                 'name': 'NewCoin',
                                                 'symbol': 'NCN',
                                                 'received': 100,
                                                 'spent': 20,
+                                                'received_v2': 100 * 10**16,
+                                                'spent_v2': 20 * 10**16,
                                             },
                                         }
                                     }

--- a/hathor/wallet/resources/thin_wallet/tokens.py
+++ b/hathor/wallet/resources/thin_wallet/tokens.py
@@ -65,6 +65,10 @@ class TokenResource(Resource):
                 'index': index
             })
 
+        total = token_info.get_total()
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
         data = {
             'name': token_info.get_name(),
             'symbol': token_info.get_symbol(),
@@ -76,7 +80,9 @@ class TokenResource(Resource):
             'melt': melt,
             'can_mint': token_info.can_mint(),
             'can_melt': token_info.can_melt(),
-            'total': token_info.get_total(),
+            # `total` is in V1 atomic units; `total_v2` is the same value in V2 atomic units.
+            'total': total,
+            'total_v2': total * v1_to_v2,
             'transactions_count': transactions_count,
         }
         return data
@@ -216,6 +222,7 @@ TokenResource.openapi = {
                                         'can_mint': True,
                                         'can_melt': True,
                                         'total': 50000,
+                                        'total_v2': 50000 * 10**16,
                                         'transactions_count': 3,
                                     }
                                 },

--- a/hathor_tests/resources/nanocontracts/test_state.py
+++ b/hathor_tests/resources/nanocontracts/test_state.py
@@ -322,7 +322,9 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances1 = data1['balances']
         self.assertEqual(
             balances1,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '0', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '0', 'value_v2': '0', 'can_mint': False, 'can_melt': False,
+            }}
         )
         calls1 = data1['calls']
         self.assertEqual(calls1, {
@@ -417,7 +419,10 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances2 = data2['balances']
         self.assertEqual(
             balances2,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '100000000000', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '100000000000', 'value_v2': str(100000000000 * 10**16),
+                'can_mint': False, 'can_melt': False,
+            }}
         )
 
         # Test __all__ balance
@@ -434,7 +439,10 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances3 = data3['balances']
         self.assertEqual(
             balances3,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '100000000000', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '100000000000', 'value_v2': str(100000000000 * 10**16),
+                'can_mint': False, 'can_melt': False,
+            }}
         )
 
         # Test getting the state in a previous block
@@ -461,7 +469,9 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances4 = data4['balances']
         self.assertEqual(
             balances4,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '0', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '0', 'value_v2': '0', 'can_mint': False, 'can_melt': False,
+            }}
         )
 
         # With block height
@@ -487,7 +497,9 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances5 = data5['balances']
         self.assertEqual(
             balances5,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '0', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '0', 'value_v2': '0', 'can_mint': False, 'can_melt': False,
+            }}
         )
 
         # With block2.timestamp, should get block2 state
@@ -513,7 +525,10 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances6 = data6['balances']
         self.assertEqual(
             balances6,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '100000000000', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '100000000000', 'value_v2': str(100000000000 * 10**16),
+                'can_mint': False, 'can_melt': False,
+            }}
         )
 
         # With block2.timestamp - 1, should get block1 state
@@ -539,7 +554,9 @@ class BaseNanoContractStateTest(_BaseResourceTest._ResourceTest):
         balances7 = data7['balances']
         self.assertEqual(
             balances7,
-            {settings.HATHOR_TOKEN_UID.hex(): {'value': '0', 'can_mint': False, 'can_melt': False}}
+            {settings.HATHOR_TOKEN_UID.hex(): {
+                'value': '0', 'value_v2': '0', 'can_mint': False, 'can_melt': False,
+            }}
         )
 
         # With block1.timestamp - 1, the contract doesn't exist

--- a/hathor_tests/resources/transaction/test_utxo_search.py
+++ b/hathor_tests/resources/transaction/test_utxo_search.py
@@ -16,6 +16,9 @@ class UtxoSearchTest(_BaseResourceTest._ResourceTest):
     @inlineCallbacks
     def test_simple_gets(self):
         address = self.get_address(0).encode('ascii')
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
 
         add_new_blocks(self.manager, 4, advance_clock=1)
 
@@ -55,6 +58,7 @@ class UtxoSearchTest(_BaseResourceTest._ResourceTest):
             'txid': b.hash_hex,
             'index': 0,
             'amount': 6400,
+            'amount_v2': 6400 * v1_to_v2,
             'timelock': None,
             'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[:1]])
@@ -68,6 +72,7 @@ class UtxoSearchTest(_BaseResourceTest._ResourceTest):
             'txid': b.hash_hex,
             'index': 0,
             'amount': 6400,
+            'amount_v2': 6400 * v1_to_v2,
             'timelock': None,
             'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[4:1:-1]])
@@ -81,6 +86,7 @@ class UtxoSearchTest(_BaseResourceTest._ResourceTest):
             'txid': b.hash_hex,
             'index': 0,
             'amount': 6400,
+            'amount_v2': 6400 * v1_to_v2,
             'timelock': None,
             'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[::-1]])
@@ -94,6 +100,7 @@ class UtxoSearchTest(_BaseResourceTest._ResourceTest):
             'txid': b.hash_hex,
             'index': 0,
             'amount': 6400,
+            'amount_v2': 6400 * v1_to_v2,
             'timelock': None,
             'heightlock': b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
         } for b in blocks[::-1]])

--- a/hathor_tests/resources/wallet/test_balance.py
+++ b/hathor_tests/resources/wallet/test_balance.py
@@ -17,10 +17,15 @@ class BalanceTest(_BaseResourceTest._ResourceTest):
 
     @inlineCallbacks
     def test_get(self):
+        settings = self.manager._settings
+        v1_to_v2 = 10 ** (settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES)
         response = yield self.web.get("wallet/balance")
         data = response.json_value()
         self.assertTrue(data['success'])
-        self.assertEqual(data['balance'], {'available': 0, 'locked': 0})
+        self.assertEqual(
+            data['balance'],
+            {'available': 0, 'locked': 0, 'available_v2': 0, 'locked_v2': 0},
+        )
 
         # Mining new block
         response_mining = yield self.web_mining.get("mining")
@@ -37,4 +42,12 @@ class BalanceTest(_BaseResourceTest._ResourceTest):
         data2 = response2.json_value()
         self.assertTrue(data2['success'])
         tokens = self.manager.get_tokens_issued_per_block(1)
-        self.assertEqual(data2['balance'], {'available': tokens, 'locked': 0})
+        self.assertEqual(
+            data2['balance'],
+            {
+                'available': tokens,
+                'locked': 0,
+                'available_v2': tokens * v1_to_v2,
+                'locked_v2': 0,
+            },
+        )

--- a/hathor_tests/resources/wallet/test_search_address.py
+++ b/hathor_tests/resources/wallet/test_search_address.py
@@ -105,13 +105,21 @@ class SearchAddressTest(_BaseResourceTest._ResourceTest):
         HTR_value = (
             self._settings.GENESIS_TOKEN_ATOMIC_UNITS - 1 + (self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK * 5)
         )
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
+        htr_uid_hex = self._settings.HATHOR_TOKEN_UID.hex()
         self.assertEqual(data['total_transactions'], 6)  # 5 blocks mined + token creation tx
-        self.assertIn(self._settings.HATHOR_TOKEN_UID.hex(), data['tokens_data'])
+        self.assertIn(htr_uid_hex, data['tokens_data'])
         self.assertIn(self.token_uid.hex(), data['tokens_data'])
-        self.assertEqual(HTR_value, data['tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['received'])
-        self.assertEqual(0, data['tokens_data'][self._settings.HATHOR_TOKEN_UID.hex()]['spent'])
+        self.assertEqual(HTR_value, data['tokens_data'][htr_uid_hex]['received'])
+        self.assertEqual(0, data['tokens_data'][htr_uid_hex]['spent'])
+        self.assertEqual(HTR_value * v1_to_v2, data['tokens_data'][htr_uid_hex]['received_v2'])
+        self.assertEqual(0, data['tokens_data'][htr_uid_hex]['spent_v2'])
         self.assertEqual(100, data['tokens_data'][self.token_uid.hex()]['received'])
         self.assertEqual(0, data['tokens_data'][self.token_uid.hex()]['spent'])
+        self.assertEqual(100 * v1_to_v2, data['tokens_data'][self.token_uid.hex()]['received_v2'])
+        self.assertEqual(0, data['tokens_data'][self.token_uid.hex()]['spent_v2'])
 
     @inlineCallbacks
     def test_zero_count(self):

--- a/hathor_tests/resources/wallet/test_send_tokens.py
+++ b/hathor_tests/resources/wallet/test_send_tokens.py
@@ -50,7 +50,18 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         response_balance = yield self.web_balance.get("wallet/balance")
         data_balance = response_balance.json_value()
         tokens_per_block = self.manager.get_tokens_issued_per_block(1)
-        self.assertEqual(data_balance['balance'], {'available': tokens_per_block - 505, 'locked': 0})
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
+        self.assertEqual(
+            data_balance['balance'],
+            {
+                'available': tokens_per_block - 505,
+                'locked': 0,
+                'available_v2': (tokens_per_block - 505) * v1_to_v2,
+                'locked_v2': 0,
+            },
+        )
 
         # Getting history, so we can get the input
         response_history = yield self.web_history.get("wallet/history", {b'page': 1, b'count': 10})

--- a/hathor_tests/resources/wallet/test_thin_wallet.py
+++ b/hathor_tests/resources/wallet/test_thin_wallet.py
@@ -376,9 +376,13 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(data['melt'][0]['tx_id'], tx.hash_hex)
         self.assertEqual(data['mint'][0]['index'], 1)
         self.assertEqual(data['melt'][0]['index'], 2)
+        v1_to_v2 = 10 ** (
+            self._settings.TOKEN_AMOUNT_V2_DECIMAL_PLACES - self._settings.TOKEN_AMOUNT_V1_DECIMAL_PLACES
+        )
         self.assertTrue(data['can_mint'])
         self.assertTrue(data['can_melt'])
         self.assertEqual(data['total'], amount)
+        self.assertEqual(data['total_v2'], amount * v1_to_v2)
         self.assertEqual(data['name'], token_name)
         self.assertEqual(data['symbol'], token_symbol)
         self.assertEqual(data['version'], token_info_version)

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -967,11 +967,11 @@ class TransactionTest(unittest.TestCase):
         tx2.update_hash()
         assert tx == tx2
 
-        # Validating that all output values must be positive
-        value = 1
+        # Output-value bounds are enforced by the output encoder when serializing the tx,
+        # so resolving a tx whose output value was mutated to a negative number fails there.
         address = decode_address('WUDtnw3GYjvUnZmiHAmus6hhs9GoSUSJMG')
         script = P2PKH.create_output_script(address)
-        output = TxOutput(value, script)
+        output = TxOutput(1, script)
         output.value = -1
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
         _input = TxInput(random_bytes, 0, random_bytes)
@@ -979,12 +979,7 @@ class TransactionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.manager.cpu_mining_service.resolve(tx)
 
-        # 'Manually resolving', to validate verify method
-        tx.hash = bytes.fromhex('012cba011be3c29f1c406f9015e42698b97169dbc6652d1f5e4d5c5e83138858')
-        with self.assertRaises(InvalidOutputValue):
-            self.manager.verification_service.verify(tx, self.get_verification_params(self.manager))
-
-        # Invalid output value
+        # Output-value bounds are also enforced at decode time.
         invalid_output = bytes.fromhex('ffffffff')
         deserializer = Deserializer.build_bytes_deserializer(invalid_output)
         with self.assertRaises(BadDataError):


### PR DESCRIPTION
Split out of #1714 (`feat/decimal/normalize-rs`) so each independent piece can land on its own. This PR carries two of the three originally-proposed splits; the third (cent-rounding in the deposit/withdraw helpers) was dropped because on this V1-only base it has no observable diff — V1 atomic units **are** cents, so the rounding is already implicit.

### Motivation

Shrinks the upcoming `htr_lib` type-swap PR by extracting two changes that are independent of the type swap and pass tests on the V1-int base.

### What's in this PR

**1. Drop redundant `InvalidOutputValue` check in `VertexVerifier.verify_outputs`.**

The same `value <= 0` condition is already enforced by:
- `TxOutput.__init__` for constructed outputs (kept).
- The V1 output-value decoder for deserialized outputs (kept).

The verifier-level check was only reachable via post-construction mutation of `output.value`, which is exercised only by test code. The `InvalidOutputValue` exception type itself, the `__init__` enforcement, and the decoder enforcement are all unchanged.

The one test that exercised the now-removed path (`test_output_value`, lines verifying post-mutation via `verification_service.verify`) is updated to no longer assert on that branch; the resolve-path `ValueError` and the `__init__` rejection of `TxOutput(-1, ...)` continue to be asserted.

**2. Add `*_v2` JSON fields to public APIs (additive).**

Five resources gain a V2-atomic-unit field alongside the existing V1-atomic-unit field. Values are computed from V1 using the configured decimal-place delta (`10 ** (V2 - V1)`). Existing V1 fields stay non-null and unchanged.

| Resource | Existing field | New field |
| --- | --- | --- |
| `BalanceResource` | `available`, `locked` | `available_v2`, `locked_v2` |
| `AddressBalanceResource` | `received`, `spent` | `received_v2`, `spent_v2` |
| `TokenResource` | `total` | `total_v2` |
| `UtxoSearchResource` | `amount` | `amount_v2` |
| `NanoContractStateResource` (NCBalanceSuccessResponse) | `value` | `value_v2` |

OpenAPI examples and resource tests are updated accordingly.

### What this PR does **not** do

- No type-system changes. `TokenAmount` / `TokenBalance` remain the `int` aliases defined on `refactor/decimals/indexes-10`.
- No behavioral change to the deposit/withdraw helpers (the cent-rounding refactor from #1714 is a no-op on V1-only and would only become meaningful once V2 inputs flow in).
- No nullability changes on V1 fields — `available` / `locked` / etc. stay non-null. The `value | null` shape from #1714 belongs to the type-swap PR where amounts can be V2-only.

### Acceptance Criteria

- [x] `hathor_tests/` full suite passes (2729 passed, 16 skipped, 6 xfailed).
- [x] `hathorlib/tests/` passes (258 passed).
- [x] `TxOutput.__init__` still rejects `value <= 0` and `value > MAX_OUTPUT_VALUE`.
- [x] V1 output decoder still rejects non-positive values.
- [x] Existing API consumers see no removed or modified fields — only new `*_v2` keys.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged