### PR TITLE
refactor(p2p): simplify entrypoint filtering in connect_to_peer

### DIFF
--- a/hathor/p2p/manager.py
+++ b/hathor/p2p/manager.py
@@ -598,14 +598,14 @@ class ConnectionsManager:
     def connect_to_peer(self, peer: UnverifiedPeer | PublicPeer, now: int) -> None:
         """ Attempts to connect if it is not connected to the peer.
         """
-        if not peer.info.entrypoints or (
-            not self.enable_ipv6 and not peer.info.get_ipv4_only_entrypoints()
-        ) or (
-            self.disable_ipv4 and not peer.info.get_ipv6_only_entrypoints()
-        ):
-            # It makes no sense to keep storing peers that have disconnected and have no entrypoints
-            # We will never be able to connect to them anymore and they will only keep spending memory
-            # and other resources when used in APIs, so we are removing them here
+        connectable_entrypoints = peer.info.get_connectable_entrypoints(
+            enable_ipv6=self.enable_ipv6, disable_ipv4=self.disable_ipv4,
+        )
+        if not connectable_entrypoints:
+            # It makes no sense to keep storing peers that have disconnected and to which we can no longer
+            # connect (no entrypoints, or none compatible with our IP-family configuration). We will never be
+            # able to connect to them anymore and they will only keep spending memory and other resources when
+            # used in APIs, so we are removing them here
             if peer.id not in self.connected_peers:
                 self.verified_peer_storage.remove(peer)
             return
@@ -614,14 +614,7 @@ class ConnectionsManager:
 
         assert peer.id is not None
         if peer.info.can_retry(now):
-            if self.enable_ipv6 and not self.disable_ipv4:
-                addr = self.rng.choice(list(peer.info.entrypoints))
-            elif self.enable_ipv6 and self.disable_ipv4:
-                addr = self.rng.choice(peer.info.get_ipv6_only_entrypoints())
-            elif not self.enable_ipv6 and not self.disable_ipv4:
-                addr = self.rng.choice(peer.info.get_ipv4_only_entrypoints())
-            else:
-                raise ValueError('IPv4 is disabled and IPv6 is not enabled')
+            addr = self.rng.choice(connectable_entrypoints)
             self.connect_to_endpoint(addr.with_id(peer.id), peer)
         else:
             self.log.debug('connecting too often, skip retrying', peer=str(peer.id))

--- a/hathor/p2p/peer.py
+++ b/hathor/p2p/peer.py
@@ -110,6 +110,13 @@ class PeerInfo:
     def get_ipv6_only_entrypoints(self) -> list[PeerAddress]:
         return list(filter(lambda e: e.is_ipv6(), self.entrypoints))
 
+    def get_connectable_entrypoints(self, *, enable_ipv6: bool, disable_ipv4: bool) -> list[PeerAddress]:
+        """Return the entrypoints we can connect to given the IP-family configuration.
+
+        IPv6 entrypoints require IPv6 to be enabled; IPv4 entrypoints require IPv4 not to be disabled.
+        """
+        return [e for e in self.entrypoints if (enable_ipv6 if e.is_ipv6() else not disable_ipv4)]
+
     def ipv4_entrypoints_as_str(self) -> list[str]:
         return sorted(map(str, self.get_ipv4_only_entrypoints()))
 


### PR DESCRIPTION
### Motivation

While supporting IPv6 (#1144), the `connect_to_peer` logic grew a compound drop-condition and an `if/elif/elif/else raise` chain that both re-derived the same "which entrypoints can we actually use given the IPv4/IPv6 configuration" question in two different shapes. A [review comment](https://github.com/HathorNetwork/hathor-core/pull/1144#discussion_r1849123098) suggested computing the set of valid addresses once and skipping the peer if it is empty; the team agreed to do it in a follow-up PR, which is this one.

### Acceptance Criteria

- Add `PeerInfo.get_connectable_entrypoints(*, enable_ipv6, disable_ipv4)`, returning the entrypoints reachable under the current IP-family configuration.
- Rewrite `connect_to_peer` to compute the connectable set once: drop the peer when it is empty, otherwise `rng.choice` over that set.
- Remove the now-unreachable `raise ValueError('IPv4 is disabled and IPv6 is not enabled')` branch — that configuration is already rejected at startup in `run_node.validate_args`.
- Preserve existing behavior (same peers dropped, same address families selected); `get_ipv4_only_entrypoints`/`get_ipv6_only_entrypoints` remain for the logging helpers.

### Checklist

- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
