### PR TITLE
fix(p2p): multi-peer sync case could lead to unnecessary reconnect

### DIFF
--- a/hathor/p2p/sync_v2/agent.py
+++ b/hathor/p2p/sync_v2/agent.py
@@ -739,12 +739,13 @@ class NodeBlockSync(SyncAgent):
         self.receiving_stream = False
         assert self.protocol.connections is not None
 
-        if self.state is not PeerState.SYNCING_BLOCKS:
-            self.log.error('unexpected BLOCKS-END', state=self.state, response_code=response_code.name)
-            self.protocol.send_error_and_close_connection('Not expecting to receive BLOCKS-END message')
+        if self.state is not PeerState.SYNCING_BLOCKS or self._blk_streaming_client is None:
+            # A stale BLOCKS-END can arrive after we already finished or aborted this stream and
+            # moved on (e.g. after a reorg-driven retry). It is harmless, so we ignore it instead
+            # of closing the connection, which would trigger a needless reconnect.
+            self.log.debug('ignoring unexpected BLOCKS-END', state=self.state, response_code=response_code.name)
             return
 
-        assert self._blk_streaming_client is not None
         self._blk_streaming_client.handle_blocks_end(response_code)
         self.log.debug('block streaming ended', reason=str(response_code))
 
@@ -993,12 +994,14 @@ class NodeBlockSync(SyncAgent):
         self.receiving_stream = False
         assert self.protocol.connections is not None
 
-        if self.state is not PeerState.SYNCING_TRANSACTIONS:
-            self.log.error('unexpected TRANSACTIONS-END', state=self.state, response_code=response_code.name)
-            self.protocol.send_error_and_close_connection('Not expecting to receive TRANSACTIONS-END message')
+        if self.state is not PeerState.SYNCING_TRANSACTIONS or self._tx_streaming_client is None:
+            # A stale TRANSACTIONS-END can arrive after we already finished or aborted this stream
+            # and moved on (e.g. after a reorg-driven retry). It is harmless, so we ignore it
+            # instead of closing the connection, which would trigger a needless reconnect.
+            self.log.debug('ignoring unexpected TRANSACTIONS-END', state=self.state,
+                           response_code=response_code.name)
             return
 
-        assert self._tx_streaming_client is not None
         self._tx_streaming_client.handle_transactions_end(response_code)
         self.log.debug('transaction streaming ended', reason=str(response_code))
 

--- a/hathor/p2p/sync_v2/streamers.py
+++ b/hathor/p2p/sync_v2/streamers.py
@@ -250,7 +250,7 @@ class TransactionsStreamingServer(_StreamingServerBase):
 
             # Check if this block is still in the best blockchain.
             if self.current_block.get_metadata().voided_by:
-                self.sync_agent.stop_tx_streaming_server(StreamEnd.STREAM_BECAME_VOIDED)
+                self._stop_streaming_server(StreamEnd.STREAM_BECAME_VOIDED)
                 return
 
             self.current_block = self.current_block.get_next_block_best_chain()
@@ -261,12 +261,22 @@ class TransactionsStreamingServer(_StreamingServerBase):
         assert self.is_running
         assert self.is_producing
 
+        # A reorg can move the requested last block off the best chain while this stream is
+        # running. Stop before advancing through its same-height replacement, whose transactions
+        # were not requested by the peer.
+        if self.last_block.get_metadata().voided_by:
+            self._stop_streaming_server(StreamEnd.STREAM_BECAME_VOIDED)
+            return
+
         try:
             cur = next(self.iter)
         except StopIteration:
-            # nothing more to send
+            # Nothing more to send. The iterator may have already stopped the server itself (for
+            # example when the current block became voided mid-stream), so only stop it if it is
+            # still running — otherwise we would stop it a second time and crash.
             self.log.debug('no more transactions, stopping streaming')
-            self.sync_agent.stop_tx_streaming_server(StreamEnd.END_HASH_REACHED)
+            if self.is_running:
+                self._stop_streaming_server(StreamEnd.END_HASH_REACHED)
             return
 
         # Skip blocks.

--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -176,15 +176,21 @@ class TransactionStreamingClient:
             if tx.hash in self._db:
                 # This case might happen during a resume, so we just log and keep syncing.
                 self.log.debug('duplicated vertex received', tx_id=tx.hash.hex())
-                self._update_dependencies(tx)
-            elif tx.hash in self._existing_deps:
+            elif tx.hash in self._existing_deps or self.tx_storage.transaction_exists(tx.hash):
                 # This case might happen if we already have the transaction from another sync.
                 self.log.debug('existing vertex received', tx_id=tx.hash.hex())
-                self._update_dependencies(tx)
             else:
-                self.log.info('unexpected vertex received', tx_id=tx.hash.hex())
-                self.fails(UnexpectedVertex(tx.hash.hex()))
-            return
+                # The server may have moved to a later block while another peer satisfied this one.
+                yield self._advance_satisfied_blocks()
+                if tx.hash not in self._waiting_for:
+                    self.log.info('unexpected vertex received', tx_id=tx.hash.hex())
+                    self.fails(UnexpectedVertex(tx.hash.hex()))
+                    return
+
+            if tx.hash not in self._waiting_for:
+                self._update_dependencies(tx)
+                yield self._advance_satisfied_blocks()
+                return
         self._waiting_for.remove(tx.hash)
 
         self._update_dependencies(tx)
@@ -194,10 +200,7 @@ class TransactionStreamingClient:
 
         if not self._waiting_for:
             self.log.debug('no pending dependencies, processing buffer')
-            while not self._waiting_for:
-                result = yield self._execute_and_prepare_next()
-                if not result:
-                    break
+            yield self._advance_satisfied_blocks()
         else:
             self.log.debug('pending dependencies', counter=len(self._waiting_for))
 
@@ -230,6 +233,13 @@ class TransactionStreamingClient:
 
         self.log.info('transactions streaming ended', reason=self._response_code, waiting_for=len(self._waiting_for))
         self._deferred.callback(self._response_code)
+
+    @inlineCallbacks
+    def _advance_satisfied_blocks(self) -> Generator[Any, Any, None]:
+        """Advance past blocks whose dependencies are already available."""
+        while not self._waiting_for and self._idx < len(self.partial_blocks):
+            if not (yield self._execute_and_prepare_next()):
+                return
 
     @inlineCallbacks
     def _execute_and_prepare_next(self) -> Generator[Any, Any, bool]:

--- a/hathor_tests/p2p/test_sync_v2.py
+++ b/hathor_tests/p2p/test_sync_v2.py
@@ -6,15 +6,18 @@ import re
 from typing import cast
 from unittest.mock import patch
 
+from structlog import get_logger
 from twisted.internet.defer import Deferred, succeed
 from twisted.python.failure import Failure
 
 from hathor.p2p.messages import ProtocolMessages
 from hathor.p2p.peer import PrivatePeer
 from hathor.p2p.states import ReadyState
-from hathor.p2p.sync_v2.agent import NodeBlockSync, _HeightInfo
+from hathor.p2p.sync_v2.agent import NodeBlockSync, PeerState, _HeightInfo
 from hathor.p2p.sync_v2.blockchain_streaming_client import BlockchainStreamingClient
 from hathor.p2p.sync_v2.exception import StreamingError
+from hathor.p2p.sync_v2.streamers import StreamEnd, TransactionsStreamingServer
+from hathor.p2p.sync_v2.transaction_streaming_client import TransactionStreamingClient
 from hathor.simulator import FakeConnection
 from hathor.simulator.trigger import (
     StopAfterNMinedBlocks,
@@ -23,13 +26,41 @@ from hathor.simulator.trigger import (
     StopWhenTrue,
     Trigger,
 )
-from hathor.transaction import Block
+from hathor.transaction import Block, Transaction
 from hathor.transaction.storage import TransactionRocksDBStorage
 from hathor.transaction.storage.transaction_storage import TransactionStorage
+from hathor.transaction.storage.traversal import BFSOrderWalk
 from hathor.types import VertexId
 from hathor.util import not_none
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.simulation.base import SimulatorTestCase
+
+
+def _make_tx_streaming_server(
+    sync_agent: object,
+    *,
+    first_block: Block,
+    last_block: Block,
+) -> TransactionsStreamingServer:
+    """Build a `TransactionsStreamingServer` driven directly, bypassing `__init__` (which is
+    otherwise coupled to a live connection). Streaming starts at `first_block`."""
+    server = object.__new__(TransactionsStreamingServer)
+    server.sync_agent = cast(NodeBlockSync, sync_agent)
+    server.tx_storage = server.sync_agent.tx_storage
+    server.log = get_logger()
+    server.first_block = first_block
+    server.last_block = last_block
+    server.start_from = []
+    server.current_block = first_block
+    server.counter = 0
+    server.limit = 10_000
+    server.is_running = True
+    server.is_producing = True
+    server.bfs = BFSOrderWalk(
+        server.tx_storage, is_dag_verifications=True, is_dag_funds=True, is_left_to_right=False
+    )
+    server.iter = server.get_iter()
+    return server
 
 
 class RandomSimulatorTestCase(SimulatorTestCase):
@@ -344,6 +375,313 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         self.assertTrue(manager.tx_storage.transaction_exists(win12.hash))
         best_block = manager.tx_storage.get_best_block()
         self.assertEqual(best_block.hash, win12.hash)
+
+    def test_sync_v2_tx_streaming_advances_past_satisfied_blocks(self) -> None:
+        """Regression test for a transaction-streaming livelock during concurrent multi-peer sync.
+
+        A block is added to the streaming `partial_blocks` list while its dependencies are still
+        missing. If those dependencies are then downloaded from another peer before this peer
+        streams the block's transactions, the block becomes fully satisfied with no pending
+        dependencies. The client must advance past such already-satisfied leading blocks; otherwise
+        it stays stuck on the first one and rejects the transactions the server legitimately sends
+        for later blocks as `UnexpectedVertex`, which (with autoreconnect) loops forever.
+        """
+        source = self.create_peer()
+        dag_builder = TestDAGBuilder.from_manager(source)
+        artifacts = dag_builder.build_from_str('''
+            blockchain genesis b[1..45]
+            b30 < dummy
+            b40 --> txA
+            b45 --> txB
+        ''')
+        artifacts.propagate_with(source)
+
+        tx_a = artifacts.get_typed_vertex('txA', Transaction)
+        tx_b = artifacts.get_typed_vertex('txB', Transaction)
+        partial_blocks = list(artifacts.get_typed_vertices([f'b{i}' for i in range(40, 46)], Block))
+
+        # Simulate a client that already has every vertex EXCEPT the blocks being streamed — in
+        # particular it already has txA and txB, as if downloaded from another peer during
+        # concurrent sync. So b40..b45 all have their dependencies satisfied even though they are
+        # streamed as partial blocks. `existing` models the client's storage existence checks.
+        existing: set[VertexId] = {tx.hash for tx in source.tx_storage.get_all_transactions()}
+        existing -= {blk.hash for blk in partial_blocks}
+
+        completed: list[VertexId] = []
+
+        class FakeStorage:
+            def transaction_exists(self, vertex_id: VertexId) -> bool:
+                return vertex_id in existing
+
+        class DummyProtocol:
+            def __init__(self) -> None:
+                self.node = source
+
+            def get_short_peer_id(self) -> str:
+                return 'dummy'
+
+        class DummySync:
+            def __init__(self) -> None:
+                self.protocol = DummyProtocol()
+                self.tx_storage = FakeStorage()
+                self.reactor = source.reactor
+
+            def on_block_complete(self, blk: Block, vertex_list: list[Transaction]) -> Deferred[None]:
+                # Completing a block makes it available for the following block's dependencies.
+                completed.append(blk.hash)
+                existing.add(blk.hash)
+                return succeed(None)
+
+        client = TransactionStreamingClient(cast(NodeBlockSync, DummySync()), partial_blocks, limit=1000)
+        errors: list[StreamingError] = []
+        client.wait().addErrback(lambda failure: errors.append(failure.value))
+
+        # The server streams transactions in block order: txA (confirmed by b40), then txB
+        # (confirmed by b45). Both are already present, so neither is in the waiting list.
+        client.handle_transaction(tx_a)
+        client.handle_transaction(tx_b)
+        # Pump the reactor so the queued transactions are processed.
+        self.simulator.run(5)
+
+        self.assertFalse(errors, 'should stream without rejecting already-satisfied transactions')
+        # The client must advance through and complete every block, in order.
+        self.assertEqual(completed, [blk.hash for blk in partial_blocks])
+
+    def test_sync_v2_tx_streaming_advances_then_processes_tx_for_later_block(self) -> None:
+        """Regression test for the advance-then-process path of the transaction-streaming client.
+
+        This complements `test_sync_v2_tx_streaming_advances_past_satisfied_blocks`: there every
+        streamed transaction already exists in storage (the `transaction_exists` branch). Here the
+        client is positioned on an early block whose dependencies are already satisfied, and the
+        first transaction it receives is one it genuinely still needs — but for a *later* block,
+        because the server moved ahead while other peers satisfied the blocks in between. The client
+        must advance past the satisfied leading blocks until the transaction becomes one it is
+        waiting for, then process it normally instead of rejecting it as `UnexpectedVertex`.
+        """
+        source = self.create_peer()
+        dag_builder = TestDAGBuilder.from_manager(source)
+        artifacts = dag_builder.build_from_str('''
+            blockchain genesis b[1..45]
+            b30 < dummy
+            b40 --> txA
+            b45 --> txB
+        ''')
+        artifacts.propagate_with(source)
+
+        tx_b = artifacts.get_typed_vertex('txB', Transaction)
+        partial_blocks = list(artifacts.get_typed_vertices([f'b{i}' for i in range(40, 46)], Block))
+
+        # The client has every vertex EXCEPT the blocks being streamed and `txB`. So b40..b44 have
+        # their dependencies satisfied, but b45 still needs `txB` — which the server will stream.
+        existing: set[VertexId] = {tx.hash for tx in source.tx_storage.get_all_transactions()}
+        existing -= {blk.hash for blk in partial_blocks}
+        existing.discard(tx_b.hash)
+
+        completed: list[VertexId] = []
+
+        class FakeStorage:
+            def transaction_exists(self, vertex_id: VertexId) -> bool:
+                return vertex_id in existing
+
+        class DummyProtocol:
+            def __init__(self) -> None:
+                self.node = source
+
+            def get_short_peer_id(self) -> str:
+                return 'dummy'
+
+        class DummySync:
+            def __init__(self) -> None:
+                self.protocol = DummyProtocol()
+                self.tx_storage = FakeStorage()
+                self.reactor = source.reactor
+
+            def on_block_complete(self, blk: Block, vertex_list: list[Transaction]) -> Deferred[None]:
+                completed.append(blk.hash)
+                existing.add(blk.hash)
+                return succeed(None)
+
+        client = TransactionStreamingClient(cast(NodeBlockSync, DummySync()), partial_blocks, limit=1000)
+        errors: list[StreamingError] = []
+        client.wait().addErrback(lambda failure: errors.append(failure.value))
+
+        # The client starts positioned on b40. The first (and only) transaction it receives is txB,
+        # which is confirmed by the last block b45 and is still genuinely missing. The client must
+        # advance past b40..b44 until txB becomes a pending dependency, then process it.
+        client.handle_transaction(tx_b)
+        self.simulator.run(5)
+
+        self.assertFalse(errors, 'should advance to the later block and process the needed tx')
+        self.assertEqual(completed, [blk.hash for blk in partial_blocks])
+
+    def test_sync_v2_tx_streaming_stops_when_last_block_is_voided(self) -> None:
+        """The transaction-streaming server must stop when the requested `last_block` is voided.
+
+        A reorg during streaming can move `last_block` off the best chain. Since the server walks
+        the best chain, it would otherwise stream transactions confirmed by the replacement block at
+        the same height, followed by later blocks. The peer did not request these transactions and
+        rejects them as unexpected, which can deadlock concurrent multi-peer sync.
+        """
+        manager = self.create_peer()
+        dag_builder = TestDAGBuilder.from_manager(manager)
+        # A long main chain plus a one-block losing fork at b38. The fork block `lose1` is at the
+        # same height as `b39` but is voided (off the best chain). `tx_same` is confirmed by the
+        # same-height replacement, while `tx_over` is confirmed one height above `lose1`.
+        artifacts = dag_builder.build_from_str('''
+            blockchain genesis b[1..40]
+            b30 < dummy
+            b39 --> tx_same
+            b40 --> tx_over
+            blockchain b38 lose[1..1]
+        ''')
+        artifacts.propagate_with(manager)
+
+        first_block = artifacts.get_typed_vertex('b35', Block)
+        last_block = artifacts.get_typed_vertex('lose1', Block)
+        b39 = artifacts.get_typed_vertex('b39', Block)
+        b40 = artifacts.get_typed_vertex('b40', Block)
+        tx_same = artifacts.get_typed_vertex('tx_same', Transaction)
+        tx_over = artifacts.get_typed_vertex('tx_over', Transaction)
+
+        # Sanity check the scenario: `last_block` is reorged out, and the two transactions are
+        # confirmed respectively at the same height and one height above it.
+        self.assertTrue(last_block.get_metadata().voided_by)
+        self.assertEqual(not_none(tx_same.get_metadata().first_block), b39.hash)
+        self.assertEqual(not_none(tx_over.get_metadata().first_block), b40.hash)
+        self.assertEqual(
+            not_none(b39.static_metadata.height), not_none(last_block.static_metadata.height)
+        )
+        self.assertGreater(
+            not_none(b40.static_metadata.height), not_none(last_block.static_metadata.height)
+        )
+
+        sent: list[Transaction] = []
+
+        class DummySync:
+            def __init__(self) -> None:
+                self.tx_storage = manager.tx_storage
+                self.stopped: StreamEnd | None = None
+                self.server: TransactionsStreamingServer | None = None
+
+            def send_transaction(self, tx: Transaction) -> None:
+                sent.append(tx)
+
+            def stop_tx_streaming_server(self, response_code: StreamEnd) -> None:
+                assert self.server is not None
+                self.server.is_running = False
+                self.stopped = response_code
+
+        sync_agent = DummySync()
+        server = _make_tx_streaming_server(sync_agent, first_block=first_block, last_block=last_block)
+        sync_agent.server = server
+
+        for _ in range(server.limit):
+            if sync_agent.stopped is not None:
+                break
+            server.send_next()
+
+        # The server must report the reorg without streaming transactions from either the
+        # same-height replacement or later blocks.
+        self.assertEqual(sync_agent.stopped, StreamEnd.STREAM_BECAME_VOIDED)
+        sent_hashes = {tx.hash for tx in sent}
+        self.assertNotIn(tx_same.hash, sent_hashes)
+        self.assertNotIn(tx_over.hash, sent_hashes)
+
+    def test_sync_v2_tx_streaming_voided_block_stops_once(self) -> None:
+        """The transaction-streaming server must stop exactly once when a streamed block becomes
+        voided.
+
+        When `get_iter` reaches a block that is voided (e.g. reorged out mid-stream), it stops the
+        server and ends the iterator. That makes the next `next(self.iter)` in `send_next` raise
+        `StopIteration`, whose handler would stop the server a second time — crashing on the
+        `assert self._tx_streaming_server is not None` in the agent. Reorgs make this happen in
+        practice, so the handler must not stop an already-stopped server.
+        """
+        manager = self.create_peer()
+        dag_builder = TestDAGBuilder.from_manager(manager)
+        artifacts = dag_builder.build_from_str('''
+            blockchain genesis b[1..40]
+            b30 < dummy
+            b40 --> tx_over
+            blockchain b38 lose[1..1]
+        ''')
+        artifacts.propagate_with(manager)
+
+        voided_block = artifacts.get_typed_vertex('lose1', Block)
+        last_block = artifacts.get_typed_vertex('b40', Block)
+        self.assertTrue(voided_block.get_metadata().voided_by)
+
+        class DummySync:
+            def __init__(self) -> None:
+                self.tx_storage = manager.tx_storage
+                # Mirrors the agent attribute the real `stop_tx_streaming_server` asserts on.
+                self._tx_streaming_server: TransactionsStreamingServer | None = None
+                self.stop_calls: list[StreamEnd] = []
+
+            def send_transaction(self, tx: Transaction) -> None:
+                pass
+
+            def stop_tx_streaming_server(self, response_code: StreamEnd) -> None:
+                # Same assertion the real agent makes — a double-stop would trip it.
+                assert self._tx_streaming_server is not None
+                self._tx_streaming_server.is_running = False
+                self._tx_streaming_server = None
+                self.stop_calls.append(response_code)
+
+        sync_agent = DummySync()
+        # Streaming starts at the voided block to reproduce the mid-stream void.
+        server = _make_tx_streaming_server(sync_agent, first_block=voided_block, last_block=last_block)
+        sync_agent._tx_streaming_server = server
+
+        for _ in range(server.limit):
+            if not server.is_running:
+                break
+            server.send_next()
+
+        # The server must have stopped exactly once, reporting that the stream became voided.
+        self.assertEqual(sync_agent.stop_calls, [StreamEnd.STREAM_BECAME_VOIDED])
+
+    def _check_ignores_stale_end(self, *, state: PeerState, client_attr: str, handler: str) -> None:
+        """A stale BLOCKS-END/TRANSACTIONS-END must be ignored, not punished by closing the
+        connection.
+
+        During concurrent multi-peer sync (especially around reorgs) a peer can finish or abort a
+        stream and move on before the peer's *-END arrives. Closing the connection on such a stale
+        message causes a needless reconnect that adds churn and can keep the network from
+        converging.
+        """
+        manager1 = self.create_peer()
+        manager2 = self.create_peer()
+        conn = FakeConnection(manager1, manager2, latency=0.05)
+        self.simulator.add_connection(conn)
+        self.simulator.run(10)
+
+        assert isinstance(conn.proto2.state, ReadyState)
+        sync_agent = conn.proto2.state.sync_agent
+        assert isinstance(sync_agent, NodeBlockSync)
+
+        # Simulate having already moved on from this stream.
+        sync_agent.state = state
+        setattr(sync_agent, client_attr, None)
+
+        self.assertFalse(conn.proto2.aborting)
+        getattr(sync_agent, handler)(str(int(StreamEnd.END_HASH_REACHED)))
+        # The stale *-END must be ignored, leaving the connection open.
+        self.assertFalse(conn.proto2.aborting)
+
+    def test_sync_v2_ignores_stale_transactions_end(self) -> None:
+        self._check_ignores_stale_end(
+            state=PeerState.SYNCING_BLOCKS,
+            client_attr='_tx_streaming_client',
+            handler='handle_transactions_end',
+        )
+
+    def test_sync_v2_ignores_stale_blocks_end(self) -> None:
+        self._check_ignores_stale_end(
+            state=PeerState.SYNCING_TRANSACTIONS,
+            client_attr='_blk_streaming_client',
+            handler='handle_blocks_end',
+        )
 
     def _prepare_sync_v2_find_best_common_block_reorg(self) -> FakeConnection:
         manager1 = self.create_peer()

--- a/hathor_tests/simulation/test_simulator.py
+++ b/hathor_tests/simulation/test_simulator.py
@@ -4,12 +4,31 @@
 from hathor.feature_activation.feature_service import FeatureService
 from hathor.manager import HathorManager
 from hathor.simulator import FakeConnection
-from hathor.simulator.trigger import All as AllTriggers, StopWhenSynced, Trigger
+from hathor.simulator.trigger import StopWhenSynced, StopWhenTrue
 from hathor.verification.vertex_verifier import VertexVerifier
 from hathor_tests.simulation.base import SimulatorTestCase
 
 
 class RandomSimulatorTestCase(SimulatorTestCase):
+    @staticmethod
+    def _network_converged(reference: HathorManager, others: list[HathorManager]) -> bool:
+        """Return True when every manager in `others` has the same best block and mempool tips
+        as `reference`, i.e. the whole network has converged.
+
+        This checks convergence directly on each node's storage, independent of the state of
+        individual peer connections. A single connection may stay stuck (e.g. flapping on a
+        sync-v2 streaming error) without preventing the network from converging through the
+        other connections, so it is a more reliable stop condition than requiring every
+        connection to report itself as synced.
+        """
+        best_block = reference.tx_storage.get_best_block_hash()
+        mempool_tips = reference.tx_storage.indexes.mempool_tips.get()
+        return all(
+            node.tx_storage.get_best_block_hash() == best_block
+            and node.tx_storage.indexes.mempool_tips.get() == mempool_tips
+            for node in others
+        )
+
     def test_verify_pow(self) -> None:
         manager1 = self.create_peer()
         # just get one of the genesis, we don't really need to create any transaction
@@ -73,7 +92,6 @@ class RandomSimulatorTestCase(SimulatorTestCase):
     def test_many_miners_since_beginning(self) -> None:
         nodes: list[HathorManager] = []
         miners = []
-        stop_triggers: list[Trigger] = []
 
         for hashpower in [10e6, 5e6, 1e6, 1e6, 1e6]:
             manager = self.create_peer()
@@ -82,7 +100,6 @@ class RandomSimulatorTestCase(SimulatorTestCase):
                 #      failing without it for some reason
                 conn = FakeConnection(manager, node, latency=0.085, autoreconnect=True)
                 self.simulator.add_connection(conn)
-                stop_triggers.append(StopWhenSynced(conn))
 
             nodes.append(manager)
 
@@ -95,9 +112,10 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         for miner in miners:
             miner.stop()
 
-        # TODO Add self.assertTrue(...) when the trigger is fixed.
-        #      For further information, see https://github.com/HathorNetwork/hathor-core/pull/815.
-        self.simulator.run(3600, trigger=AllTriggers(stop_triggers))
+        # The network must fully converge within the time budget, so the tip comparison below
+        # reflects a converged network instead of an arbitrary moment in time.
+        converged = StopWhenTrue(lambda: self._network_converged(nodes[0], nodes[1:]))
+        self.assertTrue(self.simulator.run(3600, trigger=converged))
 
         for node in nodes[1:]:
             self.assertTipsEqual(nodes[0], node)
@@ -106,7 +124,6 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         nodes = []
         miners = []
         tx_generators = []
-        stop_triggers: list[Trigger] = []
 
         manager = self.create_peer()
         nodes.append(manager)
@@ -139,7 +156,6 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         for node in nodes:
             conn = FakeConnection(late_manager, node, latency=0.300, autoreconnect=True)
             self.simulator.add_connection(conn)
-            stop_triggers.append(StopWhenSynced(conn))
 
         self.simulator.run(600)
 
@@ -148,9 +164,11 @@ class RandomSimulatorTestCase(SimulatorTestCase):
         for miner in miners:
             miner.stop()
 
-        # TODO Add self.assertTrue(...) when the trigger is fixed. Same as in test_many_miners_since_beginning.
-        #      For further information, see https://github.com/HathorNetwork/hathor-core/pull/815.
-        self.simulator.run(3600, trigger=AllTriggers(stop_triggers))
+        # The late node must fully converge with the network within the time budget. This
+        # asserts convergence actually happened, instead of merely checking consensus at an
+        # arbitrary cutoff (which would silently pass even if sync never completed).
+        converged = StopWhenTrue(lambda: self._network_converged(late_manager, nodes))
+        self.assertTrue(self.simulator.run(3600, trigger=converged))
 
         for idx, node in enumerate(nodes):
             self.log.debug(f'checking node {idx}')


### PR DESCRIPTION
### Motivation

Under heavy concurrent multi-peer sync, especially around reorgs, sync-v2 has a few streaming edge cases that error and cause a reconnect, delaying sync progress. In these cases the node either gets stuck rejecting legitimately-streamed transactions as `UnexpectedVertex`, crashes on a double-stop assertion, or closes an otherwise healthy connection and triggers a needless reconnect.

### Acceptance Criteria

- The transaction-streaming client advances past leading partial blocks whose dependencies are already satisfied (e.g. downloaded from another peer), instead of staying stuck on the first one and rejecting later, legitimately-streamed transactions as `UnexpectedVertex`.
- The transaction-streaming client treats a vertex already present in storage (`transaction_exists`) as expected rather than unexpected, sharing a single `_advance_satisfied_blocks` helper to drain satisfied blocks consistently.
- The transaction-streaming server stops with `STREAM_BECAME_VOIDED` when the requested `last_block` is reorged off the best chain mid-stream, so it never streams unrequested transactions from the same-height replacement block or later blocks.
- The transaction-streaming server stops exactly once when a streamed block becomes voided, avoiding a double-stop that would crash on the `assert self._tx_streaming_server is not None` agent assertion.
- A stale `BLOCKS-END` or `TRANSACTIONS-END` arriving after the stream was finished or aborted is ignored (logged at debug) instead of closing the connection and forcing a reconnect.
- Regression tests cover satisfied-block advancement, advance-then-process of a transaction needed by a later block, voided `last_block` handling, single-stop on void, and stale `*-END` handling.
- The simulator convergence tests assert the whole network has converged (comparing each node's best block and mempool tips directly) rather than relying on per-connection sync triggers.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
