### PR TITLE
refactor(decimals): make the test wallet version-agnostic, V2 inside [part 12]

### DIFF
--- a/hathor/wallet/base_wallet.py
+++ b/hathor/wallet/base_wallet.py
@@ -37,6 +37,7 @@ from hathor.types import AddressB58, TokenUid
 from hathor.wallet.exceptions import InputDuplicated, InsufficientFunds, PrivateKeyNotFound
 from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
 from hathorlib.token_amount import TokenAmount
+from hathorlib.token_amount_version import TokenAmountVersion
 
 logger = get_logger()
 
@@ -144,6 +145,11 @@ class BaseWallet:
     def _manually_initialize(self) -> None:
         pass
 
+    def _get_token_amount_version(self) -> TokenAmountVersion:
+        """Return the version under which token amounts in wallet-built vertices are encoded."""
+        # Hardcoded V1 until the wallet builds V2 vertices.
+        return TokenAmountVersion.V1
+
     def get_balance_per_address(self, token_uid: TokenUid) -> dict[AddressB58, TokenAmount]:
         """Return balance per address for a given token. This method ignores locks."""
         balances: defaultdict[AddressB58, TokenAmount] = defaultdict(TokenAmount.zero)
@@ -219,6 +225,9 @@ class BaseWallet:
 
         Can be used to create blocks by passing empty list to inputs.
 
+        Output values may be TokenAmounts of any version; each one is denormalized to the
+        wallet's token amount version when its TxOutput is built.
+
         :param cls: defines if we're creating a Transaction or Block
         :type cls: :py:class:`hathor.transaction.Block` or :py:class:`hathor.transaction.Transaction`
 
@@ -246,9 +255,8 @@ class BaseWallet:
                 token_dict[token_uid] = token_index
 
             timelock = int_to_bytes(txout.timelock, 4) if txout.timelock else None
-            tx_outputs.append(
-                TxOutput(txout.value.to_v1(), create_output_script(txout.address, timelock), token_index)
-            )
+            value = txout.value.to_version(self._get_token_amount_version())
+            tx_outputs.append(TxOutput(value, create_output_script(txout.address, timelock), token_index))
 
         tx_inputs = []
         private_keys = []
@@ -450,10 +458,10 @@ class BaseWallet:
         """Creates an output transaction with the change value
 
         :param sum_inputs: Sum of the input amounts
-        :type sum_inputs: int
+        :type sum_inputs: TokenAmount
 
         :param sum_outputs: Total value we're spending
-        :type outputs: int
+        :type outputs: TokenAmount
 
         :param token_uid: token uid of this utxo
         :type token_uid: bytes
@@ -480,13 +488,16 @@ class BaseWallet:
         of inputs.
 
         :param amount: amount requested
-        :type amount: int
+        :type amount: TokenAmount
 
         :param token_uid: the token uid for the requested amount
         :type token_uid: bytes
 
         :param max_ts: maximum timestamp the inputs can have
         :type max_ts: int
+
+        :return: the chosen inputs and the total amount they carry, as a V2 TokenAmount
+        :rtype: tuple[list[WalletInputInfo], TokenAmount]
 
         :raises InsufficientFunds: if the wallet does not have enough ballance
         """
@@ -518,7 +529,7 @@ class BaseWallet:
             utxo.maybe_spent_ts = int(self.reactor.seconds())
             self.maybe_spent_txs[token_uid][(_input.tx_id, _input.index)] = utxo
 
-        return inputs_tx, total_inputs_amount.to_v1()
+        return inputs_tx, total_inputs_amount
 
     def can_spend_block(self, tx_storage: 'TransactionStorage', tx_id: bytes) -> bool:
         tx = tx_storage.get_transaction(tx_id)

--- a/hathor/wallet/resources/thin_wallet/tokens.py
+++ b/hathor/wallet/resources/thin_wallet/tokens.py
@@ -65,7 +65,7 @@ class TokenResource(Resource):
                 'index': index
             })
 
-        total_token_amount = token_info.get_total().to_amount()
+        total_token_amount = token_info.get_total()
         total_v1 = total_token_amount.maybe_to_v1()
         data = {
             'name': token_info.get_name(),

--- a/hathor_tests/nanocontracts/test_consensus.py
+++ b/hathor_tests/nanocontracts/test_consensus.py
@@ -255,6 +255,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         _inputs, deposit_amount = self.wallet.get_inputs_from_amount(
             TokenAmount.from_v1(1), self.manager.tx_storage, token_uid=self.token_uid
         )
+        deposit_amount = deposit_amount.to_v1()
         tx = self.wallet.prepare_transaction(Transaction, _inputs, [], timestamp=int(self.manager.reactor.seconds()))
         tx = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx, is_custom_token=is_custom_token, nc_actions=[
             NanoHeaderAction(
@@ -586,6 +587,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         _inputs, deposit_amount_1 = self.wallet.get_inputs_from_amount(
             TokenAmount.from_v1(6500), self.manager.tx_storage
         )
+        deposit_amount_1 = deposit_amount_1.to_v1()
         tx1 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx1 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx1, address=address1, nc_actions=[
             NanoHeaderAction(
@@ -615,6 +617,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         _inputs, deposit_amount_2 = self.wallet.get_inputs_from_amount(
             TokenAmount.from_v1(3), self.manager.tx_storage
         )
+        deposit_amount_2 = deposit_amount_2.to_v1()
         tx2 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx2 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx2, address=address2, nc_actions=[
             NanoHeaderAction(
@@ -715,6 +718,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         _inputs, deposit_amount_2 = self.wallet.get_inputs_from_amount(
             TokenAmount.from_v1(6500), self.manager.tx_storage
         )
+        deposit_amount_2 = deposit_amount_2.to_v1()
         tx2 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx2 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx2, address=address2, nc_actions=[
             NanoHeaderAction(
@@ -744,6 +748,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         _inputs, deposit_amount_1 = self.wallet.get_inputs_from_amount(
             TokenAmount.from_v1(1), self.manager.tx_storage
         )
+        deposit_amount_1 = deposit_amount_1.to_v1()
         tx1 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx1 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx1, address=address1, nc_actions=[
             NanoHeaderAction(

--- a/hathor_tests/nanocontracts/test_contract_create_contract.py
+++ b/hathor_tests/nanocontracts/test_contract_create_contract.py
@@ -294,11 +294,11 @@ class NCBlueprintTestCase(BlueprintTestCase):
             self._settings.GENESIS_TOKEN_ATOMIC_UNITS
             + 34 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
             - 2 - 5 + 1
-        ).to_balance()
+        )
         # 200 from nc1.out[0]
         # +456 from nc5.nc_method
         # -123 from nc6.nc_method
-        assert tka_total == TokenAmount.from_v1(200 + 456 - 123).to_balance()
+        assert tka_total == TokenAmount.from_v1(200 + 456 - 123)
 
         # nc_history
         expected_list = [
@@ -346,9 +346,9 @@ class NCBlueprintTestCase(BlueprintTestCase):
         # genesis + 50 blocks - 2 from the TKA mint in nc1.out[0]
         assert htr_total == TokenAmount.from_v1(
             self._settings.GENESIS_TOKEN_ATOMIC_UNITS + 52 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 2
-        ).to_balance()
+        )
         # 200 from nc1.out[0]
-        assert tka_total == TokenAmount.from_v1(200).to_balance()
+        assert tka_total == TokenAmount.from_v1(200)
 
         # nc_history
         expected_list = [

--- a/hathor_tests/nanocontracts/test_indexes.py
+++ b/hathor_tests/nanocontracts/test_indexes.py
@@ -109,6 +109,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
         _inputs, deposit_amount = self.wallet.get_inputs_from_amount(
             TokenAmount.from_v1(1), self.manager.tx_storage
         )
+        deposit_amount = deposit_amount.to_v1()
         tx = self.wallet.prepare_transaction(Transaction, _inputs, [])
         self.fill_nc_tx(tx, self.myblueprint_id, 'initialize', [], nc_actions=[
             NanoHeaderAction(
@@ -126,7 +127,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
 
         token_info1 = self.manager.tx_storage.indexes.tokens.get_token_info(self._settings.HATHOR_TOKEN_UID)
         self.assertEqual(
-            token_info0.get_total() + TokenAmount.from_v1(64_00 * new_blocks).to_balance(),
+            token_info0.get_total() + TokenAmount.from_v1(64_00 * new_blocks),
             token_info1.get_total(),
         )
 
@@ -144,7 +145,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
 
         token_info1 = self.manager.tx_storage.indexes.tokens.get_token_info(self._settings.HATHOR_TOKEN_UID)
         self.assertEqual(
-            token_info0.get_total() + TokenAmount.from_v1(64_00 * new_blocks).to_balance(),
+            token_info0.get_total() + TokenAmount.from_v1(64_00 * new_blocks),
             token_info1.get_total(),
         )
 

--- a/hathor_tests/nanocontracts/test_indexes2.py
+++ b/hathor_tests/nanocontracts/test_indexes2.py
@@ -61,12 +61,10 @@ class TestIndexes2(BlueprintTestCase):
         htr_token_info = self.tokens_index.get_token_info(HATHOR_TOKEN_UID)
 
         assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
-        assert tka_token_info.get_total() == TokenAmount.from_v1(amount).to_balance()
-        # The deposit amount is already a TokenAmount; sum everything in V2-normalized form so
-        # the subtraction stays in a consistent unit (mixing V1 raw with V2 raw would underflow).
-        expected_htr_normalized = (
-            TokenAmount.from_v1(self._settings.GENESIS_TOKEN_ATOMIC_UNITS).normalized()
-            + TokenAmount.from_v1(11 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK).normalized()
-            - get_deposit_token_deposit_amount(self._settings, TokenAmount.from_v1(amount)).normalized()
+        assert tka_token_info.get_total() == TokenAmount.from_v1(amount)
+        expected_htr = (
+            TokenAmount.from_v1(self._settings.GENESIS_TOKEN_ATOMIC_UNITS)
+            + TokenAmount.from_v1(11 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
+            - get_deposit_token_deposit_amount(self._settings, TokenAmount.from_v1(amount))
         )
-        assert htr_token_info.get_total() == TokenAmount.from_v2(expected_htr_normalized).to_balance()
+        assert htr_token_info.get_total() == expected_htr

--- a/hathor_tests/tx/test_fee_tokens.py
+++ b/hathor_tests/tx/test_fee_tokens.py
@@ -343,7 +343,7 @@ class FeeTokenTest(unittest.TestCase):
             token_amount=new_token_amount
         )
         tokens_index = self.manager.tx_storage.indexes.tokens.get_token_info(deposit_token_uid)
-        self.assertEqual(TokenAmount.from_v1(400).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(400), tokens_index.get_total())
 
     def test_fee_and_deposit_token_melt_paid_with_deposit(self) -> None:
         # fbt -> Fee based token
@@ -424,7 +424,7 @@ class FeeTokenTest(unittest.TestCase):
             token_amount=new_token_amount
         )
         tokens_index = self.manager.tx_storage.indexes.tokens.get_token_info(deposit_token_uid)
-        self.assertEqual(TokenAmount.from_v1(200).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(200), tokens_index.get_total())
 
     def test_fee_token_tx_paid_with_htr_and_deposit(self) -> None:
         # fbt -> Fee based token
@@ -747,7 +747,7 @@ class FeeTokenTest(unittest.TestCase):
         self.assertEqual(TokenUtxoInfo(melt_tx_hash, melt_output), melt[0])
 
         # check total amount of tokens
-        self.assertEqual(TokenAmount.from_v1(token_amount).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(token_amount), tokens_index.get_total())
 
     def sign_inputs(self, tx: Transaction) -> None:
         wallet = self.manager.wallet

--- a/hathor_tests/tx/test_tokens.py
+++ b/hathor_tests/tx/test_tokens.py
@@ -171,7 +171,7 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # check total amount of tokens
-        self.assertEqual(TokenAmount.from_v1(500 + mint_amount).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(500 + mint_amount), tokens_index.get_total())
 
         # try to mint 1 token unit without deposit
         mint_amount = 1
@@ -280,7 +280,7 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # check total amount of tokens
-        self.assertEqual(new_amount.to_balance(), tokens_index.get_total())
+        self.assertEqual(new_amount, tokens_index.get_total())
 
         # melt tokens and withdraw more than what's allowed
         melt_amount = 100
@@ -373,7 +373,7 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # check total amount of tokens
-        self.assertEqual(TokenAmount.from_v1(100).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(100), tokens_index.get_total())
 
         # new tx minting tokens
         mint_amount = 300
@@ -418,7 +418,7 @@ class TokenTest(unittest.TestCase):
         self.assertIn(TokenUtxoInfo(tx2.hash, 0), mint)
         self.assertIn(TokenUtxoInfo(tx2.hash, 1), melt)
         # check total amount of tokens has been updated
-        self.assertEqual(TokenAmount.from_v1(400).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(400), tokens_index.get_total())
 
         # create conflicting tx by changing parents
         tx3 = Transaction.create_from_struct(tx2.get_struct())
@@ -440,7 +440,7 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # should have same amount of tokens
-        self.assertEqual(TokenAmount.from_v1(400).to_balance(), tokens_index.get_total())
+        self.assertEqual(TokenAmount.from_v1(400), tokens_index.get_total())
 
     def test_token_info(self):
         def update_tx(tx):


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1714

### Motivation

`BaseWallet` (the test wallet) kept token amounts in V1 internally, relying on the fallible `TokenAmount.to_v1()`. That is compatible with existing tests, but breaks once tests hold V2-only values. The wallet must handle amounts in V2 internally and never denormalize except at the vertex-encoding boundary.

### Acceptance Criteria

#### Wallet

- `BaseWallet` no longer calls `TokenAmount.to_v1()` anywhere; internal handling is V2/version-agnostic.
- The conversion to the vertex's native encoding happens only when each `TxOutput` is built in `prepare_transaction`, via `to_version()` parameterized by a single `_get_token_amount_version()` seam (hardcoded V1 for now), mirroring the DAGBuilder's `denormalize_amount`.
- `get_inputs_from_amount` returns its total as the V2 sum.
- Fix `thin_wallet/tokens.py` calling the nonexistent `TokenBalance.to_amount()` on `get_total()`, which already returns a `TokenAmount`.

#### Tests

- Test fixtures keep their original V1 ints, wrapped with `TokenAmount.from_v1`.
- Tests that feed the wallet-returned total into V1 nano headers or V1 `raw()` arithmetic convert it with `.to_v1()` themselves (V1-representability is guaranteed by their fixtures).
- Finish migrating tests to `get_total()` returning `TokenAmount`: comparisons drop the stale `.to_balance()` lift (`test_tokens`, `test_fee_tokens`, `test_indexes`, `test_indexes2`, `test_contract_create_contract`).
- Simplify `test_indexes2`'s expected-HTR computation to plain `TokenAmount` arithmetic.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)