### PR TITLE
tests: prevent flakiness by setting the correct tx timestamp

### DIFF
--- a/hathor/simulator/utils.py
+++ b/hathor/simulator/utils.py
@@ -164,6 +164,9 @@ def gen_new_double_spending(manager: HathorManager, *, use_same_parents: bool = 
     if use_same_parents:
         tx2.parents = list(tx.parents)
     else:
+        # the best block timestamp may be ahead of the clock (e.g. blocks mined less than a second apart), and
+        # `get_new_tx_parents` requires a timestamp not older than the best block's
+        tx2.timestamp = max(tx2.timestamp, manager.get_timestamp_for_new_vertex())
         tx2.parents = manager.get_new_tx_parents(tx2.timestamp)
 
     manager.cpu_mining_service.resolve(tx2)

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -160,6 +160,9 @@ def gen_custom_base_tx(manager: HathorManager,
         elif not tx_base.is_block:
             tx2.parents.append(tx_base.parents[0])
         else:
+            # the best block timestamp may be ahead of the clock (e.g. blocks mined less than a second apart in
+            # the simulator), and `get_new_tx_parents` requires a timestamp not older than the best block's
+            tx2.timestamp = max(tx2.timestamp, manager.get_timestamp_for_new_vertex())
             tx2.parents.extend(manager.get_new_tx_parents(tx2.timestamp))
             tx2.parents = tx2.parents[:2]
     assert len(tx2.parents) == 2


### PR DESCRIPTION
### Motivation

Some simulator tests fail intermittently when generating transactions. In the simulator, blocks can be mined less than a second apart, which makes the best block's timestamp run ahead of the clock. When a test helper then creates a transaction using the current clock time and asks `get_new_tx_parents` for parents, the requested timestamp is older than the best block's and the call fails, producing flaky test runs that depend on the simulation seed.

### Acceptance Criteria

- Transaction-generating test helpers (`gen_new_double_spending` in `hathor/simulator/utils.py` and `gen_custom_base_tx` in `hathor_tests/utils.py`) clamp the new transaction's timestamp to at least `manager.get_timestamp_for_new_vertex()` before selecting parents with `get_new_tx_parents`, so parent selection no longer fails when the best block's timestamp is ahead of the clock.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 