### PR TITLE
chore: update uv.lock and its CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
           sudo apt-get -qy install graphviz librocksdb-dev libsnappy-dev liblz4-dev
       - name: Install uv
         run: pipx install uv
+      - name: Check uv.lock is up to date
+        run: uv lock --check
       - name: Install uv dependencies
         run: uv sync --frozen --dev --python 3.13
       - name: Run checks

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ dev = [
 
 [[package]]
 name = "hathorlib"
-version = "0.14.1"
+version = "0.15.0"
 source = { editable = "hathorlib" }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
### Motivation

After releasing `hathorlib` the lockfile `uv.lock` became outdated.

### Acceptance Criteria

- Update `uv.lock` with the local `hathorlib` bump
- Add CI check to prevent this from happening again

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 