### PR TITLE
fix(nanocontracts): return 400 on invalid before/after hex in on-chain blueprints resource

### DIFF
--- a/hathor/nanocontracts/resources/on_chain.py
+++ b/hathor/nanocontracts/resources/on_chain.py
@@ -81,8 +81,13 @@ class BlueprintOnChainResource(Resource):
         if not params.before and not params.after:
             iter_bps = bp_index.get_newest() if params.order.is_desc() else bp_index.get_oldest()
         else:
-            ref_tx_id = bytes.fromhex(params.before or params.after or '')
-            assert ref_tx_id
+            ref_tx_id = bytes_from_hex(params.before or params.after or '')
+            if not ref_tx_id:
+                request.setResponseCode(400)
+                error_response = ErrorResponse(
+                    success=False, error='Invalid before/after parameter: not a valid hex string.'
+                )
+                return error_response.json_dumpb()
             try:
                 ref_tx = bp_service.get_on_chain_blueprint(blueprint_id_from_bytes(ref_tx_id))
             except (BlueprintDoesNotExist, OCBInvalidBlueprintVertexType, OCBBlueprintNotConfirmed) as e:

--- a/hathor_tests/resources/nanocontracts/test_on_chain.py
+++ b/hathor_tests/resources/nanocontracts/test_on_chain.py
@@ -400,6 +400,15 @@ class BlueprintOnChainResourceTest(_BaseResourceTest._ResourceTest):
             blueprints=[],
         )
 
+    async def test_invalid_before_after_param(self) -> None:
+        # A non-hex `before`/`after` must yield a 400, not an uncaught
+        # ValueError from bytes.fromhex() that bubbles up as a 500 (see the
+        # on-call alert for mainnet fullnodes on 2026-07-06).
+        for param in (b'before', b'after'):
+            for bad_value in (b'not-hex', b'zzzz', b'abc'):
+                response = await self.web.get('on_chain', {param: bad_value})
+                self.assertEqual(400, response.responseCode)
+
     async def test_search_by_name(self) -> None:
         response = await self.web.get('builtin', {
             b'search': b'Bet',


### PR DESCRIPTION
### Motivation

The on-chain blueprints resource (`GET /nano_contract/blueprint/on_chain`) parses the `before`/`after` pagination params with a bare `bytes.fromhex()` in `hathor/nanocontracts/resources/on_chain.py`. A non-hex value raises an uncaught `ValueError` ("non-hexadecimal number found in `fromhex()` arg") that bubbles through Twisted as a `500` and logs a traceback. On public mainnet fullnodes this endpoint is user-reachable, so a malformed request pages on-call (OpsGenie `52854`, 2026-07-06). Bad client input should be a `400`, not a server error + alert.

### Acceptance Criteria

- Parse `before`/`after` with the existing `bytes_from_hex()` helper (already used for the `search` param in the same handler) instead of a bare `bytes.fromhex()`.
- Return a `400` with an `ErrorResponse` when the value isn't valid hex, matching the resource's other validation branches (no traceback, no `500`).
- Add a regression test asserting `400` for non-hex `before`/`after` values.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged