### PR TITLE
chore: build Python 3.13 image on CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
         python-version:
           - '3.11'
           - '3.12'
+          - '3.13'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation

We don't build images for Python 3.13, even though we've supported it in code.

### Acceptance Criteria

- Include 3.13 on the docker build CI, the built image will have `-python3.13` suffix and won't be default.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 