### PR TITLE
fix(verification): accept txs with fees on mempool

### DIFF
--- a/hathor/verification/transaction_verifier.py
+++ b/hathor/verification/transaction_verifier.py
@@ -379,6 +379,11 @@ class TransactionVerifier:
             for action in nano_header.nc_actions:
                 seen_token_indexes.add(action.token_index)
 
+        if tx.has_fees():
+            fee_header = tx.get_fee_header()
+            for fee in fee_header.fees:
+                seen_token_indexes.add(fee.token_index)
+
         seen_token_indexes.discard(0)
         if sorted(seen_token_indexes) != list(range(1, len(tx.tokens) + 1)):
             raise UnusedTokensError('unused tokens are not allowed')

--- a/hathor_tests/tx/test_verification_mempool.py
+++ b/hathor_tests/tx/test_verification_mempool.py
@@ -663,3 +663,27 @@ class VertexHeadersTest(unittest.TestCase):
         tx5.timestamp = int(self.manager.reactor.seconds())
         self.dag_builder._exporter._vertex_resolver(tx5)
         self.manager.vertex_handler.on_new_mempool_transaction(tx5)
+
+    def test_unseen_fee_token_on_mempool(self) -> None:
+        artifacts = self.dag_builder.build_from_str('''
+            blockchain genesis b[1..10]
+            b10 < dummy
+
+            FBT.token_version = fee
+            FBT.fee = 1 HTR
+
+            tx.out[0] = 123 FBT
+            tx.fee = 100 DBT
+        ''')
+
+        dbt, tx = artifacts.get_typed_vertices(('DBT', 'tx'), Transaction)
+
+        assert tx.has_fees()
+        fees = tx.get_fee_header().fees
+        assert len(fees) == 1
+        fee_entry = fees[0]
+        assert tx.get_token_uid(fee_entry.token_index) == dbt.hash
+
+        artifacts.propagate_with(self.manager, up_to_before='tx')
+        tx.timestamp = int(self.manager.reactor.seconds())
+        assert self.manager.vertex_handler.on_new_mempool_transaction(tx)


### PR DESCRIPTION
### Motivation

There's a bug on mempool-hardened paths that prevents txs with fees from being accepted. This PRs fixes this.

### Acceptance Criteria

- Add fee tokens as "seen" in the unused tokens mempool rule.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 