### PR TITLE
fix(nc-types): preserve actual types when deserializing NC values

### DIFF
--- a/hathor_tests/nanocontracts/test_blueprint.py
+++ b/hathor_tests/nanocontracts/test_blueprint.py
@@ -6,7 +6,16 @@ from hathor.nanocontracts.context import Context
 from hathor.nanocontracts.exception import BlueprintSyntaxError, NCFail, NCInsufficientFunds, NCViewMethodError
 from hathor.nanocontracts.nc_types import make_nc_type_for_arg_type as make_nc_type
 from hathor.nanocontracts.storage.contract_storage import Balance, BalanceKey
-from hathor.nanocontracts.types import Address, NCDepositAction, NCWithdrawalAction, TokenUid, public, view
+from hathor.nanocontracts.types import (
+    Address,
+    Amount,
+    NCDepositAction,
+    NCWithdrawalAction,
+    Timestamp,
+    TokenUid,
+    public,
+    view,
+)
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 
 STR_NC_TYPE = make_nc_type(str)
@@ -87,12 +96,35 @@ class MyBlueprint(Blueprint):
         return 1
 
 
+class NewTypeFieldsBlueprint(Blueprint):
+    y: Amount
+    t: Timestamp
+
+    @public
+    def initialize(self, ctx: Context, y: Amount, t: Timestamp) -> None:
+        self.y = y
+        self.t = t
+
+    @view
+    def get_y(self) -> Amount:
+        # Reading `self.y` must yield an `Amount` instance, not a plain `int`. This assert would fire if reading
+        # the field degraded it to the underlying base type.
+        assert isinstance(self.y, Amount)
+        return self.y
+
+    @view
+    def get_t(self) -> Timestamp:
+        assert isinstance(self.t, Timestamp)
+        return self.t
+
+
 class NCBlueprintTestCase(BlueprintTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.simple_fields_id = self._register_blueprint_class(SimpleFields)
         self.container_fields_id = self._register_blueprint_class(ContainerFields)
         self.my_blueprint_id = self._register_blueprint_class(MyBlueprint)
+        self.new_type_fields_id = self._register_blueprint_class(NewTypeFieldsBlueprint)
 
         genesis = self.manager.tx_storage.get_all_genesis()
         self.tx = [t for t in genesis if t.is_transaction][0]
@@ -112,6 +144,20 @@ class NCBlueprintTestCase(BlueprintTestCase):
         self.assertEqual(storage.get_obj(b'b', BYTES_NC_TYPE), b)
         self.assertEqual(storage.get_obj(b'c', INT_NC_TYPE), c)
         self.assertEqual(storage.get_obj(b'd', BOOL_NC_TYPE), d)
+
+    def test_new_type_field_getters_return_actual_types(self) -> None:
+        nc_id = self.new_type_fields_id
+        ctx = self.create_context()
+        self.runner.create_contract(nc_id, self.new_type_fields_id, ctx, Amount(100), Timestamp(1234567890))
+
+        # the field getters must return instances of the declared classes, not plain ints
+        y = self.runner.call_view_method(nc_id, 'get_y')
+        self.assertIsInstance(y, Amount)
+        self.assertEqual(y, 100)
+
+        t = self.runner.call_view_method(nc_id, 'get_t')
+        self.assertIsInstance(t, Timestamp)
+        self.assertEqual(t, 1234567890)
 
     def test_container_fields(self) -> None:
         nc_id = self.container_fields_id

--- a/hathorlib/hathorlib/nanocontracts/nc_types/bytes_nc_type.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_types/bytes_nc_type.py
@@ -21,7 +21,8 @@ class BytesLikeNCType(NCType[B]):
     """ Represents values from class that inherit/new-type `bytes`.
     """
 
-    __slots__ = ('_actual_type')
+    # XXX: `_actual_type` slot is inherited from the `NCType` base class
+    __slots__ = ()
     _is_hashable = True
     _actual_type: type[B]
 
@@ -39,7 +40,7 @@ class BytesLikeNCType(NCType[B]):
     def _check_value(self, value: bytes, /, *, deep: bool) -> None:
         if isclass(self._actual_type):
             if not isinstance(value, (bytes, self._actual_type)):
-                raise TypeError('expected {self._actual_type} instance')
+                raise TypeError(f'expected {self._actual_type} instance')
         else:
             if not isinstance(value, bytes):
                 raise TypeError('expected bytes instance')
@@ -71,11 +72,10 @@ class BytesNCType(BytesLikeNCType[bytes]):
     """ Represents builtin `bytes` values.
     """
     __slots__ = ()
-    _actual_type = bytes
 
     @override
     def __init__(self) -> None:
-        pass
+        super().__init__(bytes)
 
     @override
     @classmethod

--- a/hathorlib/hathorlib/nanocontracts/nc_types/fixed_size_bytes_nc_type.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_types/fixed_size_bytes_nc_type.py
@@ -15,6 +15,8 @@ B = TypeVar('B', bound=bytes)
 
 
 class _FixedSizeBytesNCType(NCType[B]):
+    # XXX: `_actual_type` slot is inherited from the `NCType` base class
+    __slots__ = ()
     _is_hashable = True
     _size: ClassVar[int]
     _actual_type: type[B]
@@ -70,4 +72,5 @@ class _FixedSizeBytesNCType(NCType[B]):
 
 
 class Bytes32NCType(_FixedSizeBytesNCType[B]):
+    __slots__ = ()
     _size = 32

--- a/hathorlib/hathorlib/nanocontracts/nc_types/namedtuple_nc_type.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_types/namedtuple_nc_type.py
@@ -16,7 +16,8 @@ N = TypeVar('N', bound=tuple)
 
 # XXX: we can't usefully describe the tuple type
 class NamedTupleNCType(NCType[N]):
-    __slots__ = ('_is_hashable', '_args', '_actual_type')
+    # XXX: `_actual_type` slot is inherited from the `NCType` base class
+    __slots__ = ('_is_hashable', '_args')
 
     # we can't even parametrize NCType, lists are allowed in tuples and it's still hashable it just fails in runtime
     _args: tuple[NCType, ...]

--- a/hathorlib/hathorlib/nanocontracts/nc_types/nc_type.py
+++ b/hathorlib/hathorlib/nanocontracts/nc_types/nc_type.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, NamedTuple, TypeAlias, TypeVar, final
+from typing import Any, Generic, NamedTuple, TypeAlias, TypeVar, final
 
 from typing_extensions import Self
 
@@ -15,6 +15,7 @@ from hathorlib.nanocontracts.nc_types.utils import (
     get_usable_origin_type,
 )
 from hathorlib.serialization import Deserializer, Serializer
+from hathorlib.utils.typing import is_subclass
 
 T = TypeVar('T')
 
@@ -39,10 +40,17 @@ class NCType(ABC, Generic[T]):
         nc_types_map: TypeToNCTypeMap
 
     # XXX: subclasses must override this if they need any properties
-    __slots__ = ()
+    __slots__ = ('_actual_type',)
 
     # XXX: subclasses must initialize this property
     _is_hashable: bool
+
+    # XXX: set by `NCType.from_type` to the declared (post-alias) type, and used to wrap deserialized values back
+    #      into newtype-like classes (e.g. `Amount`, `Timestamp`). It is unset when an NCType is constructed
+    #      directly, so it must be read with `getattr(self, '_actual_type', None)`. Some subclass constructors
+    #      also assign it, possibly to a non-class (e.g. `NodeNCType` uses the `NodeId` NewType), which
+    #      `_to_actual_type` must skip.
+    _actual_type: type[Any]
 
     @final
     @staticmethod
@@ -53,13 +61,18 @@ class NCType(ABC, Generic[T]):
         types with substitute types to use instead.
         """
         usable_origin = get_usable_origin_type(type_, type_map=type_map)
-        nc_type = type_map.nc_types_map[usable_origin]
+        nc_type_cls = type_map.nc_types_map[usable_origin]
         # XXX: first we try to create the nc_type without making an alias, this ensures that an invalid annotation
         #      would not be accepted
-        _ = nc_type._from_type(type_, type_map=type_map)
+        _ = nc_type_cls._from_type(type_, type_map=type_map)
         # XXX: then we create the actual nc_type with type-alias
         aliased_type = get_aliased_type(type_, type_map.alias_map)
-        return nc_type._from_type(aliased_type, type_map=type_map)
+        nc_type = nc_type_cls._from_type(aliased_type, type_map=type_map)
+        # XXX: generic aliases (`tuple[int, ...]`, unions, ...) are not `type` instances and are skipped, their
+        #      inner types get their own NCType instances through recursion into `NCType.from_type`
+        if isinstance(aliased_type, type):
+            nc_type._actual_type = aliased_type
+        return nc_type
 
     @final
     @staticmethod
@@ -84,6 +97,24 @@ class NCType(ABC, Generic[T]):
         """
         # XXX: a NCType that is only meant for local use does not need to implement _from_type
         raise TypeError(f'{cls} is not compatible with use in a NCType.TypeMap')
+
+    @final
+    def _to_actual_type(self, value: T, /) -> T:
+        """ Wrap `value` into the declared actual class when the inner implementation produced a base instance.
+
+        This is what makes a field/arg/return declared as a newtype-like class (e.g. `Amount`, `Timestamp`)
+        yield instances of that class instead of the underlying base type (e.g. `int`). Only newtype-style
+        upcasts are made: the declared type must be a plain class and a subclass of the value's type.
+        """
+        actual: type[Any] | None = getattr(self, '_actual_type', None)
+        if actual is None or not isinstance(actual, type):
+            return value
+        if isinstance(value, actual) or not is_subclass(actual, type(value)):
+            return value
+        # XXX: `type[Any]` is used because newtype-style constructors take a single base-class value, which cannot
+        #      be expressed for an arbitrary `type[T]`
+        wrapped: T = actual(value)
+        return wrapped
 
     @final
     def is_hashable(self) -> bool:
@@ -126,7 +157,7 @@ class NCType(ABC, Generic[T]):
         so checking is only made as a double check and results in AssertionError (no TypeError).
         """
         # XXX: subclasses must implement NCType._deserialize, not NCType.deserialize
-        value = self._deserialize(deserializer)
+        value = self._to_actual_type(self._deserialize(deserializer))
         self._check_value(value, deep=False)
         return value
 
@@ -154,7 +185,7 @@ class NCType(ABC, Generic[T]):
         Will raise a ValueError if the given `json_value` is not compatible.
         """
         # XXX: subclasses must implement NCType._json_to_value, not NCType.json_to_value
-        value = self._json_to_value(json_value)
+        value = self._to_actual_type(self._json_to_value(json_value))
         self._check_value(value, deep=False)
         return value
 

--- a/hathorlib/tests/test_nc_types.py
+++ b/hathorlib/tests/test_nc_types.py
@@ -3,13 +3,26 @@
 
 # mypy: disable-error-code="no-untyped-def"
 
+import json
 import unittest
+from typing import Any, NewType
 
 from hathorlib.nanocontracts.exception import BlueprintSyntaxError, NCInvalidAction
+from hathorlib.nanocontracts.nc_types import (
+    ESSENTIAL_TYPE_ALIAS_MAP,
+    BytesLikeNCType,
+    NCType,
+    VarUint32NCType,
+    make_nc_type_for_arg_type,
+    make_nc_type_for_field_type,
+    make_nc_type_for_return_type,
+)
 from hathorlib.nanocontracts.types import (
     NC_HTR_TOKEN_UID,
+    Address,
     Amount,
     BlueprintId,
+    CallerId,
     ContractId,
     NCAcquireAuthorityAction,
     NCActionType,
@@ -134,6 +147,148 @@ class TestCustomTypes(unittest.TestCase):
         bid = blueprint_id_from_bytes(data)
         self.assertIsInstance(bid, BlueprintId)
         self.assertEqual(bid, data)
+
+
+class TestActualTypeWrapping(unittest.TestCase):
+    """Deserializing must yield the declared actual class (e.g. `Amount`), not its base type (e.g. `int`)."""
+
+    def _json_roundtrip(self, nc_type: NCType, value: object) -> object:
+        """Roundtrip a value through an actual JSON encode/decode cycle."""
+        return nc_type.json_to_value(json.loads(json.dumps(nc_type.value_to_json(value))))
+
+    def test_amount_all_factories(self) -> None:
+        for make in (make_nc_type_for_field_type, make_nc_type_for_arg_type, make_nc_type_for_return_type):
+            nc_type = make(Amount)
+            value = nc_type.from_bytes(nc_type.to_bytes(Amount(100)))
+            self.assertIsInstance(value, Amount)
+            self.assertEqual(value, 100)
+
+    def test_amount_from_plain_int(self) -> None:
+        # values are serialized as plain ints, but must come back as Amount
+        nc_type = make_nc_type_for_field_type(Amount)
+        value = nc_type.from_bytes(nc_type.to_bytes(100))  # type: ignore[arg-type]
+        self.assertIsInstance(value, Amount)
+        self.assertEqual(value, 100)
+
+    def test_amount_roundtrip_bytes(self) -> None:
+        nc_type = make_nc_type_for_field_type(Amount)
+        for raw in (0, 1, 100, 2**64, 2**128):
+            value = nc_type.from_bytes(nc_type.to_bytes(Amount(raw)))
+            self.assertIsInstance(value, Amount)
+            self.assertEqual(value, raw)
+
+    def test_amount_json(self) -> None:
+        nc_type = make_nc_type_for_field_type(Amount)
+        self.assertEqual(nc_type.value_to_json(Amount(7)), 7)
+        value = self._json_roundtrip(nc_type, Amount(7))
+        self.assertIsInstance(value, Amount)
+        self.assertEqual(value, 7)
+
+    def test_timestamp(self) -> None:
+        nc_type = make_nc_type_for_field_type(Timestamp)
+        value = nc_type.from_bytes(nc_type.to_bytes(Timestamp(1234567890)))
+        self.assertIsInstance(value, Timestamp)
+        self.assertEqual(value, 1234567890)
+        json_value = self._json_roundtrip(nc_type, Timestamp(1234567890))
+        self.assertIsInstance(json_value, Timestamp)
+
+    def test_plain_int_is_not_wrapped(self) -> None:
+        # a plain `int` field must not be turned into an Amount
+        nc_type = make_nc_type_for_field_type(int)
+        value = nc_type.from_bytes(nc_type.to_bytes(5))
+        self.assertNotIsInstance(value, Amount)
+        self.assertIs(type(value), int)
+        self.assertEqual(value, 5)
+
+    def test_directly_constructed_nc_type_is_not_wrapped(self) -> None:
+        # an NCType built directly (not through `NCType.from_type`) has no declared actual type
+        nc_type = VarUint32NCType()
+        value = nc_type.from_bytes(nc_type.to_bytes(Amount(5)))
+        self.assertIs(type(value), int)
+
+    def test_containers_compose(self) -> None:
+        token = TokenUid(b'\x03' * 32)
+
+        dict_nc_type = make_nc_type_for_arg_type(dict[TokenUid, Amount])
+        for out in (
+            dict_nc_type.from_bytes(dict_nc_type.to_bytes({token: Amount(5)})),
+            self._json_roundtrip(dict_nc_type, {token: Amount(5)}),
+        ):
+            assert isinstance(out, dict)
+            (key, value), = out.items()
+            self.assertIsInstance(key, TokenUid)
+            self.assertIsInstance(value, Amount)
+
+        opt_nc_type: NCType[Amount | None] = make_nc_type_for_arg_type(Amount | None)  # type: ignore[arg-type]
+        self.assertIsInstance(opt_nc_type.from_bytes(opt_nc_type.to_bytes(Amount(7))), Amount)
+        self.assertIsNone(opt_nc_type.from_bytes(opt_nc_type.to_bytes(None)))
+
+        tuple_nc_type = make_nc_type_for_arg_type(tuple[Timestamp, ...])
+        out = tuple_nc_type.from_bytes(tuple_nc_type.to_bytes((Timestamp(1), Timestamp(2))))
+        assert isinstance(out, tuple)
+        for item in out:
+            self.assertIsInstance(item, Timestamp)
+
+        # `list` is aliased to `tuple` in the field map
+        list_nc_type = make_nc_type_for_field_type(list[Amount])
+        out = list_nc_type.from_bytes(list_nc_type.to_bytes((Amount(1), Amount(2))))  # type: ignore[arg-type]
+        assert isinstance(out, tuple)
+        for item in out:
+            self.assertIsInstance(item, Amount)
+
+    def test_bytes_actual_types_no_regression(self) -> None:
+        cases: list[tuple[type, bytes]] = [
+            (BlueprintId, BlueprintId(b'\x01' * 32)),
+            (ContractId, ContractId(b'\x02' * 32)),
+            (VertexId, VertexId(b'\x03' * 32)),
+            (TokenUid, TokenUid(b'\x04' * 32)),
+            (TokenUid, NC_HTR_TOKEN_UID),
+            (TxOutputScript, TxOutputScript(b'\x76\xa9')),
+        ]
+        for type_, value in cases:
+            nc_type: NCType[Any] = make_nc_type_for_field_type(type_)
+            out = nc_type.from_bytes(nc_type.to_bytes(value))
+            self.assertIs(type(out), type_)
+            self.assertEqual(out, value)
+            json_out = self._json_roundtrip(nc_type, value)
+            self.assertIsInstance(json_out, type_)
+            self.assertEqual(json_out, value)
+
+    def test_address_and_caller_id_no_regression(self) -> None:
+        address = Address(bytes.fromhex('2873c0a326af979a12be89ee8a00e8871c8e2765022e9b803c'))
+        contract_id = ContractId(b'\x05' * 32)
+
+        address_nc_type = make_nc_type_for_field_type(Address)
+        out = address_nc_type.from_bytes(address_nc_type.to_bytes(address))
+        self.assertIs(type(out), Address)
+        self.assertIsInstance(self._json_roundtrip(address_nc_type, address), Address)
+
+        caller_id_nc_type: NCType[CallerId] = make_nc_type_for_field_type(CallerId)  # type: ignore[arg-type]
+        for caller in (address, contract_id):
+            caller_out = caller_id_nc_type.from_bytes(caller_id_nc_type.to_bytes(caller))
+            self.assertIs(type(caller_out), type(caller))
+            self.assertEqual(caller_out, caller)
+            json_out = self._json_roundtrip(caller_id_nc_type, caller)
+            self.assertIs(type(json_out), type(caller))
+
+    def test_newtype_direct_construction_is_not_wrapped(self) -> None:
+        # some NCTypes are constructed directly with a NewType instead of a class (e.g. `NodeNCType` builds
+        # `BytesLikeNCType(NodeId)`), which must be skipped since a NewType cannot be isinstance-checked
+        node_id_type = NewType('node_id_type', bytes)
+        nc_type = BytesLikeNCType(node_id_type)
+        value = nc_type.from_bytes(nc_type.to_bytes(node_id_type(b'\x01' * 32)))
+        self.assertIs(type(value), bytes)
+        self.assertEqual(value, b'\x01' * 32)
+        json_value = self._json_roundtrip(nc_type, node_id_type(b'\x01' * 32))
+        self.assertIs(type(json_value), bytes)
+
+    def test_wrapping_is_mapping_independent(self) -> None:
+        # the declared type is preserved no matter which plain NCType class it is mapped to
+        type_map = NCType.TypeMap(ESSENTIAL_TYPE_ALIAS_MAP, {Amount: VarUint32NCType})
+        nc_type = NCType.from_type(Amount, type_map=type_map)
+        value = nc_type.from_bytes(nc_type.to_bytes(Amount(100)))
+        self.assertIsInstance(value, Amount)
+        self.assertEqual(value, 100)
 
 
 class TestSetMethodType(unittest.TestCase):


### PR DESCRIPTION
### Motivation

Nano contract values typed as `Amount` or `Timestamp` were being deserialized through `VarUint32NCType` and returning a value of plain `int`. As a result, reading an that field, or calling a method that returns `Amount`/`Timestamp`, or receiving an `Amount`/`Timestamp` argument would yield a plain `int` rather than the expected new-type instance.

### Acceptance Criteria

- Values deserialized through `NCType.deserialize` and `NCType.json_to_value` are wrapped back into the declared actual class (e.g. `Amount`, `Timestamp`) when it is a newtype-style subclass of the produced value's type, instead of degrading to the base type.
- `NCType.from_type` records the declared (post-alias) type in a new `_actual_type` slot on the `NCType` base class; `BytesLikeNCType` and `NamedTupleNCType` reuse the inherited slot instead of declaring their own, and directly constructed `NCType` instances remain unaffected (no wrapping).
- Plain base types (e.g. a field declared as `int`) are not wrapped, and generic aliases (`tuple[X, ...]`, unions, containers) keep working, with their inner types wrapped through recursion.
- Add `hathorlib` tests covering bytes and JSON roundtrips for `Amount`/`Timestamp`, container composition, mapping-independent wrapping, and no-regression for bytes-like types (`Address`, `TokenUid`, `ContractId`, etc.).
- Add a blueprint test verifying that field getters return instances of the declared classes at runtime.
- All existing mainnet OCBs have been verified against this change and there is no impact (none of the Blueprints are affected by the change in type for `Amount` or `Timestamp`)

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged