### PR TITLE
docs(claude): document the PR description format

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,0 +1,25 @@
+# Pull Request Descriptions
+
+PR descriptions use the repo templates in `.github/PULL_REQUEST_TEMPLATE/`. The template is the source of truth — match it exactly. For a feature branch merging into `master`, that is `feature_branch_pr_template.md`:
+
+```markdown
+### Motivation
+
+<prose explaining why these changes are needed>
+
+### Acceptance Criteria
+
+- <one bullet per thing this PR delivers>
+
+### Checklist
+
+- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
+```
+
+## Rules
+
+- Use only these three sections — `Motivation`, `Acceptance Criteria`, `Checklist` — in this order, and add no others (no `How it works`, `Scope`, `Validation`, `Notes`, etc.).
+- Do not use `####` subsections. `Acceptance Criteria` is a single flat bullet list.
+- `Motivation` is prose answering *why*; `Acceptance Criteria` is an imperative bullet list of *what* the PR does.
+- For a stacked PR, add a single `Depends on #<number>` line at the very top, above `### Motivation`.
+- Wrap code identifiers, paths, and literals in single backticks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,12 @@ hathorlib/               # Lightweight shared library
 
 ## Key Conventions
 
-See `.claude/rules/` for detailed, scoped rules on Python style, testing, API endpoints, pydantic, nano contracts, and verification. Key highlights:
+See `.claude/rules/` for detailed, scoped rules on Python style, testing, API endpoints, pydantic, nano contracts, verification, and pull requests. Key highlights:
 
 - **License**: Apache 2.0, Hathor Labs header on all new Python files (template below).
 - **Settings**: Prefer injecting `HathorSettings` as a dependency; avoid `get_global_settings()` singleton.
 - **Docstrings**: Wrap inline code (names, literals, expressions) in single backticks — `code` — not reStructuredText double backticks or `:role:` markup. Docstrings are read as Markdown in editor hovers, so single backticks render as code spans there; this includes `.pyi` stubs.
+- **PR descriptions**: Match the `.github/PULL_REQUEST_TEMPLATE/` template exactly — only `Motivation`, `Acceptance Criteria`, and `Checklist`, as a flat bullet list with no `####` subsections.
 
 ## License
 


### PR DESCRIPTION
### Motivation

PR descriptions should match the repo's `feature_branch_pr_template.md`, but that convention was not captured in the agent-facing docs, so generated PR bodies drifted into extra sections and `####` subsections. This pins the format so future descriptions stay consistent with the template.

### Acceptance Criteria

- Add `.claude/rules/pull-requests.md` pinning the `Motivation` / `Acceptance Criteria` / `Checklist` structure (flat, no subsections) to `.github/PULL_REQUEST_TEMPLATE/` as the source of truth.
- Reference the new rule from `CLAUDE.md`'s Key Conventions.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged