### PR TITLE
chore: remove explicit license header from PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
@@ -1,8 +1,3 @@
-<!--
-SPDX-FileCopyrightText: Hathor Labs
-SPDX-License-Identifier: Apache-2.0
--->
-
 ### Motivation
 
 What was the motivation for the changes in this PR?
@@ -13,4 +8,4 @@ What was the motivation for the changes in this PR?
 
 ### Checklist
 
-- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 
+- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged

--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md
@@ -1,8 +1,3 @@
-<!--
-SPDX-FileCopyrightText: Hathor Labs
-SPDX-License-Identifier: Apache-2.0
--->
-
 # Changes
 
 Link here all the PRs that are included in this release candidate

--- a/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
@@ -1,8 +1,3 @@
-<!--
-SPDX-FileCopyrightText: Hathor Labs
-SPDX-License-Identifier: Apache-2.0
--->
-
 # Changes
 
 Link here all the PRs that are included in this release

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,6 +4,7 @@ version = 1
 path = [
     ".claude/rules/*.md",
     ".github/CODEOWNERS",
+    ".github/PULL_REQUEST_TEMPLATE/*.md",
     "CLAUDE.md",
     "docs/legacy/images/syncing-example.txt",
     "docs/legacy/make.bat",


### PR DESCRIPTION
### Motivation

Having the license on the PR template doesn't make sense. The authorship of the template itself shouldn't be suggested to carry into the PR's body.

### Acceptance Criteria

- Remove license from templates
- Add templates to `REUSE.toml`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 