### PR TITLE
fix(metrics): use DAA-version-aware avg_time in hash_rate calculation

### DIFF
--- a/hathor/manager.py
+++ b/hathor/manager.py
@@ -219,6 +219,7 @@ class HathorManager:
             tx_storage=self.tx_storage,
             reactor=self.reactor,
             websocket_factory=self.websocket_factory,
+            daa_factory=self.daa_factory,
         )
 
         self.wallet = wallet

--- a/hathor/metrics.py
+++ b/hathor/metrics.py
@@ -28,6 +28,7 @@ from hathor.transaction.block import Block
 from hathor.transaction.storage import TransactionRocksDBStorage, TransactionStorage
 
 if TYPE_CHECKING:
+    from hathor.daa.factory import DAAFactory  # noqa: F401
     from hathor.stratum import StratumFactory  # noqa: F401
     from hathor.websocket.factory import HathorAdminWebsocketFactory  # noqa: F401
 
@@ -63,6 +64,8 @@ class Metrics:
     tx_storage: TransactionStorage
     # Twisted reactor that handles the time and callLater
     reactor: Reactor
+    # DAA factory to get the correct avg_time_between_blocks per block version
+    daa_factory: Optional['DAAFactory'] = None
 
     # Transactions count in the network
     transactions: int = 0
@@ -214,7 +217,11 @@ class Metrics:
         """ Weight formula: w = log2(avg_time_between_blocks) + log2(hash_rate)
         """
         from math import log
-        return 2**(block.weight - log(self.avg_time_between_blocks, 2))
+        if self.daa_factory is not None:
+            avg_time = self.daa_factory.create_from_block(block).avg_time_between_blocks
+        else:
+            avg_time = self.avg_time_between_blocks
+        return 2**(block.weight - log(avg_time, 2))
 
     def set_websocket_data(self) -> None:
         """ Set websocket metrics data. Connections and addresses subscribed.

--- a/hathor/p2p/resources/mining_info.py
+++ b/hathor/p2p/resources/mining_info.py
@@ -55,7 +55,8 @@ class MiningInfoResource(Resource):
         difficulty = max(int(Weight(block.weight).to_pdiff()), 1)
 
         parent = block.get_block_parent()
-        hashrate = 2**(parent.weight - log(30, 2))
+        avg_time = self.manager.daa_factory.create_from_parent(parent).avg_time_between_blocks
+        hashrate = 2**(parent.weight - log(avg_time, 2))
 
         mined_tokens = self.manager.daa_factory.create_from_parent(parent).get_mined_tokens(height)
 


### PR DESCRIPTION
## Summary

- `Metrics.calculate_new_hashrate()` used a fixed `avg_time_between_blocks=30s` (from settings at construction time) to back-calculate hash rate from block weight. After `REDUCE_DAA_TARGET` activates, new blocks target 7.5s and carry proportionally lower weights — causing the formula to report 4× less than the actual hash rate.
- Pass `daa_factory` to `Metrics` so `calculate_new_hashrate` uses the correct `avg_time_between_blocks` per block version (V1=30s, V2=7.5s) via `daa_factory.create_from_block(block).avg_time_between_blocks`.
- Apply the same fix to `mining_info.py` which hardcoded `log(30, 2)` regardless of block version.

## Root cause

The formula is `hash_rate = 2^(block.weight - log2(avg_time_between_blocks))`, derived from `weight = log2(avg_time) + log2(hash_rate)`. V2 blocks have weights 2 units lower (log2(30/7.5) = 2), but the metrics code still divided by log2(30), giving `hash_rate_reported = actual / 4`.

## Test plan

- [x] All existing metrics tests pass (`8 passed`)
- [x] All mining_info and reduce_daa tests pass (`44 passed`)
- [x] mypy: no issues on modified files
- [x] Validated on a live mainnet node: fixed node reports `1.807e16` H/s vs `4.518e15` H/s on broken nodes — exactly 4× correction as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)