### PR TITLE
feat(decimal): add DAGBuilder support for token amount V2 transactions [part 19]

### DIFF
--- a/hathor/dag_builder/builder.py
+++ b/hathor/dag_builder/builder.py
@@ -48,6 +48,7 @@ logger = get_logger()
 NC_DEPOSIT_KEY = 'nc_deposit'
 NC_WITHDRAWAL_KEY = 'nc_withdrawal'
 TOKEN_VERSION_KEY = 'token_version'
+TOKEN_AMOUNT_VERSION_KEY = 'token_amount_version'
 FEE_KEY = 'fee'
 
 
@@ -105,7 +106,16 @@ class DAGBuilder:
 
     def parse_tokens(self, tokens: Iterator[Token]) -> None:
         """Parse tokens and update the DAG accordingly."""
-        for parts in tokens:
+        def is_token_amount_version(token: Token) -> bool:
+            return token[0] == TokenType.ATTRIBUTE and token[1][1] == TOKEN_AMOUNT_VERSION_KEY
+
+        # A node's token_amount_version governs how every amount on it is interpreted, so apply
+        # those attributes before any amount-bearing token, regardless of DSL line order.
+        materialized = list(tokens)
+        version_attrs = [token for token in materialized if is_token_amount_version(token)]
+        other_tokens = [token for token in materialized if not is_token_amount_version(token)]
+
+        for parts in [*version_attrs, *other_tokens]:
             match parts:
                 case (TokenType.PARENT, (_from, _to)):
                     self.add_parent_edge(_from, _to)

--- a/hathor/dag_builder/types.py
+++ b/hathor/dag_builder/types.py
@@ -91,19 +91,19 @@ class DAGNode:
         from hathor.dag_builder.builder import TOKEN_VERSION_KEY
         return TokenVersion[self.attrs.get(TOKEN_VERSION_KEY, TokenVersion.DEPOSIT.name).upper()]
 
-    def _get_token_amount_version(self) -> TokenAmountVersion:
-        """Return the version under which this node's amounts are interpreted."""
-        # Hardcoded V1 until the DSL grows a `token_amount_version` attribute.
-        return TokenAmountVersion.V1
+    def get_token_amount_version(self) -> TokenAmountVersion:
+        """Return the version under which this node's amounts are interpreted, defaulting to V1."""
+        from hathor.dag_builder.builder import TOKEN_AMOUNT_VERSION_KEY
+        version_name = self.attrs.get(TOKEN_AMOUNT_VERSION_KEY, TokenAmountVersion.V1.name)
+        return TokenAmountVersion[version_name.upper()]
 
     def as_node_amount(self, raw_amount: int) -> UnsignedAmount:
         """Wrap a raw amount (in the node's native decimal version) into a UnsignedAmount."""
-        return UnsignedAmount.from_version(raw_amount, version=self._get_token_amount_version())
+        return UnsignedAmount.from_version(raw_amount, version=self.get_token_amount_version())
 
     def denormalize_amount(self, amount: UnsignedAmount) -> UnsignedAmount:
         """Convert an `amount` to a UnsignedAmount in the node's native decimal version."""
-        token_amount_version = self._get_token_amount_version()
-        return amount.to_version(token_amount_version)
+        return amount.to_version(self.get_token_amount_version())
 
     def get_required_literal(self, attr: str) -> str:
         """Return the value of a required attribute as a literal or raise a SyntaxError if it doesn't exist."""

--- a/hathor/dag_builder/vertex_exporter.py
+++ b/hathor/dag_builder/vertex_exporter.py
@@ -231,6 +231,13 @@ class VertexExporter:
             public_key_bytes, signature = wallet.get_input_aux_data(data_to_sign, private_key)
             txin.data = P2PKH.create_input_data(public_key_bytes, signature)
 
+    def _encode_token_amount_version(self, vertex: Transaction, node: DAGNode) -> None:
+        """Encode the node's token amount version into the least significant bit of signal_bits.
+
+        This is the inverse of Transaction.get_token_amount_version().
+        """
+        vertex.signal_bits |= node.get_token_amount_version().value - 1
+
     def create_vertex_token(self, node: DAGNode) -> TokenCreationTransaction | None:
         """Create a token given a node."""
         if 'token_id' in node.attrs:
@@ -248,6 +255,7 @@ class VertexExporter:
         assert node.name != 'HTR'
 
         vertex = TokenCreationTransaction(parents=txs_parents, inputs=inputs, outputs=outputs)
+        self._encode_token_amount_version(vertex, node)
         vertex.token_name = node.name
         vertex.token_symbol = node.name
         vertex.token_version = node.get_attr_token_version()
@@ -518,6 +526,7 @@ class VertexExporter:
 
         assert len(block_parents) == 0
         tx = cls(parents=txs_parents, inputs=inputs, outputs=outputs, tokens=tokens)
+        self._encode_token_amount_version(tx, node)
         tx.timestamp = self.get_min_timestamp(node)
         self.add_headers_if_needed(node, tx)
         self.sign_all_inputs(tx, node=node)

--- a/hathor_tests/dag_builder/test_dag_builder.py
+++ b/hathor_tests/dag_builder/test_dag_builder.py
@@ -14,6 +14,7 @@ from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts import test_blueprints
 from hathor_tests.token_amount import UnsignedAmount
 from hathorlib.conf.settings import HATHOR_TOKEN_UID
+from hathorlib.token_amount_version import TokenAmountVersion
 
 
 class MyBlueprint(Blueprint):
@@ -81,6 +82,39 @@ class DAGBuilderTestCase(unittest.TestCase):
 
         # b40 --> tx1
         self.assertEqual(tx1.get_metadata().first_block, b40.hash)
+
+    def test_token_amount_version(self) -> None:
+        artifacts = self.dag_builder.build_from_str("""
+            blockchain genesis b[1..50]
+
+            b1.out[0] <<< tx_v1
+            b30 < tx_v1
+            b40 --> tx_v1
+
+            b2.out[0] <<< tx_v2
+            b31 < tx_v2
+            b41 --> tx_v2
+            tx_v2.out[0] = 100 HTR
+            tx_v2.token_amount_version = V2
+        """)
+
+        artifacts.propagate_with(self.manager)
+
+        tx_v1 = artifacts.get_typed_vertex('tx_v1', Transaction)
+        tx_v2 = artifacts.get_typed_vertex('tx_v2', Transaction)
+
+        # tx_v1 defaults to V1; tx_v2 opts into V2 through the DSL attribute.
+        self.assertEqual(tx_v1.get_token_amount_version(), TokenAmountVersion.V1)
+        self.assertEqual(tx_v1.signal_bits & 1, 0)
+        self.assertEqual(tx_v2.get_token_amount_version(), TokenAmountVersion.V2)
+        self.assertEqual(tx_v2.signal_bits & 1, 1)
+
+        # The specified output amount is interpreted in the transaction's own version.
+        self.assertEqual(tx_v2.outputs[0].value, UnsignedAmount.from_version(100, version=TokenAmountVersion.V2))
+
+        for tx in (tx_v1, tx_v2):
+            self.assertTrue(tx.get_metadata().validation.is_valid())
+            self.assertIsNone(tx.get_metadata().voided_by)
 
     def test_weight(self) -> None:
         artifacts = self.dag_builder.build_from_str("""


### PR DESCRIPTION
Stacked on top of #1707 (`feat/decimal/v2`).

### Motivation

The DAGBuilder hardcoded every transaction to token amount version V1, so there
was no way to build V2 transactions in tests. This adds that support: the
transaction's first byte (`signal_bits`) carries the token amount version in its
least significant bit.

### Acceptance Criteria

- Add a `token_amount_version` DSL attribute for transactions
  (e.g. `tx.token_amount_version = V2`), defaulting to V1.
- The selected version drives how the node's amounts are interpreted
  (`as_node_amount` / `denormalize_amount`) and is encoded into the LSB of the
  transaction's `signal_bits` — the inverse of
  `Transaction.get_token_amount_version()` — for both regular and token-creation
  transactions.
- Resolve the attribute before any amount-bearing token on the node, so amounts
  are interpreted consistently regardless of DSL line order.
- Add a test that builds both a default (V1) and an explicit V2 transaction,
  asserting the version, the `signal_bits` bit, V2 output-amount interpretation,
  and valid propagation of both.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is
  production-ready and can be included in future releases as soon as it gets
  merged (N/A — this targets `feat/decimal/v2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
