### PR TITLE
test(decimals): more production-decoupled fixture wrapping [part 16]

### DIFF
--- a/hathor_tests/dag_builder/test_dag_builder.py
+++ b/hathor_tests/dag_builder/test_dag_builder.py
@@ -15,6 +15,7 @@ from hathor.transaction.token_info import TokenVersion
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts import test_blueprints
+from hathor_tests.token_amount import UnsignedAmount
 from hathorlib.conf.settings import HATHOR_TOKEN_UID
 
 
@@ -454,8 +455,8 @@ if foo:
         assert isinstance(fee_header, FeeHeader)
         assert fee_header.tx == tx1
         assert fee_header.get_fees() == [
-            FeeEntry(token_uid=HATHOR_TOKEN_UID, amount=1),
-            FeeEntry(token_uid=dbt.hash, amount=100),
+            FeeEntry(token_uid=HATHOR_TOKEN_UID, amount=UnsignedAmount.from_v1(1)),
+            FeeEntry(token_uid=dbt.hash, amount=UnsignedAmount.from_v1(100)),
         ]
 
         assert len(fbt1.headers) == 1
@@ -463,14 +464,14 @@ if foo:
 
         assert isinstance(fee_header, FeeHeader)
         assert fee_header.tx == fbt1
-        assert fee_header.get_fees() == [FeeEntry(token_uid=HATHOR_TOKEN_UID, amount=1)]
+        assert fee_header.get_fees() == [FeeEntry(token_uid=HATHOR_TOKEN_UID, amount=UnsignedAmount.from_v1(1))]
 
         assert len(fbt2.headers) == 1
         fee_header = fbt2.headers[0]
 
         assert isinstance(fee_header, FeeHeader)
         assert fee_header.tx == fbt2
-        assert fee_header.get_fees() == [FeeEntry(token_uid=HATHOR_TOKEN_UID, amount=1)]
+        assert fee_header.get_fees() == [FeeEntry(token_uid=HATHOR_TOKEN_UID, amount=UnsignedAmount.from_v1(1))]
 
         artifacts.propagate_with(self.manager)
 

--- a/hathor_tests/feature_activation/test_reduce_daa_target.py
+++ b/hathor_tests/feature_activation/test_reduce_daa_target.py
@@ -15,6 +15,7 @@ from hathor.daa.common import _calculate_next_weight
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.feature_activation.model.feature_state import FeatureState
+from hathor_tests.token_amount import UnsignedAmount
 
 if TYPE_CHECKING:
     from hathor.conf.settings import HathorSettings
@@ -79,7 +80,9 @@ class TestAlgorithmV1:
     def test_get_tokens_issued_per_block_normal_reward(self) -> None:
         settings = _get_settings()
         v1 = _make_v1(settings)
-        assert v1.get_tokens_issued_per_block(1) == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        assert v1.get_tokens_issued_per_block(1) == UnsignedAmount.from_v1(
+            settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        )
 
     def test_get_mined_tokens_matches_per_block_sum(self) -> None:
         settings = _get_settings()
@@ -102,7 +105,7 @@ class TestAlgorithmV2:
         settings = _get_settings()
         v2 = _make_v2(settings)
         # AVG_TIME=30, REDUCED_10X=75 (7.5s), factor=300//75=4
-        expected = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
+        expected = UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4)
         assert v2.get_tokens_issued_per_block(1) == expected
 
     def test_get_mined_tokens_uses_reduced_reward(self) -> None:
@@ -272,7 +275,7 @@ class TestDAAFactoryCreateFromBlock:
         block = self._mock_non_genesis_block()
 
         reward = factory.create_from_block(block).get_tokens_issued_per_block(1)
-        assert reward == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        assert reward == UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
 
     def test_with_block_parent_feature_active_reduces_reward(self) -> None:
         settings = _get_settings()
@@ -284,7 +287,7 @@ class TestDAAFactoryCreateFromBlock:
 
         reward = factory.create_from_block(block).get_tokens_issued_per_block(1)
         # AVG_TIME=30, REDUCED_10X=75 (7.5s), factor=300//75=4
-        expected = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
+        expected = UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4)
         assert reward == expected
 
     def test_create_from_block_asserts_without_feature_service(self) -> None:
@@ -304,7 +307,7 @@ class TestDAAFactoryCreateFromBlock:
         block.is_genesis = True
 
         reward = factory.create_from_block(block).get_tokens_issued_per_block(1)
-        assert reward == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        assert reward == UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
 
 
 class TestDAAFactoryRewardForNextBlock:
@@ -319,7 +322,7 @@ class TestDAAFactoryRewardForNextBlock:
         parent_block.get_height.return_value = 10
 
         reward = factory.create_from_parent(parent_block).get_reward_for_next_block(parent_block)
-        assert reward == settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
+        assert reward == UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
 
     def test_feature_active_reduces_reward(self) -> None:
         settings = _get_settings()
@@ -331,7 +334,7 @@ class TestDAAFactoryRewardForNextBlock:
         parent_block.get_height.return_value = 10
 
         reward = factory.create_from_parent(parent_block).get_reward_for_next_block(parent_block)
-        expected = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
+        expected = UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4)
         assert reward == expected
 
     def test_create_from_parent_asserts_without_feature_service(self) -> None:
@@ -609,8 +612,8 @@ class ActivationBoundaryTest(SimulatorTestCase):
         assert feature_service.get_state(
             block=activation_block, feature=Feature.REDUCE_DAA_TARGET
         ) == FeatureState.ACTIVE
-        v1_reward = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK
-        v2_reward = settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4
+        v1_reward = UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK)
+        v2_reward = UnsignedAmount.from_v1(settings.INITIAL_TOKEN_ATOMIC_UNITS_PER_BLOCK // 4)
         assert activation_block.sum_outputs == v1_reward, (
             f'activation block (height 16) should still be V1 under Shape B '
             f'(parent at 15 is LOCKED_IN). got {activation_block.sum_outputs}, '
@@ -642,7 +645,7 @@ class ActivationBoundaryTest(SimulatorTestCase):
         # Activation boundary is 16; first V2 block is 17. v2_start_height = 17.
         assert daa._config.v2_start_height == 17
 
-        per_block_sum = 16 * v1_reward + (last_height - 16) * v2_reward
+        per_block_sum = 16 * v1_reward.raw() + (last_height - 16) * v2_reward.raw()
         assert daa.get_mined_tokens(last_height) == per_block_sum, (
             f'cumulative mined tokens at height {last_height} should split V1[1..16]+V2[17..20]: '
             f'got {daa.get_mined_tokens(last_height)}, expected {per_block_sum}'
@@ -650,7 +653,7 @@ class ActivationBoundaryTest(SimulatorTestCase):
 
         # Sanity: had we (incorrectly) applied the reduction factor to the entire chain,
         # we would get this wrong number — verify we are NOT producing it.
-        wrong_all_v2 = last_height * v2_reward
+        wrong_all_v2 = last_height * v2_reward.raw()
         assert daa.get_mined_tokens(last_height) != wrong_all_v2
 
     def test_get_activation_height_walks_back_through_boundaries(self) -> None:

--- a/hathor_tests/nanocontracts/test_actions.py
+++ b/hathor_tests/nanocontracts/test_actions.py
@@ -23,8 +23,8 @@ from hathor.wallet import HDWallet
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.utils import assert_nc_failure_reason, set_nano_header
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.nanocontracts.verification import MAX_ACTIONS_LEN
-from hathorlib.token_amount import SignedAmount
 
 
 class MyBlueprint(Blueprint):
@@ -166,14 +166,14 @@ class TestActions(unittest.TestCase):
             assert tx.get_token_uid(out.get_token_index()) == HATHOR_TOKEN_UID, (
                 'expected HTR in output index 0'
             )
-            out.value += update_htr_output
+            out.value = (out.value + update_htr_output).to_unsigned().to_v1()
 
         if update_tka_output is not None:
             out = tx.outputs[1]
             assert tx.get_token_uid(out.get_token_index()) == self.tka.hash, (
                 'expected TKA in output index 1'
             )
-            out.value += update_tka_output
+            out.value = (out.value + update_tka_output).to_unsigned().to_v1()
 
         if add_inputs:
             tx.inputs.extend(add_inputs)
@@ -207,14 +207,16 @@ class TestActions(unittest.TestCase):
         return TxInput(tx_id=self.tka.hash, index=melt_index, data=b'')
 
     def _assert_token_index(self, *, htr_total: int, tka_total: int) -> None:
-        assert self.tokens_index.get_token_info(HATHOR_TOKEN_UID).get_total() == htr_total
-        assert self.tokens_index.get_token_info(self.tka.hash).get_total() == tka_total
+        actual_htr = self.tokens_index.get_token_info(HATHOR_TOKEN_UID).get_total()
+        actual_tka = self.tokens_index.get_token_info(self.tka.hash).get_total()
+        assert actual_htr == UnsignedAmount.from_v1(htr_total)
+        assert actual_tka == UnsignedAmount.from_v1(tka_total)
 
     def test_deposit_success(self) -> None:
         # Add a DEPOSIT action and remove tokens from the HTR output accordingly.
-        self._change_tx_balance(tx=self.tx1, update_htr_output=-123)
+        self._change_tx_balance(tx=self.tx1, update_htr_output=-UnsignedAmount.from_v1(123).to_signed())
         self._set_nano_header(tx=self.tx1, nc_actions=[
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=123),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(123)),
         ])
 
         # Execute tx1
@@ -225,8 +227,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with the added tokens.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1123, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1123).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
         }
 
         # Check the token index.
@@ -237,9 +243,9 @@ class TestActions(unittest.TestCase):
 
     def test_withdrawal_success(self) -> None:
         # Add a WITHDRAWAL action and add tokens to the HTR output accordingly.
-        self._change_tx_balance(tx=self.tx1, update_htr_output=123)
+        self._change_tx_balance(tx=self.tx1, update_htr_output=UnsignedAmount.from_v1(123).to_signed())
         self._set_nano_header(tx=self.tx1, nc_actions=[
-            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=123),
+            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=UnsignedAmount.from_v1(123)),
         ])
 
         # Execute tx1
@@ -250,8 +256,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with the removed tokens.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=877, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(877).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
         }
 
         # Check the token index.
@@ -265,7 +275,9 @@ class TestActions(unittest.TestCase):
         self._change_tx_balance(tx=self.tx1, add_inputs=[self._create_tka_mint_input()])
         self._set_nano_header(tx=self.tx1, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK
+                type=NCActionType.GRANT_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
             ),
         ])
 
@@ -277,8 +289,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with the mint authority.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
     def test_grant_authority_melt_success(self) -> None:
@@ -286,7 +302,9 @@ class TestActions(unittest.TestCase):
         self._change_tx_balance(tx=self.tx1, add_inputs=[self._create_tka_melt_input()])
         self._set_nano_header(tx=self.tx1, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MELT_MASK
+                type=NCActionType.GRANT_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK),
             ),
         ])
 
@@ -298,8 +316,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with the melt authority.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
     def test_grant_authority_all_success(self) -> None:
@@ -313,7 +335,9 @@ class TestActions(unittest.TestCase):
         )
         self._set_nano_header(tx=self.tx1, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.ALL_AUTHORITIES
+                type=NCActionType.GRANT_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.ALL_AUTHORITIES),
             ),
         ])
 
@@ -325,8 +349,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with both mint and melt authorities.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=True, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True
+            ),
         }
 
     def _test_acquire_authority_to_create_output(self, authority: int) -> None:
@@ -337,12 +365,16 @@ class TestActions(unittest.TestCase):
         self._change_tx_balance(
             tx=self.tx2,
             add_outputs=[
-                TxOutput(value=authority, script=b'', token_data=TxOutput.TOKEN_AUTHORITY_MASK | token_index)
+                TxOutput(
+                    value=UnsignedAmount.from_v1(authority),
+                    script=b'',
+                    token_data=TxOutput.TOKEN_AUTHORITY_MASK | token_index,
+                )
             ]
         )
         self._set_nano_header(tx=self.tx2, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=authority
+                type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=UnsignedAmount.from_v1(authority)
             ),
         ])
 
@@ -421,12 +453,14 @@ class TestActions(unittest.TestCase):
         # Add an ACQUIRE_AUTHORITY action for TKA, minting new TKA, and updating the HTR balance accordingly.
         self._change_tx_balance(
             tx=self.tx2,
-            update_htr_output=-10,
-            update_tka_output=1000,
+            update_htr_output=-UnsignedAmount.from_v1(10).to_signed(),
+            update_tka_output=UnsignedAmount.from_v1(1000).to_signed(),
         )
         self._set_nano_header(tx=self.tx2, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK
+                type=NCActionType.ACQUIRE_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
             ),
         ])
 
@@ -445,12 +479,14 @@ class TestActions(unittest.TestCase):
         # Add an ACQUIRE_AUTHORITY action for TKA, melting TKA, and updating the HTR balance accordingly.
         self._change_tx_balance(
             tx=self.tx2,
-            update_htr_output=5,
-            update_tka_output=-500,
+            update_htr_output=UnsignedAmount.from_v1(5).to_signed(),
+            update_tka_output=-UnsignedAmount.from_v1(500).to_signed(),
         )
         self._set_nano_header(tx=self.tx2, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MELT_MASK
+                type=NCActionType.ACQUIRE_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK),
             ),
         ])
 
@@ -466,15 +502,23 @@ class TestActions(unittest.TestCase):
         # Grant a TKA mint authority to the nano contract and then use it to mint tokens.
         self.test_grant_authority_mint_success()
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
         # Add actions so both minted tokens and htr used to mint tokens are in/from the tx outputs/inputs.
-        self._change_tx_balance(tx=self.tx2, update_htr_output=-200, update_tka_output=20000)
+        self._change_tx_balance(
+            tx=self.tx2,
+            update_htr_output=-UnsignedAmount.from_v1(200).to_signed(),
+            update_tka_output=UnsignedAmount.from_v1(20000).to_signed(),
+        )
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=20000),
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=200),
+            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(20000)),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(200)),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -494,8 +538,12 @@ class TestActions(unittest.TestCase):
         # Check that the nano contract balance is unchanged because both
         # minted tokens and HTR used to mint in/were from tx outputs/inputs.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
         # Check the token index.
@@ -517,7 +565,11 @@ class TestActions(unittest.TestCase):
         self._set_nano_header(
             tx=self.tx1,
             nc_actions=[
-                NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK),
+                NanoHeaderAction(
+                    type=NCActionType.GRANT_AUTHORITY,
+                    token_index=1,
+                    amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
+                ),
             ],
             nc_method='mint',
             nc_args=(self.tka.hash, 200)
@@ -531,23 +583,33 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with the mint authority.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=998, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1200, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(998).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1200).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
     def test_mint_tokens_keep_in_contract_success(self) -> None:
         # Grant a TKA mint authority to the nano contract and then use it to mint tokens.
         self.test_grant_authority_mint_success()
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
         # Add a deposit action, paying for HTR with the input and keeping the minted token in the contract.
-        self._change_tx_balance(tx=self.tx2, update_htr_output=-200)
+        self._change_tx_balance(tx=self.tx2, update_htr_output=-UnsignedAmount.from_v1(200).to_signed())
         self._set_nano_header(
             tx=self.tx2,
-            nc_actions=[NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=200)],
+            nc_actions=[
+                NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(200))
+            ],
             nc_method='mint',
             nc_args=(self.tka.hash, 20000)
         )
@@ -560,8 +622,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=21000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(21000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
         # Check the token index.
@@ -574,15 +640,23 @@ class TestActions(unittest.TestCase):
         # Grant a TKA mint authority to the nano contract and then use it to mint tokens.
         self.test_grant_authority_mint_success()
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
         # Add actions paying for HTR with the input and withdrawing part of the minted token from the contract.
-        self._change_tx_balance(tx=self.tx2, update_htr_output=-200, update_tka_output=10000)
+        self._change_tx_balance(
+            tx=self.tx2,
+            update_htr_output=-UnsignedAmount.from_v1(200).to_signed(),
+            update_tka_output=UnsignedAmount.from_v1(10000).to_signed(),
+        )
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10000),
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=200),
+            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10000)),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(200)),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -601,8 +675,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=11000, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(11000).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
         # Check the token index.
@@ -621,15 +699,23 @@ class TestActions(unittest.TestCase):
         # Grant a TKA melt authority to the nano contract and then use it to melt tokens.
         self.test_grant_authority_melt_success()
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
         # Add actions so both melted tokens and htr received from melt are from/in the tx inputs/outputs.
-        self._change_tx_balance(tx=self.tx2, update_htr_output=5, update_tka_output=-500)
+        self._change_tx_balance(
+            tx=self.tx2,
+            update_htr_output=UnsignedAmount.from_v1(5).to_signed(),
+            update_tka_output=-UnsignedAmount.from_v1(500).to_signed(),
+        )
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=1, amount=500),
-            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=5),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=1, amount=UnsignedAmount.from_v1(500)),
+            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=UnsignedAmount.from_v1(5)),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -649,8 +735,12 @@ class TestActions(unittest.TestCase):
         # Check that the nano contract balance is unchanged because both
         # melted tokens and HTR received are from/in the tx inputs/outputs.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
         # Check the token index.
@@ -669,15 +759,21 @@ class TestActions(unittest.TestCase):
         # Grant a TKA melt authority to the nano contract and then use it to melt tokens.
         self.test_grant_authority_melt_success()
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
         # Add a withdrawal action receiving the HTR from the melt in the output and melting the tokens in the contract.
-        self._change_tx_balance(tx=self.tx2, update_htr_output=5)
+        self._change_tx_balance(tx=self.tx2, update_htr_output=UnsignedAmount.from_v1(5).to_signed())
         self._set_nano_header(
             tx=self.tx2,
-            nc_actions=[NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=5)],
+            nc_actions=[
+                NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=UnsignedAmount.from_v1(5))
+            ],
             nc_method='melt',
             nc_args=(self.tka.hash, 500)
         )
@@ -690,8 +786,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=500, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(500).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
         # Check the token index.
@@ -704,15 +804,23 @@ class TestActions(unittest.TestCase):
         # Grant a TKA melt authority to the nano contract and then use it to melt tokens.
         self.test_grant_authority_melt_success()
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1000, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
         # Add actions so part of the tokens are melted from inputs and part from the contract.
-        self._change_tx_balance(tx=self.tx2, update_htr_output=5, update_tka_output=-250)
+        self._change_tx_balance(
+            tx=self.tx2,
+            update_htr_output=UnsignedAmount.from_v1(5).to_signed(),
+            update_tka_output=-UnsignedAmount.from_v1(250).to_signed(),
+        )
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=1, amount=250),
-            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=5),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=1, amount=UnsignedAmount.from_v1(250)),
+            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=UnsignedAmount.from_v1(5)),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -731,8 +839,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=750, can_mint=False, can_melt=True),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(750).to_signed(), can_mint=False, can_melt=True
+            ),
         }
 
         # Check the token index.
@@ -749,8 +861,16 @@ class TestActions(unittest.TestCase):
 
     def _test_acquire_and_grant_same_token_not_allowed(self, *, invert_actions_order: bool) -> None:
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK),
-            NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK),
+            NanoHeaderAction(
+                type=NCActionType.ACQUIRE_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
+            ),
+            NanoHeaderAction(
+                type=NCActionType.GRANT_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
+            ),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -772,8 +892,8 @@ class TestActions(unittest.TestCase):
     def _test_conflicting_actions(self, *, invert_actions_order: bool) -> None:
         # Add 2 conflicting actions for the same token.
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=1),
-            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=2),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(1)),
+            NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=UnsignedAmount.from_v1(2)),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -793,10 +913,14 @@ class TestActions(unittest.TestCase):
         # Add a GRANT_AUTHORITY action to mint TKA, and add a mint authority input accordingly.
         # Also add a DEPOSIT action with the same token and update the tx output accordingly.
         self._change_tx_balance(tx=self.tx1, add_inputs=[self._create_tka_mint_input()])
-        self._change_tx_balance(tx=self.tx1, update_tka_output=-100)
+        self._change_tx_balance(tx=self.tx1, update_tka_output=-UnsignedAmount.from_v1(100).to_signed())
         nc_actions = [
-            NanoHeaderAction(type=NCActionType.GRANT_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK),
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=1, amount=100),
+            NanoHeaderAction(
+                type=NCActionType.GRANT_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
+            ),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=1, amount=UnsignedAmount.from_v1(100)),
         ]
         if invert_actions_order:
             nc_actions.reverse()
@@ -813,8 +937,12 @@ class TestActions(unittest.TestCase):
 
         # Check that the nano contract balance is updated with the mint authority.
         assert self._get_all_balances() == {
-            self.htr_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
-            self.tka_balance_key: Balance(value=1100, can_mint=True, can_melt=False),
+            self.htr_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
+            self.tka_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1100).to_signed(), can_mint=True, can_melt=False
+            ),
         }
 
     def test_non_conflicting_actions_success(self) -> None:
@@ -826,7 +954,7 @@ class TestActions(unittest.TestCase):
     def test_token_index_not_found(self) -> None:
         # Add an action with a token index out of bounds.
         self._set_nano_header(tx=self.tx1, nc_actions=[
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=2, amount=1),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=2, amount=UnsignedAmount.from_v1(1)),
         ])
 
         params = dataclasses.replace(self.verification_params, harden_token_restrictions=False)
@@ -836,7 +964,7 @@ class TestActions(unittest.TestCase):
 
     def test_token_uid_not_in_list(self) -> None:
         self._set_nano_header(tx=self.tx1, nc_actions=[
-            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=1),
+            NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=UnsignedAmount.from_v1(1)),
         ])
 
         nano_header = self.tx1.get_nano_header()
@@ -857,7 +985,11 @@ class TestActions(unittest.TestCase):
     def _test_invalid_unknown_authority(self, action_type: NCActionType) -> None:
         # Create an authority action with an unknown authority.
         self._set_nano_header(tx=self.tx1, nc_actions=[
-            NanoHeaderAction(type=action_type, token_index=1, amount=TxOutput.ALL_AUTHORITIES + 1),
+            NanoHeaderAction(
+                type=action_type,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.ALL_AUTHORITIES + 1),
+            ),
         ])
 
         with pytest.raises(NCInvalidAction) as e:
@@ -867,7 +999,7 @@ class TestActions(unittest.TestCase):
     def _test_invalid_htr_authority(self, action_type: NCActionType) -> None:
         # Create an authority action for HTR.
         self._set_nano_header(tx=self.tx1, nc_actions=[
-            NanoHeaderAction(type=action_type, token_index=0, amount=TxOutput.TOKEN_MINT_MASK),
+            NanoHeaderAction(type=action_type, token_index=0, amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK)),
         ])
 
         with pytest.raises(NCInvalidAction) as e:
@@ -892,7 +1024,7 @@ class TestActions(unittest.TestCase):
             NanoHeaderAction(
                 type=NCActionType.GRANT_AUTHORITY,
                 token_index=1,
-                amount=TxOutput.TOKEN_MINT_MASK
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK)
             ),
         ])
 
@@ -906,7 +1038,7 @@ class TestActions(unittest.TestCase):
             NanoHeaderAction(
                 type=NCActionType.GRANT_AUTHORITY,
                 token_index=1,
-                amount=TxOutput.TOKEN_MELT_MASK
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK)
             ),
         ])
 
@@ -919,12 +1051,18 @@ class TestActions(unittest.TestCase):
         self._change_tx_balance(
             tx=self.tx1,
             add_outputs=[
-                TxOutput(value=TxOutput.TOKEN_MINT_MASK, script=b'', token_data=TxOutput.TOKEN_AUTHORITY_MASK | 1)
+                TxOutput(
+                    value=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
+                    script=b'',
+                    token_data=TxOutput.TOKEN_AUTHORITY_MASK | 1,
+                )
             ]
         )
         self._set_nano_header(tx=self.tx1, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MELT_MASK
+                type=NCActionType.ACQUIRE_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK),
             ),
         ])
 
@@ -936,12 +1074,18 @@ class TestActions(unittest.TestCase):
         self._change_tx_balance(
             tx=self.tx1,
             add_outputs=[
-                TxOutput(value=TxOutput.TOKEN_MELT_MASK, script=b'', token_data=TxOutput.TOKEN_AUTHORITY_MASK | 1)
+                TxOutput(
+                    value=UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK),
+                    script=b'',
+                    token_data=TxOutput.TOKEN_AUTHORITY_MASK | 1,
+                )
             ]
         )
         self._set_nano_header(tx=self.tx1, nc_actions=[
             NanoHeaderAction(
-                type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=TxOutput.TOKEN_MINT_MASK
+                type=NCActionType.ACQUIRE_AUTHORITY,
+                token_index=1,
+                amount=UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK),
             ),
         ])
 
@@ -950,7 +1094,7 @@ class TestActions(unittest.TestCase):
 
     def test_actions_max_len_fail(self) -> None:
         # Try to create too many actions.
-        action = NanoHeaderAction(type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=1)
+        action = NanoHeaderAction(type=NCActionType.ACQUIRE_AUTHORITY, token_index=1, amount=UnsignedAmount.from_v1(1))
         actions = [action] * (MAX_ACTIONS_LEN + 1)
 
         self._set_nano_header(tx=self.tx1, nc_actions=actions)

--- a/hathor_tests/nanocontracts/test_actions_fee.py
+++ b/hathor_tests/nanocontracts/test_actions_fee.py
@@ -13,6 +13,7 @@ from hathor.transaction import Transaction
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.test_reentrancy import HTR_TOKEN_UID
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.conf.settings import HATHOR_TOKEN_UID
 
 
@@ -188,9 +189,11 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         # fee token creation charging 1 HTR
         # 100 - 10 - 1 = 89
         assert self.nc1_storage.get_all_balances() == {
-            nc1_htr_balance_key: Balance(value=89, can_mint=False, can_melt=False),
-            nc1_dbt_balance_key: Balance(value=1000, can_mint=True, can_melt=True),
-            nc1_fbt_balance_key: Balance(value=10000, can_mint=True, can_melt=True),
+            nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(89).to_signed(), can_mint=False, can_melt=False),
+            nc1_dbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True),
+            nc1_fbt_balance_key: Balance(
+                value=UnsignedAmount.from_v1(10000).to_signed(), can_mint=True, can_melt=True
+            ),
         }
 
         # move tokens from nc1 to nc2
@@ -207,14 +210,16 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         )
 
         assert self.nc1_storage.get_all_balances() == {
-            nc1_htr_balance_key: Balance(value=88, can_mint=False, can_melt=False),
-            nc1_dbt_balance_key: Balance(value=1000, can_mint=True, can_melt=True),
-            nc1_fbt_balance_key: Balance(value=9000, can_mint=True, can_melt=True),
+            nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(88).to_signed(), can_mint=False, can_melt=False),
+            nc1_dbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True),
+            nc1_fbt_balance_key: Balance(value=UnsignedAmount.from_v1(9000).to_signed(), can_mint=True, can_melt=True),
         }
 
         nc2_fbt_balance_key = BalanceKey(nc_id=self.nc2_id, token_uid=fbt_token_uid)
         assert self.nc2_storage.get_all_balances() == {
-            nc2_fbt_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
+            nc2_fbt_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
         }
 
         # move tokens from nc1 to nc2 paying with deposit tokens
@@ -231,14 +236,16 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         )
 
         assert self.nc1_storage.get_all_balances() == {
-            nc1_htr_balance_key: Balance(value=88, can_mint=False, can_melt=False),
-            nc1_dbt_balance_key: Balance(value=900, can_mint=True, can_melt=True),
-            nc1_fbt_balance_key: Balance(value=8000, can_mint=True, can_melt=True),
+            nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(88).to_signed(), can_mint=False, can_melt=False),
+            nc1_dbt_balance_key: Balance(value=UnsignedAmount.from_v1(900).to_signed(), can_mint=True, can_melt=True),
+            nc1_fbt_balance_key: Balance(value=UnsignedAmount.from_v1(8000).to_signed(), can_mint=True, can_melt=True),
         }
 
         nc2_fbt_balance_key = BalanceKey(nc_id=self.nc2_id, token_uid=fbt_token_uid)
         assert self.nc2_storage.get_all_balances() == {
-            nc2_fbt_balance_key: Balance(value=2000, can_mint=False, can_melt=False),
+            nc2_fbt_balance_key: Balance(
+                value=UnsignedAmount.from_v1(2000).to_signed(), can_mint=False, can_melt=False
+            ),
         }
 
         # get tokens from nc2 to nc1 paying with htr
@@ -254,14 +261,16 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         )
 
         assert self.nc1_storage.get_all_balances() == {
-            nc1_htr_balance_key: Balance(value=87, can_mint=False, can_melt=False),
-            nc1_dbt_balance_key: Balance(value=900, can_mint=True, can_melt=True),
-            nc1_fbt_balance_key: Balance(value=9000, can_mint=True, can_melt=True),
+            nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(87).to_signed(), can_mint=False, can_melt=False),
+            nc1_dbt_balance_key: Balance(value=UnsignedAmount.from_v1(900).to_signed(), can_mint=True, can_melt=True),
+            nc1_fbt_balance_key: Balance(value=UnsignedAmount.from_v1(9000).to_signed(), can_mint=True, can_melt=True),
         }
 
         nc2_fbt_balance_key = BalanceKey(nc_id=self.nc2_id, token_uid=fbt_token_uid)
         assert self.nc2_storage.get_all_balances() == {
-            nc2_fbt_balance_key: Balance(value=1000, can_mint=False, can_melt=False),
+            nc2_fbt_balance_key: Balance(
+                value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+            ),
         }
 
         # get tokens from nc2 to nc1 paying with deposit token
@@ -277,14 +286,16 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         )
 
         assert self.nc1_storage.get_all_balances() == {
-            nc1_htr_balance_key: Balance(value=87, can_mint=False, can_melt=False),
-            nc1_dbt_balance_key: Balance(value=800, can_mint=True, can_melt=True),
-            nc1_fbt_balance_key: Balance(value=10_000, can_mint=True, can_melt=True),
+            nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(87).to_signed(), can_mint=False, can_melt=False),
+            nc1_dbt_balance_key: Balance(value=UnsignedAmount.from_v1(800).to_signed(), can_mint=True, can_melt=True),
+            nc1_fbt_balance_key: Balance(
+                value=UnsignedAmount.from_v1(10_000).to_signed(), can_mint=True, can_melt=True
+            ),
         }
 
         nc2_fbt_balance_key = BalanceKey(nc_id=self.nc2_id, token_uid=fbt_token_uid)
         assert self.nc2_storage.get_all_balances() == {
-            nc2_fbt_balance_key: Balance(value=0, can_mint=False, can_melt=False),
+            nc2_fbt_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
         }
 
         # paying attempt with negative value is forbidden
@@ -370,14 +381,16 @@ class NCActionsFeeTestCase(BlueprintTestCase):
             )
 
         assert self.nc1_storage.get_all_balances() == {
-            nc1_htr_balance_key: Balance(value=87, can_mint=False, can_melt=False),
-            nc1_dbt_balance_key: Balance(value=800, can_mint=True, can_melt=True),
-            nc1_fbt_balance_key: Balance(value=10_000, can_mint=True, can_melt=True),
+            nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(87).to_signed(), can_mint=False, can_melt=False),
+            nc1_dbt_balance_key: Balance(value=UnsignedAmount.from_v1(800).to_signed(), can_mint=True, can_melt=True),
+            nc1_fbt_balance_key: Balance(
+                value=UnsignedAmount.from_v1(10_000).to_signed(), can_mint=True, can_melt=True
+            ),
         }
 
         nc2_fbt_balance_key = BalanceKey(nc_id=self.nc2_id, token_uid=fbt_token_uid)
         assert self.nc2_storage.get_all_balances() == {
-            nc2_fbt_balance_key: Balance(value=0, can_mint=False, can_melt=False),
+            nc2_fbt_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
         }
 
     def test_create_and_actions(self) -> None:
@@ -403,10 +416,10 @@ class NCActionsFeeTestCase(BlueprintTestCase):
 
         storage = self.runner.get_storage(self.nc3_id)
         assert storage.get_all_balances() == {
-            htr_balance_key: Balance(value=0, can_mint=False, can_melt=False),
-            fbt_balance_key: Balance(value=900_000, can_mint=True, can_melt=True),
-            ftt_balance_key: Balance(value=500_000, can_mint=True, can_melt=True),
-            dbt_balance_key: Balance(value=1000, can_mint=True, can_melt=True),
+            htr_balance_key: Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            fbt_balance_key: Balance(value=UnsignedAmount.from_v1(900_000).to_signed(), can_mint=True, can_melt=True),
+            ftt_balance_key: Balance(value=UnsignedAmount.from_v1(500_000).to_signed(), can_mint=True, can_melt=True),
+            dbt_balance_key: Balance(value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=True, can_melt=True),
         }
 
     def test_token_index_updates(self) -> None:
@@ -457,13 +470,13 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
 
         fbt_token_info = tokens_index.get_token_info(fbt_id)
-        assert fbt_token_info.get_total() == 1_000_000
+        assert fbt_token_info.get_total() == UnsignedAmount.from_v1(1_000_000)
 
         ftt_token_info = tokens_index.get_token_info(ftt_id)
-        assert ftt_token_info.get_total() == 500_000
+        assert ftt_token_info.get_total() == UnsignedAmount.from_v1(500_000)
 
         dbt_token_info = tokens_index.get_token_info(dbt_id)
-        assert dbt_token_info.get_total() == 800
+        assert dbt_token_info.get_total() == UnsignedAmount.from_v1(800)
 
         # Verify HTR total (genesis + mined blocks - fees paid)
         # Fees during initialize (tx1): 1 HTR (FBT) + 1 HTR (FTT) + 10 HTR (DBT, 1% of 1000) = 12 HTR
@@ -479,7 +492,7 @@ class NCActionsFeeTestCase(BlueprintTestCase):
             - 1   # 1 HTR fee for tx3 (move_tokens_to_nc)
             - 1   # 1 HTR fee for tx5 (move_tokens_to_nc_paying_with_htr_and_dbt)
         )
-        assert htr_token_info.get_total() == expected_htr_total
+        assert htr_token_info.get_total() == UnsignedAmount.from_v1(expected_htr_total)
 
         # Verify contract balances after all operations
         nc1_storage = self.manager.get_best_block_nc_storage(tx1.hash)
@@ -490,15 +503,29 @@ class NCActionsFeeTestCase(BlueprintTestCase):
         # - FBT: 1_000_000 - 1000 (tx3) - 1000 (tx4) - 1000 (tx5) = 997_000 FBT
         # - FTT: 500_000 - 1000 (tx5) = 499_000 FTT
         # - DBT: 1000 - 100 (tx4) - 100 (tx5) = 800 DBT
-        assert nc1_storage.get_balance(HATHOR_TOKEN_UID) == Balance(value=86, can_mint=False, can_melt=False)
-        assert nc1_storage.get_balance(fbt_id) == Balance(value=997_000, can_mint=True, can_melt=True)
-        assert nc1_storage.get_balance(ftt_id) == Balance(value=499_000, can_mint=True, can_melt=True)
-        assert nc1_storage.get_balance(dbt_id) == Balance(value=800, can_mint=True, can_melt=True)
+        assert nc1_storage.get_balance(HATHOR_TOKEN_UID) == Balance(
+            value=UnsignedAmount.from_v1(86).to_signed(), can_mint=False, can_melt=False
+        )
+        assert nc1_storage.get_balance(fbt_id) == Balance(
+            value=UnsignedAmount.from_v1(997_000).to_signed(), can_mint=True, can_melt=True
+        )
+        assert nc1_storage.get_balance(ftt_id) == Balance(
+            value=UnsignedAmount.from_v1(499_000).to_signed(), can_mint=True, can_melt=True
+        )
+        assert nc1_storage.get_balance(dbt_id) == Balance(
+            value=UnsignedAmount.from_v1(800).to_signed(), can_mint=True, can_melt=True
+        )
 
         # nc2 should have:
         # - HTR: 0
         # - FBT: 1000 (tx3) + 1000 (tx4) + 1000 (tx5) = 3000 FBT
         # - FTT: 1000 (tx5) = 1000 FTT
-        assert nc2_storage.get_balance(HATHOR_TOKEN_UID) == Balance(value=0, can_mint=False, can_melt=False)
-        assert nc2_storage.get_balance(fbt_id) == Balance(value=3000, can_mint=False, can_melt=False)
-        assert nc2_storage.get_balance(ftt_id) == Balance(value=1000, can_mint=False, can_melt=False)
+        assert nc2_storage.get_balance(HATHOR_TOKEN_UID) == Balance(
+            value=SignedAmount(), can_mint=False, can_melt=False
+        )
+        assert nc2_storage.get_balance(fbt_id) == Balance(
+            value=UnsignedAmount.from_v1(3000).to_signed(), can_mint=False, can_melt=False
+        )
+        assert nc2_storage.get_balance(ftt_id) == Balance(
+            value=UnsignedAmount.from_v1(1000).to_signed(), can_mint=False, can_melt=False
+        )

--- a/hathor_tests/nanocontracts/test_consensus.py
+++ b/hathor_tests/nanocontracts/test_consensus.py
@@ -25,6 +25,7 @@ from hathor.types import VertexId
 from hathor.wallet.base_wallet import WalletOutputInfo
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_custom_tx, create_tokens, gen_custom_base_tx
 
 settings = HathorSettings()
@@ -97,7 +98,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.miner.start()
 
         self.token_uid = TokenUid(b'\0')
-        trigger = StopAfterMinimumBalance(self.wallet, self.token_uid, 1)
+        trigger = StopAfterMinimumBalance(self.wallet, self.token_uid, UnsignedAmount.from_v1(1))
         self.assertTrue(self.simulator.run(7200, trigger=trigger))
 
     def assertNoBlocksVoided(self):
@@ -254,7 +255,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         add_blocks_unlock_reward(self.manager)
         _inputs, deposit_amount = self.wallet.get_inputs_from_amount(
-            1, self.manager.tx_storage, token_uid=self.token_uid
+            UnsignedAmount.from_v1(1), self.manager.tx_storage, token_uid=self.token_uid
         )
         tx = self.wallet.prepare_transaction(Transaction, _inputs, [], timestamp=int(self.manager.reactor.seconds()))
         tx = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx, is_custom_token=is_custom_token, nc_actions=[
@@ -291,7 +292,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             _output_token_index = 1
 
         tx2 = Transaction(
-            outputs=[TxOutput(1, b'', _output_token_index)],
+            outputs=[TxOutput(UnsignedAmount.from_v1(1), b'', _output_token_index)],
             timestamp=int(self.manager.reactor.seconds()),
         )
         tx2.tokens = _tokens
@@ -299,7 +300,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             NanoHeaderAction(
                 type=NCActionType.WITHDRAWAL,
                 token_index=1 if is_custom_token else 0,
-                amount=1,
+                amount=UnsignedAmount.from_v1(1),
             )
         ])
         self.manager.cpu_mining_service.resolve(tx2)
@@ -314,14 +315,15 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         nc_storage = self.manager.get_best_block_nc_storage(nc_id)
         self.assertEqual(
-            Balance(value=deposit_amount - 1, can_mint=False, can_melt=False),
+            Balance(value=(deposit_amount - UnsignedAmount.from_v1(1)), can_mint=False, can_melt=False),
             nc_storage.get_balance(self.token_uid)
         )
 
         # Make a withdrawal of the remainder.
 
+        remainder = UnsignedAmount.from_v1(deposit_amount - 2)
         tx3 = Transaction(
-            outputs=[TxOutput(deposit_amount - 2, b'', _output_token_index)],
+            outputs=[TxOutput(remainder, b'', _output_token_index)],
             timestamp=int(self.manager.reactor.seconds()),
         )
         tx3.tokens = _tokens
@@ -329,7 +331,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             NanoHeaderAction(
                 type=NCActionType.WITHDRAWAL,
                 token_index=1 if is_custom_token else 0,
-                amount=deposit_amount - 2,
+                amount=remainder,
             )
         ])
         self.manager.cpu_mining_service.resolve(tx3)
@@ -343,7 +345,10 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.assertIsNone(meta3.voided_by)
 
         nc_storage = self.manager.get_best_block_nc_storage(nc_id)
-        self.assertEqual(Balance(value=1, can_mint=False, can_melt=False), nc_storage.get_balance(self.token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(1).to_signed(), can_mint=False, can_melt=False),
+            nc_storage.get_balance(self.token_uid),
+        )
 
         # Try to withdraw more than available, so it fails.
 
@@ -354,7 +359,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             _output_token_index = 1
 
         tx4 = Transaction(
-            outputs=[TxOutput(2, b'', _output_token_index)],
+            outputs=[TxOutput(UnsignedAmount.from_v1(2), b'', _output_token_index)],
             timestamp=int(self.manager.reactor.seconds()),
         )
         tx4.tokens = _tokens
@@ -362,7 +367,7 @@ class NCConsensusTestCase(SimulatorTestCase):
             NanoHeaderAction(
                 type=NCActionType.WITHDRAWAL,
                 token_index=1 if is_custom_token else 0,
-                amount=2,
+                amount=UnsignedAmount.from_v1(2),
             )
         ])
         self.manager.cpu_mining_service.resolve(tx4)
@@ -376,14 +381,20 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.assertEqual(meta4.voided_by, {tx4.hash, NC_EXECUTION_FAIL_ID})
 
         nc_storage = self.manager.get_best_block_nc_storage(nc_id)
-        self.assertEqual(Balance(value=1, can_mint=False, can_melt=False), nc_storage.get_balance(self.token_uid))
+        self.assertEqual(
+            Balance(value=UnsignedAmount.from_v1(1).to_signed(), can_mint=False, can_melt=False),
+            nc_storage.get_balance(self.token_uid),
+        )
 
         self.assertNoBlocksVoided()
 
         # Check balance at different blocks
 
         nc_storage = self.manager.get_nc_storage(block_initialize, nc_id)
-        self.assertEqual(Balance(value=0, can_mint=False, can_melt=False), nc_storage.get_balance(self.token_uid))
+        self.assertEqual(
+            Balance(value=SignedAmount(), can_mint=False, can_melt=False),
+            nc_storage.get_balance(self.token_uid),
+        )
 
         nc_storage = self.manager.get_nc_storage(block_deposit, nc_id)
         self.assertEqual(
@@ -403,8 +414,8 @@ class NCConsensusTestCase(SimulatorTestCase):
         # tx1 is a NanoContract transaction and will fail execution.
         address = self.wallet.get_unused_address_bytes()
         _outputs = [
-            WalletOutputInfo(address, 1, None),
-            WalletOutputInfo(address, 1, None),
+            WalletOutputInfo(address, UnsignedAmount.from_v1(1), None),
+            WalletOutputInfo(address, UnsignedAmount.from_v1(1), None),
         ]
         tx1 = self.wallet.prepare_transaction_compute_inputs(Transaction, _outputs, self.manager.tx_storage)
         tx1 = self._gen_nc_tx(nc.hash, 'deposit', [], nc=tx1)
@@ -420,7 +431,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         # add tx22 with tx1 as parent in mempool before tx1 has been executed
         address = self.wallet.get_unused_address_bytes()
         _outputs = [
-            WalletOutputInfo(address, 1, None),
+            WalletOutputInfo(address, UnsignedAmount.from_v1(1), None),
         ]
         tx22 = self.wallet.prepare_transaction_compute_inputs(Transaction, _outputs, self.manager.tx_storage)
         self._finish_preparing_tx(tx22)
@@ -484,8 +495,8 @@ class NCConsensusTestCase(SimulatorTestCase):
         # tx1 is a NanoContract transaction and will fail execution.
         address = self.wallet.get_unused_address_bytes()
         _outputs = [
-            WalletOutputInfo(address, 1, None),
-            WalletOutputInfo(address, 1, None),
+            WalletOutputInfo(address, UnsignedAmount.from_v1(1), None),
+            WalletOutputInfo(address, UnsignedAmount.from_v1(1), None),
         ]
         tx1 = self.wallet.prepare_transaction_compute_inputs(Transaction, _outputs, self.manager.tx_storage)
         tx1 = self._gen_nc_tx(nc.hash, 'deposit', [], nc=tx1)
@@ -574,7 +585,9 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.assertNotEqual(address1, address2)
 
         # Prepare three sibling transactions.
-        _inputs, deposit_amount_1 = self.wallet.get_inputs_from_amount(6500, self.manager.tx_storage)
+        _inputs, deposit_amount_1 = self.wallet.get_inputs_from_amount(
+            UnsignedAmount.from_v1(6500), self.manager.tx_storage
+        )
         tx1 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx1 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx1, address=address1, nc_actions=[
             NanoHeaderAction(
@@ -587,7 +600,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         self.manager.reactor.advance(10)
 
-        withdrawal_amount_1 = deposit_amount_1 - 100
+        withdrawal_amount_1 = UnsignedAmount.from_v1(deposit_amount_1 - 100)
         tx11 = Transaction(outputs=[TxOutput(withdrawal_amount_1, b'', 0)])
         tx11 = self._gen_nc_tx(nc_id, 'withdraw', [], nc=tx11, address=address1, nc_actions=[
             NanoHeaderAction(
@@ -601,7 +614,9 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         self.manager.reactor.advance(10)
 
-        _inputs, deposit_amount_2 = self.wallet.get_inputs_from_amount(3, self.manager.tx_storage)
+        _inputs, deposit_amount_2 = self.wallet.get_inputs_from_amount(
+            UnsignedAmount.from_v1(3), self.manager.tx_storage
+        )
         tx2 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx2 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx2, address=address2, nc_actions=[
             NanoHeaderAction(
@@ -643,7 +658,11 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         nc_storage = self.manager.get_best_block_nc_storage(nc_id)
         self.assertEqual(
-            Balance(value=deposit_amount_1 - withdrawal_amount_1, can_mint=False, can_melt=False),
+            Balance(
+                value=(deposit_amount_1 - withdrawal_amount_1),
+                can_mint=False,
+                can_melt=False,
+            ),
             nc_storage.get_balance(self.token_uid)
         )
 
@@ -695,7 +714,9 @@ class NCConsensusTestCase(SimulatorTestCase):
         self.assertNotEqual(address1, address2)
 
         # Prepare three sibling transactions.
-        _inputs, deposit_amount_2 = self.wallet.get_inputs_from_amount(6500, self.manager.tx_storage)
+        _inputs, deposit_amount_2 = self.wallet.get_inputs_from_amount(
+            UnsignedAmount.from_v1(6500), self.manager.tx_storage
+        )
         tx2 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx2 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx2, address=address2, nc_actions=[
             NanoHeaderAction(
@@ -708,7 +729,7 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         self.manager.reactor.advance(10)
 
-        withdrawal_amount_1 = deposit_amount_2 - 100
+        withdrawal_amount_1 = UnsignedAmount.from_v1(deposit_amount_2 - 100)
         tx11 = Transaction(outputs=[TxOutput(withdrawal_amount_1, b'', 0)])
         tx11 = self._gen_nc_tx(nc_id, 'withdraw', [], nc=tx11, address=address1, nc_actions=[
             NanoHeaderAction(
@@ -722,7 +743,9 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         self.manager.reactor.advance(10)
 
-        _inputs, deposit_amount_1 = self.wallet.get_inputs_from_amount(1, self.manager.tx_storage)
+        _inputs, deposit_amount_1 = self.wallet.get_inputs_from_amount(
+            UnsignedAmount.from_v1(1), self.manager.tx_storage
+        )
         tx1 = self.wallet.prepare_transaction(Transaction, _inputs, [])
         tx1 = self._gen_nc_tx(nc_id, 'deposit', [], nc=tx1, address=address1, nc_actions=[
             NanoHeaderAction(
@@ -785,7 +808,11 @@ class NCConsensusTestCase(SimulatorTestCase):
 
         nc_storage = self.manager.get_best_block_nc_storage(nc_id)
         self.assertEqual(
-            Balance(value=deposit_amount_2 - withdrawal_amount_1, can_mint=False, can_melt=False),
+            Balance(
+                value=(deposit_amount_2 - withdrawal_amount_1),
+                can_mint=False,
+                can_melt=False,
+            ),
             nc_storage.get_balance(self.token_uid)
         )
 
@@ -801,7 +828,7 @@ class NCConsensusTestCase(SimulatorTestCase):
         # tx0 is a regular transaction with one output
         address = self.wallet.get_unused_address_bytes()
         _outputs = [
-            WalletOutputInfo(address, 10, None),
+            WalletOutputInfo(address, UnsignedAmount.from_v1(10), None),
         ]
         tx0 = self.wallet.prepare_transaction_compute_inputs(Transaction, _outputs, self.manager.tx_storage)
         self._finish_preparing_tx(tx0)
@@ -811,12 +838,12 @@ class NCConsensusTestCase(SimulatorTestCase):
         # tx1 is a NanoContract transaction and will fail execution.
         tx1 = gen_custom_base_tx(self.manager, tx_inputs=[(tx0, 0)])
         self.assertEqual(len(tx1.outputs), 1)
-        tx1.outputs[0].value = 3
+        tx1.outputs[0].value = UnsignedAmount.from_v1(3)
         tx1 = self._gen_nc_tx(nc.hash, 'deposit', [], nc=tx1, nc_actions=[
             NanoHeaderAction(
                 type=NCActionType.DEPOSIT,
                 token_index=0,
-                amount=tx0.outputs[0].value - 3,
+                amount=UnsignedAmount.from_v1(tx0.outputs[0].value - 3),
             )
         ])
         self.manager.cpu_mining_service.resolve(tx1)

--- a/hathor_tests/nanocontracts/test_feature_activations.py
+++ b/hathor_tests/nanocontracts/test_feature_activations.py
@@ -20,6 +20,7 @@ from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor.transaction.scripts import P2PKH, Opcode
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.token_amount import UnsignedAmount
 from hathorlib.conf.settings import FeatureSetting
 
 
@@ -382,7 +383,7 @@ class TestFeatureActivations(unittest.TestCase):
         nano_header = nc1.get_nano_header()
         assert len(nano_header.nc_actions) == 1
         deposit = nano_header.nc_actions[0]
-        deposit = dataclasses.replace(deposit, amount=deposit.amount // 2)
+        deposit = dataclasses.replace(deposit, amount=UnsignedAmount.from_v1(deposit.amount // 2))
         nano_header.nc_actions = [deposit, deposit]
 
         artifacts.propagate_with(self.manager, up_to='b3')

--- a/hathor_tests/nanocontracts/test_fee_tokens.py
+++ b/hathor_tests/nanocontracts/test_fee_tokens.py
@@ -20,6 +20,7 @@ from hathor.transaction.scripts import Opcode
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class MyBlueprint(Blueprint):
@@ -79,10 +80,12 @@ class FeeTokensTestCase(BlueprintTestCase):
         fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
         tx2.tokens.append(fbt_id)
 
-        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9), script=b'', token_data=1)
         tx2.outputs.append(fbt_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 
@@ -141,10 +144,12 @@ class FeeTokensTestCase(BlueprintTestCase):
         fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
         tx2.tokens.append(fbt_id)
 
-        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9), script=b'', token_data=1)
         tx2.outputs.append(fbt_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 
@@ -191,10 +196,12 @@ class FeeTokensTestCase(BlueprintTestCase):
         dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
         tx2.tokens.append(dbt_id)
 
-        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        dbt_output = TxOutput(value=UnsignedAmount.from_v1(100), script=b'', token_data=1)
         tx2.outputs.append(dbt_output)
 
-        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        dbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(100)
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(dbt_withdraw)
 
@@ -243,10 +250,12 @@ class FeeTokensTestCase(BlueprintTestCase):
         dbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='DBT')
         tx2.tokens.append(dbt_id)
 
-        dbt_output = TxOutput(value=100, script=b'', token_data=1)
+        dbt_output = TxOutput(value=UnsignedAmount.from_v1(100), script=b'', token_data=1)
         tx2.outputs.append(dbt_output)
 
-        dbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=100)
+        dbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(100)
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(dbt_withdraw)
 
@@ -308,13 +317,16 @@ class FeeTokensTestCase(BlueprintTestCase):
         fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
         tx2.tokens.append(fbt_id)
 
+        missing_htr = 1000
         removed_htr_output = tx2.outputs.pop()
         assert removed_htr_output.token_data == 0
-        assert removed_htr_output.value == 1000
-        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        assert removed_htr_output.value == missing_htr
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9), script=b'', token_data=1)
         tx2.outputs.append(fbt_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 
@@ -359,12 +371,15 @@ class FeeTokensTestCase(BlueprintTestCase):
         fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
         tx2.tokens.append(fbt_id)
 
-        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
-        extra_htr_output = TxOutput(value=1000, script=b'')
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9), script=b'', token_data=1)
+        extra_htr = 1000
+        extra_htr_output = TxOutput(value=UnsignedAmount.from_v1(extra_htr), script=b'')
         tx2.outputs.append(fbt_output)
         tx2.outputs.append(extra_htr_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 
@@ -405,14 +420,16 @@ class FeeTokensTestCase(BlueprintTestCase):
         fbt_id = derive_child_token_id(ContractId(tx1.hash), token_symbol='FBT')
         tx2.tokens.append(fbt_id)
 
-        fbt_output = TxOutput(value=10 ** 9 - 100, script=b'', token_data=1)
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9 - 100), script=b'', token_data=1)
         tx2.outputs.append(fbt_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 
-        fee_entry = FeeHeaderEntry(token_index=1, amount=100)
+        fee_entry = FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(100))
         fee_header = FeeHeader(self._settings, tx2, [fee_entry])
         tx2.headers.append(fee_header)
 
@@ -460,11 +477,13 @@ class FeeTokensTestCase(BlueprintTestCase):
         tx2.tokens.append(fbt_id)
         tx3.tokens.append(fbt_id)
 
-        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9), script=b'', token_data=1)
         tx2.outputs.append(fbt_output)
         tx3.outputs.append(fbt_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 
@@ -523,11 +542,13 @@ class FeeTokensTestCase(BlueprintTestCase):
         tx2.tokens.append(fbt_id)
         tx3.tokens.append(fbt_id)
 
-        fbt_output = TxOutput(value=10 ** 9, script=b'', token_data=1)
+        fbt_output = TxOutput(value=UnsignedAmount.from_v1(10 ** 9), script=b'', token_data=1)
         tx2.outputs.append(fbt_output)
         tx3.outputs.append(fbt_output)
 
-        fbt_withdraw = NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=1, amount=10 ** 9)
+        fbt_withdraw = NanoHeaderAction(
+            type=NCActionType.WITHDRAWAL, token_index=1, amount=UnsignedAmount.from_v1(10 ** 9),
+        )
         tx2_nano_header = tx2.get_nano_header()
         tx2_nano_header.nc_actions.append(fbt_withdraw)
 

--- a/hathor_tests/nanocontracts/test_indexes.py
+++ b/hathor_tests/nanocontracts/test_indexes.py
@@ -17,6 +17,7 @@ from hathor.types import AddressB58
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.simulation.base import SimulatorTestCase
+from hathor_tests.token_amount import UnsignedAmount
 
 settings = HathorSettings()
 
@@ -55,7 +56,7 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
         self.miner.start()
 
         self.token_uid = b'\0'
-        trigger = StopAfterMinimumBalance(self.wallet, self.token_uid, 1)
+        trigger = StopAfterMinimumBalance(self.wallet, self.token_uid, UnsignedAmount.from_v1(1))
         self.assertTrue(self.simulator.run(7200, trigger=trigger))
         self.assertTrue(self.simulator.run(120))
 
@@ -108,7 +109,9 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
         new_blocks = 0
 
         # Deposits 1 HTR
-        _inputs, deposit_amount = self.wallet.get_inputs_from_amount(1, self.manager.tx_storage)
+        _inputs, deposit_amount = self.wallet.get_inputs_from_amount(
+            UnsignedAmount.from_v1(1), self.manager.tx_storage
+        )
         tx = self.wallet.prepare_transaction(Transaction, _inputs, [])
         self.fill_nc_tx(tx, self.myblueprint_id, 'initialize', [], nc_actions=[
             NanoHeaderAction(
@@ -125,22 +128,28 @@ class BaseIndexesTestCase(BlueprintTestCase, SimulatorTestCase):
         nc_id = tx.hash
 
         token_info1 = self.manager.tx_storage.indexes.tokens.get_token_info(self._settings.HATHOR_TOKEN_UID)
-        self.assertEqual(token_info0.get_total() + 64_00 * new_blocks, token_info1.get_total())
+        self.assertEqual(
+            token_info0.get_total() + UnsignedAmount.from_v1(64_00 * new_blocks),
+            token_info1.get_total(),
+        )
 
         # Withdrawals 1 HTR
-        tx2 = Transaction(outputs=[TxOutput(1, b'', 0)])
+        tx2 = Transaction(outputs=[TxOutput(UnsignedAmount.from_v1(1), b'', 0)])
         self.fill_nc_tx(tx2, nc_id, 'nop', [], nc_actions=[
             NanoHeaderAction(
                 type=NCActionType.WITHDRAWAL,
                 token_index=0,
-                amount=1,
+                amount=UnsignedAmount.from_v1(1),
             )
         ])
         self.finish_and_broadcast_tx(tx2, confirmations=2)
         new_blocks += 2
 
         token_info1 = self.manager.tx_storage.indexes.tokens.get_token_info(self._settings.HATHOR_TOKEN_UID)
-        self.assertEqual(token_info0.get_total() + 64_00 * new_blocks, token_info1.get_total())
+        self.assertEqual(
+            token_info0.get_total() + UnsignedAmount.from_v1(64_00 * new_blocks),
+            token_info1.get_total(),
+        )
 
     def test_remove_voided_nano_tx_from_parents_1(self):
         vertices = self._run_test_remove_voided_nano_tx_from_parents('tx3 < b35')

--- a/hathor_tests/resources/transaction/test_create_tx.py
+++ b/hathor_tests/resources/transaction/test_create_tx.py
@@ -12,6 +12,7 @@ from hathor.transaction import Transaction
 from hathor.transaction.resources import CreateTxResource
 from hathor.transaction.scripts import P2PKH, create_base_script
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_tx
 
 
@@ -117,7 +118,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(tx.inputs[0].index, 0)
         self.assertEqual(tx.inputs[0].data, b'')
         self.assertEqual(len(tx.outputs), 1)
-        self.assertEqual(tx.outputs[0].value, 6400)
+        self.assertEqual(tx.outputs[0].value, UnsignedAmount.from_v1(6400))
         self.assertEqual(tx.outputs[0].token_data, 0)
         self.assertEqual(tx.outputs[0].script, script)
 
@@ -154,7 +155,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(tx.inputs[0].index, 1)
         self.assertEqual(tx.inputs[0].data, b'')
         self.assertEqual(len(tx.outputs), 1)
-        self.assertEqual(tx.outputs[0].value, 100)
+        self.assertEqual(tx.outputs[0].value, UnsignedAmount.from_v1(100))
         self.assertEqual(tx.outputs[0].token_data, 0)
         self.assertEqual(tx.outputs[0].script, script)
 
@@ -192,7 +193,7 @@ class TransactionTest(_BaseResourceTest._ResourceTest):
         self.assertEqual(tx.inputs[0].index, 1)
         self.assertEqual(tx.inputs[0].data, b'')
         self.assertEqual(len(tx.outputs), 1)
-        self.assertEqual(tx.outputs[0].value, 100)
+        self.assertEqual(tx.outputs[0].value, UnsignedAmount.from_v1(100))
         self.assertEqual(tx.outputs[0].token_data, 0)
         self.assertEqual(tx.outputs[0].script, script)
 

--- a/hathor_tests/resources/transaction/test_pushtx.py
+++ b/hathor_tests/resources/transaction/test_pushtx.py
@@ -14,6 +14,7 @@ from hathor.transaction.scripts import P2PKH, parse_address_script
 from hathor.wallet.base_wallet import WalletInputInfo, WalletOutputInfo
 from hathor.wallet.resources import SendTokensResource
 from hathor_tests.resources.base_resource import StubSite, _BaseResourceTest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_tx_with_data_script, create_fee_tokens, create_tokens
 
 
@@ -25,7 +26,6 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
     def setUp(self):
         super().setUp()
         self.web = StubSite(PushTxResource(self.manager))
-        # TODO(decimals): test v2
         self.web_tokens = StubSite(SendTokensResource(self.manager, self._settings, APIVersion.V1A))
 
     def get_tx(
@@ -37,8 +37,8 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
             address = self.get_address(0)
             assert address is not None
             outputs = [
-                WalletOutputInfo(address=decode_address(address), value=1, timelock=None),
-                WalletOutputInfo(address=decode_address(address), value=1, timelock=None)
+                WalletOutputInfo(address=decode_address(address), value=UnsignedAmount.from_v1(1), timelock=None),
+                WalletOutputInfo(address=decode_address(address), value=UnsignedAmount.from_v1(1), timelock=None)
             ]
         if inputs:
             tx = self.manager.wallet.prepare_transaction(Transaction, inputs, outputs)

--- a/hathor_tests/tx/test_fee_tokens.py
+++ b/hathor_tests/tx/test_fee_tokens.py
@@ -16,6 +16,7 @@ from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_withdraw_amount
 from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, create_fee_tokens, create_tokens, get_genesis_key
 from hathorlib.conf.settings import FeatureSetting
 
@@ -68,13 +69,13 @@ class FeeTokenTest(unittest.TestCase):
 
         outputs = [
             # New token amount
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
             # Melt authority
-            TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001),
-            TxOutput(htr_amount - 4, script, 0)
+            TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001),
+            TxOutput(UnsignedAmount.from_v1(htr_amount - 4), script, 0)
         ]
 
         tx2 = Transaction(
@@ -90,14 +91,14 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx2,
-            fees=[FeeHeaderEntry(token_index=0, amount=4)]
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(4))]
         )
         tx2.headers.append(fee_header)
 
         # Melt 100 tokens from fee_token and add 4 outputs, should charge only by the outputs count
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 4)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(4))
         self.assertEqual(tx_fee, fee_header.total_fee_amount())
         #  It's the tx item output signature
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -124,10 +125,10 @@ class FeeTokenTest(unittest.TestCase):
         ]
 
         outputs = [
-            TxOutput(100, script, 2),
-            TxOutput(100, script, 2),
-            TxOutput(100, script, 2),
-            TxOutput(96-5, script, 0)
+            TxOutput(UnsignedAmount.from_v1(100), script, 2),
+            TxOutput(UnsignedAmount.from_v1(100), script, 2),
+            TxOutput(UnsignedAmount.from_v1(100), script, 2),
+            TxOutput(UnsignedAmount.from_v1(96-5), script, 0)
         ]
 
         tx3 = Transaction(
@@ -142,7 +143,7 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx3,
-            fees=[FeeHeaderEntry(token_index=0, amount=5)],
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(5))],
         )
         tx3.headers.append(fee_header)
 
@@ -151,7 +152,7 @@ class FeeTokenTest(unittest.TestCase):
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx3_fee = tx3.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
         # Multiple inputs should be only charge once per token when no outputs are present
-        self.assertEqual(tx3_fee, 5)
+        self.assertEqual(tx3_fee, UnsignedAmount.from_v1(5))
 
         self.sign_inputs(tx3)
         self.resolve_and_propagate(tx3)
@@ -177,8 +178,8 @@ class FeeTokenTest(unittest.TestCase):
 
         outputs = [
             # New token amount - 500 - 100 = 400
-            TxOutput(new_token_amount, script, 1),
-            TxOutput(4, script, 0)
+            TxOutput(UnsignedAmount.from_v1(new_token_amount), script, 1),
+            TxOutput(UnsignedAmount.from_v1(4), script, 0)
         ]
 
         tx2 = Transaction(
@@ -194,14 +195,14 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx2,
-            fees=[FeeHeaderEntry(token_index=0, amount=1)],
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(1))],
         )
         tx2.headers.append(fee_header)
 
         # pick the last tip tx output in HTR then subtracts the fee
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 1)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
         self.assertEqual(tx_fee, fee_header.total_fee_amount())
 
         #  It's the tx item output signature
@@ -231,7 +232,7 @@ class FeeTokenTest(unittest.TestCase):
         ]
 
         outputs = [
-            TxOutput(4, script, 0)
+            TxOutput(UnsignedAmount.from_v1(4), script, 0)
         ]
 
         tx2 = Transaction(
@@ -247,7 +248,7 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx2,
-            fees=[FeeHeaderEntry(token_index=0, amount=1)],
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(1))],
         )
         tx2.headers.append(fee_header)
 
@@ -255,7 +256,7 @@ class FeeTokenTest(unittest.TestCase):
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
         # check if only the melting operation was considered
-        self.assertEqual(tx_fee, 1)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
         self.assertEqual(tx_fee, fee_header.total_fee_amount())
 
         self.sign_inputs(tx2)
@@ -287,11 +288,11 @@ class FeeTokenTest(unittest.TestCase):
 
         outputs = [
             # New token amount
-            TxOutput(new_token_amount, script, 1),
+            TxOutput(UnsignedAmount.from_v1(new_token_amount), script, 1),
             # Melt authority
-            TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001),
+            TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001),
             # change value: 500 from initial mint amount - 100 fee
-            TxOutput(400, script, 2)
+            TxOutput(UnsignedAmount.from_v1(400), script, 2)
         ]
 
         tx2 = Transaction(
@@ -307,13 +308,13 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx2,
-            fees=[FeeHeaderEntry(token_index=2, amount=100)],
+            fees=[FeeHeaderEntry(token_index=2, amount=UnsignedAmount.from_v1(100))],
         )
         tx2.headers.append(fee_header)
 
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 1)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
         self.assertEqual(tx_fee, fee_header.total_fee_amount())
 
         #  It's the signature of the output of the tx item
@@ -331,7 +332,7 @@ class FeeTokenTest(unittest.TestCase):
             token_amount=new_token_amount
         )
         tokens_index = self.manager.tx_storage.indexes.tokens.get_token_info(deposit_token_uid)
-        self.assertEqual(400, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(400), tokens_index.get_total())
 
     def test_fee_and_deposit_token_melt_paid_with_deposit(self) -> None:
         # fbt -> Fee based token
@@ -359,18 +360,20 @@ class FeeTokenTest(unittest.TestCase):
             TxInput(dbt_tx.hash, 0, b'')
         ]
         dbt_melt_amount = 200
-        htr_change_value = get_deposit_token_withdraw_amount(self.manager._settings, dbt_melt_amount)
+        htr_change_value = get_deposit_token_withdraw_amount(
+            self.manager._settings, UnsignedAmount.from_v1(dbt_melt_amount)
+        )
         # 200 dbt -> 2 htr
-        self.assertEqual(htr_change_value, 2)
+        self.assertEqual(htr_change_value, UnsignedAmount.from_v1(2))
         outputs = [
             # New token amount
-            TxOutput(new_token_amount, script, 1),
+            TxOutput(UnsignedAmount.from_v1(new_token_amount), script, 1),
             # Melt authority
-            TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001),
+            TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001),
             # HTR change output
             TxOutput(htr_change_value, script, 0),
             # deposit token change output: 500 - 100(fee in the header) - 200(melt) = 200
-            TxOutput(200, script, 2)
+            TxOutput(UnsignedAmount.from_v1(200), script, 2)
         ]
 
         tx2 = Transaction(
@@ -386,13 +389,13 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx2,
-            fees=[FeeHeaderEntry(token_index=2, amount=100)],
+            fees=[FeeHeaderEntry(token_index=2, amount=UnsignedAmount.from_v1(100))],
         )
         tx2.headers.append(fee_header)
 
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 1)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
         self.assertEqual(tx_fee, fee_header.total_fee_amount())
 
         #  It's the signature of the output of the tx item
@@ -410,7 +413,7 @@ class FeeTokenTest(unittest.TestCase):
             token_amount=new_token_amount
         )
         tokens_index = self.manager.tx_storage.indexes.tokens.get_token_info(deposit_token_uid)
-        self.assertEqual(200, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(200), tokens_index.get_total())
 
     def test_fee_token_tx_paid_with_htr_and_deposit(self) -> None:
         # fbt -> Fee based token
@@ -440,14 +443,14 @@ class FeeTokenTest(unittest.TestCase):
 
         outputs = [
             # New token amount
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
-            TxOutput(100, script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
+            TxOutput(UnsignedAmount.from_v1(100), script, 1),
             # Deposit token change
-            TxOutput(300, script, 2),  # 500 - 200
-            TxOutput(2, script)  # 5 - 3
+            TxOutput(UnsignedAmount.from_v1(300), script, 2),  # 500 - 200
+            TxOutput(UnsignedAmount.from_v1(2), script)  # 5 - 3
         ]
 
         tx2 = Transaction(
@@ -464,14 +467,14 @@ class FeeTokenTest(unittest.TestCase):
             settings=self._settings,
             tx=tx2,
             fees=[
-                FeeHeaderEntry(token_index=0, amount=3),
-                FeeHeaderEntry(token_index=2, amount=200)
+                FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(3)),
+                FeeHeaderEntry(token_index=2, amount=UnsignedAmount.from_v1(200))
             ],
         )
         tx2.headers.append(fee_header)
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 5)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(5))
         self.assertEqual(tx_fee, fee_header.total_fee_amount())
 
         #  It's the signature of the output of the tx item
@@ -503,11 +506,11 @@ class FeeTokenTest(unittest.TestCase):
         ]
         outputs = [
             # Token minted output
-            TxOutput(mint_amount, script, 1),
+            TxOutput(UnsignedAmount.from_v1(mint_amount), script, 1),
             # Token mint authority
-            TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001),
+            TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001),
             # change amount
-            TxOutput(4, script, 0)
+            TxOutput(UnsignedAmount.from_v1(4), script, 0)
         ]
 
         tx2 = Transaction(
@@ -522,14 +525,14 @@ class FeeTokenTest(unittest.TestCase):
         fee_header = FeeHeader(
             settings=self._settings,
             tx=tx2,
-            fees=[FeeHeaderEntry(token_index=0, amount=1)],
+            fees=[FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(1))],
         )
         tx2.headers.append(fee_header)
         # pick the last tip tx output in HTR then subtracts the fee
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 1)
-        self.assertEqual(fee_header.total_fee_amount(), 1)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
+        self.assertEqual(fee_header.total_fee_amount(), UnsignedAmount.from_v1(1))
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -562,9 +565,9 @@ class FeeTokenTest(unittest.TestCase):
         ]
         outputs = [
             # Token output
-            TxOutput(250, script, 1),
+            TxOutput(UnsignedAmount.from_v1(250), script, 1),
             # Token output
-            TxOutput(250, script, 1),
+            TxOutput(UnsignedAmount.from_v1(250), script, 1),
         ]
 
         tx2 = Transaction(
@@ -578,7 +581,7 @@ class FeeTokenTest(unittest.TestCase):
         )
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 2)
+        self.assertEqual(tx_fee, UnsignedAmount.from_v1(2))
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -587,7 +590,11 @@ class FeeTokenTest(unittest.TestCase):
         with pytest.raises(InvalidNewTransaction) as e:
             self.resolve_and_propagate(tx2)
         assert isinstance(e.value.__cause__, InputOutputMismatch)
-        assert "Fee amount is different than expected. (amount=0, expected=2)" in str(e.value)
+        expected_msg = (
+            f'Fee amount is different than expected. '
+            f'(amount=0, expected={UnsignedAmount.from_v1(2).normalized()})'
+        )
+        assert expected_msg in str(e.value)
 
     def test_fee_token_burn_authority(self) -> None:
         initial_mint_amount = 500
@@ -611,7 +618,7 @@ class FeeTokenTest(unittest.TestCase):
         )
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
         tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
-        self.assertEqual(tx_fee, 0)
+        self.assertEqual(tx_fee, UnsignedAmount.zero())
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -645,10 +652,10 @@ class FeeTokenTest(unittest.TestCase):
 
         outputs = [
             # mint output
-            TxOutput(500, script, 0b00000001),
+            TxOutput(UnsignedAmount.from_v1(500), script, 0b00000001),
             # authority outputs
-            TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001),
-            TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001),
+            TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001),
+            TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001),
             # deposit output
             TxOutput(self.genesis_blocks[0].outputs[0].value, script, 0)
         ]
@@ -729,7 +736,7 @@ class FeeTokenTest(unittest.TestCase):
         self.assertEqual(TokenUtxoInfo(melt_tx_hash, melt_output), melt[0])
 
         # check total amount of tokens
-        self.assertEqual(token_amount, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(token_amount), tokens_index.get_total())
 
     def sign_inputs(self, tx: Transaction) -> None:
         wallet = self.manager.wallet

--- a/hathor_tests/tx/test_multisig.py
+++ b/hathor_tests/tx/test_multisig.py
@@ -13,6 +13,7 @@ from hathor.transaction.scripts.opcode import OpcodesVersion
 from hathor.wallet.base_wallet import WalletBalance, WalletOutputInfo
 from hathor.wallet.util import generate_multisig_address, generate_multisig_redeem_script, generate_signature
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward
 
 
@@ -58,10 +59,13 @@ class MultisigTestCase(unittest.TestCase):
         # Adding funds to the wallet
         blocks = add_new_blocks(self.manager, 2, advance_clock=15)
         add_blocks_unlock_reward(self.manager)
+        all_block_outputs_sum = sum((blk.outputs[0].value for blk in blocks), start=UnsignedAmount.zero())
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, sum(blk.outputs[0].value for blk in blocks)))
+                         WalletBalance(UnsignedAmount.zero(), all_block_outputs_sum))
 
         first_block_amount = blocks[0].outputs[0].value
+        value_200 = UnsignedAmount.from_v1(200)
+        value_300 = UnsignedAmount.from_v1(300)
 
         # First we send tokens to a multisig address
         outputs = [
@@ -78,7 +82,7 @@ class MultisigTestCase(unittest.TestCase):
         self.clock.advance(10)
 
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, first_block_amount))
+                         WalletBalance(UnsignedAmount.zero(), first_block_amount))
 
         # Then we create a new tx that spends this tokens from multisig wallet
         tx = Transaction.create_from_struct(tx1.get_struct())
@@ -88,9 +92,12 @@ class MultisigTestCase(unittest.TestCase):
 
         multisig_script = create_output_script(self.multisig_address)
 
-        multisig_output = TxOutput(200, multisig_script)
-        wallet_output = TxOutput(300, create_output_script(self.address))
-        outside_output = TxOutput(first_block_amount - 200 - 300, create_output_script(self.outside_address))
+        multisig_output = TxOutput(value_200, multisig_script)
+        wallet_output = TxOutput(value_300, create_output_script(self.address))
+        outside_output = TxOutput(
+            (first_block_amount - value_200 - value_300),
+            create_output_script(self.outside_address),
+        )
 
         tx.outputs = [multisig_output, wallet_output, outside_output]
 
@@ -130,7 +137,7 @@ class MultisigTestCase(unittest.TestCase):
         self.clock.advance(1)
 
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, first_block_amount + 300))
+                         WalletBalance(UnsignedAmount.zero(), first_block_amount + value_300))
 
         # Testing the MultiSig class methods
         cls_script = parse_address_script(multisig_script)

--- a/hathor_tests/tx/test_tokens.py
+++ b/hathor_tests/tx/test_tokens.py
@@ -15,6 +15,7 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount, int_to_bytes
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, add_new_double_spending, create_tokens, get_genesis_key
 
 
@@ -43,7 +44,7 @@ class TokenTest(unittest.TestCase):
         parents = [tx.hash for tx in self.genesis]
 
         output_script = P2PKH.create_output_script(self.address)
-        tx_outputs = [TxOutput(100, output_script, 1)]
+        tx_outputs = [TxOutput(UnsignedAmount.from_v1(100), output_script, 1)]
 
         block = Block(
             nonce=100,
@@ -118,7 +119,7 @@ class TokenTest(unittest.TestCase):
         self.manager.verification_service.verify(tx2, self.get_verification_params(self.manager))
 
         # missing tokens
-        token_output = TxOutput(utxo.value - 1, script, 1)
+        token_output = TxOutput((utxo.value - UnsignedAmount.from_v1(1)), script, 1)
         tx3 = Transaction(weight=1, inputs=[_input1], outputs=[token_output], parents=parents, tokens=[token_uid],
                           storage=self.manager.tx_storage, timestamp=int(self.clock.seconds()))
         data_to_sign = tx3.get_sighash_all()
@@ -139,12 +140,12 @@ class TokenTest(unittest.TestCase):
 
         # mint tokens and transfer mint authority
         mint_amount = 10000000
-        deposit_amount = get_deposit_token_deposit_amount(self._settings, mint_amount)
+        deposit_amount = get_deposit_token_deposit_amount(self._settings, UnsignedAmount.from_v1(mint_amount))
         _input1 = TxInput(tx.hash, 1, b'')
         _input2 = TxInput(tx.hash, 3, b'')
-        token_output1 = TxOutput(mint_amount, script, 1)
-        token_output2 = TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001)
-        deposit_output = TxOutput(tx.outputs[3].value - deposit_amount, script, 0)
+        token_output1 = TxOutput(UnsignedAmount.from_v1(mint_amount), script, 1)
+        token_output2 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001)
+        deposit_output = TxOutput((tx.outputs[3].value - deposit_amount), script, 0)
         tx2 = Transaction(
             weight=1,
             inputs=[_input1, _input2],
@@ -173,13 +174,13 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # check total amount of tokens
-        self.assertEqual(500 + mint_amount, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(500 + mint_amount), tokens_index.get_total())
 
         # try to mint 1 token unit without deposit
         mint_amount = 1
         _input1 = TxInput(tx.hash, 1, b'')
-        token_output1 = TxOutput(mint_amount, script, 1)
-        token_output2 = TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001)
+        token_output1 = TxOutput(UnsignedAmount.from_v1(mint_amount), script, 1)
+        token_output2 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001)
         tx3 = Transaction(
             weight=1,
             inputs=[_input1],
@@ -199,12 +200,15 @@ class TokenTest(unittest.TestCase):
 
         # try to mint and deposit less tokens than necessary
         mint_amount = 10000000
-        deposit_amount = get_deposit_token_deposit_amount(self._settings, mint_amount) - 1
+        deposit_amount = (
+            get_deposit_token_deposit_amount(self._settings, UnsignedAmount.from_v1(mint_amount))
+            - UnsignedAmount.from_v1(1)
+        )
         _input1 = TxInput(tx.hash, 1, b'')
         _input2 = TxInput(tx.hash, 3, b'')
-        token_output1 = TxOutput(mint_amount, script, 1)
-        token_output2 = TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001)
-        deposit_output = TxOutput(tx.outputs[3].value - deposit_amount, script, 0)
+        token_output1 = TxOutput(UnsignedAmount.from_v1(mint_amount), script, 1)
+        token_output2 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001)
+        deposit_output = TxOutput((tx.outputs[3].value - deposit_amount), script, 0)
         tx4 = Transaction(
             weight=1,
             inputs=[_input1, _input2],
@@ -225,7 +229,7 @@ class TokenTest(unittest.TestCase):
 
         # try to mint using melt authority UTXO
         _input1 = TxInput(tx.hash, 2, b'')
-        token_output = TxOutput(10000000, script, 1)
+        token_output = TxOutput(UnsignedAmount.from_v1(10000000), script, 1)
         tx5 = Transaction(weight=1, inputs=[_input1], outputs=[token_output], parents=parents, tokens=[token_uid],
                           storage=self.manager.tx_storage, timestamp=int(self.clock.seconds()))
         data_to_sign = tx5.get_sighash_all()
@@ -244,12 +248,14 @@ class TokenTest(unittest.TestCase):
 
         # melt tokens and transfer melt authority
         melt_amount = 100
-        new_amount = tx.outputs[0].value - melt_amount
-        withdraw_amount = get_deposit_token_withdraw_amount(self._settings, melt_amount)
+        new_amount = (tx.outputs[0].value - UnsignedAmount.from_v1(melt_amount))
+        withdraw_amount = get_deposit_token_withdraw_amount(
+            self._settings, UnsignedAmount.from_v1(melt_amount)
+        )
         _input1 = TxInput(tx.hash, 0, b'')
         _input2 = TxInput(tx.hash, 2, b'')
         token_output1 = TxOutput(new_amount, script, 1)
-        token_output2 = TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001)
+        token_output2 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001)
         withdraw_output = TxOutput(withdraw_amount, script, 0)
         tx2 = Transaction(
             weight=1,
@@ -283,12 +289,12 @@ class TokenTest(unittest.TestCase):
 
         # melt tokens and withdraw more than what's allowed
         melt_amount = 100
-        withdraw_amount = get_deposit_token_withdraw_amount(self._settings, melt_amount)
+        withdraw_amount = get_deposit_token_withdraw_amount(self._settings, UnsignedAmount.from_v1(melt_amount))
         _input1 = TxInput(tx.hash, 0, b'')
         _input2 = TxInput(tx.hash, 2, b'')
-        token_output1 = TxOutput(tx.outputs[0].value - melt_amount, script, 1)
-        token_output2 = TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001)
-        withdraw_output = TxOutput(withdraw_amount + 1, script, 0)
+        token_output1 = TxOutput((tx.outputs[0].value - UnsignedAmount.from_v1(melt_amount)), script, 1)
+        token_output2 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001)
+        withdraw_output = TxOutput((withdraw_amount + UnsignedAmount.from_v1(1)), script, 0)
         tx3 = Transaction(
             weight=1,
             inputs=[_input1, _input2],
@@ -310,7 +316,7 @@ class TokenTest(unittest.TestCase):
         # try to melt using mint authority UTXO
         _input1 = TxInput(tx.hash, 0, b'')
         _input2 = TxInput(tx.hash, 1, b'')
-        token_output = TxOutput(tx.outputs[0].value - 1, script, 1)
+        token_output = TxOutput((tx.outputs[0].value - UnsignedAmount.from_v1(1)), script, 1)
         tx4 = Transaction(weight=1, inputs=[_input1, _input2], outputs=[token_output], parents=parents,
                           tokens=[token_uid], storage=self.manager.tx_storage, timestamp=int(self.clock.seconds()))
         data_to_sign = tx4.get_sighash_all()
@@ -332,7 +338,7 @@ class TokenTest(unittest.TestCase):
 
         # input with mint and output with melt
         _input1 = TxInput(tx.hash, 1, b'')
-        token_output = TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001)
+        token_output = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001)
         tx2 = Transaction(weight=1, inputs=[_input1], outputs=[token_output], parents=parents, tokens=[token_uid],
                           storage=self.manager.tx_storage, timestamp=int(self.clock.seconds()))
         data_to_sign = tx2.get_sighash_all()
@@ -344,7 +350,7 @@ class TokenTest(unittest.TestCase):
 
         # input with melt and output with mint
         _input1 = TxInput(tx.hash, 2, b'')
-        token_output = TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001)
+        token_output = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001)
         tx3 = Transaction(weight=1, inputs=[_input1], outputs=[token_output], parents=parents, tokens=[token_uid],
                           storage=self.manager.tx_storage, timestamp=int(self.clock.seconds()))
         data_to_sign = tx3.get_sighash_all()
@@ -372,21 +378,21 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # check total amount of tokens
-        self.assertEqual(100, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(100), tokens_index.get_total())
 
         # new tx minting tokens
         mint_amount = 300
-        deposit_amount = get_deposit_token_deposit_amount(self._settings, mint_amount)
+        deposit_amount = get_deposit_token_deposit_amount(self._settings, UnsignedAmount.from_v1(mint_amount))
         script = P2PKH.create_output_script(self.address)
         # inputs
         mint_input = TxInput(tx.hash, 1, b'')
         melt_input = TxInput(tx.hash, 2, b'')
         deposit_input = TxInput(tx.hash, 3, b'')
         # outputs
-        mint_output = TxOutput(mint_amount, script, 1)
-        authority_output1 = TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001)
-        authority_output2 = TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001)
-        deposit_output = TxOutput(tx.outputs[3].value - deposit_amount, script, 0)
+        mint_output = TxOutput(UnsignedAmount.from_v1(mint_amount), script, 1)
+        authority_output1 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001)
+        authority_output2 = TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001)
+        deposit_output = TxOutput((tx.outputs[3].value - deposit_amount), script, 0)
         tx2 = Transaction(
             weight=1,
             inputs=[mint_input, melt_input, deposit_input],
@@ -417,7 +423,7 @@ class TokenTest(unittest.TestCase):
         self.assertIn(TokenUtxoInfo(tx2.hash, 0), mint)
         self.assertIn(TokenUtxoInfo(tx2.hash, 1), melt)
         # check total amount of tokens has been updated
-        self.assertEqual(400, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(400), tokens_index.get_total())
 
         # create conflicting tx by changing parents
         tx3 = Transaction.create_from_struct(tx2.get_struct())
@@ -439,7 +445,7 @@ class TokenTest(unittest.TestCase):
         self.assertEqual(1, len(mint))
         self.assertEqual(1, len(melt))
         # should have same amount of tokens
-        self.assertEqual(400, tokens_index.get_total())
+        self.assertEqual(UnsignedAmount.from_v1(400), tokens_index.get_total())
 
     def test_token_info(self):
         def update_tx(tx):
@@ -536,7 +542,7 @@ class TokenTest(unittest.TestCase):
         # try an unknown authority
         input1 = TxInput(tx.hash, 1, b'')
         input2 = TxInput(tx.hash, 2, b'')
-        output = TxOutput((TxOutput.ALL_AUTHORITIES << 1), script, 0b10000001)
+        output = TxOutput(UnsignedAmount.from_v1(TxOutput.ALL_AUTHORITIES << 1), script, 0b10000001)
         tx2 = Transaction(
             weight=1,
             inputs=[input1, input2],
@@ -599,7 +605,7 @@ class TokenTest(unittest.TestCase):
         parents = [tx.hash for tx in self.genesis]
 
         output_script = P2PKH.create_output_script(self.address)
-        output = TxOutput(0b11, output_script, 0b10000000)
+        output = TxOutput(UnsignedAmount.from_v1(0b11), output_script, 0b10000000)
         self.assertTrue(output.is_token_authority())
 
         block = Block(

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -45,6 +45,7 @@ from hathor.transaction.validation_state import ValidationState
 from hathor.verification.verification_params import VerificationParams
 from hathor.wallet import Wallet
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import (
     add_blocks_unlock_reward,
     add_new_transactions,
@@ -84,7 +85,7 @@ class TransactionTest(unittest.TestCase):
         _input = TxInput(genesis_block.hash, 0, b'')
 
         # spend less than what was generated
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
         output = TxOutput(value, script)
@@ -107,7 +108,7 @@ class TransactionTest(unittest.TestCase):
         _input = TxInput(genesis_block.hash, 0, b'')
 
         # spend more than what was generated
-        value = genesis_block.outputs[0].value + 1
+        value = (genesis_block.outputs[0].value + UnsignedAmount.from_v1(1))
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
         output = TxOutput(value, script)
@@ -184,7 +185,7 @@ class TransactionTest(unittest.TestCase):
     def test_too_many_outputs(self):
         random_bytes = bytes.fromhex('0000184e64683b966b4268f387c269915cc61f6af5329823a93e3696cb0fe902')
 
-        output = TxOutput(1, random_bytes)
+        output = TxOutput(UnsignedAmount.from_v1(1), random_bytes)
         outputs = [output] * (self._settings.MAX_NUM_OUTPUTS + 1)
 
         tx = Transaction(outputs=outputs, storage=self.tx_storage)
@@ -245,7 +246,7 @@ class TransactionTest(unittest.TestCase):
 
         address = get_address_from_public_key(self.genesis_public_key)
         output_script = P2PKH.create_output_script(address)
-        tx_outputs = [TxOutput(100, output_script)]
+        tx_outputs = [TxOutput(UnsignedAmount.from_v1(100), output_script)]
 
         block = Block(
             nonce=100,
@@ -271,7 +272,7 @@ class TransactionTest(unittest.TestCase):
         parent_txs = [tx.hash for tx in self.genesis_txs]
         parents = [parent_block, *parent_txs]
         address = decode_address(self.get_address(1))
-        outputs = [TxOutput(100, P2PKH.create_output_script(address))]
+        outputs = [TxOutput(UnsignedAmount.from_v1(100), P2PKH.create_output_script(address))]
 
         b = MergeMinedBlock(
             hash=b'some_hash',
@@ -309,8 +310,8 @@ class TransactionTest(unittest.TestCase):
         address1 = decode_address(self.get_address(1))
         address2 = decode_address(self.get_address(2))
         assert address1 != address2
-        outputs1 = [TxOutput(100, P2PKH.create_output_script(address1))]
-        outputs2 = [TxOutput(100, P2PKH.create_output_script(address2))]
+        outputs1 = [TxOutput(UnsignedAmount.from_v1(100), P2PKH.create_output_script(address1))]
+        outputs2 = [TxOutput(UnsignedAmount.from_v1(100), P2PKH.create_output_script(address2))]
 
         b1 = MergeMinedBlock(
             hash=b'some_hash1',
@@ -377,7 +378,7 @@ class TransactionTest(unittest.TestCase):
 
         parents = [tx.hash for tx in self.genesis]
         address = decode_address(self.get_address(1))
-        outputs = [TxOutput(100, P2PKH.create_output_script(address))]
+        outputs = [TxOutput(UnsignedAmount.from_v1(100), P2PKH.create_output_script(address))]
 
         patch_path = 'hathor.feature_activation.feature_service.FeatureService.is_feature_active'
 
@@ -443,7 +444,7 @@ class TransactionTest(unittest.TestCase):
 
         address = get_address_from_public_key(self.genesis_public_key)
         output_script = P2PKH.create_output_script(address)
-        tx_outputs = [TxOutput(100, output_script)] * (self._settings.MAX_NUM_OUTPUTS + 1)
+        tx_outputs = [TxOutput(UnsignedAmount.from_v1(100), output_script)] * (self._settings.MAX_NUM_OUTPUTS + 1)
 
         block = Block(
             nonce=100,
@@ -496,7 +497,7 @@ class TransactionTest(unittest.TestCase):
     def test_block_unknown_parent(self):
         address = get_address_from_public_key(self.genesis_public_key)
         output_script = P2PKH.create_output_script(address)
-        tx_outputs = [TxOutput(100, output_script)]
+        tx_outputs = [TxOutput(UnsignedAmount.from_v1(100), output_script)]
 
         # Random unknown parent
         parents = [hashlib.sha256().digest()]
@@ -515,7 +516,7 @@ class TransactionTest(unittest.TestCase):
     def test_block_number_parents(self):
         address = get_address_from_public_key(self.genesis_public_key)
         output_script = P2PKH.create_output_script(address)
-        tx_outputs = [TxOutput(100, output_script)]
+        tx_outputs = [TxOutput(UnsignedAmount.from_v1(100), output_script)]
 
         parents = [tx.hash for tx in self.genesis_txs]
 
@@ -616,7 +617,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_tx_weight_too_high(self):
         parents = [tx.hash for tx in self.genesis_txs]
-        outputs = [TxOutput(1, b'')]
+        outputs = [TxOutput(UnsignedAmount.from_v1(1), b'')]
         inputs = [TxInput(b'', 0, b'')]
         tx = Transaction(weight=1, inputs=inputs, outputs=outputs, parents=parents,
                          storage=self.tx_storage, timestamp=self.last_block.timestamp + 1)
@@ -640,7 +641,7 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(
             weight=33.0,
             inputs=[TxInput(b'', 0, b'')],
-            outputs=[TxOutput(1, b'')],
+            outputs=[TxOutput(UnsignedAmount.from_v1(1), b'')],
             parents=[tx.hash for tx in self.genesis_txs],
         )
 
@@ -661,7 +662,7 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(
             weight=32.0,
             inputs=[TxInput(b'', 0, b'')],
-            outputs=[TxOutput(1, b'')],
+            outputs=[TxOutput(UnsignedAmount.from_v1(1), b'')],
             parents=[tx.hash for tx in self.genesis_txs],
         )
 
@@ -671,11 +672,11 @@ class TransactionTest(unittest.TestCase):
         tx = Transaction(
             weight=1.0,
             inputs=[TxInput(b'', 0, b'')],
-            outputs=[TxOutput(1, b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE)],
+            outputs=[TxOutput(UnsignedAmount.from_v1(1), b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE)],
             parents=[tx.hash for tx in self.genesis_txs],
         )
         while len(tx.get_struct()) <= self._settings.MAX_SERIALIZED_VERTEX_SIZE:
-            tx.outputs.append(TxOutput(1, b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE))
+            tx.outputs.append(TxOutput(UnsignedAmount.from_v1(1), b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE))
 
         tx.update_hash()
         tx_bytes = tx.get_struct()
@@ -686,7 +687,7 @@ class TransactionTest(unittest.TestCase):
     def test_block_serialized_size_too_high(self):
         block = Block(
             weight=1.0,
-            outputs=[TxOutput(1, b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE)],
+            outputs=[TxOutput(UnsignedAmount.from_v1(1), b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE)],
             parents=[
                 self._settings.GENESIS_BLOCK_HASH,
                 self._settings.GENESIS_TX1_HASH,
@@ -695,7 +696,7 @@ class TransactionTest(unittest.TestCase):
             data=b'',
         )
         while len(block.get_struct()) <= self._settings.MAX_SERIALIZED_VERTEX_SIZE:
-            block.outputs.append(TxOutput(1, b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE))
+            block.outputs.append(TxOutput(UnsignedAmount.from_v1(1), b'x' * self._settings.MAX_OUTPUT_SCRIPT_SIZE))
 
         block.update_hash()
         block_bytes = block.get_struct()
@@ -815,7 +816,7 @@ class TransactionTest(unittest.TestCase):
 
         # 3. propagate block with wrong amount of tokens
         block = manager.generate_mining_block()
-        output = TxOutput(1, block.outputs[0].script)
+        output = TxOutput(UnsignedAmount.from_v1(1), block.outputs[0].script)
         block.outputs = [output]
         self.manager.cpu_mining_service.resolve(block)
         with self.assertRaises(InvalidNewTransaction):
@@ -915,35 +916,35 @@ class TransactionTest(unittest.TestCase):
         from hathor.serialization.encoding.output_value import MAX_OUTPUT_VALUE_32
         from hathor.transaction.base_transaction import MAX_OUTPUT_VALUE
         serializer = Serializer.build_bytes_serializer()
-        encode_output_value_v1(serializer, MAX_OUTPUT_VALUE_32)
+        encode_output_value_v1(serializer, UnsignedAmount.from_v1(MAX_OUTPUT_VALUE_32))
         max_32 = serializer.finalize()
         self.assertEqual(len(max_32), 4)
         deserializer = Deserializer.build_bytes_deserializer(max_32)
         value = decode_output_value_v1(deserializer)
-        self.assertEqual(value, MAX_OUTPUT_VALUE_32)
+        self.assertEqual(value, UnsignedAmount.from_v1(MAX_OUTPUT_VALUE_32))
 
         serializer = Serializer.build_bytes_serializer()
-        encode_output_value_v1(serializer, MAX_OUTPUT_VALUE_32 + 1)
+        encode_output_value_v1(serializer, UnsignedAmount.from_v1(MAX_OUTPUT_VALUE_32 + 1))
         over_32 = serializer.finalize()
         self.assertEqual(len(over_32), 8)
         deserializer = Deserializer.build_bytes_deserializer(over_32)
         value = decode_output_value_v1(deserializer)
-        self.assertEqual(value, MAX_OUTPUT_VALUE_32 + 1)
+        self.assertEqual(value, UnsignedAmount.from_v1(MAX_OUTPUT_VALUE_32 + 1))
 
         serializer = Serializer.build_bytes_serializer()
-        encode_output_value_v1(serializer, MAX_OUTPUT_VALUE)
+        encode_output_value_v1(serializer, UnsignedAmount.from_v1(MAX_OUTPUT_VALUE))
         max_64 = serializer.finalize()
         self.assertEqual(len(max_64), 8)
         deserializer = Deserializer.build_bytes_deserializer(max_64)
         value = decode_output_value_v1(deserializer)
-        self.assertEqual(value, MAX_OUTPUT_VALUE)
+        self.assertEqual(value, UnsignedAmount.from_v1(MAX_OUTPUT_VALUE))
 
     def test_output_value(self):
         from hathor.serialization.encoding.output_value import MAX_OUTPUT_VALUE_32
 
         # first test using a small output value with 8 bytes. It should fail
         parents = [tx.hash for tx in self.genesis_txs]
-        outputs = [TxOutput(1, b'')]
+        outputs = [TxOutput(UnsignedAmount.from_v1(1), b'')]
         tx = Transaction(outputs=outputs, parents=parents)
         original_struct = tx.get_struct()
         struct_bytes = tx.get_funds_struct()
@@ -989,7 +990,7 @@ class TransactionTest(unittest.TestCase):
         assert tx == tx2
 
         # now use 8 bytes and make sure it's working
-        outputs = [TxOutput(MAX_OUTPUT_VALUE, b'')]
+        outputs = [TxOutput(UnsignedAmount.from_v1(MAX_OUTPUT_VALUE), b'')]
         tx = Transaction(outputs=outputs, parents=parents)
         tx.update_hash()
         original_struct = tx.get_struct()
@@ -1079,12 +1080,12 @@ class TransactionTest(unittest.TestCase):
         # sum of tx outputs should ignore authority outputs
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
-        output1 = TxOutput(5, script)   # regular utxo
-        output2 = TxOutput(30, script, 0b10000001)   # authority utxo
-        output3 = TxOutput(3, script)   # regular utxo
+        output1 = TxOutput(UnsignedAmount.from_v1(5), script)   # regular utxo
+        output2 = TxOutput(UnsignedAmount.from_v1(30), script, 0b10000001)   # authority utxo
+        output3 = TxOutput(UnsignedAmount.from_v1(3), script)   # regular utxo
         tx = Transaction(outputs=[output1, output2, output3], storage=self.tx_storage)
 
-        self.assertEqual(8, tx.sum_outputs)
+        self.assertEqual(UnsignedAmount.from_v1(8), tx.sum_outputs)
 
     def _test_txout_script_limit(self, offset):
         genesis_block = self.genesis_blocks[0]
@@ -1165,9 +1166,9 @@ class TransactionTest(unittest.TestCase):
         new_address_b58 = self.get_address(0)
         new_address = decode_address(new_address_b58)
 
-        output1 = TxOutput(value - 100, script)
+        output1 = TxOutput((value - UnsignedAmount.from_v1(100)), script)
         script2 = P2PKH.create_output_script(new_address)
-        output2 = TxOutput(100, script2)
+        output2 = TxOutput(UnsignedAmount.from_v1(100), script2)
 
         input1 = TxInput(tx.hash, 0, b'')
         tx2 = Transaction(weight=1, inputs=[input1], outputs=[output1, output2], parents=parents,
@@ -1190,7 +1191,7 @@ class TransactionTest(unittest.TestCase):
         output3_address_b58 = self.get_address(1)
         output3_address = decode_address(output3_address_b58)
         script3 = P2PKH.create_output_script(output3_address)
-        output3 = TxOutput(value-100, script3)
+        output3 = TxOutput((value - UnsignedAmount.from_v1(100)), script3)
 
         input2 = TxInput(tx2.hash, 0, b'')
         tx3 = Transaction(weight=1, inputs=[input2], outputs=[output3], parents=parents,
@@ -1217,7 +1218,7 @@ class TransactionTest(unittest.TestCase):
 
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
-        output = TxOutput(5, script)
+        output = TxOutput(UnsignedAmount.from_v1(5), script)
         tx = Transaction(outputs=[output], storage=self.tx_storage)
 
         original = _transaction.serialize_tx_sighash
@@ -1232,7 +1233,7 @@ class TransactionTest(unittest.TestCase):
 
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
-        output = TxOutput(5, script)
+        output = TxOutput(UnsignedAmount.from_v1(5), script)
         tx = Transaction(outputs=[output], storage=self.tx_storage)
 
         with mock.patch('hathor.transaction.vertex_parser.vertex_serializer.hashlib') as mocked:
@@ -1244,7 +1245,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_output_single_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         _input = TxInput(genesis_block.hash, 0, b'')
 
         hscript = create_script_with_sigops(self._settings.MAX_TX_SIGOPS_OUTPUT + 1)
@@ -1257,7 +1258,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_output_multi_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         _input = TxInput(genesis_block.hash, 0, b'')
         num_outputs = 5
 
@@ -1270,7 +1271,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_output_single_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         _input = TxInput(genesis_block.hash, 0, b'')
 
         hscript = create_script_with_sigops(self._settings.MAX_TX_SIGOPS_OUTPUT - 1)
@@ -1281,7 +1282,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_output_multi_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         _input = TxInput(genesis_block.hash, 0, b'')
         num_outputs = 5
 
@@ -1293,7 +1294,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_input_single_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
         _output = TxOutput(value, script)
@@ -1307,7 +1308,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_input_multi_above_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
         _output = TxOutput(value, script)
@@ -1322,7 +1323,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_input_single_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
         _output = TxOutput(value, script)
@@ -1335,7 +1336,7 @@ class TransactionTest(unittest.TestCase):
 
     def test_sigops_input_multi_below_limit(self) -> None:
         genesis_block = self.genesis_blocks[0]
-        value = genesis_block.outputs[0].value - 1
+        value = (genesis_block.outputs[0].value - UnsignedAmount.from_v1(1))
         address = get_address_from_public_key(self.genesis_public_key)
         script = P2PKH.create_output_script(address)
         _output = TxOutput(value, script)

--- a/hathor_tests/tx/test_tx_storage.py
+++ b/hathor_tests/tx/test_tx_storage.py
@@ -16,6 +16,7 @@ from hathor.transaction.scripts import P2PKH
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.transaction.validation_state import ValidationState
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.unittest import TestBuilder
 from hathor_tests.utils import BURN_ADDRESS, add_blocks_unlock_reward, add_new_transactions, create_tokens
 
@@ -53,7 +54,7 @@ class BaseTransactionStorageTest(unittest.TestCase):
         self.genesis_txs = [tx for tx in self.genesis if not tx.is_block]
 
         block_parents = [tx.hash for tx in chain(self.genesis_blocks, self.genesis_txs)]
-        output = TxOutput(200, P2PKH.create_output_script(BURN_ADDRESS))
+        output = TxOutput(UnsignedAmount.from_v1(200), P2PKH.create_output_script(BURN_ADDRESS))
         previous_timestamp = artifacts.settings.GENESIS_TX2_TIMESTAMP
         self.block = Block(timestamp=previous_timestamp + 1, weight=12, outputs=[output], parents=block_parents,
                            nonce=100781, storage=self.tx_storage)

--- a/hathor_tests/tx/test_verification.py
+++ b/hathor_tests/tx/test_verification.py
@@ -16,6 +16,7 @@ from hathor.verification.token_creation_transaction_verifier import TokenCreatio
 from hathor.verification.transaction_verifier import TransactionVerifier
 from hathor.verification.vertex_verifier import VertexVerifier
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, create_tokens, get_genesis_key
 
 
@@ -36,7 +37,7 @@ class VerificationTest(unittest.TestCase):
             hash=b'some_hash',
             storage=self.manager.tx_storage,
             weight=1,
-            outputs=[TxOutput(value=6400, script=b'')],
+            outputs=[TxOutput(value=UnsignedAmount.from_v1(6400), script=b'')],
             parents=[
                 self._settings.GENESIS_BLOCK_HASH,
                 self._settings.GENESIS_TX1_HASH,
@@ -51,7 +52,7 @@ class VerificationTest(unittest.TestCase):
             hash=b'some_hash',
             storage=self.manager.tx_storage,
             weight=1,
-            outputs=[TxOutput(value=6400, script=b'')],
+            outputs=[TxOutput(value=UnsignedAmount.from_v1(6400), script=b'')],
             aux_pow=BitcoinAuxPow.dummy(),
             parents=[
                 self._settings.GENESIS_BLOCK_HASH,

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -32,6 +32,7 @@ from hathor.transaction.token_creation_tx import TokenCreationTransaction
 from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount
 from hathor.util import Random
+from hathor_tests.token_amount import UnsignedAmount
 from hathorlib.scripts import DataScript
 
 settings = HathorSettings()
@@ -119,7 +120,7 @@ def gen_custom_base_tx(manager: HathorManager,
     assert wallet is not None
 
     inputs = []
-    value = 0
+    value = UnsignedAmount.zero()
     parents = []
     for tx_base, txout_index in tx_inputs:
         spent_tx = tx_base
@@ -140,12 +141,16 @@ def gen_custom_base_tx(manager: HathorManager,
     else:
         output_address = address
     if n_outputs == 1:
-        outputs = [WalletOutputInfo(address=decode_address(output_address), value=int(value), timelock=None)]
-    elif n_outputs == 2:
-        assert int(value) > 1
         outputs = [
-            WalletOutputInfo(address=decode_address(output_address), value=int(value) - 1, timelock=None),
-            WalletOutputInfo(address=decode_address(output_address), value=1, timelock=None),
+            WalletOutputInfo(address=decode_address(output_address), value=value, timelock=None),
+        ]
+    elif n_outputs == 2:
+        assert value > UnsignedAmount.from_v1(1)
+        outputs = [
+            WalletOutputInfo(
+                address=decode_address(output_address), value=value - UnsignedAmount.from_v1(1), timelock=None
+            ),
+            WalletOutputInfo(address=decode_address(output_address), value=UnsignedAmount.from_v1(1), timelock=None),
         ]
     else:
         raise NotImplementedError
@@ -206,7 +211,7 @@ def add_new_tx(
         :return: Transaction created
         :rtype: :py:class:`hathor.transaction.transaction.Transaction`
     """
-    tx = gen_new_tx(manager, address, value)
+    tx = gen_new_tx(manager, address, UnsignedAmount.from_v1(value))
     tx.name = name
     if propagate:
         manager.propagate_tx(tx)
@@ -461,10 +466,10 @@ def create_tokens(manager: 'HathorManager', address_b58: Optional[str] = None, m
     address = decode_address(address_b58)
     script = P2PKH.create_output_script(address)
 
-    deposit_amount = get_deposit_token_deposit_amount(manager._settings, mint_amount)
+    deposit_amount = get_deposit_token_deposit_amount(manager._settings, UnsignedAmount.from_v1(mint_amount))
     if nft_data:
         # NFT creation needs 0.01 HTR of fee
-        deposit_amount += 1
+        deposit_amount += UnsignedAmount.from_v1(1)
     genesis = manager.tx_storage.get_all_genesis()
     genesis_blocks = [tx for tx in genesis if tx.is_block]
     genesis_txs = [tx for tx in genesis if not tx.is_block]
@@ -478,11 +483,11 @@ def create_tokens(manager: 'HathorManager', address_b58: Optional[str] = None, m
         genesis_hash = genesis_block.hash
         assert genesis_hash is not None
         deposit_input = [TxInput(genesis_hash, 0, b'')]
-        change_output = TxOutput(genesis_block.outputs[0].value - deposit_amount, script, 0)
+        change_output = TxOutput((genesis_block.outputs[0].value - deposit_amount), script, 0)
         parents = [tx.hash for tx in genesis_txs]
         timestamp = int(manager.reactor.seconds())
     else:
-        total_reward = 0
+        total_reward = UnsignedAmount.zero()
         deposit_input = []
         while total_reward < deposit_amount:
             block = add_new_block(manager, advance_clock=1, address=address)
@@ -490,7 +495,7 @@ def create_tokens(manager: 'HathorManager', address_b58: Optional[str] = None, m
             total_reward += block.outputs[0].value
 
         if total_reward > deposit_amount:
-            change_output = TxOutput(total_reward - deposit_amount, script, 0)
+            change_output = TxOutput((total_reward - deposit_amount).to_v1(), script, 0)
         else:
             change_output = None
 
@@ -502,14 +507,14 @@ def create_tokens(manager: 'HathorManager', address_b58: Optional[str] = None, m
     outputs = []
     if nft_data:
         script_data = DataScript.create_output_script(nft_data)
-        output_data = TxOutput(1, script_data, 0)
+        output_data = TxOutput(UnsignedAmount.from_v1(1), script_data, 0)
         outputs.append(output_data)
     # mint output
     if mint_amount > 0:
-        outputs.append(TxOutput(mint_amount, script, 0b00000001))
+        outputs.append(TxOutput(UnsignedAmount.from_v1(mint_amount), script, 0b00000001))
     # authority outputs
-    outputs.append(TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001))
-    outputs.append(TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001))
+    outputs.append(TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001))
+    outputs.append(TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001))
     # deposit output
     if change_output:
         outputs.append(change_output)
@@ -596,19 +601,24 @@ def create_fee_tokens(
 
     outputs = []
     # mint output
-    outputs.append(TxOutput(mint_amount, script, 0b00000001))
+    outputs.append(TxOutput(UnsignedAmount.from_v1(mint_amount), script, 0b00000001))
 
     # authority outputs
-    outputs.append(TxOutput(TxOutput.TOKEN_MINT_MASK, script, 0b10000001))
-    outputs.append(TxOutput(TxOutput.TOKEN_MELT_MASK, script, 0b10000001))
+    outputs.append(TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001))
+    outputs.append(TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001))
 
     # fee
     fee = settings.FEE_PER_OUTPUT_V1
 
     # fee output
-    outputs.append(TxOutput(genesis_block.outputs[0].value - fee - (genesis_output_amount or 0), script, 0))
+    fee_output_raw = (
+        genesis_block.outputs[0].value
+        - fee
+        - (genesis_output_amount or 0)
+    )
+    outputs.append(TxOutput(UnsignedAmount.from_v1(fee_output_raw), script, 0))
     if genesis_output_amount:
-        outputs.append(TxOutput(genesis_output_amount, script, 0))
+        outputs.append(TxOutput(UnsignedAmount.from_v1(genesis_output_amount), script, 0))
 
     tx = TokenCreationTransaction(
         weight=1,
@@ -674,17 +684,17 @@ def add_tx_with_data_script(manager: 'HathorManager', data: list[str], propagate
     burn_amount = len(data)
 
     # Get the inputs to be used to burn the HTR
-    total_reward = 0
+    total_reward = UnsignedAmount.zero()
     burn_input = []
-    while total_reward < burn_amount:
+    while total_reward < UnsignedAmount.from_v1(burn_amount):
         block = add_new_block(manager, advance_clock=1, address=address)
         burn_input.append(TxInput(block.hash, 0, b''))
         total_reward += block.outputs[0].value
 
     # Create the change output, if needed
     change_output: Optional[TxOutput]
-    if total_reward > burn_amount:
-        change_output = TxOutput(total_reward - burn_amount, script, 0)
+    if total_reward > UnsignedAmount.from_v1(burn_amount):
+        change_output = TxOutput((total_reward - UnsignedAmount.from_v1(burn_amount)).to_v1(), script, 0)
     else:
         change_output = None
 
@@ -699,7 +709,7 @@ def add_tx_with_data_script(manager: 'HathorManager', data: list[str], propagate
     outputs = []
     for d in data:
         script_data = DataScript.create_output_script(d)
-        output_data = TxOutput(1, script_data, 0)
+        output_data = TxOutput(UnsignedAmount.from_v1(1), script_data, 0)
         outputs.append(output_data)
 
     # Add change output to array

--- a/hathor_tests/verification/test_fee_header_verifier.py
+++ b/hathor_tests/verification/test_fee_header_verifier.py
@@ -9,6 +9,7 @@ from hathor.transaction.headers.fee_header import FeeHeader, FeeHeaderEntry
 from hathor.types import TokenUid
 from hathor.verification.fee_header_verifier import MAX_FEES_LEN, FeeHeaderVerifier
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 
 
 class TestFeeHeaderVerifier(unittest.TestCase):
@@ -49,7 +50,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         """Test valid scenarios for verify_without_storage."""
         # Single fee entry
         tx = self._create_transaction_with_tokens(1)  # Custom token at index 1
-        fees = [FeeHeaderEntry(token_index=0, amount=100)]  # HTR fee
+        fees = [FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(100))]  # HTR fee
         header = self._create_fee_header(tx, fees)
 
         FeeHeaderVerifier.verify_fee_list(header, tx)  # +1 for HTR
@@ -57,8 +58,8 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         # Multiple fee entries with different tokens
         tx = self._create_transaction_with_tokens(2)  # Custom tokens at indices 1,2
         fees = [
-            FeeHeaderEntry(token_index=0, amount=3),  # HTR
-            FeeHeaderEntry(token_index=1, amount=200),  # Custom token 1
+            FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(3)),  # HTR
+            FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(200)),  # Custom token 1
         ]
         header = self._create_fee_header(tx, fees)
 
@@ -71,7 +72,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
 
         # Invalid zero amount
         with pytest.raises(InvalidFeeAmount, match="fees should be a positive integer, got 0"):
-            fees = [FeeHeaderEntry(token_index=0, amount=0)]  # HTR fee
+            fees = [FeeHeaderEntry(token_index=0, amount=UnsignedAmount.zero())]  # HTR fee
             header = self._create_fee_header(tx, fees)
             FeeHeaderVerifier.verify_fee_list(header, tx)
 
@@ -84,7 +85,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         # Invalid non-multiple of 100
         with pytest.raises(InvalidFeeAmount,
                            match="fees using deposit custom tokens should be a multiple of 100, got 150"):
-            fees = [FeeHeaderEntry(token_index=1, amount=150)]
+            fees = [FeeHeaderEntry(token_index=1, amount=UnsignedAmount.from_v1(150))]
             header = self._create_fee_header(tx, fees)
             FeeHeaderVerifier.verify_fee_list(header, tx)
 
@@ -100,7 +101,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         """Test that fees list exceeding MAX_FEES_LEN raises InvalidFeeHeader."""
         tx = self._create_transaction_with_tokens(MAX_FEES_LEN + 1)
         # Create MAX_FEES_LEN + 1 fees to exceed the limit
-        fees = [FeeHeaderEntry(token_index=i, amount=100) for i in range(MAX_FEES_LEN + 1)]
+        fees = [FeeHeaderEntry(token_index=i, amount=UnsignedAmount.from_v1(100)) for i in range(MAX_FEES_LEN + 1)]
         header = self._create_fee_header(tx, fees)
 
         expected_msg = f"more fees than the max allowed: {MAX_FEES_LEN + 1} > {MAX_FEES_LEN}"
@@ -111,7 +112,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         """Test that fees list exactly at MAX_FEES_LEN is valid."""
         tx = self._create_transaction_with_tokens(MAX_FEES_LEN)
         # Create exactly MAX_FEES_LEN fees
-        fees = [FeeHeaderEntry(token_index=i, amount=100) for i in range(MAX_FEES_LEN)]
+        fees = [FeeHeaderEntry(token_index=i, amount=UnsignedAmount.from_v1(100)) for i in range(MAX_FEES_LEN)]
         header = self._create_fee_header(tx, fees)
 
         # Should not raise any exception
@@ -121,8 +122,8 @@ class TestFeeHeaderVerifier(unittest.TestCase):
         """Test that duplicate token indices in fees raise InvalidFeeHeader."""
         tx = self._create_transaction_with_tokens(1)
         fees = [
-            FeeHeaderEntry(token_index=0, amount=100),
-            FeeHeaderEntry(token_index=0, amount=200),  # Duplicate HTR fee
+            FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(100)),
+            FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v1(200)),  # Duplicate HTR fee
         ]
         header = self._create_fee_header(tx, fees)
 
@@ -132,7 +133,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
     def test_invalid_token_indexes_out_of_bounds(self) -> None:
         """Test that token indices out of bounds raise FeeHeaderTokenNotFound."""
         tx = self._create_transaction_with_tokens(1)  # Only custom token at index 1
-        fees = [FeeHeaderEntry(token_index=5, amount=100)]  # Index 5 doesn't exist
+        fees = [FeeHeaderEntry(token_index=5, amount=UnsignedAmount.from_v1(100))]  # Index 5 doesn't exist
         header = self._create_fee_header(tx, fees)
 
         with pytest.raises(FeeHeaderTokenNotFound,
@@ -142,7 +143,7 @@ class TestFeeHeaderVerifier(unittest.TestCase):
     def test_invalid_token_index_greater_than_tx_tokens_len(self) -> None:
         """Test that token index greater than tx_tokens_len raises FeeHeaderTokenNotFound."""
         tx = self._create_transaction_with_tokens(1)  # tx_tokens_len = 2 (HTR + 1 custom)
-        fees = [FeeHeaderEntry(token_index=2, amount=100)]  # Index 2 > tx_tokens_len (1)
+        fees = [FeeHeaderEntry(token_index=2, amount=UnsignedAmount.from_v1(100))]  # Index 2 > tx_tokens_len (1)
         header = self._create_fee_header(tx, fees)
 
         with pytest.raises(FeeHeaderTokenNotFound,

--- a/hathor_tests/wallet/test_balance_update.py
+++ b/hathor_tests/wallet/test_balance_update.py
@@ -8,6 +8,7 @@ from hathor.transaction.scripts import P2PKH
 from hathor.wallet.base_wallet import SpentTx, UnspentTx, WalletBalance, WalletInputInfo, WalletOutputInfo
 from hathor.wallet.exceptions import PrivateKeyNotFound
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, create_tokens
 
 
@@ -19,15 +20,17 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.manager = self.create_peer(self.network, unlock_wallet=True)
 
         blocks = add_new_blocks(self.manager, 3, advance_clock=15)
-        self.blocks_tokens = [sum(txout.value for txout in blk.outputs) for blk in blocks]
+        self.blocks_tokens = [
+            sum((txout.value for txout in blk.outputs), start=UnsignedAmount.zero()) for blk in blocks
+        ]
 
         address = self.get_address(0)
-        value = 100
+        value = UnsignedAmount.from_v1(100)
 
-        self.initial_balance = sum(self.blocks_tokens[:3]) - 100
+        self.initial_balance = sum(self.blocks_tokens[:3], start=UnsignedAmount.zero()) - UnsignedAmount.from_v1(100)
 
         outputs = [
-            WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None)
+            WalletOutputInfo(address=decode_address(address), value=value, timelock=None)
         ]
 
         add_blocks_unlock_reward(self.manager)
@@ -46,7 +49,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         # Change of parents only, so it's a twin.
         # With less weight, so the balance will continue because tx1 will be the winner
@@ -67,7 +70,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         # Voided wallet history
         index_voided = 0
@@ -93,7 +96,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         # Change of parents only, so it's a twin.
         # Same weight, so both will be voided then the balance increases
@@ -113,15 +116,17 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.assertEqual(meta2.voided_by, {tx2.hash})
 
         # Balance changed
-        self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, sum(self.blocks_tokens[:3])))
+        self.assertEqual(
+            self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
+            WalletBalance(UnsignedAmount.zero(), sum(self.blocks_tokens[:3], start=UnsignedAmount.zero())),
+        )
 
     def test_balance_update3(self):
         # Tx2 is twin with tx1 with higher acc weight, so tx1 will get voided
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         # Change of parents only, so it's a twin.
         # With higher weight, so the balance will continue because tx2 will be the winner
@@ -143,7 +148,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
     def test_balance_update4(self):
         # Tx2 spends Tx1 output
@@ -153,12 +158,12 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         address = self.manager.wallet.get_unused_address_bytes()
-        value = self.blocks_tokens[0] - 100
+        value = self.blocks_tokens[0] - UnsignedAmount.from_v1(100)
         inputs = [WalletInputInfo(tx_id=self.tx1.hash, index=0, private_key=None)]
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=value, timelock=None)]
         tx2 = self.manager.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,
                                                                         self.manager.tx_storage)
         tx2.weight = 10
@@ -198,7 +203,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
     def test_balance_update5(self):
         # Tx2 spends Tx1 output
@@ -209,12 +214,12 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         address = self.manager.wallet.get_unused_address_bytes()
-        value = self.blocks_tokens[0] - 100
+        value = self.blocks_tokens[0] - UnsignedAmount.from_v1(100)
         inputs = [WalletInputInfo(tx_id=self.tx1.hash, index=0, private_key=None)]
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=value, timelock=None)]
         tx2 = self.manager.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,
                                                                         self.manager.tx_storage)
         tx2.weight = 10
@@ -242,7 +247,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
     def test_balance_update6(self):
         # Tx2 is twin of tx1, so both voided
@@ -252,7 +257,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         # Change of parents only, so it's a twin.
         tx2 = Transaction.create_from_struct(self.tx1.get_struct())
@@ -260,10 +265,10 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.cpu_mining_service.resolve(tx2)
 
         address = self.get_address(0)
-        value = 100
+        value = UnsignedAmount.from_v1(100)
 
         outputs = [
-            WalletOutputInfo(address=decode_address(address), value=int(value), timelock=None)
+            WalletOutputInfo(address=decode_address(address), value=value, timelock=None)
         ]
 
         tx3 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs, self.manager.tx_storage)
@@ -279,7 +284,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance - 100))
+                         WalletBalance(UnsignedAmount.zero(), self.initial_balance - UnsignedAmount.from_v1(100)))
 
     def test_balance_update7(self):
         # Tx2 spends Tx1 output
@@ -289,12 +294,12 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         address = self.manager.wallet.get_unused_address_bytes()
-        value = self.blocks_tokens[0] - 100
+        value = self.blocks_tokens[0] - UnsignedAmount.from_v1(100)
         inputs = [WalletInputInfo(tx_id=self.tx1.hash, index=0, private_key=None)]
-        outputs = [WalletOutputInfo(address=address, value=int(value), timelock=None)]
+        outputs = [WalletOutputInfo(address=address, value=value, timelock=None)]
         tx2 = self.manager.wallet.prepare_transaction_incomplete_inputs(Transaction, inputs, outputs,
                                                                         self.manager.tx_storage)
         tx2.weight = 10
@@ -323,17 +328,17 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
     def test_balance_update_twin_tx(self):
         # Start balance
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
         wallet_address = self.manager.wallet.get_unused_address()
 
         outputs2 = [
-            WalletOutputInfo(address=decode_address(wallet_address), value=500, timelock=None)
+            WalletOutputInfo(address=decode_address(wallet_address), value=UnsignedAmount.from_v1(500), timelock=None)
         ]
 
         tx2 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, outputs2, self.manager.tx_storage)
@@ -386,7 +391,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
 
         # Balance is the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID],
-                         WalletBalance(0, self.initial_balance))
+                         WalletBalance(UnsignedAmount.zero(),self.initial_balance))
 
     def test_tokens_balance(self):
         # create tokens and check balances
@@ -399,7 +404,7 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         amount = tx.outputs[0].value
 
         # initial token balance
-        self.assertEqual(self.manager.wallet.balance[token_id], WalletBalance(0, amount))
+        self.assertEqual(self.manager.wallet.balance[token_id], WalletBalance(UnsignedAmount.zero(),amount))
         # initial hathor balance
         # we don't consider HTR balance 0 because we transfer genesis tokens to this
         # wallet during token creation
@@ -409,8 +414,8 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         parents = self.manager.get_new_tx_parents()
         _input1 = TxInput(tx.hash, 0, b'')
         script = P2PKH.create_output_script(address)
-        token_output1 = TxOutput(30, b'', 0b00000001)
-        token_output2 = TxOutput(amount - 30, script, 0b00000001)
+        token_output1 = TxOutput(UnsignedAmount.from_v1(30), b'', 0b00000001)
+        token_output2 = TxOutput((amount - UnsignedAmount.from_v1(30)).to_v1(), script, 0b00000001)
         tx2 = Transaction(
             weight=1,
             inputs=[_input1],
@@ -430,9 +435,15 @@ class HathorSyncMethodsTestCase(unittest.TestCase):
         self.manager.propagate_tx(tx2)
         self.run_to_completion()
         # verify balance
-        self.assertEqual(self.manager.wallet.balance[token_id], WalletBalance(0, amount - 30))
+        self.assertEqual(
+            self.manager.wallet.balance[token_id],
+            WalletBalance(UnsignedAmount.zero(), amount - UnsignedAmount.from_v1(30)),
+        )
         # hathor balance remains the same
         self.assertEqual(self.manager.wallet.balance[self._settings.HATHOR_TOKEN_UID], hathor_balance)
 
         balances_per_address = self.manager.wallet.get_balance_per_address(self._settings.HATHOR_TOKEN_UID)
-        self.assertEqual(hathor_balance.available, sum(x for x in balances_per_address.values()))
+        self.assertEqual(
+            hathor_balance.available,
+            sum((x for x in balances_per_address.values()), start=UnsignedAmount.zero()),
+        )

--- a/hathor_tests/wallet/test_wallet.py
+++ b/hathor_tests/wallet/test_wallet.py
@@ -15,9 +15,10 @@ from hathor.wallet.base_wallet import WalletBalance, WalletInputInfo, WalletOutp
 from hathor.wallet.exceptions import InsufficientFunds, InvalidAddress, OutOfUnusedAddresses, WalletLocked
 from hathor.wallet.keypair import KeyPair
 from hathor_tests import unittest
+from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, create_tokens, get_genesis_key
 
-BLOCK_REWARD = 300
+BLOCK_REWARD = UnsignedAmount.from_v1(300)
 
 PASSWORD = b'passwd'
 
@@ -69,19 +70,21 @@ class BasicWalletTest(unittest.TestCase):
         w.unlock(PASSWORD)
         genesis_blocks = [tx for tx in self.storage.get_all_genesis() if tx.is_block]
         genesis_block = genesis_blocks[0]
-        genesis_value = sum([output.value for output in genesis_block.outputs])
+        genesis_value = sum(([output.value for output in genesis_block.outputs]), start=UnsignedAmount.zero())
 
         # wallet will receive genesis block and store in unspent_tx
         w.on_new_tx(genesis_block)
         for index in range(len(genesis_block.outputs)):
             utxo = w.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((genesis_block.hash, index))
             self.assertIsNotNone(utxo)
-        self.assertEqual(w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, genesis_value))
+        self.assertEqual(
+            w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(UnsignedAmount.zero(), genesis_value)
+        )
 
         # create transaction spending this value, but sending to same wallet
         add_blocks_unlock_reward(self.manager)
         new_address = w.get_unused_address()
-        out = WalletOutputInfo(decode_address(new_address), 100, timelock=None)
+        out = WalletOutputInfo(decode_address(new_address), UnsignedAmount.from_v1(100), timelock=None)
         tx1 = w.prepare_transaction_compute_inputs(Transaction, [out], self.storage)
         tx1.storage = self.storage
         tx1.update_hash()
@@ -90,14 +93,16 @@ class BasicWalletTest(unittest.TestCase):
         self.storage.save_transaction(tx1)
         w.on_new_tx(tx1)
         self.assertEqual(len(w.spent_txs), 1)
-        self.assertEqual(w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, genesis_value))
+        self.assertEqual(
+            w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(UnsignedAmount.zero(), genesis_value)
+        )
 
         # pass inputs and outputs to prepare_transaction, but not the input keys
         # spend output last transaction
         input_info = WalletInputInfo(tx1.hash, 1, None)
         new_address = w.get_unused_address()
         key2 = w.keys[new_address]
-        out = WalletOutputInfo(decode_address(key2.address), 100, timelock=None)
+        out = WalletOutputInfo(decode_address(key2.address), UnsignedAmount.from_v1(100), timelock=None)
         tx2 = w.prepare_transaction_incomplete_inputs(Transaction, inputs=[input_info],
                                                       outputs=[out], tx_storage=self.storage)
         tx2.storage = self.storage
@@ -107,7 +112,9 @@ class BasicWalletTest(unittest.TestCase):
         self.storage.save_transaction(tx2)
         w.on_new_tx(tx2)
         self.assertEqual(len(w.spent_txs), 2)
-        self.assertEqual(w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, genesis_value))
+        self.assertEqual(
+            w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(UnsignedAmount.zero(), genesis_value)
+        )
 
         # test keypair exception
         with self.assertRaises(WalletLocked):
@@ -125,7 +132,9 @@ class BasicWalletTest(unittest.TestCase):
         w.on_new_tx(tx)
         utxo = w.unspent_txs[self._settings.HATHOR_TOKEN_UID].get((tx.hash, 0))
         self.assertIsNotNone(utxo)
-        self.assertEqual(w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(0, BLOCK_REWARD))
+        self.assertEqual(
+            w.balance[self._settings.HATHOR_TOKEN_UID], WalletBalance(UnsignedAmount.zero(), BLOCK_REWARD)
+        )
 
     def test_locked(self):
         # generate a new block and check if we increase balance
@@ -152,7 +161,7 @@ class BasicWalletTest(unittest.TestCase):
 
         # create transaction spending some value
         new_address = w.get_unused_address()
-        out = WalletOutputInfo(decode_address(new_address), 100, timelock=None)
+        out = WalletOutputInfo(decode_address(new_address), UnsignedAmount.from_v1(100), timelock=None)
         with self.assertRaises(InsufficientFunds):
             w.prepare_transaction_compute_inputs(Transaction, [out], self.storage)
 
@@ -201,7 +210,7 @@ class BasicWalletTest(unittest.TestCase):
         # hathor tx
         hathor_out = WalletOutputInfo(address, hathor_balance, None)
         # token tx
-        token_out = WalletOutputInfo(address, tokens_created - 20, None, token_uid.hex())
+        token_out = WalletOutputInfo(address, tokens_created - UnsignedAmount.from_v1(20), None, token_uid.hex())
 
         tx2 = self.manager.wallet.prepare_transaction_compute_inputs(Transaction, [hathor_out, token_out],
                                                                      self.storage)
@@ -213,7 +222,7 @@ class BasicWalletTest(unittest.TestCase):
         self.manager.verification_service.verify(tx2, self.get_verification_params(self.manager))
 
         self.assertNotEqual(len(tx2.inputs), 0)
-        token_dict = defaultdict(int)
+        token_dict = defaultdict(UnsignedAmount.zero)
         for _input in tx2.inputs:
             output_tx = self.manager.tx_storage.get_transaction(_input.tx_id)
             output = output_tx.outputs[_input.index]
@@ -236,7 +245,7 @@ class BasicWalletTest(unittest.TestCase):
         block = add_new_block(self.manager, advance_clock=5)
         w = self.manager.wallet
         new_address = w.get_unused_address()
-        out = WalletOutputInfo(decode_address(new_address), 1, timelock=None)
+        out = WalletOutputInfo(decode_address(new_address), UnsignedAmount.from_v1(1), timelock=None)
         with self.assertRaises(InsufficientFunds):
             w.prepare_transaction_compute_inputs(Transaction, [out], self.storage, timestamp=block.timestamp)
 
@@ -249,7 +258,7 @@ class BasicWalletTest(unittest.TestCase):
         blocks = add_blocks_unlock_reward(self.manager)
         w = self.manager.wallet
         new_address = w.get_unused_address()
-        out = WalletOutputInfo(decode_address(new_address), 1, timelock=None)
+        out = WalletOutputInfo(decode_address(new_address), UnsignedAmount.from_v1(1), timelock=None)
         tx1 = w.prepare_transaction_compute_inputs(Transaction, [out], self.storage)
         self.assertEqual(len(tx1.inputs), 1)
         _input = tx1.inputs[0]

--- a/hathorlib/tests/__init__.py
+++ b/hathorlib/tests/__init__.py
@@ -1,2 +1,7 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
+
+from htr_lib import UnsignedAmount
+
+# Hardcoded for all tests.
+UnsignedAmount.set_decimal_places(v1_decimal_places=2, v2_decimal_places=18)


### PR DESCRIPTION
Depends on #1742

### Motivation

#1742 wrapped the cleanly-mechanical test modules whole-file. This PR recovers more modules that mixed mechanical fixture wrapping with a few production-coupled expressions. The wrapping is kept and only the coupled expressions are kept in their `int` form, so the modules stay green against the still-unflipped `int` production code.

### Acceptance Criteria

- Route the shared `hathor_tests/utils.py` fixture helpers through the shim, keeping the fee and genesis-change helpers (which read the production-only `FEE_TOKEN_AMOUNT_PER_OUTPUT` setting and use normalized arithmetic) in their `int` form.
- Wrap the fixtures in more test modules.
- Wrap `deposit_amount` at its source so its downstream conversions keep resolving against the shim.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged