### PR TITLE
fix(resources): return success false on short hex_tx and unknown token in /decode_tx

### DIFF
--- a/hathor/transaction/resources/decode_tx.py
+++ b/hathor/transaction/resources/decode_tx.py
@@ -47,8 +47,10 @@ class DecodeTxResource(Resource):
             data = get_tx_extra_data(tx)
         except ValueError:
             data = {'success': False, 'message': 'Invalid hexadecimal data'}
-        except struct.error:
+        except (IndexError, struct.error):
             data = {'success': False, 'message': 'Could not decode transaction'}
+        except KeyError:
+            data = {'success': False, 'message': 'Unknown token'}
 
         return json_dumpb(data)
 

--- a/hathor_tests/resources/transaction/test_decodetx.py
+++ b/hathor_tests/resources/transaction/test_decodetx.py
@@ -46,6 +46,12 @@ class DecodeTxTest(_BaseResourceTest._ResourceTest):
 
         self.assertFalse(data_error2['success'])
 
+        # Valid hex but too short to hold a version byte
+        response_error3 = yield self.web.get("decode_tx", {b'hex_tx': b'00'})
+        data_error3 = response_error3.json_value()
+
+        self.assertFalse(data_error3['success'])
+
         # Token creation tx
         script_type_out = parse_address_script(genesis[0].outputs[0].script)
         address = script_type_out.address


### PR DESCRIPTION
### Motivation

Fixes #1770. A valid-hex `hex_tx` shorter than 2 bytes escapes the existing handlers with an `IndexError` (deserialize reads the version byte before checking length), and a decodable tx referencing a token uid missing from the tokens index escapes with `KeyError('unknown token')`. Both turn arbitrary input on this public endpoint into an HTTP 500 plus a critical log line instead of the documented `success: false` response.

### Acceptance Criteria

- `/decode_tx` returns `{'success': false, ...}` for a too-short `hex_tx` instead of an HTTP 500
- `/decode_tx` returns `{'success': false, ...}` when the tx references an unknown token
- Regression test for the short `hex_tx` case in `test_decodetx.py`

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
