### PR TITLE
refactor(fees): introduce the fee policy configuration model [part 2/3]

### DIFF
--- a/hathor/conf/mainnet.py
+++ b/hathor/conf/mainnet.py
@@ -6,6 +6,7 @@ from hathor.conf.settings import HathorSettings
 from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.settings import Settings as FeatureActivationSettings
+from hathorlib.conf.fee_policy import FeePolicy, FeePolicyVersion
 from hathorlib.conf.settings import FeatureSetting
 
 SETTINGS = HathorSettings(
@@ -344,5 +345,15 @@ SETTINGS = HathorSettings(
                 signal_support_by_default=True,
             ),
         }
-    )
+    ),
+    FEE_POLICIES={
+        FeePolicyVersion.V1: {
+            # HTR
+            b'\x00': FeePolicy(
+                fee_based_tokens='0.01',
+                amount_shielded='0.01',
+                full_shielded='0.02',
+            ),
+        },
+    },
 )

--- a/hathor/feature_activation/utils.py
+++ b/hathor/feature_activation/utils.py
@@ -11,6 +11,7 @@ from hathor.feature_activation.feature import Feature
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.nanocontracts.nano_runtime_version import NanoRuntimeVersion
 from hathor.transaction.scripts.opcode import OpcodesVersion
+from hathorlib.conf.fee_policy import FeePolicyVersion
 from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
@@ -33,6 +34,7 @@ class Features:
     daa_version: DAAVersion
     shielded_transactions: bool
     token_amount_version: TokenAmountVersion
+    fee_policy_version: FeePolicyVersion
 
     @staticmethod
     def get_settings(settings: HathorSettings) -> dict[Feature, FeatureSetting]:
@@ -85,6 +87,7 @@ class Features:
             daa_version=daa_version,
             shielded_transactions=feature_is_active[Feature.SHIELDED_TRANSACTIONS],
             token_amount_version=token_amount_version,
+            fee_policy_version=FeePolicyVersion.V1,
         )
 
     @staticmethod
@@ -111,6 +114,7 @@ class Features:
             fee_tokens=features.fee_tokens,
             shielded_transactions=features.shielded_transactions,
             token_amount_version=features.token_amount_version,
+            fee_policy_version=features.fee_policy_version,
             # Indifferent features (come from the block state):
             nano_runtime_version=features.nano_runtime_version,
             daa_version=features.daa_version,
@@ -139,6 +143,7 @@ class Features:
             daa_version=DAAVersion.V2,
             shielded_transactions=True,
             token_amount_version=TokenAmountVersion.V2,
+            fee_policy_version=FeePolicyVersion.V1,
         )
 
 

--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Callable, Iterator, Mapping, TypeAlias, cast
 
 from hathor.feature_activation.utils import Features
 from hathor.nanocontracts.exception import NCFail
-from hathor.nanocontracts.nano_runtime_version import NanoRuntimeVersion
 from hathor.transaction import Block, Transaction
 from hathorlib.nanocontracts.runner.call_info import CallInfo
 from hathorlib.nanocontracts.runner.runner import MAX_SEQNUM_JUMP_SIZE
@@ -234,7 +233,7 @@ class NCBlockExecutor:
 
             # Execute transaction and yield the result directly
             result = self.execute_transaction(
-                runtime_version=features.nano_runtime_version,
+                features=features,
                 tx=tx,
                 block_storage=block_storage,
                 rng_seed=rng_seed,
@@ -257,7 +256,7 @@ class NCBlockExecutor:
     def execute_transaction(
         self,
         *,
-        runtime_version: NanoRuntimeVersion,
+        features: Features,
         tx: Transaction,
         block_storage: 'NCBlockStorage',
         rng_seed: bytes,
@@ -286,7 +285,7 @@ class NCBlockExecutor:
             return NCTxExecutionSkipped(tx=tx)
 
         runner = self._runner_factory.create(
-            runtime_version=runtime_version,
+            runtime_version=features.nano_runtime_version,
             token_amount_version=tx.get_token_amount_version(),
             block_storage=block_storage,
             seed=rng_seed,
@@ -336,7 +335,7 @@ class NCBlockExecutor:
 
             # after the execution we have the latest state in the storage + changes tracker
             # and at this point no tokens pending creation, so we can validate the balances
-            self._verify_transparent_balance_after_execution(tx, block_storage, runner)
+            self._verify_transparent_balance_after_execution(tx, block_storage, runner, features)
         except NCFail as e:
             runner.discard_pending_changes()
             return NCTxExecutionFailure(
@@ -357,6 +356,7 @@ class NCBlockExecutor:
         tx: Transaction,
         block_storage: 'NCBlockStorage',
         runner: 'Runner',
+        features: Features,
     ) -> None:
         """Run strict verify_sum after execution using uncommitted token overlay visibility."""
         from hathor.transaction.exceptions import TokenNotFound
@@ -367,7 +367,10 @@ class NCBlockExecutor:
         block_proxy_as_storage = cast('NCBlockStorage', block_proxy)
 
         try:
-            token_dict = tx.get_complete_token_info(block_proxy_as_storage)
+            token_dict = tx.get_complete_token_info(
+                block_proxy_as_storage,
+                fee_policy_version=features.fee_policy_version,
+            )
             TransactionVerifier.verify_transparent_balance(self._settings, tx, token_dict)
         except TokenNotFound as e:
             # Missing tokens should have failed in earlier validation paths.

--- a/hathor/p2p/sync_v2/transaction_streaming_client.py
+++ b/hathor/p2p/sync_v2/transaction_streaming_client.py
@@ -22,6 +22,7 @@ from hathor.transaction.exceptions import HathorError, TxValidationError
 from hathor.transaction.scripts.opcode import OpcodesVersion
 from hathor.types import VertexId
 from hathor.verification.verification_params import VerificationParams
+from hathorlib.conf.fee_policy import FeePolicyVersion
 from hathorlib.token_amount_version import TokenAmountVersion
 
 if TYPE_CHECKING:
@@ -58,6 +59,7 @@ class TransactionStreamingClient:
                 daa_version=DAAVersion.V1,
                 shielded_transactions=False,
                 token_amount_version=TokenAmountVersion.V1,
+                fee_policy_version=FeePolicyVersion.V1,
             )
         )
 

--- a/hathor/transaction/headers/fee_header.py
+++ b/hathor/transaction/headers/fee_header.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from hathor.transaction.util import get_deposit_token_withdraw_amount
 from hathor.types import TokenUid
 from hathorlib.token_amount import UnsignedAmount
 
@@ -48,13 +47,3 @@ class FeeHeader:
             )
             for fee in self.fees
         ]
-
-    def total_fee_amount(self) -> UnsignedAmount:
-        """Sum fees amounts in this header and return as HTR"""
-        total_fee = UnsignedAmount.zero()
-        for fee in self.get_fees():
-            if fee.token_uid == self.settings.HATHOR_TOKEN_UID:
-                total_fee += fee.amount
-            else:
-                total_fee += get_deposit_token_withdraw_amount(self.settings, fee.amount)
-        return total_fee

--- a/hathor/transaction/resources/create_tx.py
+++ b/hathor/transaction/resources/create_tx.py
@@ -118,7 +118,11 @@ class CreateTxResource(Resource):
         verifiers.vertex.verify_parents(tx)
 
         block_storage = self.manager.get_nc_block_storage(best_block)
-        verifiers.tx.verify_transparent_balance(self.manager._settings, tx, tx.get_complete_token_info(block_storage))
+        verifiers.tx.verify_transparent_balance(
+            self.manager._settings,
+            tx,
+            tx.get_complete_token_info(block_storage, fee_policy_version=params.features.fee_policy_version),
+        )
 
 
 CreateTxResource.openapi = {

--- a/hathor/transaction/token_info.py
+++ b/hathor/transaction/token_info.py
@@ -1,15 +1,18 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from hathor.types import TokenUid
+from hathorlib.conf.settings import HATHOR_TOKEN_UID
+from hathorlib.nanocontracts.runner.token_fees import FeeCharge
 from hathorlib.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion  # noqa: F401
 
 if TYPE_CHECKING:
-    from hathor.conf.settings import HathorSettings
     from hathor.nanocontracts.storage import NCBlockStorage
     from hathor.transaction.storage import TransactionStorage
 
@@ -42,41 +45,40 @@ class TokenInfo:
 
 
 class TokenInfoDict(dict[TokenUid, TokenInfo]):
-    __slots__ = ('fees_from_fee_header',)
+    __slots__ = ('header_fee',)
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.fees_from_fee_header = UnsignedAmount.zero()
+    def __init__(self) -> None:
+        super().__init__()
+        # The charge paying the header fee, aggregated by `Transaction._update_token_info_from_fees`.
+        # It is None while some fee token's version is unresolved (the token is created by the tx's
+        # own nano execution), in which case fee checks are deferred to post-execution verification.
+        self.header_fee: FeeCharge | None = None
 
-    def calculate_fee(self, settings: 'HathorSettings') -> UnsignedAmount:
+    def calculate_fee(self) -> UnsignedAmount:
         """
-         Calculate the total fee based on the number of chargeable
-         outputs and inputs for each token in the transaction.
+        Calculate the total fee based on the number of chargeable
+        outputs and inputs for each token in the transaction.
 
-         The Transaction.get_complete_token_info() should be called before calculating the fee.
+        The Transaction.get_complete_token_info() should be called before calculating the fee.
 
-         The fee is determined using the following rules:
-         - If a token has one or more chargeable outputs, the fee is calculated
-           as `chargeable_outputs * settings.FEE_PER_OUTPUT_V1`.
-         - If a token has zero chargeable outputs but one or more chargeable inputs,
-           a flat fee of `settings.FEE_PER_OUTPUT_V1` is applied.
+        Each token is charged a number of units, determined using the following rules:
+        - If a token has one or more chargeable outputs, it's charged one unit per chargeable output.
+        - If a token has zero chargeable outputs but one or more chargeable inputs, it's charged a flat single unit.
 
-         Args:
-             settings (HathorSettings): The configuration object containing fee-related
-                 parameters, such as `FEE_PER_OUTPUT_V1`.
-
-         Returns:
-             int: The total transaction fee
-         """
-        fee = 0
+        The price of a unit is set by the fee policy in `header_fee`, that is, by the token paying the fee.
+        """
+        units = 0
 
         for token_uid, token_info in self.items():
             if token_info.chargeable_outputs > 0:
-                fee += token_info.chargeable_outputs * settings.FEE_TOKEN_AMOUNT_PER_OUTPUT.normalized()
+                units += token_info.chargeable_outputs
             else:
                 if token_info.chargeable_inputs > 0:
-                    fee += settings.FEE_TOKEN_AMOUNT_PER_OUTPUT.normalized()
-        return UnsignedAmount.from_v2(fee)
+                    units += 1
+
+        assert self.header_fee is not None, 'calculate_fee is only valid after header_fee has been aggregated'
+        fee_per_unit = self.header_fee.policy.get_fee_based_tokens()
+        return UnsignedAmount.from_v2(units * fee_per_unit.normalized())
 
 
 def get_token_version(
@@ -88,7 +90,6 @@ def get_token_version(
     Get the token version for a given token uid.
     It searches first in the tx storage and then in the block storage.
     """
-    from hathorlib.conf.settings import HATHOR_TOKEN_UID
     if token_uid == HATHOR_TOKEN_UID:
         return TokenVersion.NATIVE
     from hathor.transaction.storage.exceptions import TransactionDoesNotExist

--- a/hathor/transaction/transaction.py
+++ b/hathor/transaction/transaction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypeVar
 
+from htr_lib import UnsignedAmount
 from typing_extensions import Self, final, override
 
 from hathor.checkpoint import Checkpoint
@@ -14,17 +15,14 @@ from hathor.serialization import Serializer
 from hathor.transaction import TxInput, TxOutput, TxVersion
 from hathor.transaction.base_transaction import GenericVertex
 from hathor.transaction.exceptions import InvalidToken
-from hathor.transaction.headers import (
-    AnyVertexHeader,
-    NanoHeader,
-    ShieldedOutputsHeader,
-    UnshieldBalanceHeader,
-)
+from hathor.transaction.headers import AnyVertexHeader, NanoHeader, ShieldedOutputsHeader, UnshieldBalanceHeader
 from hathor.transaction.headers.fee_header import FeeHeader
 from hathor.transaction.static_metadata import TransactionStaticMetadata
 from hathor.transaction.token_info import TokenInfo, TokenInfoDict, TokenVersion, get_token_version
 from hathor.transaction.util import VerboseCallback
 from hathor.types import TokenUid, VertexId
+from hathorlib.conf.fee_policy import FeePolicyVersion
+from hathorlib.nanocontracts.runner.token_fees import aggregate_fee_charges
 from hathorlib.token_amount_version import TokenAmountVersion
 from hathorlib.transaction.shielded_tx_output import ShieldedOutput
 
@@ -302,7 +300,12 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
         raise InvalidNewTransaction(f'Invalid new transaction {self.hash_hex}: expected to reach a checkpoint but '
                                     'none of its children is checkpoint-valid')
 
-    def get_complete_token_info(self, nc_block_storage: NCBlockStorage) -> TokenInfoDict:
+    def get_complete_token_info(
+        self,
+        nc_block_storage: NCBlockStorage,
+        *,
+        fee_policy_version: FeePolicyVersion,
+    ) -> TokenInfoDict:
         """
         Get a complete token info dict, including data from both inputs and outputs.
         It uses a block storage with the latest token changes in nano contracts
@@ -312,7 +315,7 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
         self._update_token_info_from_nano_actions(token_dict=token_dict, nc_block_storage=nc_block_storage)
         # These must be called last so token_dict already contains all tokens in inputs and nano actions.
         self._update_token_info_from_outputs(token_dict=token_dict)
-        self._update_token_info_from_fees(token_dict=token_dict)
+        self._update_token_info_from_fees(token_dict=token_dict, fee_policy_version=fee_policy_version)
 
         return token_dict
 
@@ -346,28 +349,40 @@ class Transaction(GenericVertex[TransactionStaticMetadata]):
                 )
             rules.verification_rule(token_dict)
 
-    def _update_token_info_from_fees(self, *, token_dict: TokenInfoDict) -> None:
-        """Update token_dict with fees from fee header"""
+    def _update_token_info_from_fees(self, *, token_dict: TokenInfoDict, fee_policy_version: FeePolicyVersion) -> None:
+        """Apply fee-header amounts to `token_dict` balances and aggregate `token_dict.header_fee`.
 
-        if not self.has_fees():
-            return
+        With no fee header, `header_fee` is a zero charge.
+        """
+        fees = self.get_fee_header().get_fees() if self.has_fees() else []
 
-        fee_header = self.get_fee_header()
-        fees = fee_header.get_fees()
-        # we store the total fee amount from the header to be used in verify_transparent_balance
-        token_dict.fees_from_fee_header = fee_header.total_fee_amount()
+        # `charges` becomes None when some fee token's version is unresolved, i.e., the token doesn't
+        # exist in storage yet because it's created by this tx's own nano execution. In that case fee
+        # aggregation is impossible at this point, `token_dict.header_fee` stays None, and
+        # `verify_transparent_balance` skips its fee checks; the post-execution verification re-runs
+        # this with every version resolved.
+        charges: list[tuple[bytes, TokenVersion, UnsignedAmount]] | None = []
         for fee in fees:
             token_info = token_dict.get(fee.token_uid)
             if token_info is None:
-                raise InvalidToken('no inputs/actions for token {}'.format(fee.token_uid.hex()))
+                raise InvalidToken(f'no inputs/actions for token {fee.token_uid.hex()}')
+            if token_info.version is None:
+                charges = None
+                continue
+            if charges is not None:
+                charges.append((fee.token_uid, token_info.version, fee.amount))
 
-            # it should be defined in the inputs/actions
-            if token_info.version not in (None, TokenVersion.NATIVE, TokenVersion.DEPOSIT):
-                raise InvalidToken('token {} cannot be used to pay fees'.format(fee.token_uid.hex()))
+        if charges is not None:
+            # we store the fee charge from the header to be used in verify_transparent_balance
+            token_dict.header_fee = aggregate_fee_charges(
+                settings=self._settings,
+                fee_policy_version=fee_policy_version,
+                charges=charges,
+            )
 
-            # act as a regular output subtracting from the total amount (which is done with sum in this context)
-            token_info.amount += fee.amount.to_signed()
-            token_dict[fee.token_uid] = token_info
+        # fees act as regular outputs, subtracting from the total amount (which is done with sum in this context)
+        for fee in fees:
+            token_dict[fee.token_uid].amount += fee.amount.to_signed()
 
     def _get_token_info_from_inputs(self, nc_block_storage: NCBlockStorage) -> TokenInfoDict:
         """Sum up all tokens present in the inputs and their properties (amount, can_mint, can_melt)

--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -321,11 +321,14 @@ class TransactionVerifier:
             assert tx.is_nano_contract()
             return
 
-        expected_fee = token_dict.calculate_fee(settings)
-        if expected_fee != token_dict.fees_from_fee_header:
+        # Fee tokens are always present in token_dict, so an unresolved fee token implies
+        # `has_nonexistent_tokens` above; reaching this point means header_fee was aggregated.
+        assert token_dict.header_fee is not None
+        expected_fee = token_dict.calculate_fee()
+        if expected_fee != token_dict.header_fee.amount:
             raise InputOutputMismatch(
-                f'Fee amount is different than expected. '
-                f'(amount={token_dict.fees_from_fee_header}, expected={expected_fee})'
+                f'Fee amount is different than expected. (token={token_dict.header_fee.token_uid.hex()}, '
+                f'amount={token_dict.header_fee.amount}, expected={expected_fee})'
             )
 
         if htr_info.amount < htr_expected_amount.to_signed():

--- a/hathor/verification/verification_service.py
+++ b/hathor/verification/verification_service.py
@@ -254,10 +254,11 @@ class VerificationService:
         self.verifiers.tx.verify_version(tx, params)
 
         block_storage = self._get_block_storage(params)
+        fee_policy_version = params.features.fee_policy_version
         self.verifiers.tx.verify_transparent_balance(
             self._settings,
             tx,
-            token_dict or tx.get_complete_token_info(block_storage),
+            token_dict or tx.get_complete_token_info(block_storage, fee_policy_version=fee_policy_version),
             # if this tx isn't a nano contract we assume we can find all the tokens to validate this tx
             allow_nonexistent_tokens=tx.is_nano_contract()
         )
@@ -273,7 +274,10 @@ class VerificationService:
         """
         # we should validate the token info before verifying the tx
         self.verifiers.token_creation_tx.verify_token_info(tx, params)
-        token_dict = tx.get_complete_token_info(self._get_block_storage(params))
+        token_dict = tx.get_complete_token_info(
+            self._get_block_storage(params),
+            fee_policy_version=params.features.fee_policy_version,
+        )
         self._verify_tx(tx, params, token_dict=token_dict)
         self.verifiers.token_creation_tx.verify_minted_tokens(tx, token_dict)
 

--- a/hathor_tests/dag_builder/test_dag_builder.py
+++ b/hathor_tests/dag_builder/test_dag_builder.py
@@ -669,7 +669,7 @@ if foo:
 
 
     def test_token_amount_version_fee_token(self) -> None:
-        # A fee-based token-creation transaction is charged FEE_TOKEN_AMOUNT_PER_OUTPUT (0.01 HTR)
+        # A fee-based token-creation transaction is charged the HTR fee policy's per-unit fee (0.01 HTR)
         # per minted output, and so is a transaction that holds the resulting fee tokens. The fee
         # is encoded in each vertex's own decimal version, so the V1 vertices spell 0.01 HTR as `1`
         # while the V2 vertices spell the same 0.01 HTR as 10 ** 16.

--- a/hathor_tests/nanocontracts/test_actions_fee.py
+++ b/hathor_tests/nanocontracts/test_actions_fee.py
@@ -7,7 +7,7 @@ import pytest
 
 from hathor.nanocontracts.blueprint import Blueprint
 from hathor.nanocontracts.context import Context
-from hathor.nanocontracts.exception import NCInvalidFee, NCInvalidFeePaymentToken
+from hathor.nanocontracts.exception import NCFail, NCInvalidFee
 from hathor.nanocontracts.storage.contract_storage import Balance, BalanceKey
 from hathor.nanocontracts.types import ContractId, NCDepositAction, NCFee, NCWithdrawalAction, TokenUid, public
 from hathor.nanocontracts.utils import derive_child_token_id
@@ -17,6 +17,7 @@ from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.test_reentrancy import HTR_TOKEN_UID
 from hathor_tests.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.conf.settings import HATHOR_TOKEN_UID
+from hathorlib.exceptions import InvalidFeePaymentToken
 
 
 class MyBlueprint(Blueprint):
@@ -368,9 +369,9 @@ class NCActionsFeeTestCase(BlueprintTestCase):
                 fee_amount=200
             )
 
-        # paying fees with a fee token is forbidden
-        msg = "fee-based tokens aren't allowed for paying fees"
-        with pytest.raises(NCInvalidFeePaymentToken, match=msg):
+        # paying fees with a fee token is forbidden. The metered executor converts the
+        # InvalidFeePaymentToken raised by the actions-fee validation into a bare NCFail.
+        with pytest.raises(NCFail) as e:
             self.runner.call_public_method(
                 self.nc1_id,
                 'move_tokens_to_nc',
@@ -381,6 +382,8 @@ class NCActionsFeeTestCase(BlueprintTestCase):
                 fee_payment_token=fbt_token_uid,
                 fee_amount=100
             )
+        assert isinstance(e.value.__cause__, InvalidFeePaymentToken)
+        assert str(e.value.__cause__) == f'cannot pay fees with token {fbt_token_uid.hex()}'
 
         assert self.nc1_storage.get_all_balances() == {
             nc1_htr_balance_key: Balance(value=UnsignedAmount.from_v1(87).to_signed(), can_mint=False, can_melt=False),

--- a/hathor_tests/nanocontracts/test_fee_tokens.py
+++ b/hathor_tests/nanocontracts/test_fee_tokens.py
@@ -219,7 +219,7 @@ class FeeTokensTestCase(BlueprintTestCase):
             manager=self.manager,
             tx_id=tx2.hash,
             block_id=b12.hash,
-            reason='InputOutputMismatch: Fee amount is different than expected. (amount=0.01, expected=0.0)',
+            reason='InputOutputMismatch: Fee amount is different than expected. (token=00, amount=0.01, expected=0.0)',
         )
 
     def test_postponed_token_verification_failure_does_not_contaminate_state(self) -> None:
@@ -277,7 +277,7 @@ class FeeTokensTestCase(BlueprintTestCase):
             manager=self.manager,
             tx_id=tx2.hash,
             block_id=b12.hash,
-            reason='InputOutputMismatch: Fee amount is different than expected. (amount=0.01, expected=0.0)',
+            reason='InputOutputMismatch: Fee amount is different than expected. (token=00, amount=0.01, expected=0.0)',
         )
 
         nc_storage_after_fail = self.manager.get_best_block_nc_storage(tx1.hash)
@@ -447,7 +447,7 @@ class FeeTokensTestCase(BlueprintTestCase):
             manager=self.manager,
             tx_id=tx2.hash,
             block_id=b12.hash,
-            reason=f'InvalidToken: token {fbt_id.hex()} cannot be used to pay fees',
+            reason=f'InvalidFeePaymentToken: cannot pay fees with token {fbt_id.hex()}',
         )
 
     def test_postponed_verification_tx_spending_nano(self) -> None:

--- a/hathor_tests/nanocontracts/test_runtime_v2.py
+++ b/hathor_tests/nanocontracts/test_runtime_v2.py
@@ -16,16 +16,17 @@ from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
-from hathorlib.conf.settings import FeatureSetting
+from hathorlib.conf.settings import HATHOR_TOKEN_UID, FeatureSetting
 from hathorlib.nanocontracts import NanoRuntimeVersion
 from hathorlib.nanocontracts.exception import NCFail
+from hathorlib.nanocontracts.types import TokenUid
 
 
 class MyBlueprint(Blueprint):
     @public
     def initialize(self, ctx: Context) -> int:
         settings = self.syscall.get_settings()
-        return settings.fee_per_output
+        return settings.fee_policies[TokenUid(HATHOR_TOKEN_UID)].fee_based_tokens
 
 
 class TestRuntimeV2(BlueprintTestCase):
@@ -43,7 +44,8 @@ class TestRuntimeV2(BlueprintTestCase):
     def test_syscall_get_settings_v2(self) -> None:
         self.runner = self.build_runner(NanoRuntimeVersion.V2)
         result = self.runner.create_contract(self.contract_id, self.blueprint_id, self.create_context())
-        assert result == self._settings.FEE_PER_OUTPUT_V1
+        # The V1 fee policy charges 0.01 HTR per output, and the runner reports it in V1 units.
+        assert result == 1
 
     def test_activation(self) -> None:
         feature_settings = FeatureSettings(

--- a/hathor_tests/nanocontracts/test_syscalls.py
+++ b/hathor_tests/nanocontracts/test_syscalls.py
@@ -671,22 +671,24 @@ class NCNanoContractTestCase(BlueprintTestCase):
             ft1_balance_key: Balance(value=UnsignedAmount.from_v1(1000000).to_signed(), can_mint=True, can_melt=True),
         }
 
-        # Try to create another fee token using the first fee token as payment - should be rejected
+        # Try to create another fee token using the first fee token as payment - should be rejected,
+        # since it's a fee-based token absent from the fee policy
         from hathor.nanocontracts.exception import NCInvalidFeePaymentToken
-        with pytest.raises(NCInvalidFeePaymentToken, match="fee-based tokens aren't allowed for paying fees"):
+        expected_msg = f'cannot pay fees with token {fee_token_uid.hex()}'
+        with pytest.raises(NCInvalidFeePaymentToken, match=expected_msg):
             self.runner.call_public_method(
                 nc_id, 'create_fee_token', self.create_context(),
                 'FeeToken2', 'FT2', 500000, fee_token_uid
             )
 
-        # Also test that fee tokens cannot be used as payment for minting
-        with pytest.raises(NCInvalidFeePaymentToken, match="fee-based tokens aren't allowed for paying fees"):
+        # Also test that such fee tokens cannot be used as payment for minting
+        with pytest.raises(NCInvalidFeePaymentToken, match=expected_msg):
             self.runner.call_public_method(
                 nc_id, 'mint', self.create_context(), fee_token_uid, 100, fee_token_uid
             )
 
-        # Also test that fee tokens cannot be used as payment for melting
-        with pytest.raises(NCInvalidFeePaymentToken, match="fee-based tokens aren't allowed for paying fees"):
+        # Also test that such fee tokens cannot be used as payment for melting
+        with pytest.raises(NCInvalidFeePaymentToken, match=expected_msg):
             self.runner.call_public_method(
                 nc_id, 'melt', self.create_context(), fee_token_uid, 100, fee_token_uid
             )

--- a/hathor_tests/resources/transaction/test_tx.py
+++ b/hathor_tests/resources/transaction/test_tx.py
@@ -586,9 +586,10 @@ class _BaseTransactionTest(_BaseResourceTest._ResourceTest):
         self.assertIn('token_uid', fee_entry)
         self.assertIn('amount', fee_entry)
 
-        # The fee is paid in HTR (token_index=0)
+        # The fee is paid in HTR (token_index=0), and the V1 fee policy charges 0.01 HTR per output,
+        # which this V1 vertex encodes as 1.
         self.assertEqual(fee_entry['token_uid'], self._settings.HATHOR_TOKEN_UID.hex())
-        self.assertEqual(fee_entry['amount'], self._settings.FEE_PER_OUTPUT_V1)
+        self.assertEqual(fee_entry['amount'], 1)
 
     @inlineCallbacks
     def test_get_transaction_without_fee_header(self):

--- a/hathor_tests/tx/test_fee_tokens.py
+++ b/hathor_tests/tx/test_fee_tokens.py
@@ -18,6 +18,7 @@ from hathor_tests import unittest
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.token_amount import UnsignedAmount
 from hathor_tests.utils import add_blocks_unlock_reward, create_fee_tokens, create_tokens, get_genesis_key
+from hathorlib.conf.fee_policy import FeePolicyVersion
 from hathorlib.conf.settings import FeatureSetting
 
 
@@ -97,9 +98,11 @@ class FeeTokenTest(unittest.TestCase):
 
         # Melt 100 tokens from fee_token and add 4 outputs, should charge only by the outputs count
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(4))
-        self.assertEqual(tx_fee, fee_header.total_fee_amount())
+        assert token_info.header_fee is not None
+        self.assertEqual(tx_fee, token_info.header_fee.amount)
         #  It's the tx item output signature
         #  this signature_data allows the tx output to be spent by the tx2 inputs
         self.sign_inputs(tx2)
@@ -150,7 +153,8 @@ class FeeTokenTest(unittest.TestCase):
         # melting 2 tokens without outputs, should charge FEE_PER_OUT * 2 = 2
         # melting 1 token with outputs, should charge 1 per non-authority output = 3
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx3_fee = tx3.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx3.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx3_fee = token_info.calculate_fee()
         # Multiple inputs should be only charge once per token when no outputs are present
         self.assertEqual(tx3_fee, UnsignedAmount.from_v1(5))
 
@@ -201,9 +205,11 @@ class FeeTokenTest(unittest.TestCase):
 
         # pick the last tip tx output in HTR then subtracts the fee
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
-        self.assertEqual(tx_fee, fee_header.total_fee_amount())
+        assert token_info.header_fee is not None
+        self.assertEqual(tx_fee, token_info.header_fee.amount)
 
         #  It's the tx item output signature
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -254,10 +260,12 @@ class FeeTokenTest(unittest.TestCase):
 
         # pick the last tip tx output in HTR then subtracts the fee
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         # check if only the melting operation was considered
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
-        self.assertEqual(tx_fee, fee_header.total_fee_amount())
+        assert token_info.header_fee is not None
+        self.assertEqual(tx_fee, token_info.header_fee.amount)
 
         self.sign_inputs(tx2)
         self.resolve_and_propagate(tx2)
@@ -313,9 +321,11 @@ class FeeTokenTest(unittest.TestCase):
         tx2.headers.append(fee_header)
 
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
-        self.assertEqual(tx_fee, fee_header.total_fee_amount())
+        assert token_info.header_fee is not None
+        self.assertEqual(tx_fee, token_info.header_fee.amount)
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -394,9 +404,11 @@ class FeeTokenTest(unittest.TestCase):
         tx2.headers.append(fee_header)
 
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
-        self.assertEqual(tx_fee, fee_header.total_fee_amount())
+        assert token_info.header_fee is not None
+        self.assertEqual(tx_fee, token_info.header_fee.amount)
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -473,9 +485,11 @@ class FeeTokenTest(unittest.TestCase):
         )
         tx2.headers.append(fee_header)
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(5))
-        self.assertEqual(tx_fee, fee_header.total_fee_amount())
+        assert token_info.header_fee is not None
+        self.assertEqual(tx_fee, token_info.header_fee.amount)
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -530,9 +544,11 @@ class FeeTokenTest(unittest.TestCase):
         tx2.headers.append(fee_header)
         # pick the last tip tx output in HTR then subtracts the fee
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(1))
-        self.assertEqual(fee_header.total_fee_amount(), UnsignedAmount.from_v1(1))
+        assert token_info.header_fee is not None
+        self.assertEqual(token_info.header_fee.amount, UnsignedAmount.from_v1(1))
 
         #  It's the signature of the output of the tx item
         #  this signature_data allows the tx output to be spent by the tx2 inputs
@@ -580,7 +596,8 @@ class FeeTokenTest(unittest.TestCase):
             timestamp=int(self.clock.seconds())
         )
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.from_v1(2))
 
         #  It's the signature of the output of the tx item
@@ -590,7 +607,7 @@ class FeeTokenTest(unittest.TestCase):
         with pytest.raises(InvalidNewTransaction) as e:
             self.resolve_and_propagate(tx2)
         assert isinstance(e.value.__cause__, InputOutputMismatch)
-        expected_msg = 'Fee amount is different than expected. (amount=0.0, expected=0.02)'
+        expected_msg = 'Fee amount is different than expected. (token=00, amount=0.0, expected=0.02)'
         assert expected_msg in str(e.value)
 
     def test_fee_token_burn_authority(self) -> None:
@@ -614,7 +631,8 @@ class FeeTokenTest(unittest.TestCase):
             timestamp=int(self.clock.seconds())
         )
         nc_storage = self.manager.get_nc_block_storage(self.manager.tx_storage.get_best_block())
-        tx_fee = tx2.get_complete_token_info(nc_storage).calculate_fee(self.manager._settings)
+        token_info = tx2.get_complete_token_info(nc_storage, fee_policy_version=FeePolicyVersion.V1)
+        tx_fee = token_info.calculate_fee()
         self.assertEqual(tx_fee, UnsignedAmount.zero())
 
         #  It's the signature of the output of the tx item
@@ -769,4 +787,4 @@ class FeeTokenTest(unittest.TestCase):
             artifacts.propagate_with(self.manager, up_to='tx1')
 
         assert isinstance(e.value.__cause__, InvalidNewTransaction)
-        assert e.value.__cause__.args[0] == f'full validation failed: token {fbt.hash_hex} cannot be used to pay fees'
+        assert e.value.__cause__.args[0] == f'full validation failed: cannot pay fees with token {fbt.hash_hex}'

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -51,6 +51,7 @@ from hathor_tests.utils import (
     create_script_with_sigops,
     get_genesis_key,
 )
+from hathorlib.conf.fee_policy import FeePolicyVersion
 from hathorlib.serialization import BadDataError, Deserializer, Serializer
 from hathorlib.serialization.encoding.output_value import decode_output_value_v1, encode_output_value_v1
 
@@ -98,7 +99,9 @@ class TransactionTest(unittest.TestCase):
         block_storage = self.manager.get_nc_block_storage(best_block)
         with self.assertRaises(InputOutputMismatch):
             self._verifiers.tx.verify_transparent_balance(
-                self._settings, tx, tx.get_complete_token_info(block_storage)
+                self._settings,
+                tx,
+                tx.get_complete_token_info(block_storage, fee_policy_version=FeePolicyVersion.V1),
             )
 
     def test_input_output_match_more_htr(self):
@@ -121,7 +124,9 @@ class TransactionTest(unittest.TestCase):
         block_storage = self.manager.get_nc_block_storage(best_block)
         with self.assertRaises(InputOutputMismatch):
             self._verifiers.tx.verify_transparent_balance(
-                self._settings, tx, tx.get_complete_token_info(block_storage)
+                self._settings,
+                tx,
+                tx.get_complete_token_info(block_storage, fee_policy_version=FeePolicyVersion.V1),
             )
 
     def test_validation(self):

--- a/hathor_tests/utils.py
+++ b/hathor_tests/utils.py
@@ -33,6 +33,7 @@ from hathor.transaction.token_info import TokenVersion
 from hathor.transaction.util import get_deposit_token_deposit_amount
 from hathor.util import Random
 from hathor_tests.token_amount import UnsignedAmount
+from hathorlib.conf.fee_policy import FeePolicyVersion
 from hathorlib.scripts import DataScript
 
 settings = HathorSettings()
@@ -607,8 +608,9 @@ def create_fee_tokens(
     outputs.append(TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MINT_MASK), script, 0b10000001))
     outputs.append(TxOutput(UnsignedAmount.from_v1(TxOutput.TOKEN_MELT_MASK), script, 0b10000001))
 
-    # fee
-    fee = settings.FEE_TOKEN_AMOUNT_PER_OUTPUT
+    # fee, in V1 units since this tx is built entirely with V1 amounts
+    htr_fee_policy = settings.get_fee_policies(FeePolicyVersion.V1)[settings.HATHOR_TOKEN_UID]
+    fee = htr_fee_policy.get_fee_based_tokens().to_v1()
 
     # fee output
     fee_output_raw = (

--- a/hathorlib/hathorlib/conf/fee_policy.py
+++ b/hathorlib/hathorlib/conf/fee_policy.py
@@ -1,0 +1,40 @@
+#  SPDX-FileCopyrightText: Hathor Labs
+#  SPDX-License-Identifier: Apache-2.0
+
+from enum import StrEnum, auto, unique
+from functools import lru_cache
+from typing import Annotated, TypeAlias
+
+from htr_lib import UnsignedAmount
+from pydantic import BeforeValidator
+
+from hathorlib.conf.utils import parse_hex_str
+from hathorlib.utils.pydantic import BaseModel
+
+
+@unique
+class FeePolicyVersion(StrEnum):
+    """The version of the fee policy, activated through feature activation."""
+    V1 = auto()
+
+
+class FeePolicy(BaseModel):
+    """The fee policy for a single token, that is, the fee amounts charged when paying with that token."""
+    fee_based_tokens: str
+    amount_shielded: str
+    full_shielded: str
+
+    @lru_cache
+    def get_fee_based_tokens(self) -> UnsignedAmount:
+        return UnsignedAmount.parse(self.fee_based_tokens)
+
+    @lru_cache
+    def get_amount_shielded(self) -> UnsignedAmount:
+        return UnsignedAmount.parse(self.amount_shielded)
+
+    @lru_cache
+    def get_full_shielded(self) -> UnsignedAmount:
+        return UnsignedAmount.parse(self.full_shielded)
+
+
+FeePolicyPerToken: TypeAlias = dict[Annotated[bytes, BeforeValidator(parse_hex_str)], FeePolicy]

--- a/hathorlib/hathorlib/conf/mainnet.yml
+++ b/hathorlib/hathorlib/conf/mainnet.yml
@@ -332,3 +332,11 @@ RESTRICT_DUP_ACTIONS: feature_activation
 NC_ON_CHAIN_BLUEPRINT_ALLOWED_ADDRESSES:
   - HDkKGHwDHTuUGbhET73XdTJZkS8uU7PHf9
   - HUbxYhtqW8pdRCC2WngPxN7MB4SUMDPrrh
+
+FEE_POLICIES:
+  v1:
+    # HTR
+    "00":
+      fee_based_tokens: "0.01"
+      amount_shielded: "0.01"
+      full_shielded: "0.02"

--- a/hathorlib/hathorlib/conf/settings.py
+++ b/hathorlib/hathorlib/conf/settings.py
@@ -6,11 +6,11 @@ from enum import StrEnum, auto, unique
 from math import log
 from typing import Annotated, Optional
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Self
 
+from hathorlib.conf.fee_policy import FeePolicy, FeePolicyPerToken, FeePolicyVersion
 from hathorlib.conf.utils import parse_hex_str
-from hathorlib.token_amount import UnsignedAmount
 
 HATHOR_TOKEN_UID: bytes = b'\x00'
 
@@ -114,13 +114,6 @@ class HathorSettings(BaseModel):
         """Genesis pre-mined tokens in atomic units, that is, the on-chain integer amount."""
         # Blocks are always V1.
         return int(self.GENESIS_TOKEN_MAIN_UNITS * (10 ** self.TOKEN_AMOUNT_V1_DECIMAL_PLACES))
-
-    # Fee rate settings in V1 decimals (that is, 0.01 HTR)
-    FEE_PER_OUTPUT_V1: int = 1
-
-    @property
-    def FEE_TOKEN_AMOUNT_PER_OUTPUT(self) -> UnsignedAmount:
-        return UnsignedAmount.from_v1(self.FEE_PER_OUTPUT_V1)
 
     @property
     def FEE_DIVISOR(self) -> int:
@@ -558,6 +551,16 @@ class HathorSettings(BaseModel):
     NC_INITIAL_FUEL_TO_CALL_METHOD: int = 1_000_000  # 1M opcodes
     NC_MEMORY_LIMIT_TO_CALL_METHOD: int = 1024 * 1024 * 1024  # 1GiB
 
+    FEE_POLICIES: dict[FeePolicyVersion, FeePolicyPerToken] = Field(default_factory=lambda: {
+        FeePolicyVersion.V1: {
+            HATHOR_TOKEN_UID: FeePolicy(
+                fee_based_tokens='0.01',
+                amount_shielded='0.01',
+                full_shielded='0.02',
+            )
+        },
+    })
+
     @model_validator(mode='after')
     def _validate_peer_connection_slots(self) -> Self:
         slot_total = (
@@ -585,3 +588,23 @@ class HathorSettings(BaseModel):
                 'TOKEN_AMOUNT_V2_DECIMAL_PLACES must be greater than or equal to TOKEN_AMOUNT_V1_DECIMAL_PLACES'
             )
         return self
+
+    @model_validator(mode='after')
+    def _validate_fee_policies(self) -> Self:
+        if FeePolicyVersion.V1 not in self.FEE_POLICIES:
+            raise ValueError('FEE_POLICIES must define the V1 policy')
+        for fee_policy_version, policies in self.FEE_POLICIES.items():
+            if HATHOR_TOKEN_UID not in policies:
+                raise ValueError(f'HTR policy must be defined in fee policy version {fee_policy_version}')
+        return self
+
+    def get_fee_policies(self, fee_policy_version: FeePolicyVersion) -> FeePolicyPerToken:
+        """Return the fee policies for the respective version."""
+        if policies := self.FEE_POLICIES.get(fee_policy_version):
+            return policies
+        raise ValueError(f'No policy configured for version {fee_policy_version}')
+
+    def get_htr_policy(self, fee_policy_version: FeePolicyVersion) -> FeePolicy:
+        """Return the HTR policy for the respective version."""
+        fee_policies = self.get_fee_policies(fee_policy_version)
+        return fee_policies[HATHOR_TOKEN_UID]

--- a/hathorlib/hathorlib/exceptions.py
+++ b/hathorlib/hathorlib/exceptions.py
@@ -268,6 +268,10 @@ class FeeHeaderTokenNotFound(InvalidFeeHeader):
     """Token not found in the transaction tokens list"""
 
 
+class InvalidFeePaymentToken(TxValidationError):
+    """Invalid token used to pay fees."""
+
+
 class TokenNotFound(TxValidationError):
     """Token not found."""
 

--- a/hathorlib/hathorlib/nanocontracts/nano_runtime_version.py
+++ b/hathorlib/hathorlib/nanocontracts/nano_runtime_version.py
@@ -3,6 +3,10 @@
 
 from enum import IntEnum
 
+from typing_extensions import assert_never
+
+from hathorlib.conf.fee_policy import FeePolicyVersion
+
 
 class NanoRuntimeVersion(IntEnum):
     """
@@ -17,3 +21,11 @@ class NanoRuntimeVersion(IntEnum):
     """
     V1 = 1
     V2 = 2
+
+    def get_fee_policy_version(self) -> FeePolicyVersion:
+        """Get the fee policy version used in the respective nano runtime."""
+        match self:
+            case NanoRuntimeVersion.V1 | NanoRuntimeVersion.V2:
+                return FeePolicyVersion.V1
+            case _:
+                assert_never(self)

--- a/hathorlib/hathorlib/nanocontracts/nano_settings.py
+++ b/hathorlib/hathorlib/nanocontracts/nano_settings.py
@@ -1,7 +1,39 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
+
+from htr_lib import UnsignedAmount
+from typing_extensions import assert_never
+
+from hathorlib.conf.fee_policy import FeePolicy as SettingsFeePolicy
+from hathorlib.conf.settings import HathorSettings
+from hathorlib.token_amount_version import TokenAmountVersion
+
+if TYPE_CHECKING:
+    from hathorlib.nanocontracts import NanoRuntimeVersion
+    from hathorlib.nanocontracts.types import TokenUid
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class FeePolicy:
+    fee_based_tokens: int
+    amount_shielded: int
+    full_shielded: int
+
+    @classmethod
+    def __from_settings__(cls, fee_policy: SettingsFeePolicy, token_amount_version: TokenAmountVersion) -> Self:
+        def denormalize(amount: UnsignedAmount) -> int:
+            return amount.to_version(token_amount_version).raw()
+
+        return cls(
+            fee_based_tokens=denormalize(fee_policy.get_fee_based_tokens()),
+            amount_shielded=denormalize(fee_policy.get_amount_shielded()),
+            full_shielded=denormalize(fee_policy.get_full_shielded()),
+        )
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
@@ -10,4 +42,30 @@ class NanoSettings:
     This dataclass contains information about the settings used by the current Nano runtime.
     It is returned by the `get_settings` syscall. Note that settings are not constant, they may change over time.
     """
-    fee_per_output: int
+    fee_policies: dict[TokenUid, FeePolicy]
+
+    @classmethod
+    def __from_settings__(
+        cls,
+        *,
+        settings: HathorSettings,
+        runtime_version: NanoRuntimeVersion,
+        token_amount_version: TokenAmountVersion,
+    ) -> Self:
+        from hathorlib.nanocontracts import NanoRuntimeVersion, NCFail
+        from hathorlib.nanocontracts.types import TokenUid
+        match runtime_version:
+            case NanoRuntimeVersion.V1:
+                raise NCFail('syscall `get_settings` is not yet supported')
+            case NanoRuntimeVersion.V2:
+                fee_policy_version = runtime_version.get_fee_policy_version()
+                fee_policy_per_token = settings.get_fee_policies(fee_policy_version)
+                fee_policies = {
+                    TokenUid(token_uid): FeePolicy.__from_settings__(fee_policy, token_amount_version)
+                    for token_uid, fee_policy in fee_policy_per_token.items()
+                }
+                return cls(
+                    fee_policies=fee_policies,
+                )
+            case _:
+                assert_never(runtime_version)

--- a/hathorlib/hathorlib/nanocontracts/runner/runner.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/runner.py
@@ -26,7 +26,6 @@ from hathorlib.nanocontracts.exception import (
     NCInvalidContext,
     NCInvalidContractId,
     NCInvalidFee,
-    NCInvalidFeePaymentToken,
     NCInvalidInitializeMethodCall,
     NCInvalidPublicMethodCallFromView,
     NCInvalidSyscall,
@@ -48,7 +47,7 @@ from hathorlib.nanocontracts.runner.index_records import (
     UpdateAuthoritiesRecord,
     UpdateTokenBalanceRecord,
 )
-from hathorlib.nanocontracts.runner.token_fees import calculate_melt_fee, calculate_mint_fee
+from hathorlib.nanocontracts.runner.token_fees import aggregate_fee_charges, calculate_melt_fee, calculate_mint_fee
 from hathorlib.nanocontracts.storage import NCBlockStorage, NCChangesTracker, NCContractStorage, NCStorageFactory
 from hathorlib.nanocontracts.storage.contract_storage import Balance
 from hathorlib.nanocontracts.tx_storage_protocol import NCTransactionStorageProtocol
@@ -456,7 +455,11 @@ class Runner:
                 raise NCInvalidContext('action amount must be positive')
 
         # Validate fees
+        seen_fee_tokens: set[TokenUid] = set()
         for fee in fees:
+            if fee.token_uid in seen_fee_tokens:
+                raise NCInvalidFee(f'duplicate fees for token {fee.token_uid.hex()}')
+            seen_fee_tokens.add(fee.token_uid)
             if fee.amount <= 0:
                 raise NCInvalidFee(f'fees should be a positive integer, got {fee.amount}')
             amount = UnsignedAmount.from_version(fee.amount, version=self.token_amount_version)
@@ -1062,6 +1065,7 @@ class Runner:
         token_info = self._get_token(token_uid)
         fee_amount = calculate_mint_fee(
             settings=self._settings,
+            fee_policy_version=self._runtime_version.get_fee_policy_version(),
             token_version=token_info.token_version,
             amount=token_amount,
             fee_payment_token=self._get_token(fee_payment_token),
@@ -1102,6 +1106,7 @@ class Runner:
         token_info = self._get_token(token_uid)
         fee_amount = calculate_melt_fee(
             settings=self._settings,
+            fee_policy_version=self._runtime_version.get_fee_policy_version(),
             token_version=token_info.token_version,
             amount=token_amount,
             fee_payment_token=self._get_token(fee_payment_token),
@@ -1317,22 +1322,11 @@ class Runner:
 
     def syscall_get_nano_settings(self) -> NanoSettings:
         """Get nano settings according to the current runtime."""
-        match self._runtime_version:
-            case NanoRuntimeVersion.V1:
-                raise NCFail('syscall `get_settings` is not yet supported')
-            case NanoRuntimeVersion.V2:
-                fee_per_output: int
-                assert self._settings.FEE_TOKEN_AMOUNT_PER_OUTPUT.is_v1()
-                match self.token_amount_version:
-                    case TokenAmountVersion.V1:
-                        fee_per_output = self._settings.FEE_TOKEN_AMOUNT_PER_OUTPUT.raw()
-                    case TokenAmountVersion.V2:
-                        fee_per_output = self._settings.FEE_TOKEN_AMOUNT_PER_OUTPUT.normalized()
-                    case _:
-                        assert_never(self.token_amount_version)
-                return NanoSettings(fee_per_output=fee_per_output)
-            case _:
-                assert_never(self._runtime_version)
+        return NanoSettings.__from_settings__(
+            settings=self._settings,
+            runtime_version=self._runtime_version,
+            token_amount_version=self.token_amount_version,
+        )
 
     def _get_token(self, token_uid: TokenUid) -> TokenDescription:
         """
@@ -1389,6 +1383,7 @@ class Runner:
         token_amount = UnsignedAmount.from_version(amount, version=self.token_amount_version)
         fee_amount = calculate_mint_fee(
             settings=self._settings,
+            fee_policy_version=self._runtime_version.get_fee_policy_version(),
             token_version=token_version,
             amount=token_amount,
             fee_payment_token=fee_payment_token,
@@ -1448,44 +1443,37 @@ class Runner:
         Validate if the sum of fees is the same of the provided actions fees.
         It should be called only after a nano contract method execution to ensure all tokens are already created.
         """
-        # sum of the fee provided by the caller
-        fee_sum = UnsignedAmount.zero()
-
         # sum of the expected fee calculated by this method
         expected_fee = UnsignedAmount.zero()
 
-        allowed_token_versions = {TokenVersion.DEPOSIT, TokenVersion.NATIVE}
-        # check if the payment tokens are all deposit
-        for token_uid in self._paid_actions_fees.keys():
-            token = self._get_token(token_uid)
+        fee_policy_version = self._runtime_version.get_fee_policy_version()
+        fee_charges = [
+            (
+                fee.token_uid,
+                self._get_token(fee.token_uid).token_version,
+                UnsignedAmount.from_version(fee.amount, version=self.token_amount_version),
+            )
+            for fee in fees
+        ]
+        fee_charge = aggregate_fee_charges(
+            settings=self._settings,
+            fee_policy_version=fee_policy_version,
+            charges=fee_charges,
+        )
 
-            if token.token_version not in allowed_token_versions:
-                raise NCInvalidFeePaymentToken("fee-based tokens aren't allowed for paying fees")
-
-        for fee in fees:
-            # because we registered all fee tokens in the paid fees dict, it should contain at
-            # least the length of fees
-            assert fee.token_uid in self._paid_actions_fees
-            fee_sum += fee.__get_htr_value__(self._settings, self.token_amount_version)
-
+        fee_per_unit = fee_charge.policy.get_fee_based_tokens()
         chargeable_actions = {NCActionType.DEPOSIT, NCActionType.WITHDRAWAL}
         for token_uid, actions in ctx_actions.items():
-            # it is in the paid fees, so we assume this token is deposit-based or htr
-            if token_uid in self._paid_actions_fees:
-                continue
-
-            # we still need to check here, other tokens that weren't used to pay fees can be used
-            # so we need to fetch them
             token_info = self._get_token(token_uid)
             if token_info.token_version == TokenVersion.FEE:
                 # filter actions to only include deposit and withdrawal actions
-                expected_fee += UnsignedAmount.from_v1(
-                    sum(self._settings.FEE_PER_OUTPUT_V1 for action in actions if action.type in chargeable_actions)
-                )
+                chargeable_count = sum(1 for action in actions if action.type in chargeable_actions)
+                expected_fee += UnsignedAmount.from_v2(chargeable_count * fee_per_unit.normalized())
 
-        if fee_sum != expected_fee:
+        if fee_charge.amount != expected_fee:
             raise NCInvalidFee(
-                f'Fee payment balance is different than expected. (amount={fee_sum}, expected={expected_fee})'
+                f'Fee payment balance is different than expected. (amount={fee_charge.amount}, '
+                f'expected={expected_fee})'
             )
 
     def forbid_call_on_view(self, name: str) -> None:

--- a/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
+++ b/hathorlib/hathorlib/nanocontracts/runner/token_fees.py
@@ -1,9 +1,15 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Iterable
+
 from typing_extensions import assert_never
 
+from hathorlib.conf.fee_policy import FeePolicy, FeePolicyPerToken, FeePolicyVersion
 from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
+from hathorlib.exceptions import InvalidFeePaymentToken
 from hathorlib.nanocontracts.exception import NCInvalidFeePaymentToken
 from hathorlib.token_amount import SignedAmount, UnsignedAmount
 from hathorlib.token_info import TokenDescription, TokenVersion
@@ -13,6 +19,7 @@ from hathorlib.utils import get_deposit_token_deposit_amount, get_deposit_token_
 def calculate_mint_fee(
     *,
     settings: HathorSettings,
+    fee_policy_version: FeePolicyVersion,
     token_version: TokenVersion,
     amount: UnsignedAmount,
     fee_payment_token: TokenDescription,
@@ -25,8 +32,9 @@ def calculate_mint_fee(
             _validate_deposit_based_payment_token(fee_payment_token)
             return -get_deposit_token_deposit_amount(settings, amount).to_signed()
         case TokenVersion.FEE:
-            _validate_fee_based_payment_token(fee_payment_token)
-            return -_calculate_unit_fee_token_fee(settings, fee_payment_token).to_signed()
+            fee_policies = settings.get_fee_policies(fee_policy_version)
+            _validate_fee_based_payment_token(fee_policies, fee_payment_token)
+            return -_calculate_unit_fee_token_fee(settings, fee_policies, fee_payment_token).to_signed()
         case _:  # pragma: no cover
             assert_never(token_version)
 
@@ -34,6 +42,7 @@ def calculate_mint_fee(
 def calculate_melt_fee(
     *,
     settings: HathorSettings,
+    fee_policy_version: FeePolicyVersion,
     token_version: TokenVersion,
     amount: UnsignedAmount,
     fee_payment_token: TokenDescription,
@@ -46,8 +55,9 @@ def calculate_melt_fee(
             _validate_deposit_based_payment_token(fee_payment_token)
             return +get_deposit_token_withdraw_amount(settings, amount).to_signed()
         case TokenVersion.FEE:
-            _validate_fee_based_payment_token(fee_payment_token)
-            return -_calculate_unit_fee_token_fee(settings, fee_payment_token).to_signed()
+            fee_policies = settings.get_fee_policies(fee_policy_version)
+            _validate_fee_based_payment_token(fee_policies, fee_payment_token)
+            return -_calculate_unit_fee_token_fee(settings, fee_policies, fee_payment_token).to_signed()
         case _:  # pragma: no cover
             assert_never(token_version)
 
@@ -58,21 +68,76 @@ def _validate_deposit_based_payment_token(fee_payment_token: TokenDescription) -
         raise NCInvalidFeePaymentToken('Only HTR is allowed to be used with deposit based token syscalls')
 
 
-def _validate_fee_based_payment_token(fee_payment_token: TokenDescription) -> None:
-    """Validate the token used to pay the fee of a fee-based token operation."""
+def _validate_fee_based_payment_token(fee_policies: FeePolicyPerToken, fee_payment_token: TokenDescription) -> None:
+    """Validate the token used to pay the fee of a fee-based token operation.
+
+    HTR, deposit-based tokens, and tokens listed in the active fee policy can pay; other fee-based tokens cannot.
+    """
     match fee_payment_token.token_version:
         case TokenVersion.FEE:
-            raise NCInvalidFeePaymentToken("fee-based tokens aren't allowed for paying fees")
+            if fee_payment_token.token_id not in fee_policies:
+                raise NCInvalidFeePaymentToken(f'cannot pay fees with token {fee_payment_token.token_id.hex()}')
         case TokenVersion.DEPOSIT | TokenVersion.NATIVE:
             pass
         case _:  # pragma: no cover
             assert_never(fee_payment_token.token_version)
 
 
-def _calculate_unit_fee_token_fee(settings: HathorSettings, fee_payment_token: TokenDescription) -> UnsignedAmount:
+def _calculate_unit_fee_token_fee(
+    settings: HathorSettings,
+    fee_policies: FeePolicyPerToken,
+    fee_payment_token: TokenDescription,
+) -> UnsignedAmount:
     """Calculate the fee for handling a fee-based token"""
-    if fee_payment_token.token_id == HATHOR_TOKEN_UID:
-        return settings.FEE_TOKEN_AMOUNT_PER_OUTPUT
-    numerator = settings.FEE_TOKEN_AMOUNT_PER_OUTPUT.normalized() * settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
+    if fee_payment_token.token_id in fee_policies:
+        return fee_policies[fee_payment_token.token_id].get_fee_based_tokens()
+    htr_unit_fee = fee_policies[HATHOR_TOKEN_UID].get_fee_based_tokens()
+    numerator = htr_unit_fee.normalized() * settings.TOKEN_DEPOSIT_PERCENTAGE_DENOMINATOR
     assert numerator % settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR == 0
     return UnsignedAmount.from_v2(numerator // settings.TOKEN_DEPOSIT_PERCENTAGE_NUMERATOR)
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class FeeCharge:
+    """A single aggregated fee payment: the token paying the fee, its policy, and the total amount."""
+    token_uid: bytes
+    policy: FeePolicy
+    amount: UnsignedAmount
+
+
+def aggregate_fee_charges(
+    *,
+    settings: HathorSettings,
+    fee_policy_version: FeePolicyVersion,
+    charges: Iterable[tuple[bytes, TokenVersion, UnsignedAmount]],
+) -> FeeCharge:
+    """Validate and aggregate fee payments in a single pass.
+
+    Each fee entry is a `(token_uid, token_version, amount)` tuple; entries for the same token are summed.
+    Return a `FeeCharge` with the token paying the fee, its policy, and the total amount.
+    """
+    fee_policies = settings.get_fee_policies(fee_policy_version)
+    htr_policy = settings.get_htr_policy(fee_policy_version)
+
+    amounts: dict[tuple[bytes, FeePolicy], UnsignedAmount] = defaultdict(UnsignedAmount.zero)
+
+    for token_uid, token_version, amount in charges:
+        if fee_policy := fee_policies.get(token_uid):
+            # Policy tokens charge their own amount.
+            amounts[(token_uid, fee_policy)] += amount
+        elif token_version == TokenVersion.DEPOSIT:
+            # Deposit-based tokens are converted to HTR.
+            amounts[(HATHOR_TOKEN_UID, htr_policy)] += get_deposit_token_withdraw_amount(settings, amount)
+        else:
+            raise InvalidFeePaymentToken(f'cannot pay fees with token {token_uid.hex()}')
+
+    if len(amounts) == 0:
+        return FeeCharge(token_uid=HATHOR_TOKEN_UID, policy=htr_policy, amount=UnsignedAmount.zero())
+
+    if len(amounts) != 1:
+        raise InvalidFeePaymentToken(
+            'fee payments must either use a combination of HTR and deposit-based tokens, or a single stablecoin'
+        )
+
+    (token_uid, fee_policy), amount = next(iter(amounts.items()))
+    return FeeCharge(token_uid=token_uid, policy=fee_policy, amount=amount)

--- a/hathorlib/hathorlib/nanocontracts/types.py
+++ b/hathorlib/hathorlib/nanocontracts/types.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Generic, Protocol, Self, TypeAlias, TypeVar
 
 from typing_extensions import override
 
-from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
+from hathorlib.conf.settings import HATHOR_TOKEN_UID
 from hathorlib.nanocontracts.blueprint_syntax_validation import (
     validate_has_ctx_arg,
     validate_has_not_ctx_arg,
@@ -22,9 +22,6 @@ from hathorlib.nanocontracts.blueprint_syntax_validation import (
 from hathorlib.nanocontracts.exception import BlueprintSyntaxError, NCSerializationError
 from hathorlib.nanocontracts.faux_immutable import FauxImmutableMeta
 from hathorlib.serialization import SerializationError
-from hathorlib.token_amount import UnsignedAmount
-from hathorlib.token_amount_version import TokenAmountVersion
-from hathorlib.utils import get_deposit_token_withdraw_amount
 from hathorlib.utils.address import decode_address, get_address_b58_from_bytes
 from hathorlib.utils.typing import InnerTypeMixin
 
@@ -549,13 +546,3 @@ class NCFee:
     """The dataclass for all NC actions fee"""
     token_uid: TokenUid
     amount: int
-
-    def __get_htr_value__(self, settings: HathorSettings, token_amount_version: TokenAmountVersion) -> UnsignedAmount:
-        """
-        Get the amount converted to HTR
-        """
-        amount = UnsignedAmount.from_version(self.amount, version=token_amount_version)
-        if self.token_uid == HATHOR_TOKEN_UID:
-            return amount
-        else:
-            return get_deposit_token_withdraw_amount(settings, amount)

--- a/hathorlib/hathorlib/utils/address.py
+++ b/hathorlib/hathorlib/utils/address.py
@@ -8,7 +8,6 @@ import base58
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import InvalidAddress
 
 
@@ -91,6 +90,7 @@ def get_address_from_public_key_hash(
         :return: address in bytes
         :rtype: bytes
     """
+    from hathorlib.conf import HathorSettings
     settings = HathorSettings()
     version_byte = (
         settings.P2PKH_VERSION_BYTE
@@ -117,6 +117,7 @@ def get_address_b58_from_redeem_script_hash(redeem_script_hash: bytes,
         :return: address in base 58
         :rtype: string
     """
+    from hathorlib.conf import HathorSettings
     settings = HathorSettings()
     version_byte = (
         settings.MULTISIG_VERSION_BYTE
@@ -140,6 +141,7 @@ def get_address_from_redeem_script_hash(redeem_script_hash: bytes,
         :return: address in bytes
         :rtype: bytes
     """
+    from hathorlib.conf import HathorSettings
     settings = HathorSettings()
     version_byte = (
         settings.MULTISIG_VERSION_BYTE

--- a/hathorlib/tests/test_nc_address_type.py
+++ b/hathorlib/tests/test_nc_address_type.py
@@ -4,9 +4,7 @@
 import unittest
 
 from hathorlib.exceptions import InvalidAddress
-from hathorlib.nanocontracts.types import NC_HTR_TOKEN_UID, Address, NCFee, TokenUid
-from hathorlib.token_amount import UnsignedAmount
-from hathorlib.token_amount_version import TokenAmountVersion
+from hathorlib.nanocontracts.types import Address
 from hathorlib.utils.address import get_address_b58_from_public_key, get_public_key_from_bytes_compressed
 
 
@@ -41,20 +39,3 @@ class TestAddressType(unittest.TestCase):
     def test_from_str_invalid_address(self) -> None:
         with self.assertRaises(InvalidAddress):
             Address.from_str('invalidaddress')
-
-
-class TestNCFee(unittest.TestCase):
-    def test_htr_fee_value(self) -> None:
-        from hathorlib.conf import HathorSettings
-        settings = HathorSettings()
-        fee = NCFee(token_uid=NC_HTR_TOKEN_UID, amount=100)
-        self.assertEqual(fee.__get_htr_value__(settings, TokenAmountVersion.V1), UnsignedAmount.from_v1(100))
-
-    def test_custom_token_fee_value(self) -> None:
-        from hathorlib.conf import HathorSettings
-        settings = HathorSettings()
-        fee = NCFee(token_uid=TokenUid(b'\x01' * 32), amount=1000)
-        # For custom token, it converts using deposit percentage
-        result = fee.__get_htr_value__(settings, TokenAmountVersion.V1)
-        self.assertIsInstance(result, UnsignedAmount)
-        self.assertGreater(result, UnsignedAmount.zero())

--- a/hathorlib/tests/test_token_fees.py
+++ b/hathorlib/tests/test_token_fees.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from hathorlib.conf import HathorSettings as get_settings
+from hathorlib.conf.fee_policy import FeePolicy, FeePolicyVersion
+from hathorlib.conf.settings import HATHOR_TOKEN_UID, HathorSettings
+from hathorlib.exceptions import InvalidFeePaymentToken
+from hathorlib.nanocontracts.runner.token_fees import aggregate_fee_charges
+from hathorlib.token_amount import UnsignedAmount
+from hathorlib.token_info import TokenVersion
+
+DEPOSIT_TOKEN = b'\x01' * 32
+FEE_TOKEN = b'\x02' * 32
+
+settings = get_settings()
+
+
+def test_get_fee_charge_without_fees() -> None:
+    """A tx without fees pays nothing, and HTR is reported as the paying token."""
+    fee_charge = aggregate_fee_charges(settings=settings, fee_policy_version=FeePolicyVersion.V1, charges=[])
+    assert fee_charge.token_uid == HATHOR_TOKEN_UID
+    assert fee_charge.policy == settings.get_htr_policy(FeePolicyVersion.V1)
+    assert fee_charge.amount == UnsignedAmount.zero()
+
+
+def test_get_fee_charge_in_htr() -> None:
+    fee_charge = aggregate_fee_charges(
+        settings=settings,
+        fee_policy_version=FeePolicyVersion.V1,
+        charges=[(HATHOR_TOKEN_UID, TokenVersion.NATIVE, UnsignedAmount.from_v1(100))],
+    )
+    assert fee_charge.token_uid == HATHOR_TOKEN_UID
+    assert fee_charge.amount == UnsignedAmount.from_v1(100)
+
+
+def test_get_fee_charge_converts_deposit_token_to_htr() -> None:
+    """A deposit-based token has no policy of its own, so its amount is withdrawn as HTR."""
+    fee_charge = aggregate_fee_charges(
+        settings=settings,
+        fee_policy_version=FeePolicyVersion.V1,
+        charges=[(DEPOSIT_TOKEN, TokenVersion.DEPOSIT, UnsignedAmount.from_v1(1000))],
+    )
+    assert fee_charge.token_uid == HATHOR_TOKEN_UID
+    # The deposit percentage is 1%, so melting 10.00 of the token withdraws 0.10 HTR.
+    assert fee_charge.amount == UnsignedAmount.from_v1(10)
+
+
+def test_get_fee_charge_sums_htr_and_deposit_token() -> None:
+    fee_charge = aggregate_fee_charges(
+        settings=settings,
+        fee_policy_version=FeePolicyVersion.V1,
+        charges=[
+            (HATHOR_TOKEN_UID, TokenVersion.NATIVE, UnsignedAmount.from_v1(5)),
+            (DEPOSIT_TOKEN, TokenVersion.DEPOSIT, UnsignedAmount.from_v1(1000)),
+        ],
+    )
+    assert fee_charge.token_uid == HATHOR_TOKEN_UID
+    assert fee_charge.amount == UnsignedAmount.from_v1(15)
+
+
+def test_get_fee_charge_sums_entries_of_the_same_token() -> None:
+    fee_charge = aggregate_fee_charges(
+        settings=settings,
+        fee_policy_version=FeePolicyVersion.V1,
+        charges=[
+            (HATHOR_TOKEN_UID, TokenVersion.NATIVE, UnsignedAmount.from_v1(5)),
+            (HATHOR_TOKEN_UID, TokenVersion.NATIVE, UnsignedAmount.from_v1(7)),
+        ],
+    )
+    assert fee_charge.token_uid == HATHOR_TOKEN_UID
+    assert fee_charge.amount == UnsignedAmount.from_v1(12)
+
+
+def test_get_fee_charge_rejects_fee_based_token_without_policy() -> None:
+    msg = f'cannot pay fees with token {FEE_TOKEN.hex()}'
+    with pytest.raises(InvalidFeePaymentToken) as e:
+        aggregate_fee_charges(
+            settings=settings,
+            fee_policy_version=FeePolicyVersion.V1,
+            charges=[(FEE_TOKEN, TokenVersion.FEE, UnsignedAmount.from_v1(1))],
+        )
+    assert str(e.value) == msg
+
+
+def test_get_fee_charge_with_two_policy_tokens() -> None:
+    """Fees must all be payable by a single token, so two tokens with policies of their own is an error."""
+    custom_settings = HathorSettings(
+        P2PKH_VERSION_BYTE=b'\x28',
+        MULTISIG_VERSION_BYTE=b'\x64',
+        NETWORK_NAME='testing',
+        FEE_POLICIES={
+            FeePolicyVersion.V1: {
+                HATHOR_TOKEN_UID: FeePolicy(
+                    fee_based_tokens='0.01',
+                    amount_shielded='0.01',
+                    full_shielded='0.02',
+                ),
+                FEE_TOKEN: FeePolicy(
+                    fee_based_tokens='0.005',
+                    amount_shielded='0.01',
+                    full_shielded='0.02',
+                ),
+            },
+        },
+    )
+
+    # A token with a policy of its own pays in itself, even if it's fee-based.
+    fee_charge = aggregate_fee_charges(
+        settings=custom_settings,
+        fee_policy_version=FeePolicyVersion.V1,
+        charges=[(FEE_TOKEN, TokenVersion.FEE, UnsignedAmount.from_v1(3))],
+    )
+    assert fee_charge.token_uid == FEE_TOKEN
+    assert fee_charge.policy == custom_settings.get_fee_policies(FeePolicyVersion.V1)[FEE_TOKEN]
+    assert fee_charge.amount == UnsignedAmount.from_v1(3)
+
+    msg = 'fee payments must either use a combination of HTR and deposit-based tokens, or a single stablecoin'
+    with pytest.raises(InvalidFeePaymentToken) as e:
+        aggregate_fee_charges(
+            settings=custom_settings,
+            fee_policy_version=FeePolicyVersion.V1,
+            charges=[
+                (HATHOR_TOKEN_UID, TokenVersion.NATIVE, UnsignedAmount.from_v1(1)),
+                (FEE_TOKEN, TokenVersion.FEE, UnsignedAmount.from_v1(1)),
+            ],
+        )
+    assert str(e.value) == msg


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1763

### Motivation

Fee amounts are configured as a single scalar setting, `FEE_PER_OUTPUT_V1`, which can only express a fee charged in HTR, and only with V1 decimal precision. The upcoming stable-fee work needs fees to be charged in tokens other than HTR (stablecoins) and with sub-cent precision, so that scalar cannot carry it.

This PR replaces it with the fee policy configuration model, and threads it through every fee computation, without introducing any new fee behavior. Only fee policy `V1` is defined, and its HTR policy charges the same `0.01` HTR per unit as before, so the change is behavior-preserving.

### Acceptance Criteria

- Add `FeePolicyVersion`, `FeePolicy`, and `FeePolicyPerToken`.
- Replace `HathorSettings.FEE_PER_OUTPUT_V1` and `FEE_TOKEN_AMOUNT_PER_OUTPUT` with the `FEE_POLICIES` setting.
- Replace `FeeHeader.total_fee_amount()` and `NCFee.__get_htr_value__()` with `get_fee_charge()`, which validates and aggregates fee payments in a single pass into a `FeeCharge`.
- Make fee payment validation policy-aware in the mint/melt syscalls.
- Reject duplicate fee entries for the same token in the nano runner.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged