### PR TITLE
feat(nano-runtime): change activation block to parent [part 1/3]

### DIFF
--- a/hathor/nanocontracts/execution/block_executor.py
+++ b/hathor/nanocontracts/execution/block_executor.py
@@ -197,7 +197,7 @@ class NCBlockExecutor:
         nc_cyclic_txs = sorted_txs.cyclic if sorted_txs else tuple()
         block_storage = self._nc_storage_factory.get_block_storage(parent_root_id)
         assert block_storage.get_root_id() == parent_root_id
-        features = Features.from_vertex(settings=self._settings, feature_service=self._feature_service, vertex=block)
+        features = Features.from_vertex(settings=self._settings, feature_service=self._feature_service, vertex=parent)
 
         yield NCBeginBlock(
             block=block,

--- a/hathor_tests/nanocontracts/test_runtime_v2.py
+++ b/hathor_tests/nanocontracts/test_runtime_v2.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
+
 import pytest
+from htr_lib import UnsignedAmount
 
 from hathor import Blueprint, Context, public
 from hathor.feature_activation.feature import Feature
@@ -9,13 +11,13 @@ from hathor.feature_activation.model.criteria import Criteria
 from hathor.feature_activation.model.feature_state import FeatureState
 from hathor.feature_activation.settings import Settings as FeatureSettings
 from hathor.nanocontracts import NC_EXECUTION_FAIL_ID
-from hathor.nanocontracts.nano_runtime_version import NanoRuntimeVersion
 from hathor.transaction import Block, Transaction
 from hathor.transaction.nc_execution_state import NCExecutionState
 from hathor_tests.dag_builder.builder import TestDAGBuilder
 from hathor_tests.nanocontracts.blueprints.unittest import BlueprintTestCase
 from hathor_tests.nanocontracts.utils import assert_nc_failure_reason
 from hathorlib.conf.settings import FeatureSetting
+from hathorlib.nanocontracts import NanoRuntimeVersion
 from hathorlib.nanocontracts.exception import NCFail
 
 
@@ -68,7 +70,7 @@ class TestRuntimeV2(BlueprintTestCase):
 
         dag_builder = TestDAGBuilder.from_manager(self.manager)
         artifacts = dag_builder.build_from_str(f'''
-            blockchain genesis b[1..12]
+            blockchain genesis b[1..13]
             b10 < dummy
 
             b5.signal_bits = 1
@@ -81,24 +83,32 @@ class TestRuntimeV2(BlueprintTestCase):
             nc2.nc_id = "{self.blueprint_id.hex()}"
             nc2.nc_method = initialize()
 
-            nc1 <-- b11
-            nc2 <-- b12
+            nc1 <-- b12
+            nc2 <-- b13
         ''')
-        artifacts.propagate_with(self.manager)
 
-        b5, b6, b7, b11, b12 = artifacts.get_typed_vertices(('b5', 'b6', 'b7', 'b11', 'b12'), Block)
+        b5, b6, b7, b11, b12, b13 = artifacts.get_typed_vertices(('b5', 'b6', 'b7', 'b11', 'b12', 'b13'), Block)
         nc1, nc2 = artifacts.get_typed_vertices(('nc1', 'nc2'), Transaction)
+
+        # Update b13 reward for the DAA update.
+        assert len(b13.outputs) == 1
+        b13.outputs[0].value = UnsignedAmount.from_v1(1600)
+        artifacts.propagate_with(self.manager)
 
         assert feature_service.get_state(block=b7, feature=Feature.REDUCE_DAA_TARGET) == FeatureState.STARTED
         assert feature_service.get_state(block=b11, feature=Feature.REDUCE_DAA_TARGET) == FeatureState.LOCKED_IN
         assert feature_service.get_state(block=b12, feature=Feature.REDUCE_DAA_TARGET) == FeatureState.ACTIVE
+
+        # Nano Runtime V2 activation uses the first_block's parent state
+        assert nc1.get_metadata().first_block == b12.hash
+        assert nc2.get_metadata().first_block == b13.hash
 
         assert nc1.get_metadata().voided_by == {NC_EXECUTION_FAIL_ID, nc1.hash}
         assert nc1.get_metadata().nc_execution == NCExecutionState.FAILURE
         assert_nc_failure_reason(
             manager=self.manager,
             tx_id=nc1.hash,
-            block_id=b11.hash,
+            block_id=b12.hash,
             reason='syscall `get_settings` is not yet supported',
         )
 


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-core/pull/1707

### Motivation

Currently the `NanoRuntimeVersion` feature is derived from the confirming block, that is, the block executing the nano contract. This PR changes it to use the parent block, instead, which is more coherent with how other features work — the nano execution from transaction uses the state of the best block before it (i.e., its first block's parent), instead of the state of the block that confirms it.

This means a single block's executions will be changed from V2 to V1 in mainnet, but this is safe to do because we know this block didn't execute any OCBs with dependency on V2.

### Acceptance Criteria

- Change behavior of the `NanoRuntimeVersion` feature, so it uses the state of the first block's parent instead of the first block, for consistency between nano-related features.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 