### PR TITLE
fix(thin_wallet): handle empty/invalid JSON body in send_tokens

### DIFF
--- a/hathor/wallet/resources/thin_wallet/send_tokens.py
+++ b/hathor/wallet/resources/thin_wallet/send_tokens.py
@@ -15,6 +15,7 @@
 import struct
 from dataclasses import dataclass
 from functools import partial
+from json import JSONDecodeError
 from typing import Any, Optional
 
 from structlog import get_logger
@@ -85,7 +86,7 @@ class SendTokensResource(Resource):
         assert request.content is not None
         raw_data = request.content.read()
 
-        if raw_data is None:
+        if not raw_data:
             return self.return_POST(
                 False,
                 'Missing POST data JSON',
@@ -94,6 +95,12 @@ class SendTokensResource(Resource):
 
         try:
             post_data = json_loadb(raw_data)
+        except JSONDecodeError:
+            return self.return_POST(
+                False,
+                'Invalid JSON in POST data',
+                return_code='invalid_json'
+            )
         except AttributeError:
             return self.return_POST(
                 False,

--- a/hathor_tests/resources/wallet/test_thin_wallet.py
+++ b/hathor_tests/resources/wallet/test_thin_wallet.py
@@ -8,6 +8,7 @@ from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction, TxInput, TxOutput
 from hathor.transaction.scripts import P2PKH, create_output_script, parse_address_script
 from hathor.transaction.token_info import TokenVersion
+from hathor.util import json_loadb
 from hathor.wallet.resources.thin_wallet import (
     AddressHistoryResource,
     SendTokensResource,
@@ -645,6 +646,28 @@ class SendTokensTest(_BaseResourceTest._ResourceTest):
         response = yield self.web.post('thin_wallet/send_tokens', {'tx_hex': 'aaa'})
         data = response.json_value()
         self.assertFalse(data['success'])
+
+    def test_send_tokens_invalid_json_body(self):
+        # An empty or malformed body reaches the resource as raw bytes (not None); it must
+        # produce a graceful failure response with success=False.
+        for raw_body in (b'', b'   ', b'{not json'):
+            request = TestDummyRequest('POST', 'thin_wallet/send_tokens')
+            request.content.setvalue(raw_body)
+            result = self.web.resource.render(request)
+            data = json_loadb(result)
+            self.assertFalse(data['success'])
+
+        # empty body is reported as missing JSON
+        request = TestDummyRequest('POST', 'thin_wallet/send_tokens')
+        request.content.setvalue(b'')
+        data = json_loadb(self.web.resource.render(request))
+        self.assertEqual(data['return_code'], 'missing_json')
+
+        # non-empty malformed JSON is reported as invalid JSON
+        request = TestDummyRequest('POST', 'thin_wallet/send_tokens')
+        request.content.setvalue(b'{not json')
+        data = json_loadb(self.web.resource.render(request))
+        self.assertEqual(data['return_code'], 'invalid_json')
 
     @inlineCallbacks
     def test_token_history_zero_count(self):


### PR DESCRIPTION
### Motivation

A `POST /thin_wallet/send_tokens` request with an empty body crashed with an uncaught `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. Twisted delivers an empty body as `b''` (not `None`), so the `raw_data is None` guard let it through and `json_loadb(b'')` raised, since only `AttributeError` was being caught.

### Acceptance Criteria

- An empty body returns a clean failure response (`return_code='missing_json'`) instead of raising.
- A non-empty malformed JSON body returns a clean failure response (`return_code='invalid_json'`).
- Add a regression test covering empty, whitespace-only, and malformed JSON bodies.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged