### PR TITLE
chore(ci): make hathorlib CI run in all PRs

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -11,9 +11,6 @@ on: # yamllint disable-line rule:truthy
     tags:
       - v*
   pull_request:
-    branches:
-      - master
-      - dev
 jobs:
   test:
     name: python-${{ matrix.python }} (${{ matrix.os }})


### PR DESCRIPTION
### Motivation

`hathorlib` CI currently only runs on PRs targeting `master`. This makes it run in all PRs instead, like `hathor` CI.

### Acceptance Criteria

- Make hathorlib CI run in all PRs.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 