### PR TITLE
feat(decimals): add __str__ and parse to token amounts [part 14]

### DIFF
--- a/htr-rs/crates/htr-lib-py/htr_lib.pyi
+++ b/htr-rs/crates/htr-lib-py/htr_lib.pyi
@@ -38,6 +38,7 @@ class SignedAmount:
         ...
 
     def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
     def __bool__(self) -> bool: ...
 
     def __add__(self, other: SignedAmount) -> SignedAmount: ...
@@ -63,14 +64,15 @@ class UnsignedAmount:
     """
 
     @staticmethod
-    def set_normalization_factor(*, v1_decimal_places: int, v2_decimal_places: int) -> None:
-        """Set the global factor used to scale a V1 value into the V2-normalized value.
+    def set_decimal_places(*, v1_decimal_places: int, v2_decimal_places: int) -> None:
+        """Set the fractional-digit counts of the V1 and V2 encodings.
 
-        The factor is `10 ** (v2_decimal_places - v1_decimal_places)` and must be set before any
-        V1 amount is constructed or queried. Idempotent: a repeated call yielding the same factor
+        The source of truth for rendering, parsing, and the V1-to-V2 normalization factor
+        (`10 ** (v2_decimal_places - v1_decimal_places)`). Must be set before any amount is
+        constructed, rendered, or parsed. Idempotent: a repeated call with the same decimal places
         is a no-op, so independent initializers can each set it without coordinating. Raises when
-        `v2_decimal_places < v1_decimal_places`, or when a later call would change an already-set
-        factor.
+        `v2_decimal_places < v1_decimal_places`, or when a later call would change the already-set
+        counts.
         """
         ...
 
@@ -100,6 +102,15 @@ class UnsignedAmount:
     @staticmethod
     def zero() -> UnsignedAmount:
         """Return the canonical zero, a V2 amount."""
+        ...
+
+    @staticmethod
+    def parse(s: str) -> UnsignedAmount:
+        """Parse a decimal string into a V2 amount, the inverse of `str(amount)`.
+
+        The string must carry an explicit decimal point with at least one fractional digit.
+        Raises `ValueError` on a malformed string.
+        """
         ...
 
     def is_v1(self) -> bool:
@@ -149,6 +160,7 @@ class UnsignedAmount:
         ...
 
     def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
     def __bool__(self) -> bool: ...
 
     def __add__(self, other: UnsignedAmount) -> UnsignedAmount: ...

--- a/htr-rs/crates/htr-lib-py/src/signed_amount.rs
+++ b/htr-rs/crates/htr-lib-py/src/signed_amount.rs
@@ -56,6 +56,10 @@ impl PySignedAmount {
         format!("{:?}", self.0)
     }
 
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
     fn __bool__(&self) -> bool {
         self.0.as_bool()
     }
@@ -142,6 +146,46 @@ mod tests {
                     .unwrap();
                 let repr: String = result.repr().unwrap().extract().unwrap();
                 assert_eq!(repr, expected_repr);
+            }
+        });
+    }
+
+    // Goes through Python's `repr()` so the `tp_repr` slot is exercised: `__repr__` exposes
+    // the inner tuple struct's Debug form, signed `BigInt` included.
+    #[test]
+    fn py_repr_pins_debug_form() {
+        Python::initialize();
+        Python::attach(|py| {
+            for (input, expected) in [
+                (0_i64, "SignedAmount(0)"),
+                (5, "SignedAmount(5)"),
+                (-5, "SignedAmount(-5)"),
+            ] {
+                let bound = Bound::new(py, PySignedAmount::new(signed(input))).unwrap();
+                let repr: String = bound.as_any().repr().unwrap().extract().unwrap();
+                assert_eq!(repr, expected);
+            }
+        });
+    }
+
+    // Goes through Python's `str()` so the `tp_str` slot is exercised: `__str__` renders the
+    // V2-normalized value at eighteen fractional digits, always with the point and at least one
+    // fractional digit, prefixing `-` for negatives and rendering zero as `0.0`.
+    #[test]
+    fn py_str_renders_trimmed_decimal_with_sign() {
+        UnsignedAmount::set_decimal_places(2, 18);
+        Python::initialize();
+        Python::attach(|py| {
+            for (input, expected) in [
+                (0_i64, "0.0"),
+                (5, "0.000000000000000005"),
+                (-5, "-0.000000000000000005"),
+                (1_500_000_000_000_000_000, "1.5"),
+                (-1_500_000_000_000_000_000, "-1.5"),
+            ] {
+                let bound = Bound::new(py, PySignedAmount::new(signed(input))).unwrap();
+                let rendered: String = bound.as_any().str().unwrap().extract().unwrap();
+                assert_eq!(rendered, expected);
             }
         });
     }

--- a/htr-rs/crates/htr-lib-py/src/unsigned_amount.rs
+++ b/htr-rs/crates/htr-lib-py/src/unsigned_amount.rs
@@ -28,8 +28,8 @@ impl PyUnsignedAmount {
 impl PyUnsignedAmount {
     #[staticmethod]
     #[pyo3(signature = (*, v1_decimal_places, v2_decimal_places))]
-    fn set_normalization_factor(v1_decimal_places: u32, v2_decimal_places: u32) {
-        UnsignedAmount::set_normalization_factor(v1_decimal_places, v2_decimal_places)
+    fn set_decimal_places(v1_decimal_places: u32, v2_decimal_places: u32) {
+        UnsignedAmount::set_decimal_places(v1_decimal_places, v2_decimal_places)
     }
 
     #[staticmethod]
@@ -58,6 +58,13 @@ impl PyUnsignedAmount {
     #[staticmethod]
     fn zero() -> Self {
         Self(UnsignedAmount::ZERO)
+    }
+
+    #[staticmethod]
+    fn parse(s: &str) -> PyResult<Self> {
+        UnsignedAmount::parse(s)
+            .map(Self::new)
+            .map_err(|err| PyValueError::new_err(err.to_string()))
     }
 
     fn is_v1(&self) -> bool {
@@ -118,6 +125,10 @@ impl PyUnsignedAmount {
         format!("{:?}", self.0)
     }
 
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
     fn __bool__(&self) -> bool {
         self.0.as_bool()
     }
@@ -158,7 +169,7 @@ mod tests {
     const TEN_TO_THE_SIXTEENTH: u64 = 10u64.pow(16);
 
     fn init() {
-        UnsignedAmount::set_normalization_factor(2, 18)
+        UnsignedAmount::set_decimal_places(2, 18)
     }
 
     fn big(n: u64) -> BigUint {
@@ -200,6 +211,79 @@ mod tests {
             let amount = PyUnsignedAmount::from_version(big(5), &version).unwrap();
             assert!(amount.is_v2());
             assert_eq!(amount.normalized(), &big(5));
+        });
+    }
+
+    #[test]
+    fn py_parse_creates_v2_value() {
+        init();
+        let amount = PyUnsignedAmount::parse("1.5").unwrap();
+        assert!(amount.is_v2());
+        assert_eq!(amount.normalized(), &big(1_500_000_000_000_000_000));
+    }
+
+    // A fractional part exceeding the V2 precision surfaces as a Python `ValueError` carrying
+    // the parse error's message.
+    #[test]
+    fn py_parse_too_many_decimal_places_raises_value_error() {
+        init();
+        Python::initialize();
+        Python::attach(|py| {
+            let Err(err) = PyUnsignedAmount::parse("0.0000000000000000001") else {
+                panic!("expected ValueError on excess precision");
+            };
+            assert!(err.is_instance_of::<PyValueError>(py));
+            assert_eq!(
+                err.value(py).to_string(),
+                "too many decimal places: 19 (at most 18)"
+            );
+        });
+    }
+
+    // Goes through Python's `repr()` so the `tp_repr` slot is exercised: `__repr__` exposes
+    // the inner enum's Debug form — variant tag plus `BigUint` fields. V1 carries both `raw`
+    // and its V2-scaled `normalized`; V2 carries only `normalized`.
+    #[test]
+    fn py_repr_pins_debug_form_per_variant() {
+        init();
+        Python::initialize();
+        Python::attach(|py| {
+            let v1 = Bound::new(py, PyUnsignedAmount::from_v1(big(5))).unwrap();
+            let repr: String = v1.as_any().repr().unwrap().extract().unwrap();
+            assert_eq!(repr, "V1 { raw: 5, normalized: 50000000000000000 }");
+
+            let v2 = Bound::new(py, PyUnsignedAmount::from_v2(big(5))).unwrap();
+            let repr: String = v2.as_any().repr().unwrap().extract().unwrap();
+            assert_eq!(repr, "V2 { normalized: 5 }");
+        });
+    }
+
+    // Goes through Python's `str()` so the `tp_str` slot is exercised: `__str__` renders the
+    // native encoding as a decimal — V1's `raw` at two fractional digits, V2's `normalized` at
+    // eighteen — always with the point and at least one fractional digit, so whole amounts end in
+    // `.0` and zero renders as `0.0`.
+    #[test]
+    fn py_str_renders_trimmed_decimal_per_variant() {
+        init();
+        Python::initialize();
+        Python::attach(|py| {
+            for (amount, expected) in [
+                (PyUnsignedAmount::from_v1(big(0)), "0.0"),
+                (PyUnsignedAmount::from_v1(big(5)), "0.05"),
+                (PyUnsignedAmount::from_v1(big(100)), "1.0"),
+                (PyUnsignedAmount::from_v1(big(12345)), "123.45"),
+                (PyUnsignedAmount::from_v2(big(0)), "0.0"),
+                (PyUnsignedAmount::from_v2(big(5)), "0.000000000000000005"),
+                (
+                    PyUnsignedAmount::from_v2(big(1_200_000_000_000_000_000)),
+                    "1.2",
+                ),
+                (PyUnsignedAmount::from_v2(big(10u64.pow(18))), "1.0"),
+            ] {
+                let bound = Bound::new(py, amount).unwrap();
+                let rendered: String = bound.as_any().str().unwrap().extract().unwrap();
+                assert_eq!(rendered, expected);
+            }
         });
     }
 

--- a/htr-rs/crates/htr-lib/src/decimal.rs
+++ b/htr-rs/crates/htr-lib/src/decimal.rs
@@ -1,0 +1,223 @@
+//! Decimal rendering and parsing for token amounts.
+//!
+//! Token amounts are stored as integers; the human-facing form places a decimal point a fixed
+//! number of digits from the right — the count depending on the amount's version. The point and
+//! at least one fractional digit are always present (so a whole amount reads as `1.0`, not `1`),
+//! with any further trailing zeros dropped.
+
+use num_bigint::BigUint;
+use std::fmt;
+
+/// Render `magnitude`, read as a fixed-point integer with `decimal_places` fractional digits, as a
+/// decimal string. The point and at least one fractional digit are always kept, with any further
+/// trailing zeros dropped. So `1_200_000_000_000_000_000` at eighteen places renders as `1.2`, a
+/// whole amount as `1.0`, and zero as `0.0`.
+pub(crate) fn format_decimal(magnitude: &BigUint, decimal_places: u32) -> String {
+    let decimal_places = decimal_places as usize;
+    let mut digits = magnitude.to_string();
+    if digits.len() <= decimal_places {
+        digits.insert_str(0, &"0".repeat(decimal_places + 1 - digits.len()));
+    }
+    let (integer, fraction) = digits.split_at(digits.len() - decimal_places);
+    let fraction = fraction.trim_end_matches('0');
+    let fraction = if fraction.is_empty() { "0" } else { fraction };
+    format!("{integer}.{fraction}")
+}
+
+/// Why a decimal string could not be parsed into a fixed-point integer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseDecimalError {
+    /// The string had no decimal point. An amount must be written with an explicit point and at
+    /// least one fractional digit (e.g. `1.0`, not `1`).
+    MissingDecimalPoint,
+    /// A decimal point had no digit on one side (e.g. `.`, `1.`, `.5`).
+    MissingDigits,
+    /// The string held a character other than a digit or a `.`.
+    InvalidCharacter,
+    /// The string held more than one decimal point.
+    MultipleDecimalPoints,
+    /// The fractional part had more digits than the target precision can represent.
+    TooManyDecimalPlaces { found: usize, max: u32 },
+}
+
+impl fmt::Display for ParseDecimalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseDecimalError::MissingDecimalPoint => {
+                f.write_str("decimal string is missing the decimal point")
+            }
+            ParseDecimalError::MissingDigits => {
+                f.write_str("decimal string is missing required digits")
+            }
+            ParseDecimalError::InvalidCharacter => {
+                f.write_str("decimal string contains a non-digit character")
+            }
+            ParseDecimalError::MultipleDecimalPoints => {
+                f.write_str("decimal string contains more than one decimal point")
+            }
+            ParseDecimalError::TooManyDecimalPlaces { found, max } => {
+                write!(f, "too many decimal places: {found} (at most {max})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseDecimalError {}
+
+/// Parse a decimal string into the integer it denotes scaled by `10^decimal_places`, the inverse
+/// of [`format_decimal`]. Requires an integer and a fractional part separated by a single `.`,
+/// with at least one digit on each side; the fractional part may carry at most `decimal_places`
+/// digits. A bare integer with no point is rejected.
+pub(crate) fn parse_fixed_point(
+    input: &str,
+    decimal_places: u32,
+) -> Result<BigUint, ParseDecimalError> {
+    let is_digit_or_point = |byte: u8| byte.is_ascii_digit() || byte == b'.';
+    if !input.bytes().all(is_digit_or_point) {
+        return Err(ParseDecimalError::InvalidCharacter);
+    }
+    let Some((integer_part, fractional_part)) = input.split_once('.') else {
+        return Err(ParseDecimalError::MissingDecimalPoint);
+    };
+    if fractional_part.contains('.') {
+        return Err(ParseDecimalError::MultipleDecimalPoints);
+    }
+    if integer_part.is_empty() || fractional_part.is_empty() {
+        return Err(ParseDecimalError::MissingDigits);
+    }
+    if fractional_part.len() > decimal_places as usize {
+        return Err(ParseDecimalError::TooManyDecimalPlaces {
+            found: fractional_part.len(),
+            max: decimal_places,
+        });
+    }
+
+    let trailing_zeros = decimal_places as usize - fractional_part.len();
+    let mut digits = String::with_capacity(integer_part.len() + decimal_places as usize);
+    digits.push_str(integer_part);
+    digits.push_str(fractional_part);
+    digits.push_str(&"0".repeat(trailing_zeros));
+    Ok(digits
+        .parse()
+        .expect("validated non-empty digit string parses as BigUint"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn big(n: u64) -> BigUint {
+        BigUint::from(n)
+    }
+
+    // The point and one fractional digit are always present; any further trailing zeros are
+    // dropped. A whole amount keeps a single `.0` and zero renders as `0.0`.
+    #[test]
+    fn format_decimal_keeps_at_least_one_fractional_digit() {
+        assert_eq!(format_decimal(&big(0), 18), "0.0");
+        assert_eq!(format_decimal(&big(5), 18), "0.000000000000000005");
+        assert_eq!(format_decimal(&big(1_200_000_000_000_000_000), 18), "1.2");
+        assert_eq!(format_decimal(&big(1_500_000_000_000_000_000), 18), "1.5");
+        assert_eq!(format_decimal(&big(10u64.pow(18)), 18), "1.0");
+        assert_eq!(format_decimal(&big(0), 2), "0.0");
+        assert_eq!(format_decimal(&big(5), 2), "0.05");
+        assert_eq!(format_decimal(&big(45), 2), "0.45");
+        assert_eq!(format_decimal(&big(100), 2), "1.0");
+        assert_eq!(format_decimal(&big(12345), 2), "123.45");
+        assert_eq!(format_decimal(&big(0), 0), "0.0");
+        assert_eq!(format_decimal(&big(123), 0), "123.0");
+    }
+
+    #[test]
+    fn parse_integer_and_fraction() {
+        assert_eq!(parse_fixed_point("0.0", 18).unwrap(), big(0));
+        assert_eq!(parse_fixed_point("1.0", 18).unwrap(), big(10u64.pow(18)));
+        assert_eq!(
+            parse_fixed_point("1.5", 18).unwrap(),
+            big(1_500_000_000_000_000_000)
+        );
+        assert_eq!(
+            parse_fixed_point("0.000000000000000001", 18).unwrap(),
+            big(1)
+        );
+        assert_eq!(
+            parse_fixed_point("1.000000000000000000", 18).unwrap(),
+            big(10u64.pow(18))
+        );
+    }
+
+    // A bare integer with no decimal point is rejected; every amount must carry an explicit point
+    // and at least one fractional digit.
+    #[test]
+    fn parse_rejects_missing_decimal_point() {
+        assert_eq!(
+            parse_fixed_point("0", 18),
+            Err(ParseDecimalError::MissingDecimalPoint)
+        );
+        assert_eq!(
+            parse_fixed_point("5", 18),
+            Err(ParseDecimalError::MissingDecimalPoint)
+        );
+        assert_eq!(
+            parse_fixed_point("", 18),
+            Err(ParseDecimalError::MissingDecimalPoint)
+        );
+    }
+
+    // A decimal point requires digits on both sides: a leading or trailing point is rejected.
+    #[test]
+    fn parse_rejects_empty_side() {
+        assert_eq!(
+            parse_fixed_point(".5", 18),
+            Err(ParseDecimalError::MissingDigits)
+        );
+        assert_eq!(
+            parse_fixed_point("1.", 18),
+            Err(ParseDecimalError::MissingDigits)
+        );
+    }
+
+    // The fractional part is bounded by the target precision: eighteen digits parse, nineteen
+    // do not, and the error reports both the count found and the limit.
+    #[test]
+    fn parse_rejects_excess_decimal_places() {
+        assert_eq!(
+            parse_fixed_point("0.0000000000000000001", 18),
+            Err(ParseDecimalError::TooManyDecimalPlaces { found: 19, max: 18 })
+        );
+    }
+
+    #[test]
+    fn parse_rejects_malformed_input() {
+        assert_eq!(
+            parse_fixed_point(".", 18),
+            Err(ParseDecimalError::MissingDigits)
+        );
+        assert_eq!(
+            parse_fixed_point("-1", 18),
+            Err(ParseDecimalError::InvalidCharacter)
+        );
+        assert_eq!(
+            parse_fixed_point("1 000", 18),
+            Err(ParseDecimalError::InvalidCharacter)
+        );
+        assert_eq!(
+            parse_fixed_point("abc", 18),
+            Err(ParseDecimalError::InvalidCharacter)
+        );
+        assert_eq!(
+            parse_fixed_point("1.2.3", 18),
+            Err(ParseDecimalError::MultipleDecimalPoints)
+        );
+    }
+
+    // Round-trips the rendering: a value formatted at a given precision parses back to itself,
+    // even after trailing zeros are trimmed — including a whole amount, which renders as `N.0`.
+    #[test]
+    fn parse_inverts_format() {
+        for value in [big(1_500_000_000_000_000_000), big(10u64.pow(18)), big(0)] {
+            let rendered = format_decimal(&value, 18);
+            assert_eq!(parse_fixed_point(&rendered, 18).unwrap(), value);
+        }
+    }
+}

--- a/htr-rs/crates/htr-lib/src/decimal.rs
+++ b/htr-rs/crates/htr-lib/src/decimal.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Hathor Labs
+// SPDX-License-Identifier: Apache-2.0
+
 //! Decimal rendering and parsing for token amounts.
 //!
 //! Token amounts are stored as integers; the human-facing form places a decimal point a fixed

--- a/htr-rs/crates/htr-lib/src/lib.rs
+++ b/htr-rs/crates/htr-lib/src/lib.rs
@@ -13,6 +13,7 @@ compile_error!("compilation is only allowed for 64-bit targets");
 #[macro_use]
 extern crate num_derive;
 
+pub mod decimal;
 mod signed_amount;
 mod unsigned_amount;
 

--- a/htr-rs/crates/htr-lib/src/signed_amount.rs
+++ b/htr-rs/crates/htr-lib/src/signed_amount.rs
@@ -9,8 +9,9 @@
 //! both directions; [`SignedAmount::to_unsigned`] fails on negative values.
 //! Multiplication and division are deliberately not implemented.
 
+use crate::decimal::format_decimal;
 use crate::unsigned_amount::UnsignedAmount;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, Sign};
 use std::cmp::Ordering;
 
 /// Signed token amount, stored as a `BigInt` in the V2-normalized unit.
@@ -37,6 +38,21 @@ impl SignedAmount {
     /// negative, since `UnsignedAmount` cannot represent negative values.
     pub fn to_unsigned(&self) -> Option<UnsignedAmount> {
         self.0.to_biguint().map(UnsignedAmount::from_v2)
+    }
+}
+
+/// Renders the V2-normalized value as a decimal at the configured V2 decimal places, keeping the
+/// point and at least one fractional digit while dropping any further trailing zeros and prefixing
+/// `-` for negative amounts.
+impl std::fmt::Display for SignedAmount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.sign() == Sign::Minus {
+            f.write_str("-")?;
+        }
+        f.write_str(&format_decimal(
+            self.0.magnitude(),
+            UnsignedAmount::v2_decimal_places(),
+        ))
     }
 }
 
@@ -121,6 +137,21 @@ mod tests {
     #[test]
     fn to_unsigned_none_for_negative() {
         assert!(signed(-1).to_unsigned().is_none());
+    }
+
+    // ---- Display ----
+
+    // Renders the V2-normalized value at the configured V2 decimal places, always keeping the
+    // point and at least one fractional digit; negatives carry a leading `-`, zero renders as
+    // `0.0` with no sign.
+    #[test]
+    fn display_trims_trailing_zeros_with_sign() {
+        UnsignedAmount::set_decimal_places(2, 18);
+        assert_eq!(signed(0).to_string(), "0.0");
+        assert_eq!(signed(5).to_string(), "0.000000000000000005");
+        assert_eq!(signed(-5).to_string(), "-0.000000000000000005");
+        assert_eq!(signed(1_500_000_000_000_000_000).to_string(), "1.5");
+        assert_eq!(signed(-1_500_000_000_000_000_000).to_string(), "-1.5");
     }
 
     // ---- Equality and ordering ----

--- a/htr-rs/crates/htr-lib/src/unsigned_amount.rs
+++ b/htr-rs/crates/htr-lib/src/unsigned_amount.rs
@@ -8,16 +8,25 @@
 //! so ordering, equality, and arithmetic can mix V1 and V2 operands without loss of precision.
 //! Multiplication and division are deliberately not implemented.
 
+use crate::decimal::{ParseDecimalError, format_decimal, parse_fixed_point};
 use crate::signed_amount::SignedAmount;
 use num_bigint::{BigUint, ToBigInt};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::sync::OnceLock;
 
-/// Factor used to scale a V1 value into the V2-normalized value. Set once at
-/// startup via [`UnsignedAmount::set_normalization_factor`] before any V1 amount is
-/// constructed or queried.
-static V1_V2_NORMALIZATION_FACTOR: OnceLock<BigUint> = OnceLock::new();
+/// Decimal-place configuration, set once at startup via [`UnsignedAmount::set_decimal_places`]
+/// before any amount is constructed, rendered, or parsed.
+static DECIMAL_CONFIG: OnceLock<DecimalConfig> = OnceLock::new();
+
+/// The V1 and V2 fractional-digit counts and the V1→V2 scaling factor derived from them. The V2
+/// count also governs every [`SignedAmount`].
+struct DecimalConfig {
+    v1_decimal_places: u32,
+    v2_decimal_places: u32,
+    /// `10^(v2_decimal_places - v1_decimal_places)`.
+    normalization_factor: BigUint,
+}
 
 /// Token amount version under which a token amount is encoded.
 ///
@@ -48,29 +57,46 @@ impl UnsignedAmount {
         normalized: BigUint::ZERO,
     };
 
-    /// Set the global factor used to scale a V1 value into the V2-normalized value.
+    /// Set the fractional-digit counts of the V1 and V2 encodings, the source of truth for
+    /// rendering, parsing, and the V1-to-V2 normalization factor.
     ///
-    /// The factor is `10^(v2_decimal_places - v1_decimal_places)` and must be set before any V1
-    /// [`UnsignedAmount`] is constructed or queried. Idempotent: a repeated call whose decimal places
-    /// yield the same factor is a no-op, so independent initializers can each set it without
-    /// coordinating. Panics when `v2_decimal_places < v1_decimal_places`, or when a later call
-    /// would change an already-set factor.
-    pub fn set_normalization_factor(v1_decimal_places: u32, v2_decimal_places: u32) {
+    /// Must be set before any [`UnsignedAmount`] is constructed, rendered, or parsed. Idempotent:
+    /// a repeated call with the same decimal places is a no-op, so independent initializers can
+    /// each set it without coordinating. Panics when `v2_decimal_places < v1_decimal_places`, or
+    /// when a later call would change the already-set counts.
+    pub fn set_decimal_places(v1_decimal_places: u32, v2_decimal_places: u32) {
         assert!(v2_decimal_places >= v1_decimal_places);
-        let factor = BigUint::from(10u8).pow(v2_decimal_places - v1_decimal_places);
-        let stored = V1_V2_NORMALIZATION_FACTOR.get_or_init(|| factor.clone());
-        assert_eq!(
-            stored, &factor,
-            "normalization factor already set to a different value"
+        let config = DECIMAL_CONFIG.get_or_init(|| DecimalConfig {
+            v1_decimal_places,
+            v2_decimal_places,
+            normalization_factor: BigUint::from(10u8).pow(v2_decimal_places - v1_decimal_places),
+        });
+        assert!(
+            config.v1_decimal_places == v1_decimal_places
+                && config.v2_decimal_places == v2_decimal_places,
+            "decimal places already set to different values"
         );
     }
 
-    /// Get the global factor used to scale a V1 value into the V2-normalized value.
-    /// Panics when it's not set.
+    /// The decimal-place configuration. Panics when not set.
+    fn config() -> &'static DecimalConfig {
+        DECIMAL_CONFIG.get().expect("decimal places must be set")
+    }
+
+    /// Fractional digits in the V1 encoding. Panics when not set.
+    pub(crate) fn v1_decimal_places() -> u32 {
+        Self::config().v1_decimal_places
+    }
+
+    /// Fractional digits in the V2 encoding. Panics when not set.
+    pub(crate) fn v2_decimal_places() -> u32 {
+        Self::config().v2_decimal_places
+    }
+
+    /// The V1-to-V2 scaling factor, `10^(v2_decimal_places - v1_decimal_places)`, derived from the
+    /// configured decimal places. Panics when they have not been set.
     pub fn get_normalization_factor() -> &'static BigUint {
-        V1_V2_NORMALIZATION_FACTOR
-            .get()
-            .expect("normalization factor must be set")
+        &Self::config().normalization_factor
     }
 
     /// Build a V1 amount, computing and storing the V2-scaled `normalized` form alongside
@@ -94,6 +120,13 @@ impl UnsignedAmount {
             TokenAmountVersion::V1 => Self::from_v1(amount),
             TokenAmountVersion::V2 => Self::from_v2(amount),
         }
+    }
+
+    /// Parse a decimal string into a V2 amount, the inverse of the V2 [`Display`](std::fmt::Display)
+    /// form. The string must carry an explicit decimal point with at least one fractional digit,
+    /// and no more fractional digits than the V2 unit can hold.
+    pub fn parse(s: &str) -> Result<Self, ParseDecimalError> {
+        parse_fixed_point(s, Self::v2_decimal_places()).map(Self::from_v2)
     }
 
     /// Value scaled to the V2 unit, regardless of variant. This is the form used for
@@ -175,6 +208,20 @@ impl UnsignedAmount {
     }
 }
 
+/// Renders the value's native encoding as a decimal — the `raw` V1 value at the configured V1
+/// decimal places, or the `normalized` V2 value at the V2 decimal places — always keeping the
+/// point and at least one fractional digit while dropping any further trailing zeros. So a V2
+/// `1_500_000_000_000_000_000` renders as `1.5` and a whole amount as `1.0`.
+impl std::fmt::Display for UnsignedAmount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (magnitude, decimal_places) = match self {
+            UnsignedAmount::V1 { raw, .. } => (raw, Self::v1_decimal_places()),
+            UnsignedAmount::V2 { normalized } => (normalized, Self::v2_decimal_places()),
+        };
+        f.write_str(&format_decimal(magnitude, decimal_places))
+    }
+}
+
 impl Ord for UnsignedAmount {
     fn cmp(&self, other: &Self) -> Ordering {
         self.normalized().cmp(other.normalized())
@@ -220,34 +267,33 @@ mod tests {
     const TEN_TO_THE_SIXTEENTH: u64 = 10u64.pow(16);
 
     fn init() {
-        UnsignedAmount::set_normalization_factor(2, 18)
+        UnsignedAmount::set_decimal_places(2, 18)
     }
 
     fn big(n: u64) -> BigUint {
         BigUint::from(n)
     }
 
-    // ---- set_normalization_factor ----
+    // ---- set_decimal_places ----
     //
-    // These tests rely on nextest's process-per-test isolation so the global
+    // These tests rely on nextest's process-per-test isolation so the config
     // `OnceLock` is fresh for each one. They deliberately do not call `init()`,
     // since they exercise the setter directly.
 
-    // A second call whose factor differs from the one already set panics; the global factor is
-    // fixed once chosen.
+    // A second call with different decimal places panics; the counts are fixed once chosen.
     #[test]
-    #[should_panic(expected = "normalization factor already set to a different value")]
-    fn set_normalization_factor_conflicting_second_call_panics() {
-        UnsignedAmount::set_normalization_factor(2, 18);
-        UnsignedAmount::set_normalization_factor(0, 4);
+    #[should_panic(expected = "decimal places already set to different values")]
+    fn set_decimal_places_conflicting_second_call_panics() {
+        UnsignedAmount::set_decimal_places(2, 18);
+        UnsignedAmount::set_decimal_places(0, 4);
     }
 
-    // A second call whose decimal places yield the same factor is a no-op, letting independent
-    // initializers each set it without coordinating.
+    // A second call with the same decimal places is a no-op, letting independent initializers
+    // each set it without coordinating.
     #[test]
-    fn set_normalization_factor_equal_second_call_is_noop() {
-        UnsignedAmount::set_normalization_factor(2, 18);
-        UnsignedAmount::set_normalization_factor(2, 18);
+    fn set_decimal_places_equal_second_call_is_noop() {
+        UnsignedAmount::set_decimal_places(2, 18);
+        UnsignedAmount::set_decimal_places(2, 18);
         let amount = UnsignedAmount::from_v1(big(3));
         assert_eq!(amount.raw(), &big(3));
         assert_eq!(amount.normalized(), &big(3 * TEN_TO_THE_SIXTEENTH));
@@ -255,16 +301,16 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn set_normalization_factor_panics_when_v2_smaller_than_v1() {
-        UnsignedAmount::set_normalization_factor(18, 2);
+    fn set_decimal_places_panics_when_v2_smaller_than_v1() {
+        UnsignedAmount::set_decimal_places(18, 2);
     }
 
     // Equal decimal places yield a factor of `10^0 = 1`, so a V1 amount and its
     // normalized form coincide — the V2-only arithmetic path is still correct
     // when the two encodings carry identical precision.
     #[test]
-    fn set_normalization_factor_equal_decimal_places_yields_identity_factor() {
-        UnsignedAmount::set_normalization_factor(8, 8);
+    fn set_decimal_places_equal_v1_v2_yields_identity_factor() {
+        UnsignedAmount::set_decimal_places(8, 8);
         let amount = UnsignedAmount::from_v1(big(7));
         assert_eq!(amount.raw(), &big(7));
         assert_eq!(amount.normalized(), &big(7));
@@ -358,6 +404,74 @@ mod tests {
 
         let from_zero = UnsignedAmount::ZERO.to_signed();
         assert_eq!(from_zero.raw(), &BigInt::from(0));
+    }
+
+    // ---- Display ----
+
+    // V1 renders its `raw` value at two fractional digits, V2 its `normalized` at eighteen. A
+    // fractional amount like `0.05` keeps its digits; a whole amount keeps a single `.0`, and zero
+    // renders as `0.0`.
+    #[test]
+    fn display_v1_trims_trailing_zeros() {
+        init();
+        assert_eq!(UnsignedAmount::from_v1(big(0)).to_string(), "0.0");
+        assert_eq!(UnsignedAmount::from_v1(big(5)).to_string(), "0.05");
+        assert_eq!(UnsignedAmount::from_v1(big(100)).to_string(), "1.0");
+        assert_eq!(UnsignedAmount::from_v1(big(12345)).to_string(), "123.45");
+    }
+
+    #[test]
+    fn display_v2_trims_trailing_zeros() {
+        init();
+        assert_eq!(UnsignedAmount::from_v2(big(0)).to_string(), "0.0");
+        assert_eq!(
+            UnsignedAmount::from_v2(big(5)).to_string(),
+            "0.000000000000000005"
+        );
+        assert_eq!(
+            UnsignedAmount::from_v2(big(1_200_000_000_000_000_000)).to_string(),
+            "1.2"
+        );
+        assert_eq!(
+            UnsignedAmount::from_v2(big(10u64.pow(18))).to_string(),
+            "1.0"
+        );
+        assert_eq!(UnsignedAmount::ZERO.to_string(), "0.0");
+    }
+
+    // ---- parse ----
+
+    // A decimal string parses into a V2 amount whose normalized value is scaled to eighteen
+    // places; the result is always V2 regardless of the input's precision.
+    #[test]
+    fn parse_creates_v2_amount() {
+        init();
+        let amount = UnsignedAmount::parse("1.5").unwrap();
+        assert!(amount.is_v2());
+        assert_eq!(amount.normalized(), &big(1_500_000_000_000_000_000));
+
+        let full_precision = UnsignedAmount::parse("0.000000000000000001").unwrap();
+        assert!(full_precision.is_v2());
+        assert_eq!(full_precision.normalized(), &big(1));
+    }
+
+    // Parsing rejects a fractional part longer than the V2 unit can represent.
+    #[test]
+    fn parse_rejects_more_than_eighteen_decimal_places() {
+        init();
+        assert_eq!(
+            UnsignedAmount::parse("0.0000000000000000001"),
+            Err(ParseDecimalError::TooManyDecimalPlaces { found: 19, max: 18 })
+        );
+    }
+
+    // Parsing inverts the V2 `Display` form: rendering an amount and parsing it back yields the
+    // original value.
+    #[test]
+    fn parse_inverts_v2_display() {
+        init();
+        let amount = UnsignedAmount::from_v2(big(1_500_000_000_000_000_000));
+        assert_eq!(UnsignedAmount::parse(&amount.to_string()).unwrap(), amount);
     }
 
     // ---- to_v1 ----


### PR DESCRIPTION
Depends on #1740

### Motivation

Token amounts are stored as integers, but API requests and responses read and enter them as decimal strings (e.g. `1.5`), with the decimal point placed according to the amount's version (2 fractional digits for V1, 18 for V2). This PR adds that human-facing decimal rendering — exposed to Python as `__str__` on both `UnsignedAmount` and `SignedAmount` — and its inverse, `UnsignedAmount.parse`, which reads a decimal string into a V2 amount.

### Acceptance Criteria

- Add a `decimal` module to `htr-lib` housing the shared `format_decimal` / `parse_fixed_point` helpers and the `ParseDecimalError` type.
- Rename `set_normalization_factor` to `set_decimal_places`; the global `OnceLock` now stores the `(v1_decimal_places, v2_decimal_places)` pair instead of the derived factor.
- Add a `Display` impl to `UnsignedAmount` and `SignedAmount` in `htr-lib`, exposed to Python as `__str__`.
- Implement `UnsignedAmount.parse`, the inverse of the V2 `__str__`: it reads a decimal string carrying an explicit decimal point and builds a V2 amount.
- Update `htr_lib.pyi`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
