### PR TITLE
test(decimals): pre-wrap test fixtures behind a transitional shim [part 15]

### DIFF
--- a/hathor_tests/cli/test_multisig_spend.py
+++ b/hathor_tests/cli/test_multisig_spend.py
@@ -14,6 +14,7 @@ from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from hathor_cli.multisig_spend import create_parser, execute
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -61,11 +62,11 @@ class MultiSigSpendTest(unittest.TestCase):
         block_count = 3  # 3 * 8.00 -> 24.00 HTR is enough
         blocks = add_new_blocks(self.manager, block_count, advance_clock=15)
         add_blocks_unlock_reward(self.manager)
-        blocks_tokens = [sum(txout.value for txout in blk.outputs) for blk in blocks]
-        available_tokens = sum(blocks_tokens)
+        blocks_tokens = [sum((txout.value for txout in blk.outputs), start=UnsignedAmount.zero()) for blk in blocks]
+        available_tokens = sum(blocks_tokens, start=UnsignedAmount.zero())
         self.assertEqual(
             self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-            WalletBalance(0, available_tokens)
+            WalletBalance(UnsignedAmount.zero(), available_tokens)
         )
 
         # First we send tokens to a multisig address
@@ -80,7 +81,7 @@ class MultiSigSpendTest(unittest.TestCase):
         self.manager.propagate_tx(tx1)
         self.clock.advance(10)
 
-        wallet_balance = WalletBalance(0, available_tokens - block_reward)
+        wallet_balance = WalletBalance(UnsignedAmount.zero(), available_tokens - block_reward)
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID], wallet_balance)
 
         # Then we create a new tx that spends this tokens from multisig wallet
@@ -91,9 +92,11 @@ class MultiSigSpendTest(unittest.TestCase):
 
         multisig_script = create_output_script(self.multisig_address)
 
-        multisig_output = TxOutput(200, multisig_script)
-        wallet_output = TxOutput(300, create_output_script(self.address))
-        outside_output = TxOutput(block_reward - 200 - 300, create_output_script(self.outside_address))
+        multisig_output = TxOutput(UnsignedAmount.from_v1(200), multisig_script)
+        wallet_output = TxOutput(UnsignedAmount.from_v1(300), create_output_script(self.address))
+        # The remaining change is encoded in V1, matching its sibling outputs and the tx encoding.
+        change = (block_reward - UnsignedAmount.from_v1(200) - UnsignedAmount.from_v1(300)).to_v1()
+        outside_output = TxOutput(change, create_output_script(self.outside_address))
 
         tx.outputs = [multisig_output, wallet_output, outside_output]
 

--- a/hathor_tests/conftest.py
+++ b/hathor_tests/conftest.py
@@ -4,9 +4,13 @@
 import os
 
 from hathor.reactor import initialize_global_reactor
+from hathor_tests.token_amount import UnsignedAmount
 from hathorlib.conf import UNITTESTS_SETTINGS_FILEPATH
 
 os.environ['HATHOR_CONFIG_YAML'] = os.environ.get('HATHOR_TEST_CONFIG_YAML', UNITTESTS_SETTINGS_FILEPATH)
 
 # TODO: We should remove this call from the module level.
 initialize_global_reactor(use_asyncio_reactor=True)
+
+# Hardcoded for all tests.
+UnsignedAmount.set_decimal_places(v1_decimal_places=2, v2_decimal_places=18)

--- a/hathor_tests/consensus/test_consensus.py
+++ b/hathor_tests/consensus/test_consensus.py
@@ -7,6 +7,7 @@ from hathor.execution_manager import ExecutionManager
 from hathor.simulator.utils import add_new_block, add_new_blocks, gen_new_tx
 from hathor.util import not_none
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_double_spending, add_new_transactions
 
 
@@ -26,7 +27,7 @@ class ConsensusTestCase(unittest.TestCase):
         add_blocks_unlock_reward(manager)
 
         address = 'HGov979VaeyMQ92ubYcnVooP6qPzUJU8Ro'
-        value = 1
+        value = UnsignedAmount.from_v1(1)
         tx = gen_new_tx(manager, address, value)
 
         class MyError(Exception):

--- a/hathor_tests/consensus/test_consensus2.py
+++ b/hathor_tests/consensus/test_consensus2.py
@@ -7,6 +7,7 @@ from hathor.simulator.utils import gen_new_tx
 from hathor.transaction import Transaction
 from hathor.util import not_none
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_custom_tx
 
 
@@ -79,7 +80,7 @@ class ConsensusSimulatorTestCase(SimulatorTestCase):
 
         assert manager1.wallet is not None
         address = manager1.wallet.get_unused_address(mark_as_used=False)
-        value = 10
+        value = UnsignedAmount.from_v1(10)
         initial = gen_new_tx(manager1, address, value)
         initial.weight = 25
         initial.update_hash()
@@ -115,7 +116,7 @@ class ConsensusSimulatorTestCase(SimulatorTestCase):
 
         assert manager1.wallet is not None
         address = manager1.wallet.get_unused_address(mark_as_used=False)
-        value = 10
+        value = UnsignedAmount.from_v1(10)
         initial = gen_new_tx(manager1, address, value)
         initial.weight = 25
         initial.update_hash()

--- a/hathor_tests/consensus/test_consensus3.py
+++ b/hathor_tests/consensus/test_consensus3.py
@@ -5,6 +5,7 @@ import pytest
 
 from hathor.simulator.utils import add_new_block, add_new_blocks
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -31,9 +32,9 @@ class DoubleSpendingTestCase(unittest.TestCase):
 
         addr = manager.wallet.get_unused_address()
         outputs = []
-        outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
-        outputs.append(WalletOutputInfo(decode_address(addr), 1000, None))
-        outputs.append(WalletOutputInfo(decode_address(addr), 6400 - 1001, None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1000), None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(6400 - 1001), None))
         tx_fund0 = manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, manager.tx_storage)
         tx_fund0.weight = 1
         tx_fund0.parents = manager.get_new_tx_parents()
@@ -43,7 +44,7 @@ class DoubleSpendingTestCase(unittest.TestCase):
 
         def do_step(tx_fund: Transaction) -> Transaction:
             inputs = [WalletInputInfo(tx_fund.hash, 0, manager.wallet.get_private_key(addr))]
-            outputs = [WalletOutputInfo(decode_address(addr), 1, None)]
+            outputs = [WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None)]
             tx1 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx_fund.timestamp+1)
             tx1.weight = 1
             tx1.parents = manager.get_new_tx_parents(tx1.timestamp)
@@ -53,7 +54,9 @@ class DoubleSpendingTestCase(unittest.TestCase):
             inputs = []
             inputs.append(WalletInputInfo(tx1.hash, 0, manager.wallet.get_private_key(addr)))
             inputs.append(WalletInputInfo(tx_fund.hash, 1, manager.wallet.get_private_key(addr)))
-            outputs = [WalletOutputInfo(decode_address(addr), tx_fund.outputs[1].value+1, None)]
+            outputs = [
+                WalletOutputInfo(decode_address(addr), tx_fund.outputs[1].value + UnsignedAmount.from_v1(1), None)
+            ]
             tx2 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx1.timestamp+1)
             tx2.weight = 1
             tx2.parents = manager.get_new_tx_parents(tx2.timestamp)
@@ -61,7 +64,7 @@ class DoubleSpendingTestCase(unittest.TestCase):
             self.assertTrue(manager.propagate_tx(tx2))
 
             inputs = [WalletInputInfo(tx_fund.hash, 0, manager.wallet.get_private_key(addr))]
-            outputs = [WalletOutputInfo(decode_address(addr), 1, None)]
+            outputs = [WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None)]
             tx3 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx_fund.timestamp+1)
             tx3.weight = tx1.weight + tx2.weight + 0.1
             tx3.parents = manager.get_new_tx_parents(tx3.timestamp)
@@ -80,8 +83,10 @@ class DoubleSpendingTestCase(unittest.TestCase):
             inputs.append(WalletInputInfo(tx2.hash, 0, manager.wallet.get_private_key(addr)))
             inputs.append(WalletInputInfo(tx4.hash, 0, manager.wallet.get_private_key(addr)))
             outputs = []
-            outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
-            outputs.append(WalletOutputInfo(decode_address(addr), 2*tx_fund.outputs[1].value, None))
+            outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None))
+            outputs.append(
+                WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(2*tx_fund.outputs[1].value), None)
+            )
             tx5: Transaction = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx2.timestamp+1)
             tx5.weight = tx3.weight - tx1.weight + 0.1
             tx5.parents = [tx2.hash, tx4.hash]
@@ -120,10 +125,10 @@ class DoubleSpendingTestCase(unittest.TestCase):
 
         addr = manager.wallet.get_unused_address()
         outputs = []
-        outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
-        outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
-        outputs.append(WalletOutputInfo(decode_address(addr), 1000, None))
-        outputs.append(WalletOutputInfo(decode_address(addr), 6400-1002, None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1000), None))
+        outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(6400-1002), None))
         tx_fund0 = manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, manager.tx_storage)
         tx_fund0.weight = 1
         tx_fund0.parents = manager.get_new_tx_parents()
@@ -133,7 +138,7 @@ class DoubleSpendingTestCase(unittest.TestCase):
 
         def do_step(tx_fund: Transaction) -> Transaction:
             inputs = [WalletInputInfo(tx_fund.hash, 0, manager.wallet.get_private_key(addr))]
-            outputs = [WalletOutputInfo(decode_address(addr), 1, None)]
+            outputs = [WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None)]
             tx1 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx_fund.timestamp+1)
             tx1.weight = 1
             tx1.parents = manager.get_new_tx_parents(tx1.timestamp)
@@ -143,7 +148,7 @@ class DoubleSpendingTestCase(unittest.TestCase):
             inputs = []
             inputs.append(WalletInputInfo(tx1.hash, 0, manager.wallet.get_private_key(addr)))
             inputs.append(WalletInputInfo(tx_fund.hash, 1, manager.wallet.get_private_key(addr)))
-            outputs = [WalletOutputInfo(decode_address(addr), 2, None)]
+            outputs = [WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(2), None)]
             tx2 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx1.timestamp+1)
             tx2.weight = 1.1
             tx2.parents = manager.get_new_tx_parents(tx2.timestamp)
@@ -153,7 +158,9 @@ class DoubleSpendingTestCase(unittest.TestCase):
             inputs = []
             inputs.append(WalletInputInfo(tx_fund.hash, 2, manager.wallet.get_private_key(addr)))
             inputs.append(WalletInputInfo(tx_fund.hash, 1, manager.wallet.get_private_key(addr)))
-            outputs = [WalletOutputInfo(decode_address(addr), tx_fund.outputs[2].value+1, None)]
+            outputs = [
+                WalletOutputInfo(decode_address(addr), tx_fund.outputs[2].value + UnsignedAmount.from_v1(1), None)
+            ]
             tx3 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx_fund.timestamp+1)
             tx3.weight = 1
             tx3.parents = manager.get_new_tx_parents(tx3.timestamp)
@@ -163,7 +170,9 @@ class DoubleSpendingTestCase(unittest.TestCase):
             inputs = []
             inputs.append(WalletInputInfo(tx_fund.hash, 0, manager.wallet.get_private_key(addr)))
             inputs.append(WalletInputInfo(tx_fund.hash, 2, manager.wallet.get_private_key(addr)))
-            outputs = [WalletOutputInfo(decode_address(addr), tx_fund.outputs[2].value+1, None)]
+            outputs = [
+                WalletOutputInfo(decode_address(addr), tx_fund.outputs[2].value + UnsignedAmount.from_v1(1), None)
+            ]
             tx4 = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx_fund.timestamp+1)
             tx4.weight = tx1.weight + tx2.weight + 0.1
             tx4.parents = manager.get_new_tx_parents(tx4.timestamp)
@@ -174,9 +183,11 @@ class DoubleSpendingTestCase(unittest.TestCase):
             inputs.append(WalletInputInfo(tx3.hash, 0, manager.wallet.get_private_key(addr)))
             inputs.append(WalletInputInfo(tx4.hash, 0, manager.wallet.get_private_key(addr)))
             outputs = []
-            outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
-            outputs.append(WalletOutputInfo(decode_address(addr), 1, None))
-            outputs.append(WalletOutputInfo(decode_address(addr), 2*tx_fund.outputs[2].value, None))
+            outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None))
+            outputs.append(WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(1), None))
+            outputs.append(
+                WalletOutputInfo(decode_address(addr), UnsignedAmount.from_v1(2*tx_fund.outputs[2].value), None)
+            )
             tx5: Transaction = manager.wallet.prepare_transaction(Transaction, inputs, outputs, tx4.timestamp+1)
             tx5.weight = 1
             tx5.parents = manager.get_new_tx_parents(tx5.timestamp)

--- a/hathor_tests/consensus/test_soft_voided.py
+++ b/hathor_tests/consensus/test_soft_voided.py
@@ -10,6 +10,7 @@ from hathor.simulator.utils import gen_new_tx
 from hathor.transaction import Block
 from hathor.types import VertexId
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_custom_tx
 
 
@@ -88,7 +89,7 @@ class SoftVoidedTestCase(SimulatorTestCase):
 
         assert manager2.wallet is not None
         address = manager2.wallet.get_unused_address(mark_as_used=False)
-        value = 1
+        value = UnsignedAmount.from_v1(1)
         simulator.run_to_completion()
         txC = gen_new_tx(manager2, address, value)
         txC.parents[0] = txA.hash

--- a/hathor_tests/consensus/test_soft_voided2.py
+++ b/hathor_tests/consensus/test_soft_voided2.py
@@ -11,6 +11,7 @@ from hathor.transaction import Block, Transaction
 from hathor.types import VertexId
 from hathor.wallet import HDWallet
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import BURN_ADDRESS, add_custom_tx
 
 
@@ -123,7 +124,7 @@ class ConsensusSimulatorTestCase(SimulatorTestCase):
 
         assert manager1.wallet is not None
         address = manager1.wallet.get_unused_address(mark_as_used=False)
-        value = 10
+        value = UnsignedAmount.from_v1(10)
         initial = gen_new_tx(manager1, address, value)
         initial.weight = 25
         initial.update_hash()

--- a/hathor_tests/consensus/test_soft_voided3.py
+++ b/hathor_tests/consensus/test_soft_voided3.py
@@ -10,6 +10,7 @@ from hathor.simulator.utils import gen_new_tx
 from hathor.transaction import BaseTransaction
 from hathor.types import VertexId
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_custom_tx, gen_custom_tx
 
 
@@ -95,7 +96,7 @@ class SoftVoidedTestCase(SimulatorTestCase):
         simulator.run(10)
         assert manager2.wallet is not None
         address = manager2.wallet.get_unused_address(mark_as_used=True)
-        txC = gen_new_tx(manager2, address, 6400)
+        txC = gen_new_tx(manager2, address, UnsignedAmount.from_v1(6400))
         if txD1.hash not in txC.parents:
             txC.parents[1] = txD1.hash
         txC.weight = 25

--- a/hathor_tests/feature_activation/test_feature_simulation.py
+++ b/hathor_tests/feature_activation/test_feature_simulation.py
@@ -21,6 +21,7 @@ from hathor.transaction.exceptions import BlockMustSignalError
 from hathor.util import not_none
 from hathor_tests.resources.base_resource import StubSite
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class BaseFeatureSimulationTest(SimulatorTestCase):
@@ -100,7 +101,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at the beginning, the feature is DEFINED:
             [*_, last_block] = add_new_blocks(manager, 10)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*10)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*10))
             tx.weight = 25
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -138,7 +139,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 19, the feature is DEFINED, just before becoming STARTED:
             [*_, last_block] = add_new_blocks(manager, 9)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*19)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*19))
             tx.weight = 25
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -175,7 +176,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 20, the feature becomes STARTED:
             [*_, last_block] = add_new_blocks(manager, 1)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*20)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*20))
             tx.weight = 25
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -214,7 +215,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 55, the feature is STARTED, just before becoming MUST_SIGNAL:
             [*_, last_block] = add_new_blocks(manager, 34)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*55)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*55))
             tx.weight = 30
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -250,7 +251,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 56, the feature becomes MUST_SIGNAL:
             [*_, last_block] = add_new_blocks(manager, 1)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*56)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*56))
             tx.weight = 30
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -301,7 +302,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 59, the feature is MUST_SIGNAL, just before becoming LOCKED_IN:
             [*_, last_block] = add_new_blocks(manager, num_blocks=2, signal_bits=0b1)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*59)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*59))
             tx.weight = 30
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -338,7 +339,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 60, the feature becomes LOCKED_IN:
             [*_, last_block] = add_new_blocks(manager, 1)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*60)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*60))
             tx.weight = 30
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -377,7 +378,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 71, the feature is LOCKED_IN, just before becoming ACTIVE:
             [*_, last_block] = add_new_blocks(manager, 10)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*71)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*71))
             tx.weight = 30
             tx.update_hash()
             assert manager.propagate_tx(tx)
@@ -413,7 +414,7 @@ class BaseFeatureSimulationTest(SimulatorTestCase):
             # at block 72, the feature becomes ACTIVE, forever:
             [*_, last_block] = add_new_blocks(manager, 1)
             self.simulator.run(60)
-            tx = gen_new_tx(manager, address, 6400*72)
+            tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(6400*72))
             tx.weight = 30
             tx.update_hash()
             assert manager.propagate_tx(tx)

--- a/hathor_tests/nanocontracts/blueprints/test_swap_demo.py
+++ b/hathor_tests/nanocontracts/blueprints/test_swap_demo.py
@@ -6,6 +6,7 @@ from hathor.nanocontracts.storage.contract_storage import Balance
 from hathor.nanocontracts.types import NCDepositAction, NCWithdrawalAction, TokenUid
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.test_blueprints.swap_demo import InvalidActions, InvalidRatio, InvalidTokens, SwapDemo
+from hathor_tests.token_amount import UnsignedAmount
 
 SWAP_NC_TYPE = make_nc_type(int)
 
@@ -84,10 +85,12 @@ class SwapDemoTestCase(BlueprintTestCase):
 
         # Assert:
         self.assertEqual(
-            Balance(value=100_00, can_mint=False, can_melt=False), self.nc_storage.get_balance(self.token_a)
+            Balance(value=UnsignedAmount.from_v1(100_00).to_signed(), can_mint=False, can_melt=False),
+            self.nc_storage.get_balance(self.token_a),
         )
         self.assertEqual(
-            Balance(value=100_00, can_mint=False, can_melt=False), self.nc_storage.get_balance(self.token_b)
+            Balance(value=UnsignedAmount.from_v1(100_00).to_signed(), can_mint=False, can_melt=False),
+            self.nc_storage.get_balance(self.token_b),
         )
         self.assertEqual(0, self.nc_storage.get_obj(b'swaps_counter', SWAP_NC_TYPE))
 
@@ -96,10 +99,12 @@ class SwapDemoTestCase(BlueprintTestCase):
         self._swap((20_00, self.token_a), (-20_00, self.token_b))
         # Assert:
         self.assertEqual(
-            Balance(value=120_00, can_mint=False, can_melt=False), self.nc_storage.get_balance(self.token_a)
+            Balance(value=UnsignedAmount.from_v1(120_00).to_signed(), can_mint=False, can_melt=False),
+            self.nc_storage.get_balance(self.token_a),
         )
         self.assertEqual(
-            Balance(value=80_00, can_mint=False, can_melt=False), self.nc_storage.get_balance(self.token_b)
+            Balance(value=UnsignedAmount.from_v1(80_00).to_signed(), can_mint=False, can_melt=False),
+            self.nc_storage.get_balance(self.token_b),
         )
         self.assertEqual(1, self.nc_storage.get_obj(b'swaps_counter', SWAP_NC_TYPE))
 

--- a/hathor_tests/nanocontracts/test_authorities_call_another.py
+++ b/hathor_tests/nanocontracts/test_authorities_call_another.py
@@ -9,6 +9,7 @@ from hathor.nanocontracts.storage.contract_storage import Balance
 from hathor.nanocontracts.types import ContractId, NCAcquireAuthorityAction, NCAction, NCGrantAuthorityAction, TokenUid
 from hathor.transaction.token_info import TokenVersion
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import SignedAmount
 
 
 class CalleeBlueprint(Blueprint):
@@ -169,43 +170,67 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
 
     def test_grant_mint_success(self) -> None:
         self._initialize(caller_actions=[NCGrantAuthorityAction(token_uid=self.token_a, mint=True, melt=False)])
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
         self._grant_to_other(mint=True, melt=False)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=False
+        )
 
     def test_revoke_mint_success(self) -> None:
         self.test_grant_mint_success()
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=False
+        )
         self._revoke_from_other(mint=True, melt=False)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
     def test_grant_mint_fail(self) -> None:
         self._initialize()
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
         msg = f'GRANT_AUTHORITY token {self.token_a.hex()} requires mint, but contract does not have that authority'
         with pytest.raises(NCInvalidAction, match=msg):
             self._grant_to_other(mint=True, melt=False)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
     def test_grant_melt_success(self) -> None:
         self._initialize(caller_actions=[NCGrantAuthorityAction(token_uid=self.token_a, mint=False, melt=True)])
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
         self._grant_to_other(mint=False, melt=True)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=True)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=True
+        )
 
     def test_revoke_melt_success(self) -> None:
         self.test_grant_melt_success()
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=True)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=True
+        )
         self._revoke_from_other(mint=False, melt=True)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
     def test_grant_melt_fail(self) -> None:
         self._initialize()
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
         msg = f'GRANT_AUTHORITY token {self.token_a.hex()} requires melt, but contract does not have that authority'
         with pytest.raises(NCInvalidAction, match=msg):
             self._grant_to_other(mint=False, melt=True)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
     def test_acquire_mint(self) -> None:
         self._initialize()
@@ -216,8 +241,12 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
             timestamp=self.now
         )
         self.runner.call_public_method(self.callee_id, 'nop', context)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=False)
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=False
+        )
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
         context = self.create_context(
             actions=[],
@@ -229,8 +258,12 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
             self.caller_id, 'acquire_another', context, token_uid=self.token_a, mint=True, melt=False
         )
 
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=False)
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=False
+        )
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=False
+        )
 
     def test_acquire_melt(self) -> None:
         self._initialize()
@@ -241,8 +274,12 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
             timestamp=self.now
         )
         self.runner.call_public_method(self.callee_id, 'nop', context)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=True)
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=True
+        )
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
         context = self.create_context(
             actions=[],
@@ -254,12 +291,18 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
             self.caller_id, 'acquire_another', context, token_uid=self.token_a, mint=False, melt=True
         )
 
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=True)
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=True)
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=True
+        )
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=True
+        )
 
     def test_grant_and_revoke_single_contract(self) -> None:
         self._initialize()
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
         self._revoke_from_self(
             self.caller_id,
             actions=[NCGrantAuthorityAction(token_uid=self.token_a, mint=True, melt=True)],
@@ -267,13 +310,19 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
             melt=True,
         )
         # actions run before the method, so the final result is revoked.
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
     def test_revoke_then_grant_same_call_another_contract(self) -> None:
         self._initialize(caller_actions=[NCGrantAuthorityAction(token_uid=self.token_a, mint=True, melt=True)])
         self._grant_to_other(mint=True, melt=True)
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=True)
-        assert self.callee_storage.get_balance(self.token_a) == Balance(value=0, can_mint=True, can_melt=True)
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=True
+        )
+        assert self.callee_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=True
+        )
         context = self.create_context(
             actions=[],
             vertex=self.tx,
@@ -282,7 +331,9 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
         )
         self.runner.call_public_method(self.caller_id, 'call_grant_all_to_other_then_revoke', context, self.token_a)
         # the main call calls the revoke syscall last, so the final result is revoked.
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
     def test_grant_then_revoke_same_call_another_contract(self) -> None:
         self._initialize()
@@ -294,4 +345,6 @@ class TestAuthoritiesCallAnother(BlueprintTestCase):
         )
         self.runner.call_public_method(self.caller_id, 'call_revoke_all_from_other', context, self.token_a)
         # actions run before the method, so the final result is revoked.
-        assert self.caller_storage.get_balance(self.token_a) == Balance(value=0, can_mint=False, can_melt=False)
+        assert self.caller_storage.get_balance(self.token_a) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )

--- a/hathor_tests/nanocontracts/test_authorities_index.py
+++ b/hathor_tests/nanocontracts/test_authorities_index.py
@@ -15,6 +15,7 @@ from hathor.wallet import HDWallet
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.utils import set_nano_header
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 
 
 class MyBlueprint(Blueprint):
@@ -84,7 +85,11 @@ class TestAuthoritiesIndex(BlueprintTestCase):
             wallet=self.wallet,
             nc_id=self.blueprint_id,
             nc_actions=[
-                NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.ALL_AUTHORITIES)
+                NanoHeaderAction(
+                    type=NCActionType.GRANT_AUTHORITY,
+                    token_index=1,
+                    amount=UnsignedAmount.from_v1(TxOutput.ALL_AUTHORITIES),
+                )
             ],
             nc_method='initialize',
             blueprint=MyBlueprint,
@@ -104,7 +109,9 @@ class TestAuthoritiesIndex(BlueprintTestCase):
         assert tka.get_metadata().nc_execution == NCExecutionState.SUCCESS
 
         storage = self.manager.get_best_block_nc_storage(tka.hash)
-        assert storage.get_balance(tka.hash) == Balance(value=0, can_mint=True, can_melt=True)
+        assert storage.get_balance(tka.hash) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=True
+        )
 
         token_info = self.tokens_index.get_token_info(tka.hash)
         assert list(token_info.iter_mint_utxos()) == []
@@ -129,7 +136,9 @@ class TestAuthoritiesIndex(BlueprintTestCase):
         assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
 
         storage = self.manager.get_best_block_nc_storage(tka.hash)
-        assert storage.get_balance(tka.hash) == Balance(value=0, can_mint=False, can_melt=False)
+        assert storage.get_balance(tka.hash) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
         token_info = self.tokens_index.get_token_info(tka.hash)
         assert list(token_info.iter_mint_utxos()) == []
@@ -166,7 +175,11 @@ class TestAuthoritiesIndex(BlueprintTestCase):
             wallet=self.wallet,
             nc_id=self.blueprint_id,
             nc_actions=[
-                NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.ALL_AUTHORITIES)
+                NanoHeaderAction(
+                    type=NCActionType.GRANT_AUTHORITY,
+                    token_index=1,
+                    amount=UnsignedAmount.from_v1(TxOutput.ALL_AUTHORITIES),
+                )
             ],
             nc_method='initialize',
             blueprint=MyBlueprint,
@@ -188,7 +201,9 @@ class TestAuthoritiesIndex(BlueprintTestCase):
         assert tka.get_metadata().nc_execution == NCExecutionState.SUCCESS
 
         storage = self.manager.get_best_block_nc_storage(tka.hash)
-        assert storage.get_balance(tka.hash) == Balance(value=0, can_mint=True, can_melt=True)
+        assert storage.get_balance(tka.hash) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=True
+        )
 
         token_info = self.tokens_index.get_token_info(tka.hash)
         assert list(token_info.iter_mint_utxos()) == []
@@ -260,7 +275,9 @@ class TestAuthoritiesIndex(BlueprintTestCase):
         assert nc2b.get_metadata().nc_execution is None
 
         nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
-        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=True, can_melt=True)
+        assert nc1_storage.get_balance(tka) == Balance(
+            value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True
+        )
 
         token_info = self.tokens_index.get_token_info(tka)
         assert list(token_info.iter_mint_utxos()) == []
@@ -274,8 +291,12 @@ class TestAuthoritiesIndex(BlueprintTestCase):
 
         nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
         nc2_storage = self.manager.get_best_block_nc_storage(nc2a.hash)
-        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=True, can_melt=True)
-        assert nc2_storage.get_balance(tka) == Balance(value=0, can_mint=True, can_melt=True)
+        assert nc1_storage.get_balance(tka) == Balance(
+            value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True
+        )
+        assert nc2_storage.get_balance(tka) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=True
+        )
 
         token_info = self.tokens_index.get_token_info(tka)
         assert list(token_info.iter_mint_utxos()) == []
@@ -289,8 +310,12 @@ class TestAuthoritiesIndex(BlueprintTestCase):
 
         nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
         nc2_storage = self.manager.get_best_block_nc_storage(nc2a.hash)
-        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=False, can_melt=False)
-        assert nc2_storage.get_balance(tka) == Balance(value=0, can_mint=True, can_melt=True)
+        assert nc1_storage.get_balance(tka) == Balance(
+            value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+        )
+        assert nc2_storage.get_balance(tka) == Balance(
+            value=SignedAmount(), can_mint=True, can_melt=True
+        )
 
         token_info = self.tokens_index.get_token_info(tka)
         assert list(token_info.iter_mint_utxos()) == []
@@ -304,8 +329,12 @@ class TestAuthoritiesIndex(BlueprintTestCase):
 
         nc1_storage = self.manager.get_best_block_nc_storage(nc1a.hash)
         nc2_storage = self.manager.get_best_block_nc_storage(nc2a.hash)
-        assert nc1_storage.get_balance(tka) == Balance(value=1000, can_mint=False, can_melt=False)
-        assert nc2_storage.get_balance(tka) == Balance(value=0, can_mint=False, can_melt=False)
+        assert nc1_storage.get_balance(tka) == Balance(
+            value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+        )
+        assert nc2_storage.get_balance(tka) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
         token_info = self.tokens_index.get_token_info(tka)
         assert list(token_info.iter_mint_utxos()) == []

--- a/hathor_tests/nanocontracts/test_blueprint.py
+++ b/hathor_tests/nanocontracts/test_blueprint.py
@@ -17,6 +17,7 @@ from hathor.nanocontracts.types import (
     view,
 )
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 
 STR_NC_TYPE = make_nc_type(str)
 BYTES_NC_TYPE = make_nc_type(bytes)
@@ -205,7 +206,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self._create_my_blueprint_contract()
         nc_id = self.my_blueprint_id
         storage = self.runner.get_storage(nc_id)
-        self.assertEqual(Balance(value=0, can_mint=False, can_melt=False), storage.get_balance(MOCK_ADDRESS))
+        self.assertEqual(
+            Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            storage.get_balance(MOCK_ADDRESS),
+        )
 
     def test_nop(self) -> None:
         self._create_my_blueprint_contract()
@@ -238,7 +242,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
             timestamp=0,
         )
         self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=100, can_mint=False, can_melt=False), storage.get_balance(token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid),
+        )
 
         ctx = self.create_context(
             [NCWithdrawalAction(token_uid=token_uid, amount=1)],
@@ -247,7 +254,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
             timestamp=0,
         )
         self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=99, can_mint=False, can_melt=False), storage.get_balance(token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(99).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid),
+        )
 
         ctx = self.create_context(
             [NCWithdrawalAction(token_uid=token_uid, amount=50)],
@@ -256,7 +266,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
             timestamp=0,
         )
         self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=49, can_mint=False, can_melt=False), storage.get_balance(token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(49).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid),
+        )
 
         ctx = self.create_context(
             [NCWithdrawalAction(token_uid=token_uid, amount=50)],
@@ -282,7 +295,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
             timestamp=0,
         )
         self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=100, can_mint=False, can_melt=False), storage.get_balance(token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid),
+        )
 
         ctx = self.create_context(
             [NCWithdrawalAction(token_uid=wrong_token_uid, amount=1)],
@@ -292,7 +308,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
         )
         with self.assertRaises(NCInsufficientFunds):
             self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=100, can_mint=False, can_melt=False), storage.get_balance(token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid),
+        )
 
     def test_invalid_field(self) -> None:
         with self.assertRaises(BlueprintSyntaxError):
@@ -316,7 +335,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
             timestamp=0,
         )
         self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=100, can_mint=False, can_melt=False), storage.get_balance(token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid),
+        )
 
         token_uid2 = TokenUid(b'\0' + b'\1' * 31)
         ctx = self.create_context(
@@ -326,7 +348,10 @@ class NCBlueprintTestCase(BlueprintTestCase):
             timestamp=0,
         )
         self.runner.call_public_method(nc_id, 'nop', ctx)
-        self.assertEqual(Balance(value=200, can_mint=False, can_melt=False), storage.get_balance(token_uid2))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(200).to_signed(), can_mint=False, can_melt=False),
+            storage.get_balance(token_uid2),
+        )
 
         all_balances = storage.get_all_balances()
         key1 = BalanceKey(nc_id, token_uid)
@@ -335,7 +360,7 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self.assertEqual(
             all_balances,
             {
-                key1: Balance(value=100, can_mint=False, can_melt=False),
-                key2: Balance(value=200, can_mint=False, can_melt=False),
+                key1: Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=False, can_melt=False),
+                key2: Balance(value=UnsignedAmount.from_v1(200).to_signed(), can_mint=False, can_melt=False),
             }
         )

--- a/hathor_tests/nanocontracts/test_call_other_contract.py
+++ b/hathor_tests/nanocontracts/test_call_other_contract.py
@@ -28,6 +28,7 @@ from hathor.nanocontracts.types import (
 )
 from hathor.transaction.token_info import TokenVersion
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 
 COUNTER_NC_TYPE = make_nc_type(int)
 CONTRACT_NC_TYPE: NCType[ContractId | None] = make_nc_type(ContractId | None)  # type: ignore[arg-type]
@@ -270,13 +271,19 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self.create_token(token3_uid, 'tk3', 'tk3', TokenVersion.DEPOSIT)
 
         self.assertEqual(
-            Balance(value=11, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(11).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=12, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token2_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(12).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=13, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token3_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(13).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token3_uid)
         )
 
         actions = [
@@ -287,13 +294,19 @@ class NCBlueprintTestCase(BlueprintTestCase):
         ctx = self.create_context(actions, self.tx, MOCK_ADDRESS)
         self.runner.create_contract(self.nc2_id, self.blueprint_id, ctx, 0)
         self.assertEqual(
-            Balance(value=21, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(21).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=22, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token2_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(22).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=23, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token3_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(23).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token3_uid)
         )
 
         actions = [
@@ -304,13 +317,19 @@ class NCBlueprintTestCase(BlueprintTestCase):
         ctx = self.create_context(actions, self.tx, MOCK_ADDRESS)
         self.runner.create_contract(self.nc3_id, self.blueprint_id, ctx, 0)
         self.assertEqual(
-            Balance(value=31, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(31).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=32, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token2_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(32).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=33, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token3_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(33).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token3_uid)
         )
 
         ctx = self.create_context()
@@ -326,33 +345,51 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self.runner.call_public_method(self.nc1_id, 'get_tokens_from_another_contract', ctx)
 
         self.assertEqual(
-            Balance(value=4, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(4).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=0, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token2_uid)
+            Balance(
+               value=SignedAmount(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=0, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token3_uid)
-        )
-
-        self.assertEqual(
-            Balance(value=21, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token1_uid)
-        )
-        self.assertEqual(
-            Balance(value=16, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token2_uid)
-        )
-        self.assertEqual(
-            Balance(value=0, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token3_uid)
+            Balance(
+               value=SignedAmount(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token3_uid)
         )
 
         self.assertEqual(
-            Balance(value=31, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(21).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=32, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token2_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(16).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=4, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token3_uid)
+            Balance(
+               value=SignedAmount(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token3_uid)
+        )
+
+        self.assertEqual(
+            Balance(
+               value=UnsignedAmount.from_v1(31).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token1_uid)
+        )
+        self.assertEqual(
+            Balance(
+               value=UnsignedAmount.from_v1(32).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token2_uid)
+        )
+        self.assertEqual(
+            Balance(
+               value=UnsignedAmount.from_v1(4).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token3_uid)
         )
 
         ctx = self.create_context(
@@ -395,33 +432,51 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self.runner.call_public_method(self.nc1_id, 'split_balance', ctx)
 
         self.assertEqual(
-            Balance(value=49, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(49).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=24, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token2_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(24).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=12, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc1_id, token3_uid)
-        )
-
-        self.assertEqual(
-            Balance(value=25, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token1_uid)
-        )
-        self.assertEqual(
-            Balance(value=12, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token2_uid)
-        )
-        self.assertEqual(
-            Balance(value=6, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc2_id, token3_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(12).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc1_id, token3_uid)
         )
 
         self.assertEqual(
-            Balance(value=26, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token1_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(25).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token1_uid)
         )
         self.assertEqual(
-            Balance(value=14, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token2_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(12).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token2_uid)
         )
         self.assertEqual(
-            Balance(value=7, can_mint=False, can_melt=False), self.runner.get_current_balance(self.nc3_id, token3_uid)
+            Balance(
+               value=UnsignedAmount.from_v1(6).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc2_id, token3_uid)
+        )
+
+        self.assertEqual(
+            Balance(
+               value=UnsignedAmount.from_v1(26).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token1_uid)
+        )
+        self.assertEqual(
+            Balance(
+               value=UnsignedAmount.from_v1(14).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token2_uid)
+        )
+        self.assertEqual(
+            Balance(
+               value=UnsignedAmount.from_v1(7).to_signed(), can_mint=False, can_melt=False
+           ), self.runner.get_current_balance(self.nc3_id, token3_uid)
         )
 
     def test_loop(self) -> None:

--- a/hathor_tests/nanocontracts/test_contract_create_contract.py
+++ b/hathor_tests/nanocontracts/test_contract_create_contract.py
@@ -23,6 +23,7 @@ from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import UnsignedAmount
 from hathorlib.token_amount_version import TokenAmountVersion
 
 INT_NC_TYPE = make_nc_type(int)
@@ -114,7 +115,7 @@ class NCBlueprintTestCase(BlueprintTestCase):
 
         nc_id = nc1_id
         expected = counter
-        remainder = deposit
+        remainder = UnsignedAmount.from_v1(deposit).to_signed()
         while True:
             nc_storage = self.runner.get_storage(nc_id)
             counter = nc_storage.get_obj(b'counter', INT_NC_TYPE)
@@ -124,7 +125,9 @@ class NCBlueprintTestCase(BlueprintTestCase):
             if new_nc_id is not None:
                 expected_nc_id = derive_child_contract_id(nc_id, b'x', self.blueprint1_id)
                 assert new_nc_id == expected_nc_id
-                assert balance == Balance(value=expected, can_mint=False, can_melt=False)
+                assert balance == Balance(
+                    value=UnsignedAmount.from_v1(expected).to_signed(), can_mint=False, can_melt=False
+                )
                 remainder -= balance.value
             else:
                 assert balance.value == remainder
@@ -212,7 +215,7 @@ class NCBlueprintTestCase(BlueprintTestCase):
         grant_action = NanoHeaderAction(
             type=NCActionType.GRANT_AUTHORITY,
             token_index=1,
-            amount=TxOutput.ALL_AUTHORITIES,
+            amount=UnsignedAmount.from_v1(TxOutput.ALL_AUTHORITIES),
         )
         nc1_header.nc_actions.append(grant_action)
         # XXX: Dirty hack, by purposefully not clearing the cache, we don't have to re-sign the nano header.
@@ -290,7 +293,7 @@ class NCBlueprintTestCase(BlueprintTestCase):
         # -2 from the TKA mint in nc1.out[0]
         # -5 from the mint in nc5.nc_method
         # +1 from the melt in nc6.nc_method
-        assert htr_total == (
+        assert htr_total == UnsignedAmount.from_v1(
             self._settings.GENESIS_TOKEN_ATOMIC_UNITS
             + 34 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
             - 2 - 5 + 1
@@ -298,7 +301,7 @@ class NCBlueprintTestCase(BlueprintTestCase):
         # 200 from nc1.out[0]
         # +456 from nc5.nc_method
         # -123 from nc6.nc_method
-        assert tka_total == 200 + 456 - 123
+        assert tka_total == UnsignedAmount.from_v1(200 + 456 - 123)
 
         # nc_history
         expected_list = [
@@ -344,11 +347,11 @@ class NCBlueprintTestCase(BlueprintTestCase):
         assert self.manager.tx_storage.get_height_best_block() == 50
         # TODO: Is there a bug in the token index? It should be 50, not 52 blocks
         # genesis + 50 blocks - 2 from the TKA mint in nc1.out[0]
-        assert htr_total == (
+        assert htr_total == UnsignedAmount.from_v1(
             self._settings.GENESIS_TOKEN_ATOMIC_UNITS + 52 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 2
         )
         # 200 from nc1.out[0]
-        assert tka_total == 200
+        assert tka_total == UnsignedAmount.from_v1(200)
 
         # nc_history
         expected_list = [

--- a/hathor_tests/nanocontracts/test_indexes2.py
+++ b/hathor_tests/nanocontracts/test_indexes2.py
@@ -9,6 +9,7 @@ from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor.transaction.util import get_deposit_token_deposit_amount
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class MyBlueprint(Blueprint):
@@ -49,9 +50,10 @@ class TestIndexes2(BlueprintTestCase):
         htr_token_info = self.tokens_index.get_token_info(HATHOR_TOKEN_UID)
 
         assert tx1.get_metadata().nc_execution == NCExecutionState.SUCCESS
-        assert tka_token_info.get_total() == amount
-        assert htr_token_info.get_total() == (
-            self._settings.GENESIS_TOKEN_ATOMIC_UNITS
-            + 11 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
-            - get_deposit_token_deposit_amount(self._settings, amount)
+        assert tka_token_info.get_total() == UnsignedAmount.from_v1(amount)
+        expected_htr = (
+            UnsignedAmount.from_v1(self._settings.GENESIS_TOKEN_ATOMIC_UNITS)
+            + UnsignedAmount.from_v1(11 * self._settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
+            - get_deposit_token_deposit_amount(self._settings, UnsignedAmount.from_v1(amount))
         )
+        assert htr_token_info.get_total() == expected_htr

--- a/hathor_tests/nanocontracts/test_nanocontract.py
+++ b/hathor_tests/nanocontracts/test_nanocontract.py
@@ -49,6 +49,7 @@ from hathor.verification.nano_header_verifier import MAX_NC_SCRIPT_SIGOPS_COUNT,
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import KeyPair
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 STR_NC_TYPE = make_nc_type(str)
 INT_NC_TYPE = make_nc_type(int)
@@ -416,9 +417,9 @@ class NCNanoContractTestCase(unittest.TestCase):
 
         # Incomplete transaction. It will be used as input of nc2.
         outputs = [
-            TxOutput(100, b'', 0),  # HTR
-            TxOutput(200, b'', 1),  # TOKEN A
-            TxOutput(300, b'', 2),  # TOKEN B
+            TxOutput(UnsignedAmount.from_v1(100), b'', 0),  # HTR
+            TxOutput(UnsignedAmount.from_v1(200), b'', 1),  # TOKEN A
+            TxOutput(UnsignedAmount.from_v1(300), b'', 2),  # TOKEN B
         ]
         tokens = [b'token-a', b'token-b']
         tx = Transaction(outputs=outputs, tokens=tokens)
@@ -435,9 +436,9 @@ class NCNanoContractTestCase(unittest.TestCase):
             TxInput(tx.hash, 2, b''),
         ]
         outputs = [
-            TxOutput(10, b'', 0),   # HTR
-            TxOutput(250, b'', 1),  # TOKEN A
-            TxOutput(300, b'', 2),  # TOKEN B
+            TxOutput(UnsignedAmount.from_v1(10), b'', 0),   # HTR
+            TxOutput(UnsignedAmount.from_v1(250), b'', 1),  # TOKEN A
+            TxOutput(UnsignedAmount.from_v1(300), b'', 2),  # TOKEN B
         ]
         nc2 = Transaction(
             weight=1,
@@ -458,12 +459,12 @@ class NCNanoContractTestCase(unittest.TestCase):
                 NanoHeaderAction(
                     type=NCActionType.WITHDRAWAL,
                     token_index=1,
-                    amount=50,
+                    amount=UnsignedAmount.from_v1(50),
                 ),
                 NanoHeaderAction(
                     type=NCActionType.DEPOSIT,
                     token_index=0,
-                    amount=90,
+                    amount=UnsignedAmount.from_v1(90),
                 ),
             ],
         ))

--- a/hathor_tests/nanocontracts/test_reentrancy.py
+++ b/hathor_tests/nanocontracts/test_reentrancy.py
@@ -5,7 +5,7 @@ from hathor.nanocontracts import Blueprint, Context, NCFail, public
 from hathor.nanocontracts.exception import NCForbiddenReentrancy
 from hathor.nanocontracts.types import Amount, CallerId, ContractId, NCAction, NCDepositAction, TokenUid
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
-from hathorlib.token_amount import SignedAmount
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 
 HTR_TOKEN_UID = TokenUid(b'\0')
 
@@ -170,7 +170,7 @@ class NCReentrancyTestCase(BlueprintTestCase):
         self.target_storage = self.runner.get_storage(self.nc_target_id)
         self.attacker_storage = self.runner.get_storage(self.nc_attacker_id)
 
-        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150
+        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(10_150).to_signed()
         assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == SignedAmount(0)
 
     def test_basics(self) -> None:
@@ -185,8 +185,8 @@ class NCReentrancyTestCase(BlueprintTestCase):
             method='nop',
         )
 
-        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150 - 30
-        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == 0 + 30
+        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(10_150 - 30).to_signed()
+        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(0 + 30).to_signed()
 
         # Address1 tries to send 0.80 HTR but it fails due to insufficient balance.
         # This misleads developers into thinking the safety mechanism is working.
@@ -201,8 +201,8 @@ class NCReentrancyTestCase(BlueprintTestCase):
                 method='nop',
             )
 
-        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150 - 30
-        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == 0 + 30
+        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(10_150 - 30).to_signed()
+        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(0 + 30).to_signed()
 
     def test_attack_succeed(self) -> None:
         # Attacker contract has a balance of 0.50 HTR in the target contract.
@@ -214,8 +214,10 @@ class NCReentrancyTestCase(BlueprintTestCase):
             ctx,
         )
 
-        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150 - self.n_calls * 50
-        assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == self.n_calls * 50
+        actual_target = self.target_storage.get_balance(HTR_TOKEN_UID).value
+        actual_attacker = self.attacker_storage.get_balance(HTR_TOKEN_UID).value
+        assert actual_target == UnsignedAmount.from_v1(10_150 - self.n_calls * 50).to_signed()
+        assert actual_attacker == UnsignedAmount.from_v1(self.n_calls * 50).to_signed()
 
     def test_attack_fail_fixed(self) -> None:
         # Attacker contract has a balance of 0.50 HTR in the target contract.
@@ -228,7 +230,7 @@ class NCReentrancyTestCase(BlueprintTestCase):
                 ctx,
             )
 
-        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150
+        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(10_150).to_signed()
         assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == SignedAmount(0)
 
     def test_attack_fail_protected(self) -> None:
@@ -242,5 +244,5 @@ class NCReentrancyTestCase(BlueprintTestCase):
                 ctx,
             )
 
-        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == 10_150
+        assert self.target_storage.get_balance(HTR_TOKEN_UID).value == UnsignedAmount.from_v1(10_150).to_signed()
         assert self.attacker_storage.get_balance(HTR_TOKEN_UID).value == SignedAmount(0)

--- a/hathor_tests/nanocontracts/test_syscalls.py
+++ b/hathor_tests/nanocontracts/test_syscalls.py
@@ -24,6 +24,7 @@ from hathor.nanocontracts.types import (
 )
 from hathor.transaction.token_info import TokenVersion
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 
 CONTRACT_NC_TYPE = make_nc_type(ContractId)
 BLUEPRINT_NC_TYPE = make_nc_type(BlueprintId)
@@ -219,36 +220,36 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Starting state
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            dbt_balance_key: Balance(value=1000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True),
         }
 
         # After mint
         self.runner.call_public_method(nc_id, 'mint', ctx, dbt_token_uid, 123)
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=998, can_mint=False, can_melt=False),
-            dbt_balance_key: Balance(value=1123, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(998).to_signed(), can_mint=False, can_melt=False),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(1123).to_signed(), can_mint=True, can_melt=True),
         }
 
         # After melt
         self.runner.call_public_method(nc_id, 'melt', ctx, dbt_token_uid, 456)
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=1002, can_mint=False, can_melt=False),
-            dbt_balance_key: Balance(value=667, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(1002).to_signed(), can_mint=False, can_melt=False),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(667).to_signed(), can_mint=True, can_melt=True),
         }
 
         # After revoke mint
         self.runner.call_public_method(nc_id, 'revoke', ctx, dbt_token_uid, True, False)
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=1002, can_mint=False, can_melt=False),
-            dbt_balance_key: Balance(value=667, can_mint=False, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(1002).to_signed(), can_mint=False, can_melt=False),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(667).to_signed(), can_mint=False, can_melt=True),
         }
 
         # After revoke melt
         self.runner.call_public_method(nc_id, 'revoke', ctx, dbt_token_uid, False, True)
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=1002, can_mint=False, can_melt=False),
-            dbt_balance_key: Balance(value=667, can_mint=False, can_melt=False),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(1002).to_signed(), can_mint=False, can_melt=False),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(667).to_signed(), can_mint=False, can_melt=False),
         }
 
         # Try revoke mint without having the authority
@@ -285,8 +286,8 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Final state
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=1002, can_mint=False, can_melt=False),
-            dbt_balance_key: Balance(value=667, can_mint=False, can_melt=False),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(1002).to_signed(), can_mint=False, can_melt=False),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(667).to_signed(), can_mint=False, can_melt=False),
         }
 
     def test_deposit_token_creation(self) -> None:
@@ -348,8 +349,8 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # fee token creation charging 1 HTR
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=1, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(1).to_signed(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
         }
 
         ctx_create_deposit_token = self.create_context()
@@ -361,9 +362,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # deposit token creation charging 1 HTR
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=100, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=True, can_melt=True),
         }
 
         fbt_token2_uid = self.runner.call_public_method(
@@ -373,10 +374,10 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # created fee token paying with deposit token
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=0, can_mint=True, can_melt=True),
-            fbt2_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=SignedAmount(), can_mint=True, can_melt=True),
+            fbt2_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
         }
 
         # Try to create fee tokens without enough dbt balance
@@ -419,10 +420,10 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should remain unchanged after failed melt attempt
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=0, can_mint=True, can_melt=True),
-            fbt2_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=SignedAmount(), can_mint=True, can_melt=True),
+            fbt2_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
         }
 
     def test_fee_token_melt(self) -> None:
@@ -458,9 +459,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # fee token creation charging 1 HTR, creating 1000000 tokens
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=100, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(100).to_signed(), can_mint=True, can_melt=True),
         }
 
         # Successfully melt some tokens - don't deposit, melt from existing balance using deposit token
@@ -468,9 +469,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should decrease by melted amount, DBT consumed for fee
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=500000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=0, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(500000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=SignedAmount(), can_mint=True, can_melt=True),
         }
 
         # Try to melt more tokens - should fail due to insufficient HTR for fee payment
@@ -487,9 +488,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should remain unchanged after failed melt attempt
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=500000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=0, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(500000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=SignedAmount(), can_mint=True, can_melt=True),
         }
 
         # Try to melt a deposit token paying with another deposit token
@@ -553,9 +554,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # After token creation: HTR consumed by token creation fees and deposit amounts
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=500, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(500).to_signed(), can_mint=True, can_melt=True),
         }
 
         # Successfully mint tokens using deposit token as fee payment (no HTR left)
@@ -563,9 +564,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should increase by minted amount, deposit token consumed for fee
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1100000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=400, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1100000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(400).to_signed(), can_mint=True, can_melt=True),
         }
 
         # Successfully mint more tokens using deposit token as fee payment
@@ -573,9 +574,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should increase, deposit token consumed for fee
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1300000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=300, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1300000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(300).to_signed(), can_mint=True, can_melt=True),
         }
 
         # Drain remaining deposit tokens
@@ -585,9 +586,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # All deposit tokens should be consumed
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1450000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=0, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1450000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=SignedAmount(), can_mint=True, can_melt=True),
         }
 
         # Try to mint with insufficient deposit tokens for fee payment - should fail
@@ -608,9 +609,9 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should remain unchanged after failed mint attempts
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=1450000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=0, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(1450000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=SignedAmount(), can_mint=True, can_melt=True),
         }
 
         # Try to mint a deposit token paying with another deposit token
@@ -666,8 +667,8 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # After first fee token creation
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=9, can_mint=False, can_melt=False),
-            ft1_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(9).to_signed(), can_mint=False, can_melt=False),
+            ft1_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
         }
 
         # Try to create another fee token using the first fee token as payment - should be rejected
@@ -692,8 +693,8 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Balance should remain unchanged after failed attempts
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=9, can_mint=False, can_melt=False),
-            ft1_balance_key: Balance(value=1000000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(9).to_signed(), can_mint=False, can_melt=False),
+            ft1_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
         }
 
     def test_proxy_call_public_method_nc_args(self) -> None:
@@ -717,7 +718,7 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Initial state: 10 HTR, no fee tokens
         assert target_storage.get_all_balances() == {
-            htr_balance_key: Balance(value=10, can_mint=False, can_melt=False),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(10).to_signed(), can_mint=False, can_melt=False),
         }
 
         # Proxy call with fee-based token deposit
@@ -732,6 +733,6 @@ class NCNanoContractTestCase(BlueprintTestCase):
 
         # Verify: 20 FBT deposited, 1 HTR charged as fee
         assert target_storage.get_all_balances() == {
-            htr_balance_key: Balance(value=9, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=20, can_mint=False, can_melt=False),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(9).to_signed(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(20).to_signed(), can_mint=False, can_melt=False),
         }

--- a/hathor_tests/nanocontracts/test_token_creation.py
+++ b/hathor_tests/nanocontracts/test_token_creation.py
@@ -17,6 +17,7 @@ from hathor.transaction.token_info import TokenDescription, TokenVersion
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 
 settings = HathorSettings()
 
@@ -117,7 +118,9 @@ class NCNanoContractTestCase(unittest.TestCase):
 
         nc_storage = self.manager.get_best_block_nc_storage(tx1.hash)
         assert tx1.is_nano_contract()
-        assert nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == Balance(value=1, can_mint=False, can_melt=False)
+        assert nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == Balance(
+            value=UnsignedAmount.from_v1(1).to_signed(), can_mint=False, can_melt=False
+        )
 
         vertices.propagate_with(self.manager, up_to='b32')
         TKA, ABC, DEF, GHI, JKL, tx2 = vertices.get_typed_vertices(
@@ -141,20 +144,24 @@ class NCNanoContractTestCase(unittest.TestCase):
         assert JKL.get_metadata().voided_by is None
 
         nc_storage = self.manager.get_best_block_nc_storage(tx1.hash)
-        assert nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == Balance(value=0, can_mint=False, can_melt=False)
+        assert nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
         ghi_nc_storage = self.manager.get_best_block_nc_storage(GHI.hash)
         assert ghi_nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == (
-            Balance(value=7, can_mint=False, can_melt=False)
+            Balance(value=UnsignedAmount.from_v1(7).to_signed(), can_mint=False, can_melt=False)
         )
 
         jkl_token_info = JKL._get_token_info_from_inputs(Mock())
         JKL._update_token_info_from_outputs(token_dict=jkl_token_info)
-        assert jkl_token_info[settings.HATHOR_TOKEN_UID].amount == -2
+        assert jkl_token_info[settings.HATHOR_TOKEN_UID].amount == -UnsignedAmount.from_v1(2).to_signed()
 
         jkl_context = JKL.get_nano_header().get_context()
         htr_token_uid = TokenUid(settings.HATHOR_TOKEN_UID)
-        assert jkl_context.actions[htr_token_uid] == (NCWithdrawalAction(token_uid=htr_token_uid, amount=3),)
+        assert jkl_context.actions[htr_token_uid] == (
+            NCWithdrawalAction(token_uid=htr_token_uid, amount=3),
+        )
 
         assert not tx2.is_nano_contract()
         assert tx2.get_metadata().voided_by is None
@@ -163,7 +170,9 @@ class NCNanoContractTestCase(unittest.TestCase):
         TKB, tx3 = vertices.get_typed_vertices(['TKB', 'tx3'], Transaction)
 
         nc_storage = self.manager.get_best_block_nc_storage(tx1.hash)
-        assert nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == Balance(value=0, can_mint=False, can_melt=False)
+        assert nc_storage.get_balance(settings.HATHOR_TOKEN_UID) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
 
         assert TKB.is_nano_contract()
         assert TKB.get_metadata().voided_by == {TKB.hash, NC_EXECUTION_FAIL_ID}
@@ -259,14 +268,18 @@ class NCNanoContractTestCase(unittest.TestCase):
 
         nc_storage = block_storage.get_contract_storage(tx1.hash)
         assert nc_storage.get_all_balances() == {
-            child_token_balance_key0: Balance(value=100, can_mint=False, can_melt=False),
-            child_token_balance_key1: Balance(value=30, can_mint=True, can_melt=False),
-            htr_balance_key: Balance(value=2, can_mint=False, can_melt=False),
+            child_token_balance_key0: Balance(
+                value=UnsignedAmount.from_v1(100).to_signed(), can_mint=False, can_melt=False
+            ),
+            child_token_balance_key1: Balance(
+                value=UnsignedAmount.from_v1(30).to_signed(), can_mint=True, can_melt=False
+            ),
+            htr_balance_key: Balance(value=UnsignedAmount.from_v1(2).to_signed(), can_mint=False, can_melt=False),
         }
 
         tokens_index = self.manager.tx_storage.indexes.tokens
-        assert tokens_index.get_token_info(settings.HATHOR_TOKEN_UID).get_total() == (
+        assert tokens_index.get_token_info(settings.HATHOR_TOKEN_UID).get_total() == UnsignedAmount.from_v1(
             settings.GENESIS_TOKEN_ATOMIC_UNITS + 40 * settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK - 2
         )
-        assert tokens_index.get_token_info(child_token_id0).get_total() == 100
-        assert tokens_index.get_token_info(child_token_id1).get_total() == 30
+        assert tokens_index.get_token_info(child_token_id0).get_total() == UnsignedAmount.from_v1(100)
+        assert tokens_index.get_token_info(child_token_id1).get_total() == UnsignedAmount.from_v1(30)

--- a/hathor_tests/nanocontracts/test_token_creation2.py
+++ b/hathor_tests/nanocontracts/test_token_creation2.py
@@ -8,6 +8,7 @@ from hathor.transaction.headers.nano_header import NanoHeaderAction
 from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class MyBlueprint(Blueprint):
@@ -61,10 +62,12 @@ class TokenCreationTestCase(BlueprintTestCase):
         dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
         tx3.tokens.append(dbt_id)
 
-        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        dbt_output = TxOutput(value=UnsignedAmount.from_v1(100), script=b'', token_data=1)
         tx3.outputs.append(dbt_output)
 
-        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        dbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(100)
+        )
         tx3_nano_header = tx3.get_nano_header()
         tx3_nano_header.nc_actions.append(dbt_withdraw)
 
@@ -110,10 +113,12 @@ class TokenCreationTestCase(BlueprintTestCase):
         dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
         tx3.tokens.append(dbt_id)
 
-        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        dbt_output = TxOutput(value=UnsignedAmount.from_v1(100), script=b'', token_data=1)
         tx3.outputs.append(dbt_output)
 
-        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        dbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(100)
+        )
         tx3_nano_header = tx3.get_nano_header()
         tx3_nano_header.nc_actions.append(dbt_withdraw)
 
@@ -155,10 +160,12 @@ class TokenCreationTestCase(BlueprintTestCase):
         dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
         tx2.tokens.append(dbt_id)
 
-        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        dbt_output = TxOutput(value=UnsignedAmount.from_v1(100), script=b'', token_data=1)
         tx2.outputs.append(dbt_output)
 
-        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        dbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(100)
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(dbt_withdraw)
 
@@ -189,10 +196,12 @@ class TokenCreationTestCase(BlueprintTestCase):
         fake_token_id = self.gen_random_token_uid()
         tx1.tokens.append(fake_token_id)
 
-        fake_output = TxOutput(value=100, script=b'', token_data=1)
+        fake_output = TxOutput(value=UnsignedAmount.from_v1(100), script=b'', token_data=1)
         tx1.outputs.append(fake_output)
 
-        fake_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        fake_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(100)
+        )
         tx1_nano_header = tx1.get_nano_header()
         tx1_nano_header.nc_actions.append(fake_withdraw)
 

--- a/hathor_tests/p2p/test_double_spending.py
+++ b/hathor_tests/p2p/test_double_spending.py
@@ -9,6 +9,7 @@ from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.util import not_none
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_tx
 
 
@@ -44,7 +45,7 @@ class SyncMethodsTestCase(unittest.TestCase):
 
         outputs = []
         outputs.append(
-            WalletOutputInfo(address=decode_address(address), value=value, timelock=None))
+            WalletOutputInfo(address=decode_address(address), value=UnsignedAmount.from_v1(value), timelock=None))
 
         tx1 = self.manager1.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager1.tx_storage)
         tx1.weight = 10
@@ -145,7 +146,7 @@ class SyncMethodsTestCase(unittest.TestCase):
 
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 100
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=UnsignedAmount.from_v1(int(value)), timelock=None)]
         self.clock.advance(1)
         tx1 = self.manager1.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager1.tx_storage)
         tx1.weight = 5
@@ -155,9 +156,10 @@ class SyncMethodsTestCase(unittest.TestCase):
 
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 500
-        tx_total_value = sum(txout.value for txout in tx1.outputs)
-        outputs = [WalletOutputInfo(address=address, value=value, timelock=None),
-                   WalletOutputInfo(address=address, value=tx_total_value - 500, timelock=None)]
+        tx_total_value = sum((txout.value for txout in tx1.outputs), start=UnsignedAmount.zero())
+        outputs = [WalletOutputInfo(address=address, value=UnsignedAmount.from_v1(value), timelock=None),
+                   WalletOutputInfo(address=address, value=tx_total_value - UnsignedAmount.from_v1(500),
+                                    timelock=None)]
         self.clock.advance(1)
         inputs = [WalletInputInfo(i.tx_id, i.index, Mock()) for i in tx1.inputs]
         tx4 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs,
@@ -181,7 +183,7 @@ class SyncMethodsTestCase(unittest.TestCase):
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 100
         inputs = [WalletInputInfo(tx_id=tx1.hash, index=1, private_key=Mock())]
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=UnsignedAmount.from_v1(int(value)), timelock=None)]
         self.clock.advance(1)
         tx2 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,
                                                                          self.manager1.tx_storage)
@@ -199,7 +201,7 @@ class SyncMethodsTestCase(unittest.TestCase):
 
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 500
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=UnsignedAmount.from_v1(int(value)), timelock=None)]
         self.clock.advance(1)
         tx3 = self.manager1.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager1.tx_storage)
         self.assertNotEqual(tx3.inputs[0].tx_id, tx1.hash)
@@ -231,7 +233,7 @@ class SyncMethodsTestCase(unittest.TestCase):
         address = self.manager1.wallet.get_unused_address_bytes()
         value = 500
         inputs = [WalletInputInfo(tx_id=tx4.hash, index=0, private_key=Mock())]
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=UnsignedAmount.from_v1(int(value)), timelock=None)]
         self.clock.advance(1)
         tx5 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs, force=True,
                                                                          tx_storage=self.manager1.tx_storage)
@@ -266,9 +268,9 @@ class SyncMethodsTestCase(unittest.TestCase):
         # ---
 
         address = self.manager1.wallet.get_unused_address_bytes()
-        value = blocks[3].outputs[0].value
+        block_output_value = blocks[3].outputs[0].value
         inputs = [WalletInputInfo(tx_id=blocks[3].hash, index=0, private_key=Mock())]
-        outputs = [WalletOutputInfo(address=address, value=value, timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=block_output_value, timelock=None)]
         self.clock.advance(1)
         tx7 = self.manager1.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,
                                                                          self.manager1.tx_storage)

--- a/hathor_tests/p2p/test_sync.py
+++ b/hathor_tests/p2p/test_sync.py
@@ -8,6 +8,7 @@ from hathor.transaction import Block, Transaction
 from hathor.transaction.storage.exceptions import TransactionIsNotABlock
 from hathor.util import not_none
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -31,7 +32,7 @@ class SyncMethodsTestCase(unittest.TestCase):
 
         outputs = []
         outputs.append(
-            WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None))
+            WalletOutputInfo(address=decode_address(address), value=UnsignedAmount.from_v1(int(value)), timelock=None))
 
         tx: Transaction = self.manager1.wallet.prepare_transaction_compute_inputs(
             Transaction, outputs, self.manager1.tx_storage

--- a/hathor_tests/p2p/test_sync_mempool.py
+++ b/hathor_tests/p2p/test_sync_mempool.py
@@ -10,6 +10,7 @@ from hathor.simulator import FakeConnection
 from hathor.transaction import Block, Transaction
 from hathor.util import json_loadb, not_none
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -30,7 +31,7 @@ class SyncMempoolTestCase(unittest.TestCase):
 
         outputs = []
         outputs.append(
-            WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None))
+            WalletOutputInfo(address=decode_address(address), value=UnsignedAmount.from_v1(int(value)), timelock=None))
 
         tx: Transaction = self.manager1.wallet.prepare_transaction_compute_inputs(
             Transaction, outputs, self.manager1.tx_storage

--- a/hathor_tests/p2p/test_twin_tx.py
+++ b/hathor_tests/p2p/test_twin_tx.py
@@ -7,6 +7,7 @@ from hathor.transaction import Transaction
 from hathor.util import not_none
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_double_spending
 
 
@@ -26,13 +27,21 @@ class TwinTransactionTestCase(unittest.TestCase):
         value3 = 102
 
         outputs = [
-            WalletOutputInfo(address=decode_address(address), value=int(value1), timelock=None),
-            WalletOutputInfo(address=decode_address(address), value=int(value2), timelock=None)
+            WalletOutputInfo(
+                address=decode_address(address), value=UnsignedAmount.from_v1(int(value1)), timelock=None
+            ),
+            WalletOutputInfo(
+                address=decode_address(address), value=UnsignedAmount.from_v1(int(value2)), timelock=None
+            ),
         ]
 
         outputs2 = [
-            WalletOutputInfo(address=decode_address(address), value=int(value1), timelock=None),
-            WalletOutputInfo(address=decode_address(address), value=int(value3), timelock=None)
+            WalletOutputInfo(
+                address=decode_address(address), value=UnsignedAmount.from_v1(int(value1)), timelock=None
+            ),
+            WalletOutputInfo(
+                address=decode_address(address), value=UnsignedAmount.from_v1(int(value3)), timelock=None
+            ),
         ]
 
         tx1 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager.tx_storage)

--- a/hathor_tests/poa/test_poa.py
+++ b/hathor_tests/poa/test_poa.py
@@ -16,6 +16,7 @@ from hathor.transaction.exceptions import PoaValidationError
 from hathor.transaction.poa import PoaBlock
 from hathor.transaction.static_metadata import BlockStaticMetadata
 from hathor.verification.poa_block_verifier import PoaBlockVerifier
+from hathor_tests.token_amount import UnsignedAmount
 
 
 def test_get_hashed_poa_data() -> None:
@@ -106,7 +107,7 @@ def test_verify_poa() -> None:
     )
 
     # Test no rewards
-    block.outputs = [TxOutput(123, b'')]
+    block.outputs = [TxOutput(UnsignedAmount.from_v1(123), b'')]
     with pytest.raises(PoaValidationError) as e:
         block_verifier.verify_poa(block)
     assert str(e.value) == 'blocks must not have rewards in a PoA network'

--- a/hathor_tests/poa/test_poa_simulation.py
+++ b/hathor_tests/poa/test_poa_simulation.py
@@ -27,6 +27,7 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.util import not_none
 from hathor_tests.poa.utils import get_settings, get_signer
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 
 
 def _get_blocks_by_height(manager: HathorManager) -> defaultdict[int, list[PoaBlock]]:
@@ -541,9 +542,9 @@ class PoaSimulationTest(SimulatorTestCase):
             parents=[self.simulator.settings.GENESIS_TX1_HASH, self.simulator.settings.GENESIS_TX2_HASH],
             inputs=[TxInput(self.simulator.settings.GENESIS_BLOCK_HASH, 0, b'')],
             outputs=[
-                TxOutput(1_000_000_000_000, script, 0b00000001),
-                TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001),
-                TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001),
+                TxOutput(UnsignedAmount.from_v1(1_000_000_000_000), script, 0b00000001),
+                TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001),
+                TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001),
             ],
             token_name='custom-token',
             token_symbol='CTK',

--- a/hathor_tests/simulation/test_trigger.py
+++ b/hathor_tests/simulation/test_trigger.py
@@ -8,6 +8,7 @@ from hathor.simulator import FakeConnection, Simulator
 from hathor.simulator.trigger import StopAfterMinimumBalance, StopAfterNMinedBlocks, StopWhenSendLineMatch
 from hathor.util import not_none
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class TriggerTestCase(unittest.TestCase):
@@ -58,7 +59,7 @@ class TriggerTestCase(unittest.TestCase):
         wallet = not_none(self.manager1.wallet)
         settings = self.simulator.settings
 
-        minimum_balance = 1000_00   # 16 blocks
+        minimum_balance = UnsignedAmount.from_v1(1000_00)   # 16 blocks
         token_uid = settings.HATHOR_TOKEN_UID
 
         trigger = StopAfterMinimumBalance(wallet, token_uid, minimum_balance)

--- a/hathor_tests/token_amount.py
+++ b/hathor_tests/token_amount.py
@@ -1,16 +1,5 @@
-#  Copyright 2025 Hathor Labs
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
 
 """Transitional test shim for the versioned token-amount types.
 

--- a/hathor_tests/token_amount.py
+++ b/hathor_tests/token_amount.py
@@ -1,0 +1,130 @@
+#  Copyright 2025 Hathor Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Transitional test shim for the versioned token-amount types.
+
+`UnsignedAmount` and `SignedAmount` mirror the public API of the real `htr_lib` types as thin
+`int` subclasses, with V1 and V2 collapsed onto a single identity unit. Test fixtures import the
+versioned types from here so the entire codebase's test suite can adopt the wrapped form while
+`hathorlib.token_amount` still aliases both names to `int`. Every value therefore stays a plain
+integer at runtime and under `mypy --strict-equality`, so the fixtures keep passing against the
+unflipped production code. The single import indirection lets a later change repoint this module
+at `htr_lib` without touching each fixture.
+"""
+
+from __future__ import annotations
+
+
+class SignedAmount(int):
+    """Signed token amount, an `int` subclass with the `htr_lib.SignedAmount` surface."""
+
+    __slots__ = ()
+
+    def raw(self) -> int:
+        return int(self)
+
+    def to_signed(self) -> SignedAmount:
+        return self
+
+    def to_unsigned(self) -> UnsignedAmount:
+        assert self >= 0
+        return UnsignedAmount(int(self))
+
+    def __add__(self, other: int, /) -> SignedAmount:
+        return SignedAmount(int(self) + int(other))
+
+    def __radd__(self, other: int, /) -> SignedAmount:
+        return SignedAmount(int(other) + int(self))
+
+    def __sub__(self, other: int, /) -> SignedAmount:
+        return SignedAmount(int(self) - int(other))
+
+    def __rsub__(self, other: int, /) -> SignedAmount:
+        return SignedAmount(int(other) - int(self))
+
+    def __neg__(self) -> SignedAmount:
+        return SignedAmount(-int(self))
+
+    def __pos__(self) -> SignedAmount:
+        return SignedAmount(+int(self))
+
+
+class UnsignedAmount(int):
+    """Unsigned token amount, an `int` subclass with the `htr_lib.UnsignedAmount` surface."""
+
+    __slots__ = ()
+
+    @staticmethod
+    def set_decimal_places(*, v1_decimal_places: int, v2_decimal_places: int) -> None:
+        pass
+
+    @staticmethod
+    def get_normalization_factor() -> int:
+        return 1
+
+    @classmethod
+    def from_v1(cls, amount: int) -> UnsignedAmount:
+        return cls(amount)
+
+    @classmethod
+    def from_v2(cls, amount: int) -> UnsignedAmount:
+        return cls(amount)
+
+    @classmethod
+    def from_version(cls, amount: int, *, version: int) -> UnsignedAmount:
+        return cls(amount)
+
+    @classmethod
+    def zero(cls) -> UnsignedAmount:
+        return cls(0)
+
+    @classmethod
+    def parse(cls, s: str) -> UnsignedAmount:
+        return cls(int(s))
+
+    def is_v1(self) -> bool:
+        return True
+
+    def is_v2(self) -> bool:
+        return True
+
+    def normalized(self) -> int:
+        return int(self)
+
+    def raw(self) -> int:
+        return int(self)
+
+    def to_signed(self) -> SignedAmount:
+        return SignedAmount(int(self))
+
+    def to_v1(self) -> UnsignedAmount:
+        return self
+
+    def maybe_to_v1(self) -> UnsignedAmount | None:
+        return self
+
+    def to_v2(self) -> UnsignedAmount:
+        return self
+
+    def to_version(self, version: int) -> UnsignedAmount:
+        return self
+
+    def __add__(self, other: int, /) -> UnsignedAmount:
+        return UnsignedAmount(int(self) + int(other))
+
+    def __radd__(self, other: int, /) -> UnsignedAmount:
+        return UnsignedAmount(int(other) + int(self))
+
+    def __sub__(self, other: int, /) -> UnsignedAmount:
+        return UnsignedAmount(int(self) - int(other))

--- a/hathor_tests/tx/test_blockchain.py
+++ b/hathor_tests/tx/test_blockchain.py
@@ -7,6 +7,7 @@ from hathor.daa import DAAFactory, TestMode
 from hathor.simulator.utils import add_new_blocks
 from hathor.utils.weight import weight_to_work
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_new_transactions
 
 
@@ -360,14 +361,14 @@ class BlockchainTestCase(unittest.TestCase):
         for _i_halving in range(0, self._settings.MAXIMUM_NUMBER_OF_HALVINGS):
             for _i_block in range(0, self._settings.BLOCKS_PER_HALVING):
                 reward = manager.get_tokens_issued_per_block(height)
-                self.assertEqual(reward, expected_reward, f'reward at height {height}')
+                self.assertEqual(reward, UnsignedAmount.from_v1(expected_reward), f'reward at height {height}')
                 height += 1
-            expected_reward /= 2
+            expected_reward //= 2
         self.assertEqual(expected_reward, final_reward)
         # check that halving stops, for at least two "halving rounds"
         for _i_block in range(0, 2 * self._settings.BLOCKS_PER_HALVING):
             reward = manager.get_tokens_issued_per_block(height)
-            self.assertEqual(reward, expected_reward, f'reward at height {height}')
+            self.assertEqual(reward, UnsignedAmount.from_v1(expected_reward), f'reward at height {height}')
             height += 1
 
     def test_block_rewards(self):

--- a/hathor_tests/tx/test_fee_header.py
+++ b/hathor_tests/tx/test_fee_header.py
@@ -11,6 +11,7 @@ from hathor.transaction.vertex_parser._fee_header import deserialize_fee_header,
 from hathor.transaction.vertex_parser._headers import get_header_sighash_bytes
 from hathor.types import TokenUid
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 def _serialize_fee_header(header: FeeHeader) -> bytes:
@@ -43,8 +44,8 @@ class FeeHeaderTest(unittest.TestCase):
             settings=self._settings,
             tx=tx,
             fees=[
-                FeeHeaderEntry(token_index=0, amount=100),  # HTR paying
-                FeeHeaderEntry(token_index=1, amount=200),  # Custom token paying
+                FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(100)),  # HTR paying
+                FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(200)),  # Custom token paying
             ],
         )
         serialized = _serialize_fee_header(header_round_trip)
@@ -61,7 +62,7 @@ class FeeHeaderTest(unittest.TestCase):
         header_verbose = FeeHeader(
             settings=self._settings,
             tx=tx,
-            fees=[FeeHeaderEntry(token_index=0, amount=300)],  # HTR paying
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(300))],  # HTR paying
         )
         serialized_verbose = _serialize_fee_header(header_verbose)
         deserialized_verbose, remaining = _deserialize_fee_header(tx, serialized_verbose, verbose=verbose_callback)
@@ -79,7 +80,7 @@ class FeeHeaderTest(unittest.TestCase):
         header_sighash = FeeHeader(
             settings=self._settings,
             tx=tx,
-            fees=[FeeHeaderEntry(token_index=0, amount=500)],  # HTR paying
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(500))],  # HTR paying
         )
         sighash_bytes = get_header_sighash_bytes(header_sighash, token_amount_version=tx.get_token_amount_version())
         serialized_bytes = _serialize_fee_header(header_sighash)
@@ -98,25 +99,25 @@ class FeeHeaderTest(unittest.TestCase):
             settings=self._settings,
             tx=tx,
             fees=[
-                FeeHeaderEntry(token_index=0, amount=100),  # HTR
-                FeeHeaderEntry(token_index=1, amount=200),  # token1 (must be multiple of 100)
+                FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(100)),  # HTR
+                FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(200)),  # token1 (must be multiple of 100)
             ],
         )
         fees = header.get_fees()
 
         assert len(fees) == 2
-        assert fees[0] == FeeEntry(token_uid=tx.get_token_uid(0), amount=100)  # HTR
-        assert fees[1] == FeeEntry(token_uid=token1_uid, amount=200)  # token1
+        assert fees[0] == FeeEntry(token_uid=tx.get_token_uid(0), amount=UnsignedAmount.from_v1(100))  # HTR
+        assert fees[1] == FeeEntry(token_uid=token1_uid, amount=UnsignedAmount.from_v1(200))  # token1
 
         # Test with single fee
         header_single = FeeHeader(
             settings=self._settings,
             tx=tx,
-            fees=[FeeHeaderEntry(token_index=0, amount=300)],  # HTR only
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(300))],  # HTR only
         )
         fees_single = header_single.get_fees()
         assert len(fees_single) == 1
-        assert fees_single[0] == FeeEntry(token_uid=tx.get_token_uid(0), amount=300)
+        assert fees_single[0] == FeeEntry(token_uid=tx.get_token_uid(0), amount=UnsignedAmount.from_v1(300))
 
     def test_fee_header_edge_cases(self) -> None:
         """Test FeeHeader edge cases and comprehensive scenarios."""
@@ -131,9 +132,9 @@ class FeeHeaderTest(unittest.TestCase):
             settings=self._settings,
             tx=tx,
             fees=[
-                FeeHeaderEntry(token_index=0, amount=100),  # HTR
-                FeeHeaderEntry(token_index=2, amount=50),  # token2
-                FeeHeaderEntry(token_index=4, amount=25),  # token4
+                FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(100)),  # HTR
+                FeeHeaderEntry(token_index=2, amount=UnsignedAmount.from_v1(50)),  # token2
+                FeeHeaderEntry(token_index=4, amount=UnsignedAmount.from_v1(25)),  # token4
             ],
         )
         serialized_complex = _serialize_fee_header(header_complex)
@@ -142,35 +143,35 @@ class FeeHeaderTest(unittest.TestCase):
         assert len(remaining) == 0
         assert len(deserialized_complex.fees) == 3
         assert deserialized_complex.fees[0].token_index == 0
-        assert deserialized_complex.fees[0].amount == 100
+        assert deserialized_complex.fees[0].amount == UnsignedAmount.from_v1(100)
         assert deserialized_complex.fees[1].token_index == 2
-        assert deserialized_complex.fees[1].amount == 50
+        assert deserialized_complex.fees[1].amount == UnsignedAmount.from_v1(50)
         assert deserialized_complex.fees[2].token_index == 4
-        assert deserialized_complex.fees[2].amount == 25
+        assert deserialized_complex.fees[2].amount == UnsignedAmount.from_v1(25)
 
         # Test max values
         header_max = FeeHeader(
             settings=self._settings,
             tx=tx,
-            fees=[FeeHeaderEntry(token_index=0, amount=2 ** 63 - 1)],  # Max amount
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(2 ** 63 - 1))],  # Max amount
         )
         serialized_max = _serialize_fee_header(header_max)
         deserialized_max, remaining = _deserialize_fee_header(tx, serialized_max)
         assert len(remaining) == 0
-        assert deserialized_max.fees[0].amount == 2 ** 63 - 1
+        assert deserialized_max.fees[0].amount == UnsignedAmount.from_v1(2 ** 63 - 1)
 
         # Test single fee
         header_single = FeeHeader(
             settings=self._settings,
             tx=tx,
-            fees=[FeeHeaderEntry(token_index=1, amount=42)],  # Single custom token fee
+            fees=[FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(42))],  # Single custom token fee
         )
         serialized_single = _serialize_fee_header(header_single)
         deserialized_single, remaining = _deserialize_fee_header(tx, serialized_single)
         assert len(remaining) == 0
         assert len(deserialized_single.fees) == 1
         assert deserialized_single.fees[0].token_index == 1
-        assert deserialized_single.fees[0].amount == 42
+        assert deserialized_single.fees[0].amount == UnsignedAmount.from_v1(42)
 
     def test_to_json_includes_fees(self) -> None:
         """Test that Transaction.to_json() includes fee header data when present."""
@@ -182,8 +183,8 @@ class FeeHeaderTest(unittest.TestCase):
             settings=self._settings,
             tx=tx,
             fees=[
-                FeeHeaderEntry(token_index=0, amount=100),
-                FeeHeaderEntry(token_index=1, amount=200),
+                FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(100)),
+                FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(200)),
             ],
         )
         tx.headers = [fee_header]
@@ -214,7 +215,7 @@ class FeeHeaderTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx,
-            fees=[FeeHeaderEntry(token_index=0, amount=50)],
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(50))],
         )
         tx.headers = [fee_header]
 

--- a/hathor_tests/tx/test_genesis.py
+++ b/hathor_tests/tx/test_genesis.py
@@ -10,6 +10,7 @@ from hathor.verification.verification_service import VerificationService
 from hathor.verification.vertex_verifier import VertexVerifier
 from hathor.verification.vertex_verifiers import VertexVerifiers
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 settings = HathorSettings()
 
@@ -74,7 +75,10 @@ class GenesisTest(unittest.TestCase):
         genesis_blocks = [tx for tx in genesis if tx.is_block]
         genesis_block = genesis_blocks[0]
 
-        self.assertEqual(settings.GENESIS_TOKEN_ATOMIC_UNITS, sum([output.value for output in genesis_block.outputs]))
+        self.assertEqual(
+            UnsignedAmount.from_v1(settings.GENESIS_TOKEN_ATOMIC_UNITS),
+            sum(([output.value for output in genesis_block.outputs]), start=UnsignedAmount.zero()),
+        )
 
     def test_genesis_weight(self):
         genesis = self.storage.get_all_genesis()

--- a/hathor_tests/tx/test_indexes.py
+++ b/hathor_tests/tx/test_indexes.py
@@ -12,6 +12,7 @@ from hathor.transaction.vertex_parser import VertexParser
 from hathor.util import initialize_hd_wallet, iwindows
 from hathor.wallet import Wallet
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import DEFAULT_WORDS, add_blocks_unlock_reward, add_custom_tx, add_new_tx, get_genesis_key
 
 
@@ -25,7 +26,7 @@ class BaseIndexesTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
 
         address = self.get_address(0)
-        value = 500
+        value = UnsignedAmount.from_v1(500)
 
         outputs = [WalletOutputInfo(address=decode_address(address), value=value, timelock=None)]
 
@@ -78,9 +79,9 @@ class BaseIndexesTest(unittest.TestCase):
         address1 = self.get_address(0)
         address2 = self.get_address(1)
         address3 = self.get_address(2)
-        output1 = WalletOutputInfo(address=decode_address(address1), value=123, timelock=None)
-        output2 = WalletOutputInfo(address=decode_address(address2), value=234, timelock=None)
-        output3 = WalletOutputInfo(address=decode_address(address3), value=345, timelock=None)
+        output1 = WalletOutputInfo(address=decode_address(address1), value=UnsignedAmount.from_v1(123), timelock=None)
+        output2 = WalletOutputInfo(address=decode_address(address2), value=UnsignedAmount.from_v1(234), timelock=None)
+        output3 = WalletOutputInfo(address=decode_address(address3), value=UnsignedAmount.from_v1(345), timelock=None)
         outputs = [output1, output2, output3]
 
         tx1 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager.tx_storage)
@@ -142,7 +143,7 @@ class BaseIndexesTest(unittest.TestCase):
                 tx_id=self._settings.GENESIS_BLOCK_HASH,
                 index=0,
                 address=GENESIS_ADDRESS_B58,
-                amount=self._settings.GENESIS_TOKEN_ATOMIC_UNITS,
+                amount=UnsignedAmount.from_v1(self._settings.GENESIS_TOKEN_ATOMIC_UNITS),
                 timelock=None,
                 heightlock=self._settings.REWARD_SPEND_MIN_BLOCKS,
             ),
@@ -151,7 +152,7 @@ class BaseIndexesTest(unittest.TestCase):
         # height just not enough should be empty
         self.assertEqual(
             list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
-                                       target_amount=self._settings.GENESIS_TOKEN_MAIN_UNITS,
+                                       target_amount=UnsignedAmount.from_v1(self._settings.GENESIS_TOKEN_MAIN_UNITS),
                                        target_height=self._settings.REWARD_SPEND_MIN_BLOCKS - 1)),
             [],
         )
@@ -159,7 +160,7 @@ class BaseIndexesTest(unittest.TestCase):
         # height is now enough
         self.assertEqual(
             list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
-                                       target_amount=self._settings.GENESIS_TOKEN_MAIN_UNITS,
+                                       target_amount=UnsignedAmount.from_v1(self._settings.GENESIS_TOKEN_MAIN_UNITS),
                                        target_height=self._settings.REWARD_SPEND_MIN_BLOCKS)),
             expected_genesis_utxos,
         )
@@ -167,7 +168,7 @@ class BaseIndexesTest(unittest.TestCase):
         # otherwise we can leave out the height and it should give the utxos
         self.assertEqual(
             list(utxo_index.iter_utxos(address=GENESIS_ADDRESS_B58, token_uid=self._settings.HATHOR_TOKEN_UID,
-                                       target_amount=self._settings.GENESIS_TOKEN_MAIN_UNITS)),
+                                       target_amount=UnsignedAmount.from_v1(self._settings.GENESIS_TOKEN_MAIN_UNITS))),
             expected_genesis_utxos,
         )
 
@@ -185,14 +186,14 @@ class BaseIndexesTest(unittest.TestCase):
             """Pass a values of tuples (tx_id, index, amount, heightlock)"""
             # target_amount doesn't really matter as long as it is large enough, since we want to see the most UTXOs
             # for the given address that we can
-            actual = list(utxo_index.iter_utxos(address=address, target_amount=9999999))
+            actual = list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(9999999)))
             expected = [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx_id,
                     index=index,
                     address=address,
-                    amount=amount,
+                    amount=UnsignedAmount.from_v1(amount),
                     timelock=None,
                     heightlock=heightlock,
                 ) for tx_id, index, amount, heightlock in args
@@ -277,7 +278,7 @@ class BaseIndexesTest(unittest.TestCase):
         add_new_blocks(self.manager, 4, advance_clock=1)
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             []
         )
 
@@ -286,14 +287,14 @@ class BaseIndexesTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[:1]
@@ -301,14 +302,14 @@ class BaseIndexesTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=6500)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(6500))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[4:1:-1]
@@ -316,14 +317,14 @@ class BaseIndexesTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=25600)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(25600))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[::-1]
@@ -331,14 +332,14 @@ class BaseIndexesTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=30000)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(30000))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                 ) for b in blocks[::-1]
@@ -353,7 +354,7 @@ class BaseIndexesTest(unittest.TestCase):
 
         address = self.get_address(0)
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             []
         )
 
@@ -381,12 +382,12 @@ class BaseIndexesTest(unittest.TestCase):
                     tx_id=tx.hash,
                     index=1,
                     address=address,
-                    amount=amount,
+                    amount=UnsignedAmount.from_v1(amount),
                     timelock=None,
                     heightlock=None,
                 ) for tx, amount in reversed(txs_window)
             ]
-            actual = list(utxo_index.iter_utxos(address=address, target_amount=target_amount))
+            actual = list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(target_amount)))
             if _debug:
                 print('expected = [')
                 for x in expected:
@@ -400,14 +401,14 @@ class BaseIndexesTest(unittest.TestCase):
 
         # now check that at most 255 utxos will be returned when we check for a large enough amount
         max_outputs = self._settings.MAX_NUM_OUTPUTS
-        actual = list(utxo_index.iter_utxos(address=address, target_amount=sum(range(301))))
+        actual = list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(sum(range(301)))))
         expected = [
             UtxoIndexItem(
                 token_uid=self._settings.HATHOR_TOKEN_UID,
                 tx_id=tx.hash,
                 index=1,
                 address=address,
-                amount=amount,
+                amount=UnsignedAmount.from_v1(amount),
                 timelock=None,
                 heightlock=None,
             ) for tx, amount in txs_and_values[-1:-(max_outputs + 1):-1]  # these are the last 255 utxos
@@ -439,14 +440,14 @@ class BaseIndexesTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                     ) for b in blocks
@@ -461,7 +462,7 @@ class BaseIndexesTest(unittest.TestCase):
             timestamp=int(self.clock.seconds()),
             weight=1.0,
             inputs=[TxInput(blocks[0].hash, 0, b'')],
-            outputs=[TxOutput(6400, P2PKH.create_output_script(decode_address(address1)))],
+            outputs=[TxOutput(UnsignedAmount.from_v1(6400), P2PKH.create_output_script(decode_address(address1)))],
             parents=list(self.manager.get_new_tx_parents()),
             storage=self.tx_storage,
         )
@@ -472,19 +473,19 @@ class BaseIndexesTest(unittest.TestCase):
         self.assertTrue(self.manager.propagate_tx(tx1))
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             []
         )
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address1, target_amount=6400)),
+            list(utxo_index.iter_utxos(address=address1, target_amount=UnsignedAmount.from_v1(6400))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=0,
                     address=address1,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=None,
                 )
@@ -509,14 +510,14 @@ class BaseIndexesTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=b.hash,
                     index=0,
                     address=address,
-                    amount=6400,
+                    amount=UnsignedAmount.from_v1(6400),
                     timelock=None,
                     heightlock=b.static_metadata.height + self._settings.REWARD_SPEND_MIN_BLOCKS,
                     ) for b in blocks
@@ -533,8 +534,10 @@ class BaseIndexesTest(unittest.TestCase):
             timestamp=int(self.clock.seconds()),
             weight=1.0,
             inputs=[TxInput(blocks[0].hash, 0, b'')],
-            outputs=[TxOutput(change_value, P2PKH.create_output_script(decode_address(address))),
-                     TxOutput(transfer_value, P2PKH.create_output_script(decode_address(address1)))],
+            outputs=[
+                TxOutput(UnsignedAmount.from_v1(change_value), P2PKH.create_output_script(decode_address(address))),
+                TxOutput(UnsignedAmount.from_v1(transfer_value), P2PKH.create_output_script(decode_address(address1))),
+            ],
             parents=list(self.manager.get_new_tx_parents()),
             storage=self.tx_storage,
         )
@@ -547,14 +550,14 @@ class BaseIndexesTest(unittest.TestCase):
         # querying for exact values
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address1, target_amount=transfer_value)),
+            list(utxo_index.iter_utxos(address=address1, target_amount=UnsignedAmount.from_v1(transfer_value))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=1,
                     address=address1,
-                    amount=transfer_value,
+                    amount=UnsignedAmount.from_v1(transfer_value),
                     timelock=None,
                     heightlock=None,
                 )
@@ -562,14 +565,14 @@ class BaseIndexesTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=change_value)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(change_value))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=0,
                     address=address,
-                    amount=change_value,
+                    amount=UnsignedAmount.from_v1(change_value),
                     timelock=None,
                     heightlock=None,
                 )
@@ -579,14 +582,14 @@ class BaseIndexesTest(unittest.TestCase):
         # querying for minimum value, should also return same UTXOs
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address1, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address1, target_amount=UnsignedAmount.from_v1(1))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=1,
                     address=address1,
-                    amount=transfer_value,
+                    amount=UnsignedAmount.from_v1(transfer_value),
                     timelock=None,
                     heightlock=None,
                 )
@@ -594,14 +597,14 @@ class BaseIndexesTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            list(utxo_index.iter_utxos(address=address, target_amount=1)),
+            list(utxo_index.iter_utxos(address=address, target_amount=UnsignedAmount.from_v1(1))),
             [
                 UtxoIndexItem(
                     token_uid=self._settings.HATHOR_TOKEN_UID,
                     tx_id=tx1.hash,
                     index=0,
                     address=address,
-                    amount=change_value,
+                    amount=UnsignedAmount.from_v1(change_value),
                     timelock=None,
                     heightlock=None,
                 )

--- a/hathor_tests/tx/test_indexes4.py
+++ b/hathor_tests/tx/test_indexes4.py
@@ -6,6 +6,7 @@ from hathor.simulator.utils import add_new_blocks, gen_new_tx
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -21,9 +22,9 @@ class SimulatorIndexesTestCase(unittest.TestCase):
         address1 = self.get_address(0)
         address2 = self.get_address(1)
         address3 = self.get_address(2)
-        output1 = WalletOutputInfo(address=decode_address(address1), value=123, timelock=None)
-        output2 = WalletOutputInfo(address=decode_address(address2), value=234, timelock=None)
-        output3 = WalletOutputInfo(address=decode_address(address3), value=345, timelock=None)
+        output1 = WalletOutputInfo(address=decode_address(address1), value=UnsignedAmount.from_v1(123), timelock=None)
+        output2 = WalletOutputInfo(address=decode_address(address2), value=UnsignedAmount.from_v1(234), timelock=None)
+        output3 = WalletOutputInfo(address=decode_address(address3), value=UnsignedAmount.from_v1(345), timelock=None)
         outputs = [output1, output2, output3]
 
         tx1 = manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, manager.tx_storage)
@@ -49,7 +50,7 @@ class SimulatorIndexesTestCase(unittest.TestCase):
 
         for _ in range(100):
             address = self.get_address(0)
-            value = 500
+            value = UnsignedAmount.from_v1(500)
             tx = gen_new_tx(manager, address, value)
             assert manager.propagate_tx(tx)
             self.clock.advance(1)

--- a/hathor_tests/tx/test_mempool_iter_all.py
+++ b/hathor_tests/tx/test_mempool_iter_all.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from hathor.simulator.utils import add_new_blocks, gen_new_tx
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class MempoolIterAllTraversalTestCase(unittest.TestCase):
@@ -22,7 +23,7 @@ class MempoolIterAllTraversalTestCase(unittest.TestCase):
 
         address = self.get_address(0)
         assert address is not None
-        tx = gen_new_tx(self.manager, address, value=10)
+        tx = gen_new_tx(self.manager, address, value=UnsignedAmount.from_v1(10))
         self.manager.propagate_tx(tx)
         self.run_to_completion()
 

--- a/hathor_tests/tx/test_metadata.py
+++ b/hathor_tests/tx/test_metadata.py
@@ -20,6 +20,7 @@ from hathor.transaction.types import MetaNCCallRecord
 from hathor.transaction.validation_state import ValidationState
 from hathor.util import not_none
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class TestMetadata(unittest.TestCase):
@@ -50,14 +51,14 @@ class TestMetadata(unittest.TestCase):
                     ),
                     CreateTokenRecord(
                         token_uid=TokenUid(b'ttt'),
-                        amount=123,
+                        amount=UnsignedAmount.from_v1(123),
                         token_symbol='s',
                         token_name='n',
                         token_version=TokenVersion.FEE,
                     ),
                     UpdateTokenBalanceRecord(
                         token_uid=TokenUid(b'ttt'),
-                        amount=123,
+                        amount=UnsignedAmount.from_v1(123).to_signed(),
                     ),
                     UpdateAuthoritiesRecord(
                         type=IndexRecordType.REVOKE_AUTHORITIES,

--- a/hathor_tests/tx/test_mining.py
+++ b/hathor_tests/tx/test_mining.py
@@ -8,6 +8,7 @@ from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Block
 from hathor.utils.weight import weight_to_work
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class MiningTest(unittest.TestCase):
@@ -43,7 +44,7 @@ class MiningTest(unittest.TestCase):
 
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
-            reward=self._settings.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * 100,
+            reward=UnsignedAmount.from_v1(self._settings.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * 100),
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=self._settings.GENESIS_BLOCK_TIMESTAMP + 3,
@@ -72,7 +73,7 @@ class MiningTest(unittest.TestCase):
 
         self.assertEqual(block_templates[0], BlockTemplate(
             versions={0, 3},
-            reward=self._settings.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * 100,
+            reward=UnsignedAmount.from_v1(self._settings.INITIAL_TOKEN_MAIN_UNITS_PER_BLOCK * 100),
             weight=1.0,
             timestamp_now=int(manager.reactor.seconds()),
             timestamp_min=blocks[-1].timestamp + 1,
@@ -90,7 +91,7 @@ class MiningTest(unittest.TestCase):
     def test_minimally_valid_block(self) -> None:
         template = BlockTemplate(
             versions={0},
-            reward=6400,
+            reward=UnsignedAmount.from_v1(6400),
             weight=60,
             timestamp_now=12345,
             timestamp_min=12344,

--- a/hathor_tests/tx/test_nano_contracts.py
+++ b/hathor_tests/tx/test_nano_contracts.py
@@ -10,6 +10,7 @@ from hathor.transaction.scripts import P2PKH, NanoContractMatchValues, script_ev
 from hathor.transaction.scripts.opcode import OpcodesVersion
 from hathor.util import json_dumpb
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class NanoContracts(unittest.TestCase):
@@ -40,6 +41,6 @@ class NanoContracts(unittest.TestCase):
         input_data = NanoContractMatchValues.create_input_data(
             base64.b64decode(oracle_data), base64.b64decode(oracle_signature), base64.b64decode(pubkey))
         txin = TxInput(b'aa', 0, input_data)
-        spent_tx = Transaction(outputs=[TxOutput(20, script)])
-        tx = Transaction(outputs=[TxOutput(20, P2PKH.create_output_script(address))])
+        spent_tx = Transaction(outputs=[TxOutput(UnsignedAmount.from_v1(20), script)])
+        tx = Transaction(outputs=[TxOutput(UnsignedAmount.from_v1(20), P2PKH.create_output_script(address))])
         script_eval(tx, txin, spent_tx, OpcodesVersion.V1)

--- a/hathor_tests/tx/test_nano_header.py
+++ b/hathor_tests/tx/test_nano_header.py
@@ -15,6 +15,7 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.vertex_parser._nano_header import deserialize_nano_header, serialize_nano_header
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.token_amount import UnsignedAmount
 
 
 def _serialize_nano_header(header: NanoHeader) -> bytes:
@@ -130,7 +131,9 @@ class VertexHeadersTest(unittest.TestCase):
                 ('nc_seqnum', vertex.get_nano_header().nc_seqnum + 1),
                 ('nc_method', 'new_method'),
                 ('nc_args_bytes', b'new args'),
-                ('nc_actions', [NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=123)]),
+                ('nc_actions', [
+                    NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(123)),
+                ]),
                 ('nc_address', b'\x01' * ADDRESS_LEN_BYTES),
                 ('nc_script', b'new script'),
             ]
@@ -171,7 +174,9 @@ class VertexHeadersTest(unittest.TestCase):
                 ('nc_seqnum', vertex.get_nano_header().nc_seqnum + 1),
                 ('nc_method', 'new_method'),
                 ('nc_args_bytes', b'new args'),
-                ('nc_actions', [NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=123)]),
+                ('nc_actions', [
+                    NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(123)),
+                ]),
                 ('nc_address', b'\x01' * ADDRESS_LEN_BYTES),
             ]
 
@@ -224,7 +229,7 @@ class VertexHeadersTest(unittest.TestCase):
                 NanoHeaderAction(
                     type=NCActionType.DEPOSIT,
                     token_index=0,
-                    amount=123,
+                    amount=UnsignedAmount.from_v1(123),
                 ),
             ],
             nc_address=b'\x01' * ADDRESS_LEN_BYTES,

--- a/hathor_tests/tx/test_reward_lock.py
+++ b/hathor_tests/tx/test_reward_lock.py
@@ -14,6 +14,7 @@ from hathor.transaction.scripts import P2PKH
 from hathor.wallet import Wallet
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, get_genesis_key
 
 DEBUG: bool = False
@@ -170,7 +171,7 @@ class TransactionTest(unittest.TestCase):
         self.assertTrue(self.manager.on_new_tx(tx))
         self.clock.advance(1)
         balance_per_address = self.manager.wallet.get_balance_per_address(self._settings.HATHOR_TOKEN_UID)
-        assert balance_per_address[tx_address] == 6400
+        assert balance_per_address[tx_address] == UnsignedAmount.from_v1(6400)
 
         # re-org: replace last two blocks with one block, new height will be just one short of enough
         block_to_replace = blocks[-2]

--- a/hathor_tests/tx/test_scripts.py
+++ b/hathor_tests/tx/test_scripts.py
@@ -56,6 +56,7 @@ from hathor.transaction.scripts.opcode import (
 from hathor.transaction.scripts.script_context import ScriptContext
 from hathor.wallet import HDWallet
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import BURN_ADDRESS, get_genesis_key
 
 
@@ -510,33 +511,47 @@ class TestScripts(unittest.TestCase):
         out_genesis = P2PKH.create_output_script(genesis_address)
 
         from hathor.transaction import Transaction, TxInput, TxOutput
-        spent_tx = Transaction(outputs=[TxOutput(1, b'nano_contract_code')])
+        spent_tx = Transaction(outputs=[TxOutput(UnsignedAmount.from_v1(1), b'nano_contract_code')])
         txin = TxInput(b'dont_care', 0, b'data')
 
         # try with just 1 output
         stack: Stack = [genesis_address]
-        tx = Transaction(outputs=[TxOutput(1, out_genesis)])
+        tx = Transaction(outputs=[TxOutput(UnsignedAmount.from_v1(1), out_genesis)])
         extras = UtxoScriptExtras(tx=tx, txin=txin, spent_tx=spent_tx, version=OpcodesVersion.V2)
         op_find_p2pkh(ScriptContext(stack=stack, logs=[], extras=extras))
         self.assertEqual(stack.pop(), 1)
 
         # several outputs and correct output among them
         stack = [genesis_address]
-        tx = Transaction(outputs=[TxOutput(1, out1), TxOutput(1, out2), TxOutput(1, out_genesis), TxOutput(1, out3)])
+        tx = Transaction(outputs=[
+            TxOutput(UnsignedAmount.from_v1(1), out1),
+            TxOutput(UnsignedAmount.from_v1(1), out2),
+            TxOutput(UnsignedAmount.from_v1(1), out_genesis),
+            TxOutput(UnsignedAmount.from_v1(1), out3),
+        ])
         extras = UtxoScriptExtras(tx=tx, txin=txin, spent_tx=spent_tx, version=OpcodesVersion.V2)
         op_find_p2pkh(ScriptContext(stack=stack, logs=[], extras=extras))
         self.assertEqual(stack.pop(), 1)
 
         # several outputs without correct amount output
         stack = [genesis_address]
-        tx = Transaction(outputs=[TxOutput(1, out1), TxOutput(1, out2), TxOutput(2, out_genesis), TxOutput(1, out3)])
+        tx = Transaction(outputs=[
+            TxOutput(UnsignedAmount.from_v1(1), out1),
+            TxOutput(UnsignedAmount.from_v1(1), out2),
+            TxOutput(UnsignedAmount.from_v1(2), out_genesis),
+            TxOutput(UnsignedAmount.from_v1(1), out3),
+        ])
         extras = UtxoScriptExtras(tx=tx, txin=txin, spent_tx=spent_tx, version=OpcodesVersion.V2)
         with self.assertRaises(VerifyFailed):
             op_find_p2pkh(ScriptContext(stack=stack, logs=[], extras=extras))
 
         # several outputs without correct address output
         stack = [genesis_address]
-        tx = Transaction(outputs=[TxOutput(1, out1), TxOutput(1, out2), TxOutput(1, out3)])
+        tx = Transaction(outputs=[
+            TxOutput(UnsignedAmount.from_v1(1), out1),
+            TxOutput(UnsignedAmount.from_v1(1), out2),
+            TxOutput(UnsignedAmount.from_v1(1), out3),
+        ])
         extras = UtxoScriptExtras(tx=tx, txin=txin, spent_tx=spent_tx, version=OpcodesVersion.V2)
         with self.assertRaises(VerifyFailed):
             op_find_p2pkh(ScriptContext(stack=stack, logs=[], extras=extras))

--- a/hathor_tests/tx/test_timelock.py
+++ b/hathor_tests/tx/test_timelock.py
@@ -8,6 +8,7 @@ from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -19,21 +20,24 @@ class TimelockTransactionTestCase(unittest.TestCase):
 
     def test_timelock(self):
         blocks = add_new_blocks(self.manager, 5, advance_clock=15)
-        blocks_tokens = [sum(txout.value for txout in blk.outputs) for blk in blocks]
+        blocks_tokens = [sum((txout.value for txout in blk.outputs), start=UnsignedAmount.zero()) for blk in blocks]
         add_blocks_unlock_reward(self.manager)
 
         address = self.manager.wallet.get_unused_address()
         outside_address = self.get_address(0)
 
+        value_500 = UnsignedAmount.from_v1(500)
+        value_700 = UnsignedAmount.from_v1(700)
         outputs = [
             WalletOutputInfo(
-                address=decode_address(address), value=500,
+                address=decode_address(address), value=value_500,
                 timelock=int(self.clock.seconds()) + 10),
             WalletOutputInfo(
-                address=decode_address(address), value=700,
+                address=decode_address(address), value=value_700,
                 timelock=int(self.clock.seconds()) - 10),
             WalletOutputInfo(
-                address=decode_address(address), value=sum(blocks_tokens[:2]) - 500 - 700,
+                address=decode_address(address),
+                value=sum(blocks_tokens[:2], start=UnsignedAmount.zero()) - value_500 - value_700,
                 timelock=None)
         ]
 
@@ -45,13 +49,15 @@ class TimelockTransactionTestCase(unittest.TestCase):
         self.manager.propagate_tx(tx1)
         self.clock.advance(1)
 
+        all_blocks_sum = sum(blocks_tokens, start=UnsignedAmount.zero())
+        first_three_blocks_sum = sum(blocks_tokens[:3], start=UnsignedAmount.zero())
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(500, sum(blocks_tokens) - 500))
+                         WalletBalance(value_500, all_blocks_sum - value_500))
 
         self.clock.advance(1)
 
         outputs1 = [
-            WalletOutputInfo(address=decode_address(outside_address), value=500, timelock=None)
+            WalletOutputInfo(address=decode_address(outside_address), value=value_500, timelock=None)
         ]
 
         inputs1 = [WalletInputInfo(tx_id=tx1.hash, index=0, private_key=None)]
@@ -66,12 +72,12 @@ class TimelockTransactionTestCase(unittest.TestCase):
             self.manager.propagate_tx(tx2)
 
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(500, sum(blocks_tokens) - 500))
+                         WalletBalance(value_500, all_blocks_sum - value_500))
 
         self.clock.advance(1)
 
         outputs2 = [
-            WalletOutputInfo(address=decode_address(outside_address), value=700, timelock=None)
+            WalletOutputInfo(address=decode_address(outside_address), value=value_700, timelock=None)
         ]
 
         inputs2 = [WalletInputInfo(tx_id=tx1.hash, index=1, private_key=None)]
@@ -85,13 +91,14 @@ class TimelockTransactionTestCase(unittest.TestCase):
         propagated = self.manager.propagate_tx(tx3)
         self.clock.advance(1)
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(500, sum(blocks_tokens) - 500 - 700))
+                         WalletBalance(value_500, all_blocks_sum - value_500 - value_700))
         self.assertTrue(propagated)
         self.clock.advance(1)
 
         outputs3 = [
             WalletOutputInfo(
-                address=decode_address(outside_address), value=sum(blocks_tokens[:2]) - 500 - 700,
+                address=decode_address(outside_address),
+                value=sum(blocks_tokens[:2], start=UnsignedAmount.zero()) - value_500 - value_700,
                 timelock=None)
         ]
 
@@ -106,7 +113,7 @@ class TimelockTransactionTestCase(unittest.TestCase):
         propagated = self.manager.propagate_tx(tx4)
         self.clock.advance(1)
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(500, sum(blocks_tokens[:3])))
+                         WalletBalance(value_500, first_three_blocks_sum))
         self.assertTrue(propagated)
 
         self.clock.advance(8)
@@ -115,12 +122,12 @@ class TimelockTransactionTestCase(unittest.TestCase):
         propagated = self.manager.propagate_tx(tx2)
         self.clock.advance(1)
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, sum(blocks_tokens[:3])))
+                         WalletBalance(UnsignedAmount.zero(), first_three_blocks_sum))
         self.assertTrue(propagated)
 
     def test_choose_inputs(self):
         blocks = add_new_blocks(self.manager, 1, advance_clock=15)
-        blocks_tokens = [sum(txout.value for txout in blk.outputs) for blk in blocks]
+        blocks_tokens = [sum((txout.value for txout in blk.outputs), start=UnsignedAmount.zero()) for blk in blocks]
         add_blocks_unlock_reward(self.manager)
 
         address = self.manager.wallet.get_unused_address(mark_as_used=False)
@@ -140,7 +147,7 @@ class TimelockTransactionTestCase(unittest.TestCase):
         self.clock.advance(1)
 
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(blocks_tokens[0], 0))
+                         WalletBalance(blocks_tokens[0], UnsignedAmount.zero()))
 
         outputs = [WalletOutputInfo(address=decode_address(address), value=blocks_tokens[0], timelock=None)]
 
@@ -157,4 +164,4 @@ class TimelockTransactionTestCase(unittest.TestCase):
         self.manager.propagate_tx(tx2)
 
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, blocks_tokens[0]))
+                         WalletBalance(UnsignedAmount.zero(), blocks_tokens[0]))

--- a/hathor_tests/tx/test_tx_serialization.py
+++ b/hathor_tests/tx/test_tx_serialization.py
@@ -6,6 +6,7 @@ from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -24,10 +25,10 @@ class BaseSerializationTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
 
         address = self.get_address(0)
-        value = 100
+        value = UnsignedAmount.from_v1(100)
 
         outputs = [
-            WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None)
+            WalletOutputInfo(address=decode_address(address), value=value, timelock=None)
         ]
 
         self.tx1 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.tx_storage)

--- a/hathor_tests/wallet/test_index.py
+++ b/hathor_tests/wallet/test_index.py
@@ -6,6 +6,7 @@ from hathor.simulator.utils import add_new_blocks
 from hathor.transaction import Transaction
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -21,12 +22,12 @@ class WalletIndexTest(unittest.TestCase):
         add_blocks_unlock_reward(self.manager)
 
         address = self.get_address(0)
-        value1 = 100
-        value2 = 101
+        value1 = UnsignedAmount.from_v1(100)
+        value2 = UnsignedAmount.from_v1(101)
 
         outputs = [
-            WalletOutputInfo(address=decode_address(address), value=int(value1), timelock=None),
-            WalletOutputInfo(address=decode_address(address), value=int(value2), timelock=None)
+            WalletOutputInfo(address=decode_address(address), value=value1, timelock=None),
+            WalletOutputInfo(address=decode_address(address), value=value2, timelock=None)
         ]
 
         tx1 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager.tx_storage)

--- a/hathor_tests/wallet/test_wallet_hd.py
+++ b/hathor_tests/wallet/test_wallet_hd.py
@@ -9,6 +9,7 @@ from hathor.wallet import HDWallet
 from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import InsufficientFunds
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -34,7 +35,10 @@ class WalletHDTest(unittest.TestCase):
         self.manager.verification_service.verify(block, self.get_verification_params(self.manager))
         utxo = self.wallet.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((block.hash, 0))
         self.assertIsNotNone(utxo)
-        self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.BLOCK_TOKENS))
+        self.assertEqual(
+            self.wallet.balance[self._settings.HATHOR_TOKEN_UID],
+            WalletBalance(UnsignedAmount.zero(),self.BLOCK_TOKENS),
+        )
 
         # create transaction spending this value, but sending to same wallet
         add_blocks_unlock_reward(self.manager)
@@ -52,7 +56,10 @@ class WalletHDTest(unittest.TestCase):
         self.assertEqual(len(self.wallet.spent_txs), 1)
         utxo = self.wallet.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((tx1.hash, 0))
         self.assertIsNotNone(utxo)
-        self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.TOKENS))
+        self.assertEqual(
+            self.wallet.balance[self._settings.HATHOR_TOKEN_UID],
+            WalletBalance(UnsignedAmount.zero(),self.TOKENS),
+        )
 
         # pass inputs and outputs to prepare_transaction, but not the input keys
         # spend output last transaction
@@ -70,7 +77,10 @@ class WalletHDTest(unittest.TestCase):
         self.tx_storage.save_transaction(tx2)
         self.wallet.on_new_tx(tx2)
         self.assertEqual(len(self.wallet.spent_txs), 2)
-        self.assertEqual(self.wallet.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, self.TOKENS))
+        self.assertEqual(
+            self.wallet.balance[self._settings.HATHOR_TOKEN_UID],
+            WalletBalance(UnsignedAmount.zero(),self.TOKENS),
+        )
 
         # Test getting more unused addresses than the gap limit
         for i in range(3):

--- a/hathor_tests/websocket/test_websocket.py
+++ b/hathor_tests/websocket/test_websocket.py
@@ -13,6 +13,7 @@ from hathor.wallet.base_wallet import SpentTx, UnspentTx, WalletBalance
 from hathor.websocket import WebsocketStatsResource
 from hathor.websocket.factory import HathorAdminWebsocketFactory, HathorAdminWebsocketProtocol
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class WebsocketTest(_BaseResourceTest._ResourceTest):
@@ -99,7 +100,8 @@ class WebsocketTest(_BaseResourceTest._ResourceTest):
         self.factory.connections.add(self.protocol)
         self.protocol.state = HathorAdminWebsocketProtocol.STATE_OPEN
         gen_tx = self.genesis[0]
-        output = UnspentTx(gen_tx.hash, 0, 10, gen_tx.timestamp, '', gen_tx.outputs[0].token_data)
+        output = UnspentTx(gen_tx.hash, 0, UnsignedAmount.from_v1(10), gen_tx.timestamp, '',
+                           gen_tx.outputs[0].token_data)
         self.manager.pubsub.publish(HathorEvents.WALLET_OUTPUT_RECEIVED, total=10, output=output)
         self.run_to_completion()
         value = self._decode_value(self.transport.value())
@@ -112,7 +114,7 @@ class WebsocketTest(_BaseResourceTest._ResourceTest):
         self.protocol.state = HathorAdminWebsocketProtocol.STATE_OPEN
         gen_tx = self.genesis[0]
         gen_tx2 = self.genesis[1]
-        spent = SpentTx(gen_tx2.hash, gen_tx.hash, 0, 10, gen_tx.timestamp + 1)
+        spent = SpentTx(gen_tx2.hash, gen_tx.hash, 0, UnsignedAmount.from_v1(10), gen_tx.timestamp + 1)
         self.manager.pubsub.publish(HathorEvents.WALLET_INPUT_SPENT, output_spent=spent)
         self.run_to_completion()
         value = self._decode_value(self.transport.value())


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1741

### Motivation

#1714 updates the codebase to the new versioned token amount model, flipping the `hathorlib.token_amount` `int` aliases to the real `htr_lib` types. That flip forces every test fixture to wrap its literal amounts, which dominates the diff. This PR lands the value-preserving fixture wrapping ahead of the flip, so the implementation PR is left with the production changes and only the behavioural test updates.

The wrapping stays green against the current `int`-based production code because the shim is itself an `int` subclass: every wrapped value is a plain integer at runtime. A single indirection module lets the implementation PR repoint the fixtures at `htr_lib` in one place, without touching each module again.

### Acceptance Criteria

- Add `hathor_tests/token_amount.py`, an `int`-subclass shim mirroring the `htr_lib` `UnsignedAmount`/`SignedAmount` API with V1 and V2 collapsed to an identity unit.
- Route the cleanly-mechanical test modules through the shim, wrapping their fixtures with `UnsignedAmount.from_v1(x)`, `.to_signed()`, and `UnsignedAmount.zero()`.
- Make no production changes and keep the `hathorlib.token_amount` aliases as `int`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged