### PR TITLE
fix(nc-types): type `Amount` should not be `int` in runtime

### DIFF
--- a/hathor/nanocontracts/nc_types/__init__.py
+++ b/hathor/nanocontracts/nc_types/__init__.py
@@ -10,6 +10,7 @@ from hathorlib.nanocontracts.nc_types import (  # noqa: F401
     FIELD_TYPE_TO_NC_TYPE_MAP,
     RETURN_TYPE_TO_NC_TYPE_MAP,
     AddressNCType,
+    AmountNCType,
     BoolNCType,
     Bytes32NCType,
     BytesLikeNCType,

--- a/hathor/nanocontracts/nc_types/varint_nc_type.py
+++ b/hathor/nanocontracts/nc_types/varint_nc_type.py
@@ -3,4 +3,8 @@
 
 # Re-export from hathorlib for backward compatibility
 from hathorlib.nanocontracts.nc_types.varint_nc_type import *  # noqa: F401,F403
-from hathorlib.nanocontracts.nc_types.varint_nc_type import VarInt32NCType, VarUint32NCType  # noqa: F401
+from hathorlib.nanocontracts.nc_types.varint_nc_type import (  # noqa: F401
+    AmountNCType,
+    VarInt32NCType,
+    VarUint32NCType,
+)

--- a/hathor_tests/nanocontracts/test_blueprint.py
+++ b/hathor_tests/nanocontracts/test_blueprint.py
@@ -6,7 +6,7 @@ from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import BlueprintSyntaxError, NCFail, NCInsufficientFunds, NCViewMethodError
 from hathor.nanocontracts.nc_types import make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage.contract_storage import Balance, BalanceKey
-from hathor.nanocontracts.types import Address, NCDepositAction, NCWithdrawalAction, TokenUid, public, view
+from hathor.nanocontracts.types import Address, Amount, NCDepositAction, NCWithdrawalAction, TokenUid, public, view
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 STR_NC_TYPE = make_nc_type(str)
@@ -87,12 +87,28 @@ class MyBlueprint(Blueprint):
         return 1
 
 
+class AmountFieldBlueprint(Blueprint):
+    y: Amount
+
+    @public
+    def initialize(self, ctx: Context, y: Amount) -> None:
+        self.y = y
+
+    @view
+    def get_y(self) -> Amount:
+        # Reading `self.y` must yield an `Amount` instance, not a plain `int`. This assert would
+        # fire if the field were mapped to a plain integer NCType (e.g. `Amount: VarUint32NCType`).
+        assert isinstance(self.y, Amount)
+        return self.y
+
+
 class NCBlueprintTestCase(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.simple_fields_id = self._register_blueprint_class(SimpleFields)
         self.container_fields_id = self._register_blueprint_class(ContainerFields)
         self.my_blueprint_id = self._register_blueprint_class(MyBlueprint)
+        self.amount_field_id = self._register_blueprint_class(AmountFieldBlueprint)
 
         genesis = self.manager.tx_storage.get_all_genesis()
         self.tx = [t for t in genesis if t.is_transaction][0]
@@ -128,6 +144,16 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self.assertEqual(storage.get_obj(b'a:\x01a', STR_NC_TYPE), '1')
         self.assertEqual(storage.get_obj(b'a:\x01b', STR_NC_TYPE), '2')
         self.assertEqual(storage.get_obj(b'a:\x01c', STR_NC_TYPE), '3')
+
+    def test_amount_field_getter_returns_amount(self) -> None:
+        nc_id = self.amount_field_id
+        ctx = self.create_context()
+        self.runner.create_contract(nc_id, self.amount_field_id, ctx, Amount(100))
+
+        # the field getter (`self.y`) must return an `Amount` instance, not a plain `int`
+        value = self.runner.call_view_method(nc_id, 'get_y')
+        self.assertIsInstance(value, Amount)
+        self.assertEqual(value, 100)
 
     def _create_my_blueprint_contract(self) -> None:
         nc_id = self.my_blueprint_id

--- a/hathorlib/hathorlib/nanocontracts/nc_types/__init__.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_types/__init__.py
@@ -23,7 +23,7 @@ from hathorlib.nanocontracts.nc_types.str_nc_type import StrNCType
 from hathorlib.nanocontracts.nc_types.token_uid_nc_type import TokenUidNCType
 from hathorlib.nanocontracts.nc_types.tuple_nc_type import TupleNCType
 from hathorlib.nanocontracts.nc_types.utils import TypeAliasMap, TypeToNCTypeMap
-from hathorlib.nanocontracts.nc_types.varint_nc_type import VarInt32NCType, VarUint32NCType
+from hathorlib.nanocontracts.nc_types.varint_nc_type import AmountNCType, VarInt32NCType, VarUint32NCType
 from hathorlib.nanocontracts.types import (
     Address,
     Amount,
@@ -43,6 +43,7 @@ __all__ = [
     'FIELD_TYPE_TO_NC_TYPE_MAP',
     'RETURN_TYPE_TO_NC_TYPE_MAP',
     'AddressNCType',
+    'AmountNCType',
     'BoolNCType',
     'BytesLikeNCType',
     'BytesNCType',
@@ -106,7 +107,7 @@ FIELD_TYPE_TO_NC_TYPE_MAP: TypeToNCTypeMap = {
     NamedTuple: NamedTupleNCType,
     # hathor types:
     Address: AddressNCType,
-    Amount: VarUint32NCType,
+    Amount: AmountNCType,
     BlueprintId: Bytes32NCType,
     ContractId: Bytes32NCType,
     Timestamp: Uint32NCType,

--- a/hathorlib/hathorlib/nanocontracts/nc_types/varint_nc_type.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_types/varint_nc_type.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from typing_extensions import Self, override
 
 from hathorlib.nanocontracts.nc_types.nc_type import NCType
+from hathorlib.nanocontracts.types import Amount
 from hathorlib.serialization import Deserializer, Serializer
 from hathorlib.serialization.adapters import MaxBytesExceededError
 from hathorlib.serialization.encoding.leb128 import decode_leb128, encode_leb128
@@ -105,3 +106,11 @@ class VarUint32NCType(_VarIntNCType):
 
     _signed = False
     _max_byte_size = 32
+
+
+class AmountNCType(VarUint32NCType):
+    """Extension of `VarUint32NCType` that returns an `Amount` new-type instead of a plain `int`."""
+
+    @override
+    def _deserialize(self, deserializer: Deserializer, /) -> Amount:
+        return Amount(super()._deserialize(deserializer))

--- a/hathorlib/tests/test_nc_types.py
+++ b/hathorlib/tests/test_nc_types.py
@@ -136,6 +136,74 @@ class TestCustomTypes(unittest.TestCase):
         self.assertEqual(bid, data)
 
 
+class TestAmountNCType(unittest.TestCase):
+    def _make(self):
+        from hathorlib.nanocontracts.nc_types import AmountNCType, make_nc_type_for_field_type
+        nc_type = make_nc_type_for_field_type(Amount)
+        self.assertIsInstance(nc_type, AmountNCType)
+        return nc_type
+
+    def test_field_type_maps_to_amount_nc_type(self) -> None:
+        from hathorlib.nanocontracts.nc_types import (
+            AmountNCType,
+            make_nc_type_for_arg_type,
+            make_nc_type_for_field_type,
+            make_nc_type_for_return_type,
+        )
+        for make in (make_nc_type_for_field_type, make_nc_type_for_arg_type, make_nc_type_for_return_type):
+            self.assertIsInstance(make(Amount), AmountNCType)
+
+    def test_deserialize_returns_amount_instance(self) -> None:
+        nc_type = self._make()
+        value = nc_type.from_bytes(nc_type.to_bytes(Amount(100)))
+        self.assertIsInstance(value, Amount)
+        self.assertEqual(value, 100)
+
+    def test_deserialize_from_plain_int_returns_amount_instance(self) -> None:
+        # values are serialized as plain ints, but must come back as Amount
+        nc_type = self._make()
+        value = nc_type.from_bytes(nc_type.to_bytes(100))
+        self.assertIsInstance(value, Amount)
+        self.assertEqual(value, 100)
+
+    def test_roundtrip_bytes(self) -> None:
+        nc_type = self._make()
+        for raw in (0, 1, 100, 2**64, 2**128):
+            value = nc_type.from_bytes(nc_type.to_bytes(Amount(raw)))
+            self.assertIsInstance(value, Amount)
+            self.assertEqual(value, raw)
+
+    def test_value_to_json(self) -> None:
+        nc_type = self._make()
+        self.assertEqual(nc_type.value_to_json(Amount(7)), 7)
+
+    def test_plain_int_field_is_not_amount(self) -> None:
+        # a plain `int` field must not be turned into an Amount
+        from hathorlib.nanocontracts.nc_types import make_nc_type_for_field_type
+        nc_type = make_nc_type_for_field_type(int)
+        value = nc_type.from_bytes(nc_type.to_bytes(5))
+        self.assertNotIsInstance(value, Amount)
+        self.assertEqual(value, 5)
+
+    def test_custom_mapping_controls_deserialized_type(self) -> None:
+        # Building the NCType for `Amount` with a custom type map shows the mapping is what decides
+        # whether `Amount` round-trips as an `Amount` or degrades to a plain `int`.
+        from hathorlib.nanocontracts.nc_types import ESSENTIAL_TYPE_ALIAS_MAP, AmountNCType, NCType, VarUint32NCType
+
+        amount_map = NCType.TypeMap(ESSENTIAL_TYPE_ALIAS_MAP, {Amount: AmountNCType})
+        int_map = NCType.TypeMap(ESSENTIAL_TYPE_ALIAS_MAP, {Amount: VarUint32NCType})
+
+        amount_nc_type = NCType.from_type(Amount, type_map=amount_map)
+        int_nc_type = NCType.from_type(Amount, type_map=int_map)
+
+        # same serialized bytes, different deserialized type depending on the mapping
+        data = amount_nc_type.to_bytes(Amount(100))
+        self.assertEqual(int_nc_type.to_bytes(Amount(100)), data)
+
+        self.assertIsInstance(amount_nc_type.from_bytes(data), Amount)
+        self.assertNotIsInstance(int_nc_type.from_bytes(data), Amount)
+
+
 class TestSetMethodType(unittest.TestCase):
     def test_set_method_type(self) -> None:
         def my_func() -> None:


### PR DESCRIPTION
### Motivation

Nano contract values typed as `Amount` were being serialized and deserialized through `VarUint32NCType`, whose deserialization returns a plain `int`. As a result, reading an `Amount` field, calling a method that returns `Amount`, or receiving an `Amount` argument would yield a plain `int` rather than an `Amount` new-type instance, silently dropping the semantic type on the static surface. This PR makes `Amount` round-trip as an actual `Amount`.

### Acceptance Criteria

- Add an `AmountNCType` (subclass of `VarUint32NCType`) that serializes identically but deserializes into an `Amount` new-type instance, and export it from the `nc_types` packages in both `hathor` and `hathorlib`.
- Map the `Amount` field type to `AmountNCType` (instead of `VarUint32NCType`) so contract fields, arguments, and return values typed as `Amount` deserialize back as `Amount`, while plain `int` fields remain unaffected.
- Preserve wire compatibility: the serialized bytes are unchanged, so only the deserialized Python type differs and existing stored data continues to decode.
- Cover the behavior with tests verifying that field/arg/return type maps resolve `Amount` to `AmountNCType`, that deserialization (including from plain-int input) yields an `Amount`, that byte round-trips hold across a range of values, and that a blueprint's `Amount` field getter returns an `Amount` instance.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 