### PR TITLE
test(decimals): test token amount version V2 [part 19]

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -4,6 +4,15 @@ globs: ["hathor_tests/**/*.py"]
 
 # Testing Conventions
 
+## Assertions
+Use pytest primitives, even inside `unittest.TestCase` subclasses (pytest runs them):
+- Use bare `assert` — `assert x == y`, `assert x is None`, `assert x in y` — not `self.assertEqual`,
+  `self.assertIsNone`, `self.assertIn`, `self.assertTrue`, etc.
+- Use `pytest.raises` (optionally with `match=...`) — not `self.assertRaises`.
+- Prefer exact-value assertions: exact exception types, exact messages (`match=re.escape('...')` pins the
+  whole message), and exact rendered output. Avoid `contains`-style checks that pass when surrounding text
+  drifts.
+
 ## Base Classes
 - `TestCase` — general tests (from `hathor_tests.unittest`)
 - `SimulatorTestCase` — DAG/consensus simulation tests

--- a/hathor_tests/token_amount_version/test_authorities.py
+++ b/hathor_tests/token_amount_version/test_authorities.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authority (mint/melt) outputs under V2: the value field is a bitmask read via `.raw()`, not a token amount.
+
+An authority output carries its mint/melt capability in the bits of its value field, so that field is read
+through `.raw()` no matter the transaction's token amount version. Authority outputs are therefore
+version-agnostic: they are excluded from a token's balance sum, their bitmask must stay within
+`ALL_AUTHORITIES`, and native HTR may never carry one. A V2 transaction treats them exactly as V1 does. The
+accepting cases run through the DAG builder; the rejecting cases mutate a built transaction's outputs and
+drive the verifier directly (the builder always emits a balanced, well-formed tx).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from htr_lib import UnsignedAmount
+
+from hathor.transaction import Transaction
+from hathor.transaction.base_transaction import TxInput, TxOutput
+from hathor.transaction.exceptions import InvalidToken
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.token_info import TokenInfoDict
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.token_amount_version import TokenAmountVersion
+
+
+class TestAuthoritiesV2(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.tx_verifier = self.manager.verification_service.verifiers.tx
+        self.vertex_verifier = self.manager.verification_service.verifiers.vertex
+
+    def _token_dict(self, tx: Transaction) -> TokenInfoDict:
+        """Build the complete per-token info for `tx`, reading its (possibly mutated) inputs and outputs."""
+        params = self.get_verification_params(self.manager)
+        block_storage = self.manager.verification_service._get_block_storage(params)
+        return tx.get_complete_token_info(block_storage)
+
+    def _verify_balance(self, tx: Transaction) -> None:
+        """Run only the input/output balance check on `tx`, reading its (possibly mutated) outputs directly.
+
+        This isolates `verify_transparent_balance` from script verification, which runs earlier in the full
+        pipeline and would reject a mutated tx on its now-stale input signatures before the balance is reached.
+        """
+        token_dict = self._token_dict(tx)
+        self.tx_verifier.verify_transparent_balance(self.manager._settings, tx, token_dict)
+
+    def test_authority_output_value_is_bitmask_not_amount_v2(self) -> None:
+        """A V2 tx with a mint/melt authority output; assert the authority bits are read via `value.raw()` and the
+        output does not contribute to the token's balance sum. Pins authority outputs are version-agnostic."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            spend.out[0] = 100 TKA
+            spend.token_amount_version = V2
+            TKA.token_amount_version = V2
+
+            b11 < TKA
+            b12 < spend
+            TKA <-- spend <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        tka = artifacts.get_typed_vertex('TKA', TokenCreationTransaction)
+
+        assert tka.get_token_amount_version() == TokenAmountVersion.V2
+
+        mint_auth = next(output for output in tka.outputs if output.can_mint_token())
+        melt_auth = next(output for output in tka.outputs if output.can_melt_token())
+        minted = next(
+            output for output in tka.outputs
+            if output.get_token_index() == 1 and not output.is_token_authority()
+        )
+
+        # The value field holds the capability bitmask, read via `.raw()`, even though the tx is V2.
+        assert mint_auth.value.is_v2()
+        assert mint_auth.value.raw() == TxOutput.TOKEN_MINT_MASK
+        assert mint_auth.can_mint_token()
+        assert not mint_auth.can_melt_token()
+
+        assert melt_auth.value.is_v2()
+        assert melt_auth.value.raw() == TxOutput.TOKEN_MELT_MASK
+        assert melt_auth.can_melt_token()
+        assert not melt_auth.can_mint_token()
+
+        # The token's balance sum counts only the minted output; the authority bitmasks (raw 1 and 2) are excluded.
+        token_uid = tka.get_token_uid(minted.get_token_index())
+        token_info = self._token_dict(tka)[token_uid]
+        assert token_info.amount.raw() == minted.value.raw() == 100
+        assert token_info.can_mint
+        assert token_info.can_melt
+
+        assert tka.get_metadata().validation.is_valid()
+        assert tka.get_metadata().voided_by is None
+
+    def test_invalid_authority_bits_rejected_v2(self) -> None:
+        """A V2 authority output whose `value.raw()` exceeds `ALL_AUTHORITIES` raises
+        `InvalidToken('Invalid authorities in output ...')`. Pins the ceiling check uses `raw()` under V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            spend.out[0] = 100 TKA
+            spend.token_amount_version = V2
+            TKA.token_amount_version = V2
+
+            b11 < TKA
+            b12 < spend
+            TKA <-- spend <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        spend = artifacts.get_typed_vertex('spend', Transaction)
+
+        # 0b100 sets neither mint nor melt but keeps the authority flag, so it clears the input-capability
+        # check and reaches the ceiling check, which compares `raw()` against ALL_AUTHORITIES (0b11).
+        assert 0b100 > TxOutput.ALL_AUTHORITIES
+        spend.outputs.append(TxOutput(
+            value=UnsignedAmount.from_v2(0b100),
+            token_data=TxOutput.TOKEN_AUTHORITY_MASK | 1,
+            script=spend.outputs[0].script,
+        ))
+        with pytest.raises(InvalidToken, match=re.escape('Invalid authorities in output (0b100)')):
+            self._verify_balance(spend)
+
+    def test_authority_passthrough_does_not_affect_balance_v2(self) -> None:
+        """A V2 tx passes a mint authority through (authority in -> authority out) with no value change; assert
+        balance verification ignores authority outputs and the tx verifies."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            spend.out[0] = 100 TKA
+            spend.token_amount_version = V2
+            TKA.token_amount_version = V2
+
+            b11 < TKA
+            b12 < spend
+            TKA <-- spend <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        tka = artifacts.get_typed_vertex('TKA', TokenCreationTransaction)
+        spend = artifacts.get_typed_vertex('spend', Transaction)
+
+        # Spend TKA's still-unspent mint authority and re-emit an identical mint authority: capability in,
+        # capability out, no value moved.
+        mint_auth_index = next(i for i, output in enumerate(tka.outputs) if output.can_mint_token())
+        spend.inputs.append(TxInput(tka.hash, mint_auth_index, b''))
+        spend.outputs.append(TxOutput(
+            value=UnsignedAmount.from_v2(TxOutput.TOKEN_MINT_MASK),
+            token_data=TxOutput.TOKEN_AUTHORITY_MASK | 1,
+            script=spend.outputs[0].script,
+        ))
+
+        token_uid = tka.hash
+        token_info = self._token_dict(spend)[token_uid]
+        # The passthrough leaves the token balanced (100 in, 100 out) and carries the mint capability.
+        assert token_info.amount.raw() == 0
+        assert token_info.can_mint
+
+        # No exception: the authority output is ignored by the balance sum.
+        self._verify_balance(spend)
+
+    def test_hathor_authority_output_rejected_v2(self) -> None:
+        """A V2 tx with an authority UTXO on native HTR (token_index 0) raises `InvalidToken('Cannot have authority
+        UTXO for hathor tokens')`, regardless of version."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert tx.get_token_amount_version() == TokenAmountVersion.V2
+
+        # token_index 0 is native HTR; flag the output as a mint authority on it.
+        tx.outputs[0].token_data = TxOutput.TOKEN_AUTHORITY_MASK | 0
+        tx.outputs[0].value = UnsignedAmount.from_v2(TxOutput.TOKEN_MINT_MASK)
+        assert tx.outputs[0].get_token_index() == 0
+        assert tx.outputs[0].is_token_authority()
+        with pytest.raises(InvalidToken, match=re.escape('Cannot have authority UTXO for hathor tokens')):
+            self.vertex_verifier.verify_outputs(tx)

--- a/hathor_tests/token_amount_version/test_cross_version_balance.py
+++ b/hathor_tests/token_amount_version/test_cross_version_balance.py
@@ -1,0 +1,414 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sum-of-inputs == sum-of-outputs balance verification when V1 and V2 amounts mix. The heart of the project.
+
+Amounts are compared in their shared `normalized()` form, so a V1 input (2 decimal places) and a V2 output
+(18 decimal places) balance whenever their normalized values are equal, even though their raw values differ
+by the `10**16` normalization factor. These tests drive that property through the DAG builder for the
+accepting cases, and through the balance verifier directly for the rejecting cases (the builder always emits
+a balanced tx, so an unbalanced one is produced by mutating a built tx's output and re-running the check).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from htr_lib import UnsignedAmount
+
+from hathor.transaction import Block, Transaction
+from hathor.transaction.exceptions import InputOutputMismatch, InvalidOutputValue
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.serialization.encoding.output_value import get_max_output_value_v2
+from hathorlib.token_amount_version import TokenAmountVersion
+
+# One V2 "cent" in normalized units: the smallest amount representable in V1 (10**-2) expressed at V2's
+# 18-decimal scale. A V2 amount that is not a multiple of this is "sub-cent" and has no V1 representation.
+ONE_V2_CENT = 10 ** 16
+
+
+class TestCrossVersionBalance(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.tx_verifier = self.manager.verification_service.verifiers.tx
+
+    def _verify_balance(self, tx: Transaction) -> None:
+        """Run only the input/output balance check on `tx`, reading its (possibly mutated) outputs directly.
+
+        This isolates `verify_transparent_balance` from script verification, which runs earlier in the full
+        pipeline and would reject a mutated tx on its now-stale input signatures before the balance is reached.
+        """
+        params = self.get_verification_params(self.manager)
+        block_storage = self.manager.verification_service._get_block_storage(params)
+        token_dict = tx.get_complete_token_info(block_storage)
+        self.tx_verifier.verify_transparent_balance(self.manager._settings, tx, token_dict)
+
+    def test_v1_input_v1_output_balances(self) -> None:
+        """Baseline control: a V1 tx spends a V1 HTR utxo with V1 outputs summing equal; it verifies."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_v2_input_v2_output_balances(self) -> None:
+        """Baseline control: a V2 tx spends a V2 HTR utxo with V2 outputs summing equal; it verifies."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< src
+            src.out[0] = 1.00 HTR
+            src.token_amount_version = V2
+
+            src.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < src
+            b12 < tx
+            src <-- tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert tx.get_token_amount_version() == TokenAmountVersion.V2
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_v1_input_v2_output_balances(self) -> None:
+        """A V2 tx spends a V1-created HTR utxo (the block reward is always V1) and emits a V2 output of equal
+        normalized value; verification passes. Proves inputs/outputs are compared normalized across versions."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+        b1 = artifacts.get_typed_vertex('b1', Block)
+
+        assert b1.outputs[0].value.is_v1()
+        assert tx.get_token_amount_version() == TokenAmountVersion.V2
+        assert tx.outputs[0].value.is_v2()
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_v2_input_v1_output_balances(self) -> None:
+        """A V1 tx spends a cent-aligned V2-created HTR utxo and emits an equal V1 output; it balances and
+        verifies. Confirms a V1 spending tx normalizes a V2 input correctly."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< src
+            src.out[0] = 1.00 HTR
+            src.token_amount_version = V2
+
+            src.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+
+            b11 < src
+            b12 < tx
+            src <-- tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        src = artifacts.get_typed_vertex('src', Transaction)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert src.outputs[0].value.is_v2()
+        assert tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert tx.outputs[0].value.is_v1()
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_balance_compares_normalized_not_raw(self) -> None:
+        """A V1 input (raw 100) and a single V2 output of equal normalized value (raw 10**18) balance, even
+        though their raw values differ by the normalization factor. Guards against raw-integer comparison."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< src
+            src.out[0] = 1.00 HTR
+
+            src.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < src
+            b12 < tx
+            src <-- tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        src = artifacts.get_typed_vertex('src', Transaction)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        # The raw representations differ by the 10**16 normalization factor, yet the normalized values match.
+        assert src.outputs[0].value.raw() == 100
+        assert tx.outputs[0].value.raw() == 100 * UnsignedAmount.get_normalization_factor()
+        assert src.outputs[0].value.normalized() == tx.outputs[0].value.normalized()
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_mixed_v1_and_v2_inputs_same_token_summed(self) -> None:
+        """A tx spends two HTR utxos of the same token, one created by a V1 tx and one by a V2 tx, and outputs
+        their combined normalized total; balance passes. Confirms per-token aggregation across input versions."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..14]
+            b10 < dummy
+
+            b1.out[0] <<< src_v1
+            src_v1.out[0] = 1.00 HTR
+
+            b2.out[0] <<< src_v2
+            src_v2.out[0] = 1.00 HTR
+            src_v2.token_amount_version = V2
+
+            src_v1.out[0] <<< tx
+            src_v2.out[0] <<< tx
+            tx.out[0] = 2.00 HTR
+
+            b11 < src_v1
+            b12 < src_v2
+            b13 < tx
+            src_v1 <-- src_v2 <-- tx <-- b14
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert len(tx.inputs) == 2
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_cross_version_surplus_rejected(self) -> None:
+        """A V2 tx spends a 1.00 V1 HTR utxo but emits one V2 raw unit too much; balance verification raises
+        `InputOutputMismatch` reporting a surplus. Off-by-one at the finest V2 unit across versions."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        # emit one raw V2 unit more than the input provides -> surplus
+        tx.outputs[0].value = UnsignedAmount.from_v2(tx.outputs[0].value.raw() + 1)
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(tx)
+
+    def test_cross_version_deficit_rejected(self) -> None:
+        """Same setup but one V2 raw unit too little; balance verification raises `InputOutputMismatch`
+        reporting a deficit. Pins deficit detection at normalized granularity."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        # emit one raw V2 unit less than the input provides -> deficit
+        tx.outputs[0].value = UnsignedAmount.from_v2(tx.outputs[0].value.raw() - 1)
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid deficit of HTR.")):
+            self._verify_balance(tx)
+
+    def test_v2_tx_splits_htr_into_sub_cent_outputs(self) -> None:
+        """A V2 tx spends a 1.00 V1 HTR input and emits 0.005 + 0.995 (one sub-cent output, not V1-representable);
+        balance passes. Establishes that sub-cent V2 utxos can be created from V1 funds."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 0.005 HTR
+            tx.out[1] = 0.995 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        # 0.005 is half a cent: not a multiple of ONE_V2_CENT, so it has no V1 representation.
+        assert tx.outputs[0].value.normalized() == ONE_V2_CENT // 2
+        assert tx.outputs[0].value.normalized() % ONE_V2_CENT != 0
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_v1_tx_cannot_spend_single_sub_cent_v2_utxo(self) -> None:
+        """A V1 tx spending only a 0.005 sub-cent V2 HTR utxo has no valid output set: a V1 output is cent-granular,
+        so a 0.00 output is rejected as non-positive and the smallest positive one (0.01) overspends the 0.005
+        input, raising `InputOutputMismatch` for the surplus."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< src
+            src.out[0] = 0.005 HTR
+            src.out[1] = 0.995 HTR
+            src.token_amount_version = V2
+
+            src.out[0] <<< tx
+            tx.out[0] = 0.005 HTR
+            tx.token_amount_version = V2
+
+            b11 < src
+            b12 < tx
+            src <-- tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+        assert tx.outputs[0].value.normalized() == ONE_V2_CENT // 2
+
+        # Re-cast the spend as a V1 tx: the smallest positive V1 output is 0.01, which exceeds the 0.005 input.
+        tx.outputs[0].value = UnsignedAmount.from_v1(1)
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(tx)
+
+    def test_v1_tx_combining_two_sub_cent_v2_utxos_balances(self) -> None:
+        """A V1 tx spends two 0.005 V2 HTR utxos (total 0.01, cent-aligned) into a single V1 0.01 output; it
+        balances. Pins that sub-cent V2 dust consolidates into a V1 tx when the total is cent-aligned."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< src
+            src.out[0] = 0.005 HTR
+            src.out[1] = 0.005 HTR
+            src.out[2] = 0.99 HTR
+            src.token_amount_version = V2
+
+            src.out[0] <<< tx
+            src.out[1] <<< tx
+            tx.out[0] = 0.01 HTR
+
+            b11 < src
+            b12 < tx
+            src <-- tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert tx.outputs[0].value.raw() == 1  # 0.01 in V1 cents
+        assert len(tx.inputs) == 2
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_multi_token_mixed_versions_each_balanced_independently(self) -> None:
+        """A tx moves HTR and a custom token, spending a V1 utxo of one and a V2 utxo of the other; each token's
+        normalized sum balances in its own `TokenInfo` entry and the tx verifies."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..14]
+            b10 < dummy
+
+            b1.out[0] <<< src_htr
+            src_htr.out[0] = 1.00 HTR
+
+            tka.out[0] = 50 TKA
+            tka.token_amount_version = V2
+            TKA.token_amount_version = V2
+
+            src_htr.out[0] <<< tx
+            tka.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.out[1] = 50 TKA
+            tx.token_amount_version = V2
+
+            b11 < src_htr
+            b12 < tka
+            b13 < tx
+            src_htr <-- tka <-- tx <-- b14
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_zero_value_output_rejected_in_both_versions(self) -> None:
+        """A V1 output of raw 0 and a V2 output of normalized 0 each raise `InvalidOutputValue`. Pins the
+        positivity guard is version-agnostic (it compares against `UnsignedAmount.zero()`)."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+        vertex_verifier = self.manager.verification_service.verifiers.vertex
+
+        tx.outputs[0].value = UnsignedAmount.from_v1(0)
+        with pytest.raises(InvalidOutputValue, match=re.escape('Output value must be a positive integer.')):
+            vertex_verifier.verify_outputs(tx)
+
+        tx.outputs[0].value = UnsignedAmount.from_v2(0)
+        with pytest.raises(InvalidOutputValue, match=re.escape('Output value must be a positive integer.')):
+            vertex_verifier.verify_outputs(tx)
+
+    def test_v2_max_output_value_boundary(self) -> None:
+        """A V2 output at `get_max_output_value_v2()` (`2**63 * 10**16`) serializes, while one unit beyond raises
+        `ValueError: value is too big` at encoding time. Pins the V2 ceiling, distinct from V1's `2**63`."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+        max_value = get_max_output_value_v2()
+
+        # At the ceiling the value encodes. The amount type itself does not bound construction; the ceiling is
+        # enforced by the output-value encoding, so the boundary is exercised through serialization.
+        tx.outputs[0].value = UnsignedAmount.from_v2(max_value)
+        assert len(tx.get_struct()) > 0
+
+        tx.outputs[0].value = UnsignedAmount.from_v2(max_value + 1)
+        with pytest.raises(ValueError, match=re.escape(f'value is too big; max is {max_value}')):
+            tx.get_struct()

--- a/hathor_tests/token_amount_version/test_derivation.py
+++ b/hathor_tests/token_amount_version/test_derivation.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""How a vertex's token amount version is derived from `signal_bits`, and which vertices are exempt.
+"""
+
+from __future__ import annotations
+
+from hathor.transaction import Block, Transaction
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.token_amount_version import TokenAmountVersion
+
+
+class TestTokenAmountVersionDerivation(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def _build_simple_tx(self) -> Transaction:
+        """Build a single, well-formed HTR transaction whose `signal_bits` we can then manipulate."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy
+
+            tx.out[0] = 100 HTR
+        ''')
+        return artifacts.get_typed_vertex('tx', Transaction)
+
+    def test_version_reads_only_signal_bits_lsb(self) -> None:
+        """Only bit 0 of `signal_bits` selects the version; the higher (feature-signaling) bits are
+        independent. An even LSB is V1 and an odd LSB is V2, regardless of the higher bits."""
+        tx = self._build_simple_tx()
+
+        expected_by_signal_bits = {
+            0b0: TokenAmountVersion.V1,
+            0b1: TokenAmountVersion.V2,
+            0b10: TokenAmountVersion.V1,
+            0b11: TokenAmountVersion.V2,
+            0b100: TokenAmountVersion.V1,
+            0b101: TokenAmountVersion.V2,
+        }
+
+        for signal_bits, expected in expected_by_signal_bits.items():
+            tx.signal_bits = signal_bits
+            assert tx.get_token_amount_version() == expected
+
+    def test_version_is_one_indexed(self) -> None:
+        """The on-chain mapping is 1-indexed: LSB 0 maps to V1 (not V0) and LSB 1 maps to V2. This mapping
+        is encoded on-chain and must never drift."""
+        assert int(TokenAmountVersion.V1) == 1
+        assert int(TokenAmountVersion.V2) == 2
+        assert not hasattr(TokenAmountVersion, 'V0')
+
+        tx = self._build_simple_tx()
+        tx.signal_bits = 0b0
+        assert tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert int(tx.get_token_amount_version()) == 1
+
+    def test_block_token_amount_version_is_always_v1(self) -> None:
+        """A block's feature-signaling bits never make it V2: with the LSB set (and the feature active, as
+        it is by default in `unittests.yml`) the block still reports V1 and its reward outputs encode as V1."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..11]
+            b10 < dummy
+        ''')
+        block = artifacts.get_typed_vertex('b1', Block)
+
+        # The LSB is the bit that selects V2 on a transaction; on a block it is only a feature-signaling bit.
+        block.signal_bits = 0b11
+
+        assert block.to_json()['token_amount_version'] == TokenAmountVersion.V1.value
+        assert len(block.outputs) > 0
+        for output in block.outputs:
+            assert output.value.is_v1()
+
+    def test_genesis_is_v1(self) -> None:
+        """Genesis vertices, including the genesis transactions, report V1: genesis is unaffected by the
+        feature."""
+        genesis = self.manager.tx_storage.get_all_genesis()
+        genesis_txs = [vertex for vertex in genesis if not vertex.is_block]
+        genesis_blocks = [vertex for vertex in genesis if vertex.is_block]
+
+        assert len(genesis_txs) > 0
+        assert len(genesis_blocks) > 0
+
+        for tx in genesis_txs:
+            assert isinstance(tx, Transaction)
+            assert tx.get_token_amount_version() == TokenAmountVersion.V1
+
+        for block in genesis_blocks:
+            assert block.to_json()['token_amount_version'] == TokenAmountVersion.V1.value
+
+    def test_token_creation_tx_version_round_trips(self) -> None:
+        """The token amount version is part of a token-creation tx's serialization contract: a V2
+        `TokenCreationTransaction` keeps V2 across `get_struct()`/`create_from_struct`, and its outputs
+        decode under V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            tx_v1.out[0] = 100 TK1
+
+            tx_v2.out[0] = 100 TK2
+            tx_v2.token_amount_version = V2
+            TK2.token_amount_version = V2
+
+            b11 < tx_v1
+            b12 < tx_v2
+            tx_v1 <-- tx_v2 <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        token_creation_tx = artifacts.get_typed_vertex('TK2', TokenCreationTransaction)
+
+        assert token_creation_tx.get_token_amount_version() == TokenAmountVersion.V2
+
+        parsed = TokenCreationTransaction.create_from_struct(token_creation_tx.get_struct())
+        assert parsed == token_creation_tx
+        assert parsed.get_token_amount_version() == TokenAmountVersion.V2
+        assert parsed.signal_bits == token_creation_tx.signal_bits
+
+        assert len(parsed.outputs) > 0
+        for output in parsed.outputs:
+            assert output.value.is_v2()

--- a/hathor_tests/token_amount_version/test_feature_activation_lifecycle.py
+++ b/hathor_tests/token_amount_version/test_feature_activation_lifecycle.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""The `TOKEN_AMOUNT_V2` feature-activation lifecycle and its end-to-end (manager-level) effect on V2 acceptance.
+
+The feature is gated two ways that combine in `Features.from_vertex`: the per-network `ENABLE_TOKEN_AMOUNT_V2`
+setting (`DISABLED` / `ENABLED` / `FEATURE_ACTIVATION`) and, under `FEATURE_ACTIVATION`, the best block's feature
+state (`DEFINED` -> `STARTED` -> `LOCKED_IN` -> `ACTIVE`). A V2 token amount is only allowed once the feature is
+active for the best block, so a V2 tx relayed on the mempool is accepted exactly when the best block is `ACTIVE`,
+while V1 traffic is accepted at every state. These tests drive the state machine by mining through the
+evaluation-interval boundaries (setting the signal bits on the blocks of the locking interval) and relay V1/V2
+txs through the manager at each state. The `ENABLE_TOKEN_AMOUNT_V2` setting short-circuits the state machine:
+when `DISABLED`, the feature reports inactive even at an `ACTIVE` block state.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hathor.conf.settings import HathorSettings
+from hathor.daa import DAAFactory, DAAVersion, TestMode
+from hathor.exception import InvalidNewTransaction
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.model.criteria import Criteria
+from hathor.feature_activation.model.feature_state import FeatureState
+from hathor.feature_activation.settings import Settings as FeatureSettings
+from hathor.feature_activation.utils import Features
+from hathor.nanocontracts.nano_runtime_version import NanoRuntimeVersion
+from hathor.transaction import Block, Transaction
+from hathor.transaction.scripts.opcode import OpcodesVersion
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.conf import (
+    MAINNET_SETTINGS_FILEPATH,
+    NANO_TESTNET_SETTINGS_FILEPATH,
+    TESTNET_INDIA_SETTINGS_FILEPATH,
+    UNITTESTS_SETTINGS_FILEPATH,
+)
+from hathorlib.conf.settings import FeatureSetting
+from hathorlib.conf.utils import load_yaml_settings
+from hathorlib.token_amount_version import TokenAmountVersion
+
+if TYPE_CHECKING:
+    from hathor.dag_builder.artifacts import DAGArtifacts
+
+# A chain long enough to carry `TOKEN_AMOUNT_V2` from DEFINED to ACTIVE under the criteria below, plus a single
+# V2 tx that spends `b1`'s entire block reward as one input (so it is self-funded and can be relayed on the
+# mempool without a separately-propagated funding tx) and is ordered after the last block so it is only ever
+# relayed by hand, never auto-propagated with the chain.
+_V2_TX_DAG = '''
+    blockchain genesis b[1..13]
+
+    b1.out[0] = 64.00 HTR
+    b1.out[0] <<< tx_v2
+    tx_v2.out[0] = 1.00 HTR
+    tx_v2.token_amount_version = V2
+
+    b13 < tx_v2
+'''
+
+
+class TestFeatureActivationLifecycle(unittest.TestCase):
+    def _lifecycle_settings(self, token_amount_v2_setting: FeatureSetting) -> HathorSettings:
+        """Settings that put `TOKEN_AMOUNT_V2` on a short feature-activation schedule.
+
+        Block rewards mature immediately (`REWARD_SPEND_MIN_BLOCKS=0`) so a tx spending an early block can be
+        relayed at any best-block height, including the pre-activation states.
+        """
+        feature_settings = FeatureSettings(
+            evaluation_interval=4,
+            default_threshold=3,
+            features={
+                Feature.TOKEN_AMOUNT_V2: Criteria(
+                    bit=0,
+                    start_height=4,
+                    timeout_height=12,
+                    signal_support_by_default=True,
+                    version='0.0.0',
+                ),
+            },
+        )
+        return self._settings.model_copy(update=dict(
+            ENABLE_TOKEN_AMOUNT_V2=token_amount_v2_setting,
+            REWARD_SPEND_MIN_BLOCKS=0,
+            FEATURE_ACTIVATION=feature_settings,
+        ))
+
+    def _prepare(self, settings: HathorSettings) -> None:
+        daa_factory = DAAFactory(settings=settings, test_mode=TestMode.TEST_ALL_WEIGHT)
+        builder = self.get_builder(settings).set_daa_factory(daa_factory)
+        self.manager = self.create_peer_from_builder(builder)
+        self.feature_service = self.manager.feature_service
+        self.vertex_handler = self.manager.vertex_handler
+        self.bit_signaling_service = self.manager._bit_signaling_service
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def _propagate_signaling(self, artifacts: DAGArtifacts) -> None:
+        """Propagate the blocks of the interval [b5, b7], each signaling support so the feature locks in at b8."""
+        for block_name in ('b5', 'b6', 'b7'):
+            block = artifacts.by_name[block_name].vertex
+            assert isinstance(block, Block)
+            block.storage = self.manager.tx_storage
+            block.signal_bits = self.bit_signaling_service.generate_signal_bits(block=block.get_block_parent())
+            artifacts.propagate_with(self.manager, up_to=block_name)
+
+    def _propagate_to_active(self, artifacts: DAGArtifacts) -> None:
+        """Mine through every boundary until `TOKEN_AMOUNT_V2` is ACTIVE, leaving b12 as the best block."""
+        artifacts.propagate_with(self.manager, up_to='b4')
+        self._propagate_signaling(artifacts)
+        artifacts.propagate_with(self.manager, up_to='b12')
+
+    def test_setting_default_disabled_on_all_real_networks(self) -> None:
+        """Build mainnet/testnet/production settings (no override) and assert `ENABLE_TOKEN_AMOUNT_V2` is DISABLED.
+        Pins that V2 ships gated OFF everywhere real."""
+        for filepath in (MAINNET_SETTINGS_FILEPATH, TESTNET_INDIA_SETTINGS_FILEPATH, NANO_TESTNET_SETTINGS_FILEPATH):
+            settings = load_yaml_settings(HathorSettings, filepath=filepath)
+            assert settings.ENABLE_TOKEN_AMOUNT_V2 == FeatureSetting.DISABLED
+
+    def test_unittests_yml_enables_feature(self) -> None:
+        """Assert the unittest settings set `ENABLE_TOKEN_AMOUNT_V2` to ENABLED. Pins the test-suite-wide default
+        (so inactive-path tests must explicitly override it)."""
+        settings = load_yaml_settings(HathorSettings, filepath=UNITTESTS_SETTINGS_FILEPATH)
+        assert settings.ENABLE_TOKEN_AMOUNT_V2 == FeatureSetting.ENABLED
+
+    def test_disabled_setting_overrides_state_machine(self) -> None:
+        """With the setting DISABLED, assert the feature reports inactive even for an ACTIVE block state, end-to-end:
+        V2 txs are rejected at every height. Pins the DISABLED short-circuit."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.DISABLED))
+        artifacts = self.dag_builder.build_from_str(_V2_TX_DAG)
+        b3, b12 = artifacts.get_typed_vertices(('b3', 'b12'), Block)
+        tx_v2, = artifacts.get_typed_vertices(('tx_v2',), Transaction)
+
+        # A V2 tx is rejected while the state is still DEFINED.
+        artifacts.propagate_with(self.manager, up_to='b3')
+        assert self.feature_service.get_state(block=b3, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.DEFINED
+        with pytest.raises(InvalidNewTransaction, match=re.escape('invalid token amount version: V2')):
+            self.vertex_handler.on_new_relayed_vertex(tx_v2)
+
+        # The state machine drives the feature to ACTIVE, but the DISABLED setting keeps it inactive.
+        artifacts.propagate_with(self.manager, up_to='b4')
+        self._propagate_signaling(artifacts)
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+
+        features_b12 = Features.from_vertex(
+            settings=self.manager._settings, feature_service=self.feature_service, vertex=b12,
+        )
+        assert features_b12.token_amount_version == TokenAmountVersion.V1
+
+        # The same V2 tx is still rejected at the ACTIVE block state.
+        with pytest.raises(InvalidNewTransaction, match=re.escape('invalid token amount version: V2')):
+            self.vertex_handler.on_new_relayed_vertex(tx_v2)
+        assert tx_v2.get_metadata().validation.is_initial()
+        assert tx_v2.get_metadata().voided_by is None
+        assert not self.manager.tx_storage.transaction_exists(tx_v2.hash)
+
+    def test_features_carries_token_amount_version_field(self) -> None:
+        """Assert `Features.from_vertex(block).token_amount_version` is V2 when the feature is active for that block
+        and V1 otherwise, and that constructing `Features(...)` without the field raises (every call site must set
+        it). Pins the new permissive feature field."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.FEATURE_ACTIVATION))
+        artifacts = self.dag_builder.build_from_str(_V2_TX_DAG)
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        self._propagate_to_active(artifacts)
+
+        # b11 is LOCKED_IN (feature inactive) -> V1; b12 is ACTIVE (feature active) -> V2.
+        assert self.feature_service.get_state(block=b11, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.LOCKED_IN
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+
+        features_b11 = Features.from_vertex(
+            settings=self.manager._settings, feature_service=self.feature_service, vertex=b11,
+        )
+        features_b12 = Features.from_vertex(
+            settings=self.manager._settings, feature_service=self.feature_service, vertex=b12,
+        )
+        assert features_b11.token_amount_version == TokenAmountVersion.V1
+        assert features_b12.token_amount_version == TokenAmountVersion.V2
+
+        # The field has no default, so every construction site must provide it.
+        with pytest.raises(
+            TypeError,
+            match=re.escape("missing 1 required keyword-only argument: 'token_amount_version'"),
+        ):
+            Features(  # type: ignore[call-arg]
+                count_checkdatasig_op=True,
+                nanocontracts=True,
+                fee_tokens=True,
+                opcodes_version=OpcodesVersion.V2,
+                nano_runtime_version=NanoRuntimeVersion.V2,
+                restrict_dup_actions=True,
+                daa_version=DAAVersion.V2,
+                shielded_transactions=True,
+            )
+
+    def test_lifecycle_transitions_to_active(self) -> None:
+        """With FEATURE_ACTIVATION criteria, mine through the boundaries and assert the feature state progresses
+        DEFINED -> STARTED -> LOCKED_IN -> ACTIVE at the expected blocks. Mirrors other features' lifecycle tests."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.FEATURE_ACTIVATION))
+        artifacts = self.dag_builder.build_from_str(_V2_TX_DAG)
+        b3, b4, b8, b11, b12 = artifacts.get_typed_vertices(('b3', 'b4', 'b8', 'b11', 'b12'), Block)
+
+        artifacts.propagate_with(self.manager, up_to='b3')
+        assert self.feature_service.get_state(block=b3, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.DEFINED
+
+        artifacts.propagate_with(self.manager, up_to='b4')
+        assert self.feature_service.get_state(block=b4, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.STARTED
+
+        self._propagate_signaling(artifacts)
+        artifacts.propagate_with(self.manager, up_to='b8')
+        assert self.feature_service.get_state(block=b8, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.LOCKED_IN
+
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert self.feature_service.get_state(block=b11, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.LOCKED_IN
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+
+    def test_v2_tx_rejected_before_activation_via_manager(self) -> None:
+        """While the best block state is pre-ACTIVE, relay a V2 tx through the manager and assert it is rejected
+        (wrapping `invalid token amount version: V2`), stays initial, and is not voided/stored. End-to-end reject."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.FEATURE_ACTIVATION))
+        artifacts = self.dag_builder.build_from_str(_V2_TX_DAG)
+        b4, = artifacts.get_typed_vertices(('b4',), Block)
+        tx_v2, = artifacts.get_typed_vertices(('tx_v2',), Transaction)
+
+        artifacts.propagate_with(self.manager, up_to='b4')
+        assert self.feature_service.get_state(block=b4, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.STARTED
+
+        with pytest.raises(InvalidNewTransaction, match=re.escape('invalid token amount version: V2')):
+            self.vertex_handler.on_new_relayed_vertex(tx_v2)
+        assert tx_v2.get_metadata().validation.is_initial()
+        assert tx_v2.get_metadata().voided_by is None
+        assert not self.manager.tx_storage.transaction_exists(tx_v2.hash)
+
+    def test_v2_tx_accepted_after_activation_via_manager(self) -> None:
+        """Once the best block reaches ACTIVE, relay/propagate the same V2 tx and assert it is valid, not voided,
+        stored, and appears among mempool tips. End-to-end accept."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.FEATURE_ACTIVATION))
+        artifacts = self.dag_builder.build_from_str(_V2_TX_DAG)
+        b12, = artifacts.get_typed_vertices(('b12',), Block)
+        tx_v2, = artifacts.get_typed_vertices(('tx_v2',), Transaction)
+
+        self._propagate_to_active(artifacts)
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+
+        self.vertex_handler.on_new_relayed_vertex(tx_v2)
+        assert tx_v2.get_metadata().validation.is_valid()
+        assert tx_v2.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(tx_v2.hash)
+        assert tx_v2 in list(self.manager.tx_storage.iter_mempool_tips())
+
+    def test_v1_tx_accepted_throughout_lifecycle(self) -> None:
+        """Relay a V1 tx at DEFINED, STARTED, LOCKED_IN, and ACTIVE best-block states; assert it is accepted at
+        every stage. Pins that the lifecycle never blocks V1 traffic."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.FEATURE_ACTIVATION))
+        # Four independent, self-funded V1 txs, one per lifecycle state, each ordered after the last block so it is
+        # only ever relayed by hand.
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+
+            b1.out[0] = 64.00 HTR
+            b1.out[0] <<< tx_defined
+            tx_defined.out[0] = 1.00 HTR
+            b13 < tx_defined
+
+            b2.out[0] = 64.00 HTR
+            b2.out[0] <<< tx_started
+            tx_started.out[0] = 1.00 HTR
+            b13 < tx_started
+
+            b3.out[0] = 64.00 HTR
+            b3.out[0] <<< tx_locked
+            tx_locked.out[0] = 1.00 HTR
+            b13 < tx_locked
+
+            b4.out[0] = 64.00 HTR
+            b4.out[0] <<< tx_active
+            tx_active.out[0] = 1.00 HTR
+            b13 < tx_active
+        ''')
+        b3, b4, b8, b12 = artifacts.get_typed_vertices(('b3', 'b4', 'b8', 'b12'), Block)
+        tx_defined, tx_started, tx_locked, tx_active = artifacts.get_typed_vertices(
+            ('tx_defined', 'tx_started', 'tx_locked', 'tx_active'), Transaction,
+        )
+
+        artifacts.propagate_with(self.manager, up_to='b3')
+        assert self.feature_service.get_state(block=b3, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.DEFINED
+        self.vertex_handler.on_new_relayed_vertex(tx_defined)
+        assert tx_defined.get_metadata().validation.is_valid()
+        assert tx_defined.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b4')
+        assert self.feature_service.get_state(block=b4, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.STARTED
+        self.vertex_handler.on_new_relayed_vertex(tx_started)
+        assert tx_started.get_metadata().validation.is_valid()
+        assert tx_started.get_metadata().voided_by is None
+
+        self._propagate_signaling(artifacts)
+        artifacts.propagate_with(self.manager, up_to='b8')
+        assert self.feature_service.get_state(block=b8, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.LOCKED_IN
+        self.vertex_handler.on_new_relayed_vertex(tx_locked)
+        assert tx_locked.get_metadata().validation.is_valid()
+        assert tx_locked.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+        self.vertex_handler.on_new_relayed_vertex(tx_active)
+        assert tx_active.get_metadata().validation.is_valid()
+        assert tx_active.get_metadata().voided_by is None
+
+    def test_relayed_v2_tx_accepted_exactly_when_best_block_active(self) -> None:
+        """Propagate to the first ACTIVE best block and assert a relayed V2 tx is accepted, while one block earlier
+        (best block LOCKED_IN) the same tx is rejected. Pins the exact activation boundary for the mempool path."""
+        self._prepare(self._lifecycle_settings(FeatureSetting.FEATURE_ACTIVATION))
+        artifacts = self.dag_builder.build_from_str(_V2_TX_DAG)
+        b11, b12 = artifacts.get_typed_vertices(('b11', 'b12'), Block)
+        tx_v2, = artifacts.get_typed_vertices(('tx_v2',), Transaction)
+
+        # One block before activation: best block b11 is LOCKED_IN, so the V2 tx is rejected.
+        artifacts.propagate_with(self.manager, up_to='b4')
+        self._propagate_signaling(artifacts)
+        artifacts.propagate_with(self.manager, up_to='b11')
+        assert self.feature_service.get_state(block=b11, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.LOCKED_IN
+        with pytest.raises(InvalidNewTransaction, match=re.escape('invalid token amount version: V2')):
+            self.vertex_handler.on_new_relayed_vertex(tx_v2)
+        assert tx_v2.get_metadata().validation.is_initial()
+        assert not self.manager.tx_storage.transaction_exists(tx_v2.hash)
+
+        # The first ACTIVE best block b12: the same V2 tx is now accepted.
+        artifacts.propagate_with(self.manager, up_to='b12')
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+        self.vertex_handler.on_new_relayed_vertex(tx_v2)
+        assert tx_v2.get_metadata().validation.is_valid()
+        assert tx_v2.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(tx_v2.hash)
+        assert tx_v2 in list(self.manager.tx_storage.iter_mempool_tips())

--- a/hathor_tests/token_amount_version/test_fee_tokens.py
+++ b/hathor_tests/token_amount_version/test_fee_tokens.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fee-based token (FBT) economics under V2 token amounts.
+
+A fee-based token charges a flat per-output fee (`FEE_PER_OUTPUT_V1`, one V1 cent) for every non-authority
+output it appears in, and locks no HTR deposit. The fee is expressed as a native-HTR amount, so under
+V2 it normalizes to the same `0.01 HTR` a V1 tx pays: the fee-header total and the expected fee are both
+compared in `normalized()` units, making the comparison independent of the tx's token amount version. A fee may
+be paid in HTR or in a deposit token (never in a fee-based token), and a deposit-token payment costs
+`FEE_DIVISOR` deposit-token units per fee unit, since melting that many deposit-token units frees exactly one
+fee unit of HTR.
+
+These tests drive the accepting cases through the DAG builder and direct balance verification, and the rejecting
+cases by mutating a built tx's fee header (or output) and re-running the balance verifier directly (mutation
+invalidates the input scripts, which the full pipeline checks before the balance), plus one end-to-end
+propagation for the fee-payment-token prohibition, which is raised during full validation.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from htr_lib import SignedAmount, UnsignedAmount
+
+from hathor.exception import InvalidNewTransaction
+from hathor.transaction import Transaction
+from hathor.transaction.base_transaction import TxInput, TxOutput
+from hathor.transaction.exceptions import InputOutputMismatch
+from hathor.transaction.headers.fee_header import FeeHeaderEntry
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.token_info import TokenInfoDict
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.token_amount_version import TokenAmountVersion
+from hathorlib.token_info import TokenVersion
+
+# One V2 "cent" in normalized units: the smallest amount representable in V1 (10**-2) written at V2's
+# 18-decimal scale. The per-output fee is exactly this amount of HTR.
+ONE_V2_CENT = 10 ** 16
+
+
+class TestFeeTokensV2(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.settings = self.manager._settings
+        self.tx_verifier = self.manager.verification_service.verifiers.tx
+        self.htr_uid = self.settings.HATHOR_TOKEN_UID
+
+    # -- helpers --------------------------------------------------------------------------------------------
+
+    def _token_dict(self, tx: Transaction) -> TokenInfoDict:
+        params = self.get_verification_params(self.manager)
+        block_storage = self.manager.verification_service._get_block_storage(params)
+        return tx.get_complete_token_info(block_storage)
+
+    def _verify_balance(self, tx: Transaction) -> None:
+        """Run only the input/output balance check, reading the tx's (possibly mutated) fee header directly."""
+        self.tx_verifier.verify_transparent_balance(self.settings, tx, self._token_dict(tx))
+
+    def _spent_output(self, tx_input: TxInput) -> TxOutput:
+        """The `TxOutput` a given input spends."""
+        return self.manager.tx_storage.get_transaction(tx_input.tx_id).outputs[tx_input.index]
+
+    def _spent_token_uid(self, tx_input: TxInput) -> bytes:
+        """The token uid of the output a given input spends."""
+        spent_tx = self.manager.tx_storage.get_transaction(tx_input.tx_id)
+        return spent_tx.get_token_uid(spent_tx.outputs[tx_input.index].get_token_index())
+
+    def test_fee_token_creation_charges_normalized_fee_v2(self) -> None:
+        """A V2 fee-based token-creation tx minting one output charges the per-output fee normalized to V2 (e.g.
+        `0.01 HTR`); assert the tx verifies. Pins fee normalization under V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            FBT.token_version = fee
+            FBT.token_amount_version = V2
+            FBT.fee = 0.01 HTR
+
+            mint_tx.out[0] = 5.0 FBT
+            mint_tx.token_amount_version = V2
+            mint_tx.fee = 0.01 HTR
+
+            b11 < mint_tx
+            mint_tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        fbt = artifacts.get_typed_vertex('FBT', TokenCreationTransaction)
+
+        assert fbt.get_token_amount_version() == TokenAmountVersion.V2
+        assert fbt.token_version == TokenVersion.FEE
+        # the single minted output charges exactly one V2-normalized cent of HTR, and it is the expected fee.
+        token_dict = self._token_dict(fbt)
+        assert fbt.get_fee_header().total_fee_amount().normalized() == ONE_V2_CENT
+        assert token_dict.calculate_fee(self.settings).normalized() == ONE_V2_CENT
+        assert fbt.get_metadata().validation.is_valid()
+        assert fbt.get_metadata().voided_by is None
+
+    def test_v1_and_v2_fee_encodings_yield_same_normalized_fee(self) -> None:
+        """Two equivalent fee txs, one V1 (fee spelled `1`) and one V2 (fee spelled as the normalized equivalent),
+        both representing `0.01 HTR`; assert both produce the same expected fee and verify. Confirms fee comparison
+        is version-independent."""
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..20]
+            b15 < dummy
+
+            FA.token_version = fee
+            FA.fee = 1 HTR
+            mint_a.out[0] = 5 FA
+            mint_a.fee = 1 HTR
+
+            FB.token_version = fee
+            FB.token_amount_version = V2
+            FB.fee = {ONE_V2_CENT} HTR
+            mint_b.out[0] = 5.0 FB
+            mint_b.token_amount_version = V2
+            mint_b.fee = {ONE_V2_CENT} HTR
+
+            b16 < mint_a
+            b17 < mint_b
+            mint_a <-- mint_b <-- b18
+        ''')
+        artifacts.propagate_with(self.manager)
+        fa = artifacts.get_typed_vertex('FA', TokenCreationTransaction)
+        fb = artifacts.get_typed_vertex('FB', TokenCreationTransaction)
+
+        assert fa.get_token_amount_version() == TokenAmountVersion.V1
+        assert fb.get_token_amount_version() == TokenAmountVersion.V2
+
+        # the V1 fee (spelled `1`) and the V2 fee (spelled `10**16`, the normalized equivalent) both mean 0.01 HTR.
+        assert fa.get_fee_header().total_fee_amount().normalized() == ONE_V2_CENT
+        assert fb.get_fee_header().total_fee_amount().normalized() == ONE_V2_CENT
+        assert self._token_dict(fa).calculate_fee(self.settings).normalized() == ONE_V2_CENT
+        assert self._token_dict(fb).calculate_fee(self.settings).normalized() == ONE_V2_CENT
+
+        for tx in (fa, fb):
+            assert tx.get_metadata().validation.is_valid()
+            assert tx.get_metadata().voided_by is None
+
+    def test_v2_fee_mismatch_rejected(self) -> None:
+        """A V2 tx whose fee-header total differs from the expected fee raises `InputOutputMismatch('Fee amount is
+        different than expected. (amount=..., expected=...)')`. Pins the fee-mismatch exception under V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            FBT.token_version = fee
+            FBT.token_amount_version = V2
+            FBT.fee = 0.01 HTR
+
+            mint_tx.out[0] = 5.0 FBT
+            mint_tx.token_amount_version = V2
+            mint_tx.fee = 0.01 HTR
+
+            b11 < mint_tx
+            mint_tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        mint_tx = artifacts.get_typed_vertex('mint_tx', Transaction)
+
+        # replace the exact 0.01 HTR fee with a sub-cent 0.005 HTR fee, only expressible under V2.
+        mint_tx.get_fee_header().fees = [
+            FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v2(ONE_V2_CENT // 2))
+        ]
+        with pytest.raises(
+            InputOutputMismatch,
+            match=re.escape('Fee amount is different than expected. (amount=0.005, expected=0.01)'),
+        ):
+            self._verify_balance(mint_tx)
+
+    def test_v2_fee_paid_with_v1_htr_input(self) -> None:
+        """A V2 tx pays its fee from a V1-created HTR utxo; assert the fee-header total normalizes against the V1
+        input and verification passes. Mixing on the fee path."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..14]
+            b10 < dummy
+
+            FBT.token_version = fee
+            FBT.token_amount_version = V2
+            FBT.fee = 0.01 HTR
+            mint_fbt.out[0] = 5.0 FBT
+            mint_fbt.token_amount_version = V2
+            mint_fbt.fee = 0.01 HTR
+
+            b1.out[0] <<< tx
+            mint_fbt.out[0] <<< tx
+            tx.out[0] = 5.0 FBT
+            tx.token_amount_version = V2
+            tx.fee = 0.01 HTR
+
+            b11 < mint_fbt
+            b12 < tx
+            mint_fbt <-- tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+
+        # the HTR input funding the fee is the block reward at b1, which is always V1.
+        htr_input = next(inp for inp in tx.inputs if self._spent_token_uid(inp) == self.htr_uid)
+        assert self._spent_output(htr_input).value.is_v1()
+
+        assert tx.get_token_amount_version() == TokenAmountVersion.V2
+        assert tx.get_fee_header().total_fee_amount().normalized() == ONE_V2_CENT
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_fee_added_to_balance_normalized_v2(self) -> None:
+        """A V2 tx with a fee header contributes the fee to the token's balance sum in normalized units; an
+        off-by-one fee is rejected. Pins fee-into-balance accounting under V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            FBT.token_version = fee
+            FBT.token_amount_version = V2
+            FBT.fee = 0.01 HTR
+
+            mint_tx.out[0] = 5.0 FBT
+            mint_tx.token_amount_version = V2
+            mint_tx.fee = 0.01 HTR
+
+            b11 < mint_tx
+            mint_tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        mint_tx = artifacts.get_typed_vertex('mint_tx', Transaction)
+
+        # the 0.01 HTR input exactly funds the 0.01 HTR fee: the fee, summed into the HTR balance, nets to zero.
+        token_dict = self._token_dict(mint_tx)
+        assert token_dict.fees_from_fee_header.normalized() == ONE_V2_CENT
+        assert token_dict[self.htr_uid].amount == SignedAmount()
+
+        # raising the fee by one raw V2 unit leaves that unit unbacked by any HTR input: a surplus.
+        mint_tx.get_fee_header().fees = [
+            FeeHeaderEntry(token_index=0, amount=UnsignedAmount.from_v2(ONE_V2_CENT + 1))
+        ]
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(mint_tx)
+
+    def test_fee_paid_with_deposit_token_costs_fee_divisor_per_unit_v2(self) -> None:
+        """Paying an FBT fee with a deposit token requires `FEE_DIVISOR` deposit-token units per fee unit under V2;
+        assert the matching fee-header entry is accepted. Pins the deposit-token-denominated fee."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..20]
+            b15 < dummy
+
+            FBT.token_version = fee
+            FBT.token_amount_version = V2
+            FBT.fee = 0.01 HTR
+            mint_fbt.out[0] = 5.0 FBT
+            mint_fbt.token_amount_version = V2
+            mint_fbt.fee = 0.01 HTR
+
+            DBT.token_amount_version = V2
+            mint_dbt.out[0] = 10.0 DBT
+            mint_dbt.token_amount_version = V2
+
+            mint_fbt.out[0] <<< tx
+            mint_dbt.out[0] <<< tx
+            tx.out[0] = 5.0 FBT
+            tx.out[1] = 9.0 DBT
+            tx.token_amount_version = V2
+            tx.fee = 1.0 DBT
+
+            b16 < mint_fbt
+            b17 < mint_dbt
+            b18 < tx
+            mint_fbt <-- mint_dbt <-- tx <-- b19
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+        dbt = artifacts.get_typed_vertex('DBT', TokenCreationTransaction)
+
+        fees = tx.get_fee_header().fees
+        assert len(fees) == 1
+        # the single fee entry pays in the deposit token DBT, not HTR.
+        assert tx.get_token_uid(fees[0].token_index) == dbt.hash
+        # one fee unit (0.01 HTR) costs FEE_DIVISOR deposit-token units, i.e. FEE_DIVISOR cents of DBT.
+        assert fees[0].amount.normalized() == self.settings.FEE_DIVISOR * ONE_V2_CENT
+        # melting those deposit-token units frees exactly one fee unit of HTR.
+        assert tx.get_fee_header().total_fee_amount().normalized() == ONE_V2_CENT
+        assert tx.get_metadata().validation.is_valid()
+        assert tx.get_metadata().voided_by is None
+
+    def test_fbt_cannot_pay_its_own_fee_v2(self) -> None:
+        """A V2 tx attempting to pay an FBT fee in that same fee-based token fails full validation with the
+        `token {uid} cannot be used to pay fees` message. Pins the FBT-as-payment prohibition under V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..15]
+            b10 < dummy
+
+            FBT.token_version = fee
+            FBT.token_amount_version = V2
+            FBT.fee = 0.01 HTR
+
+            tx1.out[0] = 1.23 FBT
+            tx1.token_amount_version = V2
+            tx1.fee = 1.0 FBT
+        ''')
+        fbt = artifacts.get_typed_vertex('FBT', TokenCreationTransaction)
+        # the fee-based token creation itself, paying its per-output fee in HTR, is valid.
+        artifacts.propagate_with(self.manager, up_to='FBT')
+
+        with pytest.raises(Exception) as exc_info:
+            artifacts.propagate_with(self.manager, up_to='tx1')
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, InvalidNewTransaction)
+        assert cause.args[0] == f'full validation failed: token {fbt.hash_hex} cannot be used to pay fees'

--- a/hathor_tests/token_amount_version/test_indexes.py
+++ b/hathor_tests/token_amount_version/test_indexes.py
@@ -1,0 +1,443 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tokens-total and UTXO indexes under V1 and V2 amounts.
+
+The UTXO index keys the amount as `amount.normalized()` in a length-prefixed varint, so the byte width
+follows the value's magnitude (1..15+ bytes) and lexicographic key order stays numeric order for range
+scans; both V1 and V2 outputs read back as V2-tagged amounts compared on their shared normalized form. The
+tokens index stores each token's total in normalized units and reports it as a V2 amount, so V1 totals come
+back scaled by the normalization factor while V2 totals have raw == normalized; authority UTXOs carry a
+bitmask, not an amount, and never contribute to a total.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from htr_lib import SignedAmount, UnsignedAmount
+
+from hathor.daa import DAAFactory, TestMode
+from hathor.indexes.rocksdb_utxo_index import _key_from_index_item, _KeyNoLock, _parse_key
+from hathor.indexes.utxo_index import UtxoIndexItem
+from hathor.transaction import Block, Transaction, TxOutput
+from hathor.transaction.scripts import parse_address_script
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.util import not_none
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.serialization import Serializer
+from hathorlib.serialization.encoding.output_value import encode_length_prefix_varint
+
+# Byte offset of the amount field inside a no-lock UTXO key: [tag:1][token_uid:32][address:25][amount...].
+_NOLOCK_AMOUNT_OFFSET = 1 + 32 + 25
+
+
+def _varint_byte_length(normalized: int) -> int:
+    """Return the number of payload bytes the length-prefixed varint uses for `normalized`."""
+    return (normalized.bit_length() + 7) // 8
+
+
+def _encode_amount_field(normalized: int) -> bytes:
+    """Return the exact key bytes the UTXO index writes for an amount: `[length][big-endian payload]`."""
+    serializer = Serializer.build_bytes_serializer()
+    encode_length_prefix_varint(serializer, normalized, strict=False)
+    return bytes(serializer.finalize())
+
+
+class TestIndexesTokenAmountV2(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # `wallet_index` enables the tokens index; `utxo_index` enables the UTXO index.
+        self.manager = self.create_peer('unittests', wallet_index=True, utxo_index=True)
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.utxo_index = not_none(self.manager.tx_storage.indexes.utxo)
+        self.tokens_index = not_none(self.manager.tx_storage.indexes.tokens)
+        self.htr_uid = self._settings.HATHOR_TOKEN_UID
+
+    @staticmethod
+    def _output_address(output: TxOutput) -> str:
+        """Return the base58 address a P2PKH output pays to."""
+        script = parse_address_script(output.script)
+        assert script is not None
+        return script.address
+
+    def _address_utxo_amounts(self, address: str) -> list[int]:
+        """Return the normalized amounts the UTXO index holds for `address` (HTR), in descending order."""
+        items = self.utxo_index.iter_utxos(
+            address=address,
+            token_uid=self.htr_uid,
+            target_amount=UnsignedAmount.from_v2(2 ** 200),
+        )
+        return [item.amount.normalized() for item in items]
+
+    def test_utxo_index_amount_is_length_prefixed_varint(self) -> None:
+        """Round-trip a UTXO index item and assert the key stores `amount.normalized()` as a length-prefixed varint
+        (variable length), not a fixed 8-byte field, and parses back to the original normalized value. Pins the
+        encoding the commit introduced."""
+        address = self.manager.wallet.get_unused_address()
+        item = UtxoIndexItem(
+            token_uid=self.htr_uid,
+            tx_id=b'\x11' * 32,
+            index=0,
+            address=address,
+            amount=UnsignedAmount.from_v2(0xc0ffee),
+            timelock=None,
+            heightlock=None,
+        )
+        key = bytes(_key_from_index_item(item))
+
+        # The amount field is `[length][payload]`, its width tracking the value: 3 payload bytes here, length byte 3.
+        amount_field = _encode_amount_field(0xc0ffee)
+        assert amount_field == bytes([3, 0xc0, 0xff, 0xee])
+        assert key[_NOLOCK_AMOUNT_OFFSET:_NOLOCK_AMOUNT_OFFSET + len(amount_field)] == amount_field
+
+        # The width follows the value, so a 1-byte and a 9-byte amount occupy different-length key fields.
+        small_key = bytes(_key_from_index_item(replace(item, amount=UnsignedAmount.from_v2(1))))
+        big_key = bytes(_key_from_index_item(replace(item, amount=UnsignedAmount.from_v2(2 ** 64))))
+        assert len(small_key) == _NOLOCK_AMOUNT_OFFSET + 2 + 32 + 1
+        assert len(big_key) == _NOLOCK_AMOUNT_OFFSET + 10 + 32 + 1
+        assert len(small_key) != len(big_key)
+
+        parsed = _parse_key(key)
+        assert isinstance(parsed, _KeyNoLock)
+        assert parsed.amount == 0xc0ffee
+        assert parsed.to_index_item().amount.normalized() == item.amount.normalized()
+
+    def test_utxo_index_v1_block_reward_exceeds_8_bytes_when_normalized(self) -> None:
+        """A V1 block reward normalizes above 2**64 (needs 9 varint bytes); add it and query it back via the index.
+        Regression guard that the old fixed 8-byte packing would truncate/raise — the load-bearing reason for the
+        encoding change."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..3]
+        ''')
+        artifacts.propagate_with(self.manager)
+        b1 = artifacts.get_typed_vertex('b1', Block)
+        reward = b1.outputs[0].value
+
+        # A block reward is always V1, and one V1 reward unit (10**16 normalized) times 6400 exceeds 2**64.
+        assert reward.is_v1()
+        assert reward.normalized() > 2 ** 64
+        assert _varint_byte_length(reward.normalized()) == 9
+
+        address = self.manager.wallet.get_unused_address()
+        item = UtxoIndexItem(
+            token_uid=self.htr_uid,
+            tx_id=b'\x22' * 32,
+            index=0,
+            address=address,
+            amount=reward,
+            timelock=None,
+            heightlock=None,
+        )
+        self.utxo_index._add_utxo(item)
+
+        # The key carries all 9 payload bytes (length prefix 9), so a value above 2**64 keys losslessly.
+        key = bytes(_key_from_index_item(item))
+        amount_field = _encode_amount_field(reward.normalized())
+        assert amount_field[0] == 9
+        assert key[_NOLOCK_AMOUNT_OFFSET:_NOLOCK_AMOUNT_OFFSET + len(amount_field)] == amount_field
+        parsed = _parse_key(key)
+        assert isinstance(parsed, _KeyNoLock)
+        assert parsed.amount == reward.normalized()
+
+        got = list(self.utxo_index.iter_utxos(
+            address=address, token_uid=self.htr_uid, target_amount=UnsignedAmount.from_v1(1),
+        ))
+        assert len(got) == 1
+        assert got[0].amount.is_v2()
+        assert got[0].amount.normalized() == reward.normalized()
+
+    def test_utxo_index_orders_amounts_across_varint_lengths(self) -> None:
+        """Store UTXOs (same token+address) whose normalized amounts need 1, 2, 7, 9, and 15 bytes (mix of V1 and
+        V2) and assert `iter_utxos` returns them in strictly descending numeric order. Pins that the varint
+        preserves lexicographic == numeric ordering for range scans."""
+        address = self.manager.wallet.get_unused_address()
+
+        # Normalized widths: V2(1)->1, V2(256)->2, V1(1)->7, V1(6400)->9, V2(2**113)->15 bytes.
+        amounts = [
+            UnsignedAmount.from_v2(1),
+            UnsignedAmount.from_v2(256),
+            UnsignedAmount.from_v1(1),
+            UnsignedAmount.from_v1(6400),
+            UnsignedAmount.from_v2(2 ** 113),
+        ]
+        for i, amount in enumerate(amounts):
+            self.utxo_index._add_utxo(UtxoIndexItem(
+                token_uid=self.htr_uid,
+                tx_id=bytes([i + 1]) * 32,
+                index=0,
+                address=address,
+                amount=amount,
+                timelock=None,
+                heightlock=None,
+            ))
+
+        normalized = self._address_utxo_amounts(address)
+        assert [_varint_byte_length(value) for value in normalized] == [15, 9, 7, 2, 1]
+        assert all(normalized[i] > normalized[i + 1] for i in range(len(normalized) - 1))
+
+    def test_utxo_index_returns_normalized_v2_amount_for_v1_output(self) -> None:
+        """Index a single V1 output and read it back; assert the returned item's amount is V2-tagged and equals the
+        V1 value by normalized comparison. Pins that the index normalizes-to-V2 on read regardless of source
+        version."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tx = artifacts.get_typed_vertex('tx', Transaction)
+        assert tx.outputs[0].value.is_v1()
+
+        address = self._output_address(tx.outputs[0])
+        got = list(self.utxo_index.iter_utxos(
+            address=address, token_uid=self.htr_uid, target_amount=UnsignedAmount.from_v1(1),
+        ))
+        assert len(got) == 1
+        assert got[0].amount.is_v2()
+        assert got[0].amount.normalized() == tx.outputs[0].value.normalized()
+
+    def test_utxo_index_iter_utxos_mixed_v1_v2_same_token(self) -> None:
+        """A token+address holds both V1 and V2 outputs; assert `iter_utxos` selects/merges them by normalized value
+        for various target amounts. Pins mixed-version coexistence in one address book."""
+        factor = UnsignedAmount.get_normalization_factor()
+        address = self.manager.wallet.get_unused_address()
+
+        # Interleave V1 cents (2, 1) with sub-/inter-cent V2 amounts (1.5, 0.5) that have no V1 encoding.
+        specs = [
+            (UnsignedAmount.from_v1(2), b'\xa1' * 32),
+            (UnsignedAmount.from_v2(factor + factor // 2), b'\xb2' * 32),
+            (UnsignedAmount.from_v1(1), b'\xa3' * 32),
+            (UnsignedAmount.from_v2(factor // 2), b'\xc4' * 32),
+        ]
+        for amount, tx_id in specs:
+            self.utxo_index._add_utxo(UtxoIndexItem(
+                token_uid=self.htr_uid,
+                tx_id=tx_id,
+                index=0,
+                address=address,
+                amount=amount,
+                timelock=None,
+                heightlock=None,
+            ))
+
+        def query(target: UnsignedAmount) -> list[int]:
+            return [item.amount.normalized() for item in self.utxo_index.iter_utxos(
+                address=address, token_uid=self.htr_uid, target_amount=target,
+            )]
+
+        # A large target returns every UTXO, V1 and V2 interleaved by normalized value.
+        assert query(UnsignedAmount.from_v2(2 ** 200)) == [2 * factor, factor + factor // 2, factor, factor // 2]
+        # A one-cent target is served by the exact V1 cent, merging the sub-cent V2 below it.
+        assert query(UnsignedAmount.from_v1(1)) == [factor, factor // 2]
+        # A sub-cent target is served by exactly the sub-cent V2 UTXO.
+        assert query(UnsignedAmount.from_v2(factor // 2)) == [factor // 2]
+
+    def test_utxo_index_consistency_after_reorg_removing_v2(self) -> None:
+        """Build a branch with V2 outputs, reorg it out with a heavier block, and assert the voided V2 outputs are
+        removed from the UTXO index and re-confirming restores them. Pins index updates with V2 amounts."""
+        settings = self._settings.model_copy(update={'REWARD_SPEND_MIN_BLOCKS': 1})
+        daa_factory = DAAFactory(settings=settings, test_mode=TestMode.TEST_ALL_WEIGHT)
+        builder = self.get_builder(settings).set_daa_factory(daa_factory)
+        builder.enable_utxo_index()
+        manager = self.create_peer_from_builder(builder)
+        dag_builder = TestDAGBuilder.from_manager(manager)
+        utxo_index = not_none(manager.tx_storage.indexes.utxo)
+
+        # tx3 carries a V2 output and conflicts with tx2 (both spend tx1.out[0]); the heavier side chain a
+        # confirms tx2 first, then a heavier b3 extension re-confirms tx3.
+        artifacts = dag_builder.build_from_str('''
+            blockchain genesis b[1..3]
+            blockchain b1 a[2..3]
+            b1 < dummy
+
+            b1 < tx1 < tx2 < tx3 < b2
+            tx3 <-- b2
+
+            tx1.out[0] <<< tx2
+            tx1.out[0] <<< tx3
+
+            tx3.out[0] = 1.00 HTR
+            tx3.token_amount_version = V2
+
+            a2.weight = 10
+            b2 < a2
+            tx2 <-- a3
+
+            a3 < b3
+            b3.weight = 20
+            tx3 <-- b3
+        ''')
+        tx3 = artifacts.get_typed_vertex('tx3', Transaction)
+        assert tx3.outputs[0].value.is_v2()
+        address = self._output_address(tx3.outputs[0])
+        expected_normalized = tx3.outputs[0].value.normalized()
+
+        def utxo_amounts() -> list[int]:
+            return [item.amount.normalized() for item in utxo_index.iter_utxos(
+                address=address, token_uid=settings.HATHOR_TOKEN_UID,
+                target_amount=UnsignedAmount.from_v2(2 ** 200),
+            )]
+
+        def voided_by(vertex: Transaction) -> object:
+            return manager.tx_storage.get_transaction(vertex.hash).get_metadata().voided_by
+
+        # tx3 confirmed by b2: its V2 output is indexed.
+        artifacts.propagate_with(manager, up_to='b2')
+        assert voided_by(tx3) is None
+        assert utxo_amounts() == [expected_normalized]
+
+        # Side chain a reorgs b2 out and confirms tx2, voiding tx3: its V2 output is removed.
+        artifacts.propagate_with(manager, up_to='a3')
+        assert voided_by(tx3) == {tx3.hash}
+        assert utxo_amounts() == []
+
+        # A heavier b3 extension reorgs back and re-confirms tx3: its V2 output is restored.
+        artifacts.propagate_with(manager, up_to='b3')
+        assert voided_by(tx3) is None
+        assert utxo_amounts() == [expected_normalized]
+
+    def test_utxo_index_rebuild_matches_live_with_v2(self) -> None:
+        """Snapshot the UTXO index over a DAG with mixed V1/V2 outputs (incl. time/height locks), reinitialize the
+        index from storage, and assert the rebuilt index is byte-identical. Pins deterministic re-derivation."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..14]
+            b10 < dummy
+
+            b1.out[0] <<< tx1
+            tx1.out[0] = 0.005 HTR
+            tx1.out[1] = 0.995 HTR
+            tx1.token_amount_version = V2
+
+            b2.out[0] <<< tx2
+            tx2.out[0] = 1.00 HTR
+
+            b11 < tx1
+            b12 < tx2
+            tx1 <-- tx2 <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+
+        # Heightlocked block rewards plus V1 and sub-cent V2 tx outputs populate the index.
+        live = list(self.utxo_index.get_all_internal())
+        assert len(live) > 0
+
+        # Clear and force a full re-derivation from storage, then compare the raw rocksdb keys byte-for-byte.
+        tx_storage = self.manager.tx_storage
+        self.utxo_index.force_clear()
+        assert list(self.utxo_index.get_all_internal()) == []
+        tx_storage.set_index_last_started_at(self.utxo_index.get_db_name(), 0)
+        tx_storage._manually_initialize()
+
+        rebuilt = list(self.utxo_index.get_all_internal())
+        assert rebuilt == live
+
+    def test_tokens_index_total_v1_stored_normalized(self) -> None:
+        """Mint a V1 custom token; assert `get_token_info(uid).get_total()` equals the V1 amount, is reported as a
+        V2-tagged amount, and its normalized value is scaled by the normalization factor. Pins V1 totals are stored
+        normalized and reported as V2."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tka.out[0] = 100 TKA
+
+            b11 < tka
+            tka <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tka = artifacts.get_typed_vertex('TKA', TokenCreationTransaction)
+
+        total = self.tokens_index.get_token_info(tka.hash).get_total()
+        factor = UnsignedAmount.get_normalization_factor()
+        assert total == UnsignedAmount.from_v1(100)
+        assert total.is_v2()
+        assert total.normalized() == 100 * factor
+        assert total.raw() == total.normalized()
+
+    def test_tokens_index_total_v2_raw_equals_normalized(self) -> None:
+        """Mint a V2 custom token; assert `get_total()` equals the V2 amount with raw == normalized. Contrasts with
+        the V1 case to pin the scaling difference at equal nominal mint."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tkb.out[0] = 100 TKB
+            tkb.token_amount_version = V2
+            TKB.token_amount_version = V2
+
+            b11 < tkb
+            tkb <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tkb = artifacts.get_typed_vertex('TKB', TokenCreationTransaction)
+
+        total = self.tokens_index.get_token_info(tkb.hash).get_total()
+        assert total == UnsignedAmount.from_v2(100)
+        assert total.is_v2()
+        assert total.raw() == 100
+        assert total.raw() == total.normalized()
+        # Equal nominal mint (100) yields a smaller normalized total for V2 than for V1 (which scales by the factor).
+        assert total.normalized() != UnsignedAmount.from_v1(100).normalized()
+
+    def test_tokens_index_tracks_mint_then_melt_v2(self) -> None:
+        """For a V2 token, mint additional supply then melt some; assert `get_total()` tracks the running normalized
+        sum exactly after each step, and authority UTXOs (no amount) are version-agnostic and excluded from total."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            tkb.out[0] = 100 TKB
+            tkb.token_amount_version = V2
+            TKB.token_amount_version = V2
+
+            b11 < tkb
+            tkb <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tkb = artifacts.get_typed_vertex('TKB', TokenCreationTransaction)
+        info = self.tokens_index.get_token_info(tkb.hash)
+
+        # The creation tx carries mint and melt authority outputs, yet the total is exactly the minted amount:
+        # authority UTXOs carry a bitmask, not an amount, so they never enter the total.
+        assert info.can_mint()
+        assert info.can_melt()
+        assert info.get_total() == UnsignedAmount.from_v2(100)
+
+        # Mint 50 more V2 units, then melt 30, and check the running normalized total after each step.
+        mint_delta: SignedAmount = UnsignedAmount.from_v2(50).to_signed()
+        self.tokens_index.add_to_total(tkb.hash, mint_delta)
+        assert self.tokens_index.get_token_info(tkb.hash).get_total() == UnsignedAmount.from_v2(150)
+
+        melt_delta: SignedAmount = -UnsignedAmount.from_v2(30).to_signed()
+        self.tokens_index.add_to_total(tkb.hash, melt_delta)
+        after_melt = self.tokens_index.get_token_info(tkb.hash).get_total()
+        assert after_melt == UnsignedAmount.from_v2(120)
+        assert after_melt.raw() == after_melt.normalized() == 120
+
+    def test_tokens_index_htr_total_accumulates_v1_block_rewards(self) -> None:
+        """After N blocks, assert the HTR `get_total()` equals genesis total + the V1 block reward times N
+        (normalized). Pins that always-V1 block rewards accumulate into the normalized HTR total."""
+        n_blocks = 12
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+        ''')
+        artifacts.propagate_with(self.manager)
+
+        blocks = artifacts.get_typed_vertices([f'b{i}' for i in range(1, n_blocks + 1)], Block)
+        rewards = [block.outputs[0].value for block in blocks]
+        # Every block reward is always encoded as V1.
+        assert all(reward.is_v1() for reward in rewards)
+        assert all(reward.raw() == rewards[0].raw() for reward in rewards)
+
+        genesis_total = UnsignedAmount.from_v1(self._settings.GENESIS_TOKEN_ATOMIC_UNITS)
+        expected = genesis_total.normalized() + n_blocks * rewards[0].normalized()
+
+        htr_total = self.tokens_index.get_token_info(self.htr_uid).get_total()
+        assert htr_total.normalized() == expected

--- a/hathor_tests/token_amount_version/test_reorg.py
+++ b/hathor_tests/token_amount_version/test_reorg.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Consensus reorg handling for the token amount version V2 feature.
+
+When a reorg moves the best chain below the `TOKEN_AMOUNT_V2` activation height, the feature deactivates and
+every V2 transaction that was valid under the old (active) chain becomes invalid. The consensus algorithm
+enforces this through `_token_amount_v2_rule`, applied to mempool transactions during the reorg
+re-verification pass (`_compute_vertices_that_became_invalid`). The rule is selective: V2 transactions are
+removal-eligible when the feature is inactive, while V1 transactions are always kept.
+
+These tests drive the rule both directly (calling `_token_amount_v2_rule` on built V1/V2 transactions) and
+end-to-end through the manager, mining a chain past activation with `FEATURE_ACTIVATION` criteria and then
+reorging onto a heavier side chain below the activation height. They mirror the feature-reorg coverage in
+`hathor_tests/nanocontracts/test_feature_activations.py`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from hathor.daa import DAAFactory, TestMode
+from hathor.feature_activation.feature import Feature
+from hathor.feature_activation.model.criteria import Criteria
+from hathor.feature_activation.model.feature_state import FeatureState
+from hathor.feature_activation.settings import Settings as FeatureSettings
+from hathor.transaction import Block, Transaction
+from hathor.transaction.validation_state import ValidationState
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.conf.settings import FeatureSetting
+from hathorlib.token_amount_version import TokenAmountVersion
+
+if TYPE_CHECKING:
+    from hathor.conf.settings import HathorSettings
+    from hathor.dag_builder.artifacts import DAGArtifacts
+
+
+class TestReorgTokenAmountV2(unittest.TestCase):
+    """Consensus reorg handling: deactivating the feature invalidates V2 transactions (`_token_amount_v2_rule`)."""
+
+    def _prepare(self, settings: HathorSettings) -> None:
+        """Build a manager (with all-weight DAA so a heavier side chain can be forced) and its helpers."""
+        daa_factory = DAAFactory(settings=settings, test_mode=TestMode.TEST_ALL_WEIGHT)
+        builder = self.get_builder(settings).set_daa_factory(daa_factory)
+        self.manager = self.create_peer_from_builder(builder)
+        self.consensus = self.manager.consensus_algorithm
+        self.feature_service = self.manager.feature_service
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    def _prepare_with_feature_activation(self) -> None:
+        """Build a manager where `TOKEN_AMOUNT_V2` is gated by feature-activation criteria.
+
+        With `evaluation_interval=4`, `default_threshold=3`, `start_height=4` and support signaling on blocks
+        5, 6, 7, the feature is DEFINED before height 4, STARTED at 4, LOCKED_IN at 8, and ACTIVE at 12.
+        """
+        feature_settings = FeatureSettings(
+            evaluation_interval=4,
+            default_threshold=3,
+            features={
+                Feature.TOKEN_AMOUNT_V2: Criteria(
+                    bit=0,
+                    start_height=4,
+                    timeout_height=12,
+                    signal_support_by_default=True,
+                    version='0.0.0',
+                ),
+            },
+        )
+        settings = self._settings.model_copy(update=dict(
+            ENABLE_TOKEN_AMOUNT_V2=FeatureSetting.FEATURE_ACTIVATION,
+            FEATURE_ACTIVATION=feature_settings,
+        ))
+        self._prepare(settings)
+
+    def _propagate_to_active(self, artifacts: DAGArtifacts) -> None:
+        """Propagate the main chain up to block 12, where `TOKEN_AMOUNT_V2` is ACTIVE."""
+        artifacts.propagate_with(self.manager, up_to='b12')
+        b12 = artifacts.get_typed_vertex('b12', Block)
+        assert self.feature_service.get_state(block=b12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+
+    def _reset_vertex(self, vertex: Transaction) -> None:
+        """Detach a vertex's cached metadata and child links so it can be relayed to the mempool again."""
+        assert vertex.storage is not None
+        vertex._metadata = None
+        for child in vertex.get_children():
+            vertex.storage.vertex_children.remove_child(vertex, child)
+
+    def _build_v1_and_v2_txs(self) -> tuple[Transaction, Transaction]:
+        """Build and propagate one V1 and one V2 transaction (feature enabled throughout)."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< v1tx
+            v1tx.out[0] = 1.00 HTR
+
+            b2.out[0] <<< v2tx
+            v2tx.out[0] = 1.00 HTR
+            v2tx.token_amount_version = V2
+
+            b12 < v1tx
+            b12 < v2tx
+            v1tx <-- b13
+            v2tx <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        v1tx = artifacts.get_typed_vertex('v1tx', Transaction)
+        v2tx = artifacts.get_typed_vertex('v2tx', Transaction)
+        assert v1tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert v2tx.get_token_amount_version() == TokenAmountVersion.V2
+        return v1tx, v2tx
+
+    def test_rule_active_is_noop(self) -> None:
+        """Call `_token_amount_v2_rule(tx, is_active=True)` for a V1 and a V2 tx; assert both return True. Pins that
+        an active feature never invalidates anything."""
+        self._prepare(self._settings)
+        v1tx, v2tx = self._build_v1_and_v2_txs()
+
+        assert self.consensus._token_amount_v2_rule(v1tx, is_active=True) is True
+        assert self.consensus._token_amount_v2_rule(v2tx, is_active=True) is True
+
+    def test_rule_inactive_rejects_v2_allows_v1(self) -> None:
+        """Call the rule with `is_active=False`: a V2 tx returns False (removal-eligible), a V1 tx returns True.
+        Pins selective removal of only V2 txs."""
+        self._prepare(self._settings)
+        v1tx, v2tx = self._build_v1_and_v2_txs()
+
+        assert self.consensus._token_amount_v2_rule(v1tx, is_active=False) is True
+        assert self.consensus._token_amount_v2_rule(v2tx, is_active=False) is False
+
+    def test_reorg_below_activation_removes_v2_tx(self) -> None:
+        """Confirm a V2 tx while ACTIVE, then reorg to a heavier side chain whose new best block is below the
+        activation height; assert the V2 tx becomes INVALID, is removed from storage, and is absent from the
+        mempool tips. Direct analogue of other feature-reorg tests."""
+        self._prepare_with_feature_activation()
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            blockchain b10 a[11..11]
+            b10 < dummy < b11
+
+            b5.signal_bits = 1
+            b6.signal_bits = 1
+            b7.signal_bits = 1
+
+            b1.out[0] <<< v2tx
+            v2tx.out[0] = 1.00 HTR
+            v2tx.token_amount_version = V2
+
+            b12 < v2tx
+            v2tx <-- b13
+            b13 < a11
+            a11.weight = 20
+        ''')
+        v2tx = artifacts.get_typed_vertex('v2tx', Transaction)
+        assert v2tx.get_token_amount_version() == TokenAmountVersion.V2
+
+        self._propagate_to_active(artifacts)
+        artifacts.propagate_with(self.manager, up_to='v2tx')
+        assert v2tx.get_metadata().validation == ValidationState.FULL
+        assert v2tx.get_metadata().voided_by is None
+
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert v2tx.get_metadata().first_block is not None
+
+        # The side chain (best block a11, height 11) is below the activation height (12), so the feature
+        # deactivates and the confirmed V2 tx becomes invalid and is removed.
+        artifacts.propagate_with(self.manager, up_to='a11')
+        assert v2tx.get_metadata().validation == ValidationState.INVALID
+        assert not self.manager.tx_storage.transaction_exists(v2tx.hash)
+        assert v2tx not in list(self.manager.tx_storage.iter_mempool_tips())
+
+    def test_reorg_below_activation_keeps_v1_tx(self) -> None:
+        """In the same deactivating reorg, a V1 tx present in the old chain/mempool remains valid and present after
+        the reorg. Pins selectivity."""
+        self._prepare_with_feature_activation()
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            blockchain b10 a[11..11]
+            b10 < dummy < b11
+
+            b5.signal_bits = 1
+            b6.signal_bits = 1
+            b7.signal_bits = 1
+
+            b1.out[0] <<< v1tx
+            v1tx.out[0] = 1.00 HTR
+
+            b12 < v1tx
+            v1tx <-- b13
+            b13 < a11
+            a11.weight = 20
+        ''')
+        v1tx = artifacts.get_typed_vertex('v1tx', Transaction)
+        assert v1tx.get_token_amount_version() == TokenAmountVersion.V1
+
+        self._propagate_to_active(artifacts)
+        artifacts.propagate_with(self.manager, up_to='v1tx')
+        artifacts.propagate_with(self.manager, up_to='b13')
+        assert v1tx.get_metadata().first_block is not None
+
+        # The same deactivating reorg (best block a11, height 11, below activation) returns the V1 tx to the
+        # mempool but never invalidates it: the token-amount-V2 rule only targets V2 vertices.
+        artifacts.propagate_with(self.manager, up_to='a11')
+        assert v1tx.get_metadata().validation == ValidationState.FULL
+        assert v1tx.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(v1tx.hash)
+        assert v1tx in list(self.manager.tx_storage.iter_mempool_tips())
+
+    def test_reorg_re_activation_re_allows_v2_tx(self) -> None:
+        """After a deactivating reorg removes a V2 tx, extend the new chain back above activation, reset and re-relay
+        the V2 tx, and assert it is re-accepted. Reorg direction = chain grows back above activation."""
+        self._prepare_with_feature_activation()
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            blockchain b10 a[11..12]
+            b10 < dummy < b11
+
+            b5.signal_bits = 1
+            b6.signal_bits = 1
+            b7.signal_bits = 1
+
+            b1.out[0] <<< v2tx
+            v2tx.out[0] = 1.00 HTR
+            v2tx.token_amount_version = V2
+
+            b12 < v2tx
+            v2tx <-- b13
+            b13 < a11
+            a11.weight = 20
+        ''')
+        v2tx = artifacts.get_typed_vertex('v2tx', Transaction)
+        a12 = artifacts.get_typed_vertex('a12', Block)
+        assert v2tx.get_token_amount_version() == TokenAmountVersion.V2
+
+        self._propagate_to_active(artifacts)
+        artifacts.propagate_with(self.manager, up_to='v2tx')
+        artifacts.propagate_with(self.manager, up_to='b13')
+
+        # Deactivating reorg to a11 (height 11) removes the V2 tx.
+        artifacts.propagate_with(self.manager, up_to='a11')
+        assert v2tx.get_metadata().validation == ValidationState.INVALID
+        assert not self.manager.tx_storage.transaction_exists(v2tx.hash)
+
+        # Growing the winning chain to a12 (height 12) re-activates the feature.
+        artifacts.propagate_with(self.manager, up_to='a12')
+        assert self.feature_service.get_state(block=a12, feature=Feature.TOKEN_AMOUNT_V2) == FeatureState.ACTIVE
+
+        self._reset_vertex(v2tx)
+        self.manager.vertex_handler.on_new_relayed_vertex(v2tx)
+        assert v2tx.get_metadata().validation == ValidationState.FULL
+        assert v2tx.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(v2tx.hash)
+        assert v2tx in list(self.manager.tx_storage.iter_mempool_tips())
+
+    def test_mempool_v2_tx_invalidated_on_deactivating_reorg(self) -> None:
+        """An unconfirmed V2 tx in the mempool while ACTIVE is marked INVALID and removed after a reorg whose new
+        best block is pre-activation; a V1 mempool tx survives. Pins mempool re-verification."""
+        self._prepare_with_feature_activation()
+        # A single V1 `funding` tx spends the only reward that is unlocked at the reorg height (block 1's, at
+        # height 11) and feeds both mempool txs, so neither is removed by the reward-lock rule at height 11 —
+        # isolating the token-amount-V2 rule as the sole cause of removal.
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            blockchain b10 a[11..11]
+            b10 < dummy < b11
+
+            b5.signal_bits = 1
+            b6.signal_bits = 1
+            b7.signal_bits = 1
+
+            b1.out[0] <<< funding
+            funding.out[0] = 1.00 HTR
+            funding.out[1] = 1.00 HTR
+
+            funding.out[0] <<< v1tx
+            v1tx.out[0] = 1.00 HTR
+
+            funding.out[1] <<< v2tx
+            v2tx.out[0] = 1.00 HTR
+            v2tx.token_amount_version = V2
+
+            b12 < funding
+            funding < v1tx
+            funding < v2tx
+            v1tx < a11
+            v2tx < a11
+            a11.weight = 20
+        ''')
+        v1tx = artifacts.get_typed_vertex('v1tx', Transaction)
+        v2tx = artifacts.get_typed_vertex('v2tx', Transaction)
+        assert v1tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert v2tx.get_token_amount_version() == TokenAmountVersion.V2
+
+        self._propagate_to_active(artifacts)
+        artifacts.propagate_with(self.manager, up_to_before='a11')
+
+        # Both txs are unconfirmed mempool tips while the feature is ACTIVE.
+        assert v1tx.get_metadata().validation == ValidationState.FULL
+        assert v2tx.get_metadata().validation == ValidationState.FULL
+        assert v1tx.get_metadata().first_block is None
+        assert v2tx.get_metadata().first_block is None
+
+        # Deactivating reorg (best block a11, height 11): the V2 mempool tx is invalidated and removed, the V1
+        # mempool tx survives.
+        artifacts.propagate_with(self.manager, up_to='a11')
+        assert v2tx.get_metadata().validation == ValidationState.INVALID
+        assert not self.manager.tx_storage.transaction_exists(v2tx.hash)
+        assert v2tx not in list(self.manager.tx_storage.iter_mempool_tips())
+
+        assert v1tx.get_metadata().validation == ValidationState.FULL
+        assert v1tx.get_metadata().voided_by is None
+        assert self.manager.tx_storage.transaction_exists(v1tx.hash)
+        assert v1tx in list(self.manager.tx_storage.iter_mempool_tips())

--- a/hathor_tests/token_amount_version/test_serialization.py
+++ b/hathor_tests/token_amount_version/test_serialization.py
@@ -1,0 +1,471 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-wire encode/decode of output values and the token-amount version bit. Consensus-critical wire-format.
+
+An output value is serialized in the enclosing vertex's token amount version: V1 is a fixed 4-or-8-byte
+signed-integer field, V2 is a length-prefixed varint (a length byte followed by that many big-endian payload
+bytes). The version is carried by the LSB of `signal_bits` and is committed in the sighash, so the two
+encodings are not self-describing out of band; the parser assigns `signal_bits` before decoding the outputs
+it governs. Nano action and fee-header amounts follow the same per-vertex version as the outputs.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from htr_lib import UnsignedAmount
+
+from hathor.transaction import Transaction
+from hathor.transaction.base_transaction import TxOutput
+from hathor.transaction.headers import FeeHeader, NanoHeader
+from hathor.transaction.headers.fee_header import FeeHeaderEntry
+from hathor.transaction.headers.nano_header import NanoHeaderAction
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.nanocontracts.types import NCActionType
+from hathorlib.serialization import Deserializer, Serializer
+from hathorlib.serialization.encoding.output_value import (
+    decode_output_value_v1,
+    decode_output_value_v2,
+    encode_output_value_v1,
+    encode_output_value_v2,
+    get_max_output_value_v2,
+)
+from hathorlib.serialization.exceptions import BadDataError, OutOfDataError
+from hathorlib.token_amount_version import TokenAmountVersion
+
+# Fixed wire-format golden vectors for V1 output values, spanning the 4-byte/8-byte boundary. Computed once
+# from the current encoder and hard-coded so any drift in the V1 encoding fails the backward-compat anchor.
+# 2**31 - 1 is the largest value that still fits in 4 bytes; 2**31 is the first to spill into 8 bytes.
+V1_GOLDEN: list[tuple[int, str]] = [
+    (1, '00000001'),
+    (100, '00000064'),
+    (2 ** 31 - 1, '7fffffff'),
+    (2 ** 31, 'ffffffff80000000'),
+    (2 ** 63, '8000000000000000'),
+]
+
+# Fixed wire-format golden vectors for V2 output values, spanning the length-prefix from 1 to 15 payload bytes.
+# Each entry is a length byte equal to the payload byte count, followed by the big-endian payload.
+V2_GOLDEN: list[tuple[int, str]] = [
+    (1, '0101'),
+    (0xff, '01ff'),
+    (0x100, '020100'),
+    (0xff00, '02ff00'),
+    (0xc0ffee, '03c0ffee'),
+    (256 ** 14, '0f010000000000000000000000000000'),
+    (2 ** 113, '0f020000000000000000000000000000'),
+    (get_max_output_value_v2(), '0f11c37937e080000000000000000000'),
+]
+
+
+def _encode_v1(value: int) -> bytes:
+    """Encode `value` as a standalone V1 output-value field."""
+    serializer = Serializer.build_bytes_serializer()
+    encode_output_value_v1(serializer, UnsignedAmount.from_v1(value))
+    return bytes(serializer.finalize())
+
+
+def _encode_v2(value: int) -> bytes:
+    """Encode `value` as a standalone V2 length-prefixed output-value field."""
+    serializer = Serializer.build_bytes_serializer()
+    encode_output_value_v2(serializer, UnsignedAmount.from_v2(value))
+    return bytes(serializer.finalize())
+
+
+def _decode_v1(data: bytes) -> UnsignedAmount:
+    """Decode `data` as a single V1 output value, consuming it exactly."""
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    amount = decode_output_value_v1(deserializer)
+    deserializer.finalize()
+    return amount
+
+
+def _decode_v2(data: bytes) -> UnsignedAmount:
+    """Decode `data` as a single V2 output value, consuming it exactly."""
+    deserializer = Deserializer.build_bytes_deserializer(data)
+    amount = decode_output_value_v2(deserializer)
+    deserializer.finalize()
+    return amount
+
+
+class TestSerializationV1V2(unittest.TestCase):
+    """On-wire encode/decode of output values and the version bit. Consensus-critical wire-format coverage."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+
+    # -- helpers ------------------------------------------------------------------------------------------
+
+    def _p2pkh_script(self) -> bytes:
+        """Return a standard P2PKH output script, sourced from a propagated HTR transaction."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        return artifacts.get_typed_vertex('tx', Transaction).outputs[0].script
+
+    def _minimal_tx(self, outputs: list[TxOutput], *, signal_bits: int, tokens: list[bytes] | None = None
+                    ) -> Transaction:
+        """Build a hashed, input-less transaction carrying `outputs`, for direct serialization round-trips."""
+        tx = Transaction(
+            weight=1,
+            timestamp=int(self.clock.seconds()),
+            parents=[],
+            inputs=[],
+            outputs=outputs,
+            tokens=tokens or [],
+            storage=self.manager.tx_storage,
+            signal_bits=signal_bits,
+        )
+        tx.update_hash()
+        return tx
+
+    def _build_v1_tx(self) -> Transaction:
+        """Build and propagate a V1 HTR transaction with several outputs."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 0.50 HTR
+            tx.out[1] = 0.30 HTR
+            tx.out[2] = 0.20 HTR
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        return artifacts.get_typed_vertex('tx', Transaction)
+
+    def _build_v2_tx(self) -> Transaction:
+        """Build and propagate a V2 HTR transaction."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..12]
+            b10 < dummy
+
+            b1.out[0] <<< tx
+            tx.out[0] = 1.00 HTR
+            tx.token_amount_version = V2
+
+            b11 < tx
+            tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        return artifacts.get_typed_vertex('tx', Transaction)
+
+    # -- byte-level output value encoding -----------------------------------------------------------------
+
+    def test_v1_wire_format_unchanged(self) -> None:
+        """Round-trip a set of V1 output values spanning the 4-byte/8-byte boundary and assert byte-for-byte
+        equality against fixed golden vectors. The backward-compatibility anchor: any drift in V1 encoding breaks
+        consensus."""
+        for value, expected_hex in V1_GOLDEN:
+            assert _encode_v1(value).hex() == expected_hex
+            decoded = _decode_v1(bytes.fromhex(expected_hex))
+            assert decoded.raw() == value
+            assert decoded.is_v1()
+
+    def test_v2_output_value_round_trips(self) -> None:
+        """Round-trip V2 output values across length-prefix boundaries (1, 0xff, 0x100, ..., near
+        `get_max_output_value_v2()`); assert decode returns an equal V2 amount and the length byte equals the
+        payload byte count. Pins the length-prefixed varint layout."""
+        for value, expected_hex in V2_GOLDEN:
+            data = _encode_v2(value)
+            assert data.hex() == expected_hex
+            # the first byte is the length prefix; it must equal the number of payload bytes that follow.
+            assert data[0] == len(data) - 1
+            decoded = _decode_v2(data)
+            assert decoded == UnsignedAmount.from_v2(value)
+            assert decoded.raw() == value
+            assert decoded.is_v2()
+
+    def test_v2_decode_rejects_non_canonical_and_oversized(self) -> None:
+        """Decoding a V2 payload with a leading zero byte raises `ValueError('non-canonical encoding ...')`; a length
+        byte > 15 raises `ValueError('length is too big ...')`; an in-range length but over-max value raises
+        `ValueError('value is too big ...')`. Pins the anti-malleability and bound guards."""
+        # length 1, payload 0x00: the value 0 would also encode as the empty '00', so the leading zero is rejected.
+        with pytest.raises(ValueError, match=re.escape('non-canonical encoding, leading zero byte: 00')):
+            _decode_v2(bytes.fromhex('0100'))
+
+        # a length prefix of 16 exceeds the 15-byte ceiling of the max V2 value.
+        with pytest.raises(ValueError, match=re.escape('length is too big; max is 15, got: 16')):
+            _decode_v2(bytes.fromhex('10'))
+
+        # an in-range 15-byte length whose payload is one past the maximum value.
+        max_value = get_max_output_value_v2()
+        over = max_value + 1
+        oversized = bytes([15]) + over.to_bytes(15, byteorder='big')
+        with pytest.raises(ValueError, match=re.escape(f'value is too big; max is {max_value}, got: {over}')):
+            _decode_v2(oversized)
+
+    def test_v2_decode_truncated_raises_out_of_data(self) -> None:
+        """Decoding a V2 output whose length byte over-promises the payload raises `OutOfDataError`, distinct from
+        V1's `BadDataError`. Pins the truncation behavior and exact exception type."""
+        # length byte promises 3 payload bytes but only 2 are present.
+        with pytest.raises(OutOfDataError) as v2_exc:
+            _decode_v2(bytes.fromhex('03ffff'))
+        assert v2_exc.type is OutOfDataError
+
+        # a V1 field promises 4 bytes but only 2 are present; V1 truncation surfaces as a different type.
+        with pytest.raises(BadDataError) as v1_exc:
+            _decode_v1(bytes.fromhex('0101'))
+        assert v1_exc.type is BadDataError
+
+        # the two truncation exceptions are unrelated types, so a handler cannot conflate the encodings.
+        assert not issubclass(OutOfDataError, BadDataError)
+        assert not issubclass(BadDataError, OutOfDataError)
+
+    # -- full vertex round-trips --------------------------------------------------------------------------
+
+    def test_full_v1_transaction_round_trip_byte_for_byte(self) -> None:
+        """Build a V1 tx with several outputs, serialize, `create_from_struct`, and assert object equality,
+        byte-identical re-serialization, and unchanged hash. The regression anchor that the parser refactor left V1
+        vertices on the wire untouched."""
+        tx = self._build_v1_tx()
+        assert tx.get_token_amount_version() == TokenAmountVersion.V1
+        assert len(tx.outputs) >= 3
+
+        parsed = Transaction.create_from_struct(tx.get_struct())
+        assert parsed == tx
+        assert parsed.get_struct() == tx.get_struct()
+        assert parsed.hash == tx.hash
+        assert parsed.signal_bits == tx.signal_bits
+        for output in parsed.outputs:
+            assert output.value.is_v1()
+
+    def test_full_v2_transaction_round_trip(self) -> None:
+        """Build a V2 tx whose outputs are V2 amounts (small and near max), round-trip through `create_from_struct`,
+        and assert equality, byte-identical re-serialization, `get_token_amount_version() == V2`, every output is
+        V2, and `signal_bits` is preserved."""
+        tx = self._build_v2_tx()
+        script = tx.outputs[0].script
+        tx.outputs = [
+            TxOutput(UnsignedAmount.from_v2(1), script, 0),
+            TxOutput(UnsignedAmount.from_v2(get_max_output_value_v2()), script, 0),
+        ]
+        tx.update_hash()
+
+        parsed = Transaction.create_from_struct(tx.get_struct())
+        assert parsed == tx
+        assert parsed.get_struct() == tx.get_struct()
+        assert parsed.get_token_amount_version() == TokenAmountVersion.V2
+        assert parsed.signal_bits == tx.signal_bits
+        assert parsed.outputs[0].value.raw() == 1
+        assert parsed.outputs[1].value.raw() == get_max_output_value_v2()
+        for output in parsed.outputs:
+            assert output.value.is_v2()
+
+    def test_full_v2_token_creation_transaction_round_trip(self) -> None:
+        """Same for a `TokenCreationTransaction` with V2 outputs; additionally assert token name/symbol/version and
+        the mint/melt authority outputs survive. Pins V2 encoding composes with the token-info trailer."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            tx_v2.out[0] = 100 TK2
+            tx_v2.token_amount_version = V2
+            TK2.token_amount_version = V2
+
+            b11 < tx_v2
+            tx_v2 <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        token_creation_tx = artifacts.get_typed_vertex('TK2', TokenCreationTransaction)
+        assert token_creation_tx.get_token_amount_version() == TokenAmountVersion.V2
+
+        parsed = TokenCreationTransaction.create_from_struct(token_creation_tx.get_struct())
+        assert parsed == token_creation_tx
+        assert parsed.get_struct() == token_creation_tx.get_struct()
+        assert parsed.get_token_amount_version() == TokenAmountVersion.V2
+        assert parsed.token_name == token_creation_tx.token_name
+        assert parsed.token_symbol == token_creation_tx.token_symbol
+
+        mint_outputs = [output for output in parsed.outputs if output.can_mint_token()]
+        melt_outputs = [output for output in parsed.outputs if output.can_melt_token()]
+        assert len(mint_outputs) == 1
+        assert len(melt_outputs) == 1
+        for output in parsed.outputs:
+            if not output.is_token_authority():
+                assert output.value.is_v2()
+
+    def test_deserialize_sets_signal_bits_before_decoding_outputs(self) -> None:
+        """Regression guard: round-trip a V2 tx whose first output requires V2 decoding and assert it parses (it
+        would raise on a V1 mis-decode if the parser read outputs before assigning `signal_bits`). Names the
+        invariant that the version field precedes the outputs it governs."""
+        tx = self._build_v2_tx()
+        script = tx.outputs[0].script
+        # A single raw V2 unit has no V1 representation, so decoding this output under V1 would not reproduce it:
+        # the round-trip only succeeds because `signal_bits` is assigned before the outputs are decoded.
+        tx.outputs = [TxOutput(UnsignedAmount.from_v2(1), script, 0)]
+        tx.update_hash()
+
+        parsed = Transaction.create_from_struct(tx.get_struct())
+        assert parsed == tx
+        assert parsed.signal_bits == tx.signal_bits
+        assert parsed.get_token_amount_version() == TokenAmountVersion.V2
+        assert parsed.outputs[0].value.is_v2()
+        assert parsed.outputs[0].value.raw() == 1
+
+    def test_authority_output_round_trips_using_raw_under_v2(self) -> None:
+        """Round-trip V2 authority outputs (mint/melt/both) and assert `can_mint_token()`/`can_melt_token()` are
+        preserved because the bitmask is read via `.raw()` (not the normalized value). Pins authority semantics
+        over the V2 wire."""
+        script = self._p2pkh_script()
+        authority_token_data = TxOutput.TOKEN_AUTHORITY_MASK | 1
+        tx = self._minimal_tx(
+            outputs=[
+                TxOutput(UnsignedAmount.from_v2(TxOutput.TOKEN_MINT_MASK), script, authority_token_data),
+                TxOutput(UnsignedAmount.from_v2(TxOutput.TOKEN_MELT_MASK), script, authority_token_data),
+                TxOutput(UnsignedAmount.from_v2(TxOutput.ALL_AUTHORITIES), script, authority_token_data),
+            ],
+            signal_bits=0b1,
+            tokens=[b'\x11' * 32],
+        )
+
+        parsed = Transaction.create_from_struct(tx.get_struct())
+        assert parsed == tx
+        assert parsed.get_struct() == tx.get_struct()
+        assert parsed.get_token_amount_version() == TokenAmountVersion.V2
+
+        mint_only, melt_only, both = parsed.outputs
+        assert mint_only.can_mint_token() and not mint_only.can_melt_token()
+        assert melt_only.can_melt_token() and not melt_only.can_mint_token()
+        assert both.can_mint_token() and both.can_melt_token()
+        assert both.value.raw() == TxOutput.ALL_AUTHORITIES
+
+    def test_nano_and_fee_header_amounts_follow_tx_version(self) -> None:
+        """Serialize/deserialize a tx carrying both a nano header (deposit/withdrawal actions) and a fee header,
+        under V1 and under V2; assert all header amounts encode in the enclosing tx's version and round-trip. Pins
+        header amount encoding parity with outputs."""
+        script = self._p2pkh_script()
+        deposit_raw = {TokenAmountVersion.V1: 5, TokenAmountVersion.V2: 5 * 10 ** 16}
+        withdrawal_raw = {TokenAmountVersion.V1: 3, TokenAmountVersion.V2: 3 * 10 ** 16}
+        fee_raw = {TokenAmountVersion.V1: 2, TokenAmountVersion.V2: 2 * 10 ** 16}
+
+        for version, signal_bits in [(TokenAmountVersion.V1, 0b0), (TokenAmountVersion.V2, 0b1)]:
+            deposit = UnsignedAmount.from_version(deposit_raw[version], version=int(version))
+            withdrawal = UnsignedAmount.from_version(withdrawal_raw[version], version=int(version))
+            fee = UnsignedAmount.from_version(fee_raw[version], version=int(version))
+
+            tx = self._minimal_tx(outputs=[TxOutput(deposit, script, 0)], signal_bits=signal_bits)
+            tx.headers = [
+                NanoHeader(
+                    tx=tx,
+                    nc_seqnum=0,
+                    nc_id=b'\x00' * 32,
+                    nc_method='my_method',
+                    nc_args_bytes=b'',
+                    nc_actions=[
+                        NanoHeaderAction(type=NCActionType.DEPOSIT, token_index=0, amount=deposit),
+                        NanoHeaderAction(type=NCActionType.WITHDRAWAL, token_index=0, amount=withdrawal),
+                    ],
+                    nc_address=b'\x00' * 25,
+                    nc_script=b'',
+                ),
+                FeeHeader(
+                    settings=self.manager._settings,
+                    tx=tx,
+                    fees=[FeeHeaderEntry(token_index=0, amount=fee)],
+                ),
+            ]
+            tx.update_hash()
+
+            parsed = Transaction.create_from_struct(tx.get_struct())
+            assert parsed == tx
+            assert parsed.get_struct() == tx.get_struct()
+            assert parsed.get_token_amount_version() == version
+
+            nano_header = parsed.get_nano_header()
+            deposit_action, withdrawal_action = nano_header.nc_actions
+            assert deposit_action.amount == deposit
+            assert deposit_action.amount.raw() == deposit_raw[version]
+            assert withdrawal_action.amount.raw() == withdrawal_raw[version]
+            fee_entry, = parsed.get_fee_header().fees
+            assert fee_entry.amount.raw() == fee_raw[version]
+            if version == TokenAmountVersion.V1:
+                assert deposit_action.amount.is_v1()
+                assert withdrawal_action.amount.is_v1()
+                assert fee_entry.amount.is_v1()
+            else:
+                assert deposit_action.amount.is_v2()
+                assert withdrawal_action.amount.is_v2()
+                assert fee_entry.amount.is_v2()
+
+    def test_version_bit_is_committed_in_sighash_and_hash(self) -> None:
+        """Flip only the `signal_bits` LSB (and re-encode outputs into the matching variant) and assert both the
+        sighash bytes and the vertex hash change. Pins that the token-amount version is committed data; outputs
+        cannot be re-encoded under a different version without invalidating the signature/PoW."""
+        tx = self._build_v1_tx()
+        assert tx.get_token_amount_version() == TokenAmountVersion.V1
+        original_sighash = tx.get_sighash_all()
+        original_hash = tx.hash
+
+        tx.signal_bits |= 0b1
+        for output in tx.outputs:
+            output.value = output.value.to_v2()
+        tx.clear_sighash_cache()
+        tx.update_hash()
+
+        assert tx.get_token_amount_version() == TokenAmountVersion.V2
+        assert tx.get_sighash_all() != original_sighash
+        assert tx.hash != original_hash
+
+    def test_v1_and_v2_bytes_are_not_self_describing(self) -> None:
+        """Decode V1 bytes as V2 (and vice versa) and assert it either errors or misparses to a different value.
+        Pins that the encodings are ambiguous out-of-band, justifying why the version MUST come from `signal_bits`."""
+        # V1 bytes read under V2: the 4-byte field's leading 0x00 is read as a zero length prefix and rejected.
+        v1_bytes = _encode_v1(100)
+        assert v1_bytes.hex() == '00000064'
+        with pytest.raises(ValueError, match=re.escape('value must not be zero')):
+            _decode_v2(v1_bytes)
+
+        # V2 bytes read under V1: `03c0ffee` is a length-prefixed 0xc0ffee, but V1 reads all four bytes as one
+        # integer, silently yielding a different value.
+        v2_bytes = _encode_v2(0xc0ffee)
+        assert v2_bytes.hex() == '03c0ffee'
+        misparsed = _decode_v1(v2_bytes)
+        assert misparsed.raw() == 0x03c0ffee
+        assert misparsed.raw() != 0xc0ffee
+        assert misparsed.normalized() != UnsignedAmount.from_v2(0xc0ffee).normalized()
+
+    def test_malformed_v2_output_propagates_at_vertex_level(self) -> None:
+        """Hand-craft a V2 tx whose first output is non-canonical/truncated and assert `create_from_struct`
+        propagates the `ValueError`/`OutOfDataError` (the V2 path is not wrapped as `InvalidOutputValue` the way V1
+        struct failures are). Pins the end-to-end error behavior and the wrapping asymmetry."""
+        script = self._p2pkh_script()
+
+        # The funds prefix is signal_bits(1) + version(1) + tokens_len(1) + inputs_len(1) + outputs_len(1), so with
+        # no tokens and no inputs the first output value begins at byte 5. A V2 `from_v2(1)` encodes as `01 01`.
+        non_canonical_tx = self._minimal_tx(
+            outputs=[TxOutput(UnsignedAmount.from_v2(1), script, 0)],
+            signal_bits=0b1,
+        )
+        non_canonical = bytearray(non_canonical_tx.get_struct())
+        assert non_canonical[5] == 0x01 and non_canonical[6] == 0x01
+        non_canonical[6] = 0x00  # length 1 with a zero payload byte -> non-canonical
+        with pytest.raises(ValueError, match=re.escape('non-canonical encoding, leading zero byte: 00')):
+            Transaction.create_from_struct(bytes(non_canonical))
+
+        # A V2 `from_v2(0xc0ffee)` encodes as `03 c0ffee`; cutting the struct right after the length byte leaves the
+        # payload unreadable, and the truncation surfaces as OutOfDataError rather than an InvalidOutputValue.
+        truncated_tx = self._minimal_tx(
+            outputs=[TxOutput(UnsignedAmount.from_v2(0xc0ffee), script, 0)],
+            signal_bits=0b1,
+        )
+        truncated = bytes(truncated_tx.get_struct())
+        assert truncated[5] == 0x03
+        with pytest.raises(OutOfDataError):
+            Transaction.create_from_struct(truncated[:6])

--- a/hathor_tests/token_amount_version/test_token_creation_economics.py
+++ b/hathor_tests/token_amount_version/test_token_creation_economics.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTR deposit/withdraw economics for minting and melting deposit tokens under V2.
+
+A deposit token locks HTR proportional to the amount minted (`TOKEN_DEPOSIT_PERCENTAGE`, 1%) and returns HTR
+when melted. Under V2 the percentage is applied to the amount's `normalized()` value and the result is rounded
+to a whole V1 cent: the deposit rounds UP (so the protocol is never short-changed) and the withdraw rounds
+DOWN (so melting never returns more than was locked). That ceil/floor asymmetry means a mint-then-melt round
+trip of a non-cent-aligned amount permanently retains one cent. The math is done in exact integer arithmetic,
+so it stays correct at the magnitudes V2's 18-decimal amounts reach, where 64-bit float would lose precision.
+
+These tests drive the economics three ways: the accepting cases through the DAG builder, the deposit/withdraw
+formulas as pure-function contracts, and the rejecting cases by mutating a built tx and re-running the balance
+verifier directly (mutation invalidates the input scripts, which the full pipeline checks before the balance).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+import pytest
+from htr_lib import UnsignedAmount
+
+from hathor.transaction import Transaction
+from hathor.transaction.base_transaction import TxInput, TxOutput
+from hathor.transaction.exceptions import InputOutputMismatch
+from hathor.transaction.token_creation_tx import TokenCreationTransaction
+from hathor.transaction.token_info import TokenInfoDict
+from hathor.transaction.util import get_deposit_token_deposit_amount, get_deposit_token_withdraw_amount
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.token_amount_version import TokenAmountVersion
+from hathorlib.token_info import TokenVersion
+
+# One V2 "cent": the smallest unit a V1 amount can express, written at V2's 18-decimal scale. Deposits ceil up
+# to a multiple of this and withdraws floor down to one.
+ONE_V2_CENT = 10 ** 16
+# One whole token at V2 scale; minting one more whole token raises the required 1% deposit by exactly one cent.
+ONE_V2_TOKEN = 10 ** 18
+
+
+class TestTokenCreationEconomicsV2(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.settings = self.manager._settings
+        self.tx_verifier = self.manager.verification_service.verifiers.tx
+        self._numerator = self.settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR
+        self._denominator = self.settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+
+    # -- helpers --------------------------------------------------------------------------------------------
+
+    def _token_dict(self, tx: Transaction) -> TokenInfoDict:
+        params = self.get_verification_params(self.manager)
+        block_storage = self.manager.verification_service._get_block_storage(params)
+        return tx.get_complete_token_info(block_storage)
+
+    def _verify_balance(self, tx: Transaction) -> None:
+        """Run only the input/output balance check, reading the tx's (possibly mutated) outputs directly."""
+        self.tx_verifier.verify_transparent_balance(self.settings, tx, self._token_dict(tx))
+
+    def _htr_consumed(self, tx: Transaction) -> UnsignedAmount:
+        """The net HTR a tx locks: `inputs - outputs` of the native token, i.e. the deposit it pays."""
+        htr_info = self._token_dict(tx)[self.settings.HATHOR_TOKEN_UID]
+        return (-htr_info.amount).to_unsigned()
+
+    def _minted_amount(self, tx: Transaction) -> UnsignedAmount:
+        """The amount of the single deposit token this creation tx mints (its positive `TokenInfo`)."""
+        deposit_infos = [ti for ti in self._token_dict(tx).values() if ti.version == TokenVersion.DEPOSIT]
+        assert len(deposit_infos) == 1
+        return deposit_infos[0].amount.to_unsigned()
+
+    def _output_index(self, tx: Transaction, *, token_data: int, authority: bool) -> int:
+        for index, output in enumerate(tx.outputs):
+            if output.token_data == token_data and output.is_token_authority() == authority:
+                return index
+        raise AssertionError(f'no output with token_data={token_data} authority={authority}')
+
+    def _ref_deposit(self, mint_normalized: int) -> int:
+        """Reference deposit in normalized units: ceil(1% of mint) then ceil up to a whole cent."""
+        rounded_up_to_1 = -(-mint_normalized * self._numerator // self._denominator)
+        return -(-rounded_up_to_1 // ONE_V2_CENT) * ONE_V2_CENT
+
+    def _ref_withdraw(self, melt_normalized: int) -> int:
+        """Reference withdraw in normalized units: floor(1% of melt) then floor down to a whole cent."""
+        rounded_down_to_0 = melt_normalized * self._numerator // self._denominator
+        return rounded_down_to_0 // ONE_V2_CENT * ONE_V2_CENT
+
+    def _build_v2_token(self, mint_amount: str) -> TokenCreationTransaction:
+        """Build and propagate a V2 deposit-token creation minting `mint_amount` of token `TK` (e.g. '2.0').
+
+        The token-creation vertex `TK` carries the deposit economics; `mint_tx` is the separate vertex that
+        receives the minted tokens.
+        """
+        artifacts = self.dag_builder.build_from_str(f'''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            mint_tx.out[0] = {mint_amount} TK
+            mint_tx.token_amount_version = V2
+            TK.token_amount_version = V2
+
+            b11 < mint_tx
+            mint_tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        return artifacts.get_typed_vertex('TK', TokenCreationTransaction)
+
+    def _build_v2_melt_tx(self, tk: TokenCreationTransaction, *, melt_normalized: int,
+                          withdraw: UnsignedAmount) -> Transaction:
+        """Build (unsigned) a V2 melt tx that burns `melt_normalized` of `tk`'s token and withdraws `withdraw`.
+
+        Only the transparent balance is exercised, so the inputs are left unsigned; the melt authority input
+        is spent so the token may be melted.
+        """
+        token_index = self._output_index(tk, token_data=1, authority=False)
+        melt_index = next(i for i, o in enumerate(tk.outputs)
+                          if o.is_token_authority() and o.value.raw() == TxOutput.TOKEN_MELT_MASK)
+        script = tk.outputs[token_index].script
+        remaining = UnsignedAmount.from_v2(tk.outputs[token_index].value.raw() - melt_normalized)
+        melt_passthrough = UnsignedAmount.from_v2(TxOutput.TOKEN_MELT_MASK)
+        tx = Transaction(
+            weight=1,
+            inputs=[TxInput(tk.hash, token_index, b''), TxInput(tk.hash, melt_index, b'')],
+            outputs=[
+                TxOutput(remaining, script, 0b00000001),
+                TxOutput(melt_passthrough, script, 0b10000001),
+                TxOutput(withdraw, script, 0),
+            ],
+            parents=self.manager.get_new_tx_parents(),
+            tokens=[tk.tokens[0]],
+            storage=self.manager.tx_storage,
+            timestamp=int(self.clock.seconds()),
+        )
+        tx.init_static_metadata_from_storage(self.settings, self.manager.tx_storage)
+        return tx
+
+    # -- deposit (mint) happy paths -------------------------------------------------------------------------
+
+    def test_v1_deposit_token_creation_baseline(self) -> None:
+        """Control for the deposit path: a V1 deposit-token creation locks exactly
+        `get_deposit_token_deposit_amount(mint)` HTR and verifies."""
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            mint_tx.out[0] = 100 TK
+
+            b11 < mint_tx
+            mint_tx <-- b12
+        ''')
+        artifacts.propagate_with(self.manager)
+        tk = artifacts.get_typed_vertex('TK', TokenCreationTransaction)
+
+        assert tk.get_token_amount_version() == TokenAmountVersion.V1
+        expected_deposit = get_deposit_token_deposit_amount(self.settings, self._minted_amount(tk))
+        assert self._htr_consumed(tk) == expected_deposit
+        assert tk.get_metadata().validation.is_valid()
+        assert tk.get_metadata().voided_by is None
+
+    def test_v2_deposit_token_creation_locks_normalized_deposit(self) -> None:
+        """A V2 deposit-token creation locks HTR computed from the NORMALIZED mint amount (1% of normalized,
+        ceil to cent) and verifies. Minting 2.0 tokens locks 0.02 HTR."""
+        tk = self._build_v2_token('2.0 TK')
+
+        assert tk.get_token_amount_version() == TokenAmountVersion.V2
+        minted = self._minted_amount(tk)
+        assert minted.normalized() == 2 * ONE_V2_TOKEN
+        deposit = self._htr_consumed(tk)
+        assert deposit == get_deposit_token_deposit_amount(self.settings, minted)
+        assert deposit.normalized() == self._ref_deposit(minted.normalized()) == 2 * ONE_V2_CENT
+        assert tk.get_metadata().validation.is_valid()
+        assert tk.get_metadata().voided_by is None
+
+    def test_deposit_token_mint_with_v1_htr_input_and_v2_token_output(self) -> None:
+        """A V2 token-creation tx funds its HTR deposit from a V1-created HTR utxo (a genesis output, always V1)
+        while minting the new token as V2; the normalized deposit balances against the V1 input and it passes the
+        balance check.
+
+        The DAG builder's filler funds a V2 creation from a freshly minted V2 utxo, leaving no V1 input to spend,
+        so this tx is constructed by hand.
+        """
+        genesis = self.manager.tx_storage.get_all_genesis()
+        genesis_block = next(vertex for vertex in genesis if vertex.is_block)
+        funding_output = genesis_block.outputs[0]
+        assert funding_output.value.is_v1()
+
+        mint = UnsignedAmount.from_v2(2 * ONE_V2_TOKEN)
+        deposit = get_deposit_token_deposit_amount(self.settings, mint)
+        change = UnsignedAmount.from_v2(funding_output.value.normalized() - deposit.normalized())
+        script = funding_output.script
+        tk = TokenCreationTransaction(
+            weight=1,
+            parents=[vertex.hash for vertex in genesis if not vertex.is_block],
+            storage=self.manager.tx_storage,
+            inputs=[TxInput(genesis_block.hash, 0, b'')],
+            outputs=[
+                TxOutput(mint, script, 0b00000001),
+                TxOutput(UnsignedAmount.from_v2(TxOutput.TOKEN_MINT_MASK), script, 0b10000001),
+                TxOutput(UnsignedAmount.from_v2(TxOutput.TOKEN_MELT_MASK), script, 0b10000001),
+                TxOutput(change, script, 0),
+            ],
+            token_name='CrossVersionCoin',
+            token_symbol='CVC',
+            timestamp=int(self.clock.seconds()),
+        )
+        tk.signal_bits = 0b1  # mark the creation tx as V2
+        # the token uid is the creation tx's hash, so it must be set before reading token info; a deterministic
+        # hash (without valid proof-of-work) is enough, since only the transparent balance is exercised.
+        tk.update_hash()
+        tk.init_static_metadata_from_storage(self.settings, self.manager.tx_storage)
+
+        assert tk.get_token_amount_version() == TokenAmountVersion.V2
+        assert funding_output.value.is_v1()
+        assert tk.outputs[0].value.is_v2()
+        # the V2 deposit balances against the V1 genesis input; no exception means it verifies.
+        self._verify_balance(tk)
+
+    # -- deposit/withdraw rounding (pure-function contracts) ------------------------------------------------
+
+    def test_v2_mint_requires_ceil_to_cent_deposit(self) -> None:
+        """A V2 mint whose 1% lands between cents forces the deposit UP to the next whole cent; under-depositing
+        by less than a cent is rejected. 1% of 1.005 is 0.01005, which ceils to a 0.02 deposit."""
+        mint = UnsignedAmount.from_v2(1005 * 10 ** 15)  # 1.005 tokens
+        deposit = get_deposit_token_deposit_amount(self.settings, mint)
+        assert deposit.normalized() == 2 * ONE_V2_CENT
+        # the un-rounded 1% is strictly less than the charged deposit: the remainder is rounded up, not dropped.
+        assert mint.normalized() * self._numerator // self._denominator < deposit.normalized()
+
+        tk = self._build_v2_token('1.005 TK')
+        htr_index = self._output_index(tk, token_data=0, authority=False)
+        # keep half a cent more HTR than the deposit allows -> under-deposit -> surplus
+        tk.outputs[htr_index].value = UnsignedAmount.from_v2(tk.outputs[htr_index].value.raw() + ONE_V2_CENT // 2)
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(tk)
+
+    def test_v2_melt_withdraws_floor_to_cent(self) -> None:
+        """A V2 melt returns HTR FLOORED to the whole cent; over-withdrawing by a sub-cent is rejected. 1% of
+        1.005 is 0.01005, which floors to a 0.01 withdraw."""
+        melt = UnsignedAmount.from_v2(1005 * 10 ** 15)  # 1.005 tokens
+        withdraw = get_deposit_token_withdraw_amount(self.settings, melt)
+        assert withdraw.normalized() == ONE_V2_CENT
+        # the un-rounded 1% is strictly more than the returned withdraw: the remainder is dropped, not paid out.
+        assert melt.normalized() * self._numerator // self._denominator > withdraw.normalized()
+
+        tk = self._build_v2_token('2.0 TK')
+        # the exact floored withdraw balances...
+        ok_melt = self._build_v2_melt_tx(tk, melt_normalized=1005 * 10 ** 15, withdraw=withdraw)
+        self._verify_balance(ok_melt)
+        # ...but claiming half a cent more HTR than the floor allows is a surplus.
+        over = UnsignedAmount.from_v2(withdraw.raw() + ONE_V2_CENT // 2)
+        bad_melt = self._build_v2_melt_tx(tk, melt_normalized=1005 * 10 ** 15, withdraw=over)
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(bad_melt)
+
+    def test_minimum_deposit_is_nonzero_for_any_positive_mint(self) -> None:
+        """Minting the smallest positive amount still requires a nonzero (one-cent) HTR deposit, because the 1%
+        is ceiled. A token-creation tx that mints with zero deposit is rejected."""
+        smallest = UnsignedAmount.from_v2(1)
+        deposit = get_deposit_token_deposit_amount(self.settings, smallest)
+        assert deposit.normalized() == ONE_V2_CENT
+        assert deposit > UnsignedAmount.zero()
+
+        tk = self._build_v2_token('2.0 TK')
+        htr_index = self._output_index(tk, token_data=0, authority=False)
+        # return the entire one-cent deposit as change -> zero net deposit -> surplus
+        tk.outputs[htr_index].value = UnsignedAmount.from_v2(tk.outputs[htr_index].value.raw() + 2 * ONE_V2_CENT)
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(tk)
+
+    def test_deposit_math_backward_compatible_for_v1(self) -> None:
+        """Across a range of V1 amounts the integer deposit/withdraw math equals the legacy 1% float result.
+        At V1 scale (cents) the float computation is exact, so the integer refactor is byte-for-byte compatible."""
+        for v1_cents in (1, 7, 100, 333, 12_345, 99_999):
+            mint = UnsignedAmount.from_v1(v1_cents)
+            deposit = get_deposit_token_deposit_amount(self.settings, mint)
+            withdraw = get_deposit_token_withdraw_amount(self.settings, mint)
+
+            # the legacy formula worked in whole HTR-cents: 1% of the amount, ceil for deposit, floor for withdraw.
+            legacy_deposit_cents = math.ceil(v1_cents * 0.01)
+            legacy_withdraw_cents = math.floor(v1_cents * 0.01)
+            assert deposit.normalized() == legacy_deposit_cents * ONE_V2_CENT
+            assert withdraw.normalized() == legacy_withdraw_cents * ONE_V2_CENT
+
+    def test_deposit_math_no_float_precision_loss_at_v2_scale(self) -> None:
+        """At a magnitude only V2 amounts reach, the integer deposit (ceil) and withdraw (floor) are exact to the
+        unit, where a 64-bit float intermediate would round and disagree."""
+        mint_normalized = 10 ** 30 + 5 * 10 ** 15  # huge, with a sub-cent tail
+        mint = UnsignedAmount.from_v2(mint_normalized)
+
+        deposit = get_deposit_token_deposit_amount(self.settings, mint)
+        withdraw = get_deposit_token_withdraw_amount(self.settings, mint)
+        assert deposit.normalized() == self._ref_deposit(mint_normalized)
+        assert withdraw.normalized() == self._ref_withdraw(mint_normalized)
+
+        # a float intermediate cannot hold this many significant digits, so it disagrees with the exact result.
+        float_based = int(mint_normalized * self._numerator / self._denominator)
+        assert float_based != mint_normalized * self._numerator // self._denominator
+
+    def test_mint_then_melt_dust_asymmetry(self) -> None:
+        """Minting then melting a non-cent-aligned amount retains one cent (deposit ceil exceeds withdraw floor by
+        a cent); for a cent-aligned amount the round trip is neutral."""
+        non_aligned = UnsignedAmount.from_v2(1005 * 10 ** 15)  # 1% = 0.01005, not a whole cent
+        deposit = get_deposit_token_deposit_amount(self.settings, non_aligned)
+        withdraw = get_deposit_token_withdraw_amount(self.settings, non_aligned)
+        assert deposit.normalized() - withdraw.normalized() == ONE_V2_CENT
+
+        aligned = UnsignedAmount.from_v2(ONE_V2_TOKEN)  # 1% = 0.01, exactly a whole cent
+        deposit_aligned = get_deposit_token_deposit_amount(self.settings, aligned)
+        withdraw_aligned = get_deposit_token_withdraw_amount(self.settings, aligned)
+        assert deposit_aligned.normalized() == withdraw_aligned.normalized()
+
+    # -- deposit (mint) rejections --------------------------------------------------------------------------
+
+    def test_v2_deposit_insufficient_htr_rejected(self) -> None:
+        """A V2 mint that locks less HTR than required is rejected: consuming too little HTR for the amount
+        minted manifests as a surplus of HTR."""
+        tk = self._build_v2_token('2.0 TK')
+        token_index = self._output_index(tk, token_data=1, authority=False)
+        # mint one more whole token (raising the required deposit by a cent) without locking more HTR
+        bumped = UnsignedAmount.from_v2(tk.outputs[token_index].value.raw() + ONE_V2_TOKEN)
+        tk.outputs[token_index].value = bumped
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid surplus of HTR.")):
+            self._verify_balance(tk)
+
+    def test_v2_deposit_excess_htr_rejected(self) -> None:
+        """A V2 mint that locks more HTR than required is rejected: consuming too much HTR for the amount minted
+        manifests as a deficit of HTR."""
+        tk = self._build_v2_token('2.0 TK')
+        token_index = self._output_index(tk, token_data=1, authority=False)
+        # mint one fewer whole token (lowering the required deposit by a cent) while still locking the same HTR
+        lowered = UnsignedAmount.from_v2(tk.outputs[token_index].value.raw() - ONE_V2_TOKEN)
+        tk.outputs[token_index].value = lowered
+        with pytest.raises(InputOutputMismatch, match=re.escape("There's an invalid deficit of HTR.")):
+            self._verify_balance(tk)

--- a/hathor_tests/token_amount_version/test_verification.py
+++ b/hathor_tests/token_amount_version/test_verification.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""The feature gate `TransactionVerifier.verify_token_amount_version`, which runs in storage-less basic
+verify.
+
+The gate rejects a tx whose token amount version exceeds the version the feature allows, so it is a pure
+function of the tx's version and `params.features.token_amount_version` (V1 when the feature is inactive,
+V2 when active). Each test drives that truth table directly. The transactions themselves are built and
+fully verified through the DAG builder, so the V1/V2 fixtures are real, valid vertices.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+
+import pytest
+
+from hathor.feature_activation.utils import Features
+from hathor.transaction import Transaction
+from hathor.verification.verification_params import VerificationParams
+from hathor_tests import unittest
+from hathor_tests.dag_builder.builder import TestDAGBuilder
+from hathorlib.exceptions import TxValidationError
+from hathorlib.token_amount_version import TokenAmountVersion
+
+
+class TestTokenAmountVersionVerification(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.manager = self.create_peer('unittests')
+        self.dag_builder = TestDAGBuilder.from_manager(self.manager)
+        self.tx_verifier = self.manager.verification_service.verifiers.tx
+
+        # The feature is enabled in unittests.yml, so both fixtures pass full verification when propagated.
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..13]
+            b10 < dummy
+
+            b1.out[0] <<< tx_v1
+            tx_v1.out[0] = 100 HTR
+
+            b2.out[0] <<< tx_v2
+            tx_v2.out[0] = 100 HTR
+            tx_v2.token_amount_version = V2
+
+            b11 < tx_v1
+            b12 < tx_v2
+            tx_v1 <-- tx_v2 <-- b13
+        ''')
+        artifacts.propagate_with(self.manager)
+        self.tx_v1, self.tx_v2 = artifacts.get_typed_vertices(('tx_v1', 'tx_v2'), Transaction)
+
+        assert self.tx_v1.get_token_amount_version() == TokenAmountVersion.V1
+        assert self.tx_v2.get_token_amount_version() == TokenAmountVersion.V2
+
+    @staticmethod
+    def _params(feature_version: TokenAmountVersion) -> VerificationParams:
+        """Verification params whose only relevant field is the version the feature allows."""
+        features = dataclasses.replace(Features.all_enabled(), token_amount_version=feature_version)
+        return VerificationParams(nc_block_root_id=None, features=features)
+
+    def test_v1_tx_accepted_when_feature_inactive(self) -> None:
+        """The gate never rejects V1: with the feature inactive (1 > 1 is false) the V1 tx passes the gate,
+        and it passed full verification when propagated."""
+        self.tx_verifier.verify_token_amount_version(self.tx_v1, self._params(TokenAmountVersion.V1))
+        assert self.tx_v1.get_metadata().validation.is_valid()
+        assert self.tx_v1.get_metadata().voided_by is None
+
+    def test_v1_tx_accepted_when_feature_active(self) -> None:
+        """Activation never forces V2: with the feature active (1 > 2 is false) the V1 tx is still
+        accepted, preserving backward compatibility."""
+        self.tx_verifier.verify_token_amount_version(self.tx_v1, self._params(TokenAmountVersion.V2))
+        assert self.tx_v1.get_metadata().validation.is_valid()
+        assert self.tx_v1.get_metadata().voided_by is None
+
+    def test_v2_tx_rejected_when_feature_inactive(self) -> None:
+        """The core gating case: with the feature inactive a V2 tx is rejected with the exact
+        `TxValidationError('invalid token amount version: V2')`."""
+        with pytest.raises(TxValidationError, match=re.escape('invalid token amount version: V2')):
+            self.tx_verifier.verify_token_amount_version(self.tx_v2, self._params(TokenAmountVersion.V1))
+
+    def test_v2_tx_accepted_when_feature_active(self) -> None:
+        """The boundary equality accepts: with the feature active (2 > 2 is false) the V2 tx passes the
+        gate, and it passed full verification when propagated."""
+        self.tx_verifier.verify_token_amount_version(self.tx_v2, self._params(TokenAmountVersion.V2))
+        assert self.tx_v2.get_metadata().validation.is_valid()
+        assert self.tx_v2.get_metadata().voided_by is None


### PR DESCRIPTION
Depends on #1707

### Motivation

The token amount version V2 ("decimals") project changes how token amounts are encoded and validated across many subsystems — version derivation, transaction verification, cross-version balance, on-wire serialization, token-creation economics, authorities, fee tokens, the tokens and UTXO indexes, feature activation, and consensus reorgs. This PR pins that behavior with a dedicated, executable test suite under `hathor_tests/token_amount_version/`, one module per subsystem, so the V2 semantics are locked in and regressions surface early. Each module documents the scenario it exercises and the exact behavior it pins.

### Acceptance Criteria

- Add the `hathor_tests/token_amount_version/` test package with one module per subsystem, each documenting its scenario and the behavior it pins.
- Pin how a vertex's token amount version is derived from `signal_bits` and which vertices are exempt (`test_derivation.py`).
- Pin the `TransactionVerifier.verify_token_amount_version` feature gate that runs in storage-less basic verify (`test_verification.py`).
- Pin sum-of-inputs equals sum-of-outputs balance when V1 and V2 amounts mix, in both directions (`test_cross_version_balance.py`).
- Pin V1/V2 on-wire encode/decode of output values and the token-amount version bit (`test_serialization.py`).
- Pin HTR deposit/withdraw economics for minting and melting deposit tokens under V2 (`test_token_creation_economics.py`).
- Pin authority (mint/melt) outputs under V2, where the value field is a bitmask read via `.raw()` rather than a token amount (`test_authorities.py`).
- Pin fee-based token economics under V2 (`test_fee_tokens.py`).
- Pin the tokens-total and UTXO indexes under V1 and V2 amounts (`test_indexes.py`).
- Pin the `Feature.TOKEN_AMOUNT_V2` feature-activation lifecycle and its manager-level effect on V2 acceptance (`test_feature_activation_lifecycle.py`).
- Pin consensus reorg handling for V2 transactions (`test_reorg.py`).
- Document the pytest-primitive and exact-value assertion conventions in `.claude/rules/testing.md`.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
