### PR TITLE
chore(ci): implement parallel CI build with matching workers

### DIFF
--- a/.github/actions/prep-docker-tags/action.yml
+++ b/.github/actions/prep-docker-tags/action.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Hathor Labs
+# SPDX-License-Identifier: Apache-2.0
+
+name: prep-docker-tags
+description: Derive the image version, tag list and registry list for the current ref
+inputs:
+  python-version:
+    description: The python version of this build, used as the image tag suffix
+  dockerhub-image:
+    description: The Docker Hub repository to publish to, empty to skip Docker Hub
+  ghcr-image:
+    description: The GitHub Container Registry repository to publish to, empty to skip GHCR
+outputs:
+  check-version:
+    description: Version to check against the source files, empty when the ref is not a tag
+    value: ${{ steps.prep.outputs.check-version }}
+  version:
+    description: The base version with the python suffix, always present in the tag list
+    value: ${{ steps.prep.outputs.version }}
+  created:
+    description: Build timestamp, for the org.opencontainers.image.created label
+    value: ${{ steps.prep.outputs.created }}
+  dockerfile:
+    description: The Dockerfile to build
+    value: ${{ steps.prep.outputs.dockerfile }}
+  repositories:
+    description: Comma-separated repositories to publish to, without tags
+    value: ${{ steps.prep.outputs.repositories }}
+  tags:
+    description: Comma-separated fully qualified tags, the product of repositories and tags
+    value: ${{ steps.prep.outputs.tags }}
+  push:
+    description: Whether there is at least one repository to publish to
+    value: ${{ steps.prep.outputs.push }}
+  login-dockerhub:
+    description: Whether Docker Hub is one of the repositories
+    value: ${{ steps.prep.outputs.login-dockerhub }}
+  login-ghcr:
+    description: Whether GHCR is one of the repositories
+    value: ${{ steps.prep.outputs.login-ghcr }}
+  slack-notification-version:
+    description: Version to announce on Slack, empty for non-default python versions
+    value: ${{ steps.prep.outputs.slack-notification-version }}
+  disable-slack-notification:
+    description: Whether this ref must not trigger a Slack notification
+    value: ${{ steps.prep.outputs.disable-slack-notification }}
+runs:
+  using: composite
+  steps:
+    # XXX: pass every value through `env` rather than interpolating it into the `run` body. git
+    # ref names may contain single quotes, so exporting a ref inside a single quoted shell string
+    # lets anyone who can push a branch break out of it and run commands in a step that has the
+    # registry credentials in scope. GITHUB_REF, GITHUB_EVENT_NAME, GITHUB_SHA and
+    # GITHUB_REPOSITORY are already in the runner environment, so they need not be passed at all.
+    - name: Prepare tags
+      id: prep
+      shell: bash
+      env:
+        GITHUB_EVENT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+        MATRIX_PYTHON_VERSION: ${{ inputs.python-version }}
+        SECRETS_DOCKERHUB_IMAGE: ${{ inputs.dockerhub-image }}
+        SECRETS_GHCR_IMAGE: ${{ inputs.ghcr-image }}
+      run: python extras/github/docker.py

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,97 +13,131 @@ on: # yamllint disable-line rule:truthy
       - v*
   schedule:
     - cron: '0 4 * * *'  # nightlies at 4am UTC
+permissions:
+  contents: read
+  packages: write
+# one run per ref, newest wins: two pushes in a row would otherwise race in `merge`, and the slower run could
+# publish the older image over the newer one on the shared tags (`stable`, `latest`, `sha-<short>`).
+# `github.event_name` is part of the group because the nightly schedule also runs on the default branch, and the
+# nightly and a `master` push publish different tags, so neither should cancel the other
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 env:
   TEST_TAG: hathor-core:test
+  # the architectures the `merge` job expects to find, as OCI architecture names. keep in sync with the
+  # `architecture` matrix of the `buildx` job below, which cannot reference the `env` context
+  ARCHITECTURES: amd64 arm64
 jobs:
   buildx:
-    name: buildx ${{ matrix.python-impl }}-${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 180  # default is 360
+    name: buildx python-${{ matrix.python-version }} ${{ matrix.architecture.platform }}
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 60  # default is 360
     strategy:
       fail-fast: false
       matrix:
-        python-impl:
-          - python
         python-version:
           - '3.11'
           - '3.12'
+        architecture:
+          - name: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+            runner_arch: X64
+            uname_arch: x86_64
+          - name: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            runner_arch: ARM64
+            uname_arch: aarch64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Prepare base version
         id: prep
-        run: |
-          export GITHUB_REF='${{ github.ref }}'
-          export GITHUB_EVENT_NAME='${{ github.event_name }}'
-          export GITHUB_SHA='${{ github.sha }}'
-          export GITHUB_EVENT_DEFAULT_BRANCH='${{ github.event.repository.default_branch }}'
-          export GITHUB_EVENT_NUMBER='${{ github.event.number }}'
-          export MATRIX_PYTHON_IMPL='${{ matrix.python-impl }}'
-          export MATRIX_PYTHON_VERSION='${{ matrix.python-version }}'
-          export SECRETS_DOCKERHUB_IMAGE='${{ secrets.DOCKERHUB_IMAGE }}'
-          export SECRETS_GHCR_IMAGE='${{ secrets.GHCR_IMAGE }}'
-
-          python extras/github/docker.py
+        uses: ./.github/actions/prep-docker-tags
+        with:
+          python-version: ${{ matrix.python-version }}
+          dockerhub-image: ${{ secrets.DOCKERHUB_IMAGE }}
+          ghcr-image: ${{ secrets.GHCR_IMAGE }}
       - name: Check version
         if: steps.prep.outputs.check-version
+        shell: bash
         env:
           VERSION: ${{ steps.prep.outputs.check-version }}
         run: make check-version
-      - name: Set up QEMU  # arm64 is not available natively
-        uses: docker/setup-qemu-action@v3
+      - name: Assert runner architecture
+        shell: bash
+        env:
+          EXPECTED_RUNNER_ARCH: ${{ matrix.architecture.runner_arch }}
+          EXPECTED_UNAME_ARCH: ${{ matrix.architecture.uname_arch }}
+        run: |
+          if [ "$RUNNER_ARCH" != "$EXPECTED_RUNNER_ARCH" ]; then
+            echo "Expected runner architecture $EXPECTED_RUNNER_ARCH, got $RUNNER_ARCH" >&2
+            exit 1
+          fi
+          if [ "$(uname -m)" != "$EXPECTED_UNAME_ARCH" ]; then
+            echo "Expected uname architecture $EXPECTED_UNAME_ARCH, got $(uname -m)" >&2
+            exit 1
+          fi
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           version: latest
-          install: true
           driver-opts: network=host
       - name: Login to DockerHub
-        uses: docker/login-action@v3
-        if: steps.prep.outputs.login-dockerhub == 'true'
+        uses: docker/login-action@v4
+        if: env.ACT == '' && steps.prep.outputs.login-dockerhub == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: steps.prep.outputs.login-ghcr == 'true'
+        uses: docker/login-action@v4
+        if: env.ACT == '' && steps.prep.outputs.login-ghcr == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        if: steps.prep_base_version.outputs.is-nightly == 'false'
-        with:
-          path: /tmp/.buildx-cache
-          # this key is setup such that every branch has its cache and new branches can reuse master's cache, but not the other way around
-          key: ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-${{ github.head_ref || github.ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.python-impl }}${{ matrix.python-version }}-refs/heads/master-
-      - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+      # build and smoke test before pushing anything, so a broken build never gets a tag pointing at it. this is a
+      # per-leg guarantee only: the legs push independently, so a leg that fails after another already pushed still
+      # leaves that other leg's manifest behind, unreferenced and only reachable by digest. `merge` is what turns
+      # digests into tags, and it only runs once every leg is in.
+      # the push below re-runs this same build, which hits the builder's local cache and costs seconds
+      - name: Build and load locally
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ steps.prep.outputs.dockerfile }}
           build-args: PYTHON=${{ matrix.python-version }}
+          platforms: ${{ matrix.architecture.platform }}
           pull: true
           load: true
           tags: ${{ env.TEST_TAG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # no labels here on purpose: this image is only fed to the smoke test below and then thrown away, so
+          # leaving them off avoids a second copy of the label block to keep in sync. labels do not affect
+          # layer content, so the push below still reuses every layer built here
+          # XXX: no layer cache on purpose, don't add one back without measuring first. on native runners this
+          # builds in about two minutes, and the layers that change on every commit (COPY hathor, poetry build,
+          # pip install) come after the only ones a cache could hold, so they can never hit. a type=gha cache
+          # needs mode=max to be worth anything at all here (the expensive work happens in stage-0, which
+          # mode=min drops since it only keeps the final image's layers) and that measured ~600MB per matrix
+          # leg, competing with main.yml's poetry/mypy caches and htr-rs.yml's cargo caches for the 10GB
+          # repository-wide budget, for no reliable wall-clock gain
       - name: Test image
+        shell: bash
         run: docker run --rm ${{ env.TEST_TAG }} quick_test --data / --testnet
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        if: ${{ !env.ACT }}  # Skip this step when testing locally with https://github.com/nektos/act
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
         with:
           context: .
           file: ${{ steps.prep.outputs.dockerfile }}
           build-args: PYTHON=${{ matrix.python-version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.architecture.platform }}
           pull: true
-          push: ${{ github.event_name != 'pull_request' && steps.prep.outputs.push }}
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.prep.outputs.repositories }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           # see: https://github.com/opencontainers/image-spec/blob/master/annotations.md
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
@@ -114,10 +148,190 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Save digest
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          # `merge` checks this again on the way out of the artifact, on purpose: failing here names the leg that
+          # produced the bad digest, which a failure over there cannot
+          if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Invalid image digest: $DIGEST" >&2
+            exit 1
+          fi
+          mkdir -p '${{ runner.temp }}/digests'
+          printf '%s\n' "$DIGEST" > '${{ runner.temp }}/digests/${{ matrix.architecture.name }}'
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        with:
+          name: docker-digest-python${{ matrix.python-version }}-${{ matrix.architecture.name }}
+          path: ${{ runner.temp }}/digests/${{ matrix.architecture.name }}
+          if-no-files-found: error
+          # artifacts belong to the run, not to the attempt, so the one this leg uploaded on a previous attempt is
+          # still there when the whole run is re-run. without this the upload would fail on the name conflict
+          overwrite: true
+          # these are a few dozen bytes each, keep them around long enough that re-running only the `merge` job
+          # remains possible for a while after the build
+          retention-days: 7
+
+  merge:
+    name: merge python-${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs:
+      - buildx
+    # not success(): each python version is merged independently, so a failing leg of one version must not hold back
+    # the other. not always() either, that would keep spawning doomed merge jobs after a run is cancelled
+    if: ${{ !cancelled() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.11'
+          - '3.12'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Prepare tags
+        id: prep
+        uses: ./.github/actions/prep-docker-tags
+        with:
+          python-version: ${{ matrix.python-version }}
+          dockerhub-image: ${{ secrets.DOCKERHUB_IMAGE }}
+          ghcr-image: ${{ secrets.GHCR_IMAGE }}
+      # every step below is skipped when there is no registry to publish to, so without this the job would report
+      # success over a failed build in a repository with no registry secrets configured. when there is something to
+      # publish, a missing leg is caught by `Validate digests` instead, per python version
+      - name: Assert the build succeeded
+        if: needs.buildx.result != 'success' && steps.prep.outputs.push != 'true'
+        shell: bash
+        env:
+          BUILDX_RESULT: ${{ needs.buildx.result }}
+        run: |
+          echo "Nothing to merge and the buildx job did not succeed: $BUILDX_RESULT" >&2
+          exit 1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        with:
+          version: latest
+          driver-opts: network=host
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        if: env.ACT == '' && steps.prep.outputs.login-dockerhub == 'true'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        if: env.ACT == '' && steps.prep.outputs.login-ghcr == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        with:
+          pattern: docker-digest-python${{ matrix.python-version }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+      - name: Validate digests
+        id: digests
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        shell: bash
+        run: |
+          digest_dir='${{ runner.temp }}/digests'
+          read -ra architectures <<< "$ARCHITECTURES"
+          mapfile -t digest_files < <(find "$digest_dir" -maxdepth 1 -type f -print)
+          if [ "${#digest_files[@]}" -ne "${#architectures[@]}" ]; then
+            echo "Expected ${#architectures[@]} digest artifacts, found ${#digest_files[@]}" >&2
+            exit 1
+          fi
+          digests=()
+          for architecture in "${architectures[@]}"; do
+            digest_file="$digest_dir/$architecture"
+            if [ ! -f "$digest_file" ]; then
+              echo "Missing $architecture digest artifact" >&2
+              exit 1
+            fi
+            digest="$(<"$digest_file")"
+            if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "Invalid $architecture digest: $digest" >&2
+              exit 1
+            fi
+            digests+=("$digest")
+          done
+          # two architectures resolving to the same digest means a leg built for the wrong platform
+          if [ "$(printf '%s\n' "${digests[@]}" | sort -u | wc -l)" -ne "${#digests[@]}" ]; then
+            echo 'Expected one distinct digest per architecture, got:' >&2
+            printf '%s\n' "${digests[@]}" >&2
+            exit 1
+          fi
+          printf 'digests=%s\n' "${digests[*]}" >> "$GITHUB_OUTPUT"
+      - name: Create multi-platform manifests
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        shell: bash
+        env:
+          DIGESTS: ${{ steps.digests.outputs.digests }}
+          REPOSITORIES: ${{ steps.prep.outputs.repositories }}
+          TAGS: ${{ steps.prep.outputs.tags }}
+        run: |
+          read -ra digests <<< "$DIGESTS"
+          IFS=',' read -ra repositories <<< "$REPOSITORIES"
+          IFS=',' read -ra tags <<< "$TAGS"
+          for repository in "${repositories[@]}"; do
+            tag_arguments=()
+            for tag in "${tags[@]}"; do
+              if [ "${tag%:*}" = "$repository" ]; then
+                tag_arguments+=(--tag "$tag")
+              fi
+            done
+            if [ "${#tag_arguments[@]}" -eq 0 ]; then
+              echo "No tags found for repository $repository" >&2
+              exit 1
+            fi
+            references=()
+            for digest in "${digests[@]}"; do
+              references+=("$repository@$digest")
+            done
+            docker buildx imagetools create "${tag_arguments[@]}" "${references[@]}"
+          done
+      - name: Inspect multi-platform manifests
+        if: env.ACT == '' && steps.prep.outputs.push == 'true'
+        shell: bash
+        env:
+          REPOSITORIES: ${{ steps.prep.outputs.repositories }}
+          VERSION: ${{ steps.prep.outputs.version }}
+        run: |
+          # every architecture we build is a plain, variant-less linux platform, so the platform string is just
+          # `linux/<architecture>`. a variant such as `linux/arm/v7` would need its own mapping here
+          read -ra architectures <<< "$ARCHITECTURES"
+          expected_platforms="$(printf 'linux/%s\n' "${architectures[@]}" | sort)"
+          IFS=',' read -ra repositories <<< "$REPOSITORIES"
+          for repository in "${repositories[@]}"; do
+            platforms="$(
+              docker buildx imagetools inspect "$repository:$VERSION" --raw |
+                jq -r '
+                  [
+                    .manifests[]?.platform
+                    | select(.os != "unknown" or .architecture != "unknown")
+                    | "\(.os)/\(.architecture)"
+                  ]
+                  | unique
+                  | .[]
+                '
+            )"
+            if [ "$platforms" != "$expected_platforms" ]; then
+              echo "Unexpected platforms for $repository:$VERSION" >&2
+              printf 'Expected:\n%s\nActual:\n%s\n' "$expected_platforms" "$platforms" >&2
+              exit 1
+            fi
+          done
       - name: Slack Notification
-        if: ${{ steps.prep.outputs.slack-notification-version && steps.prep_base_version.outputs.disable-slack-notification == 'false' && job.status == 'success' }}
+        if: env.ACT == '' && steps.prep.outputs.push == 'true' && steps.prep.outputs.slack-notification-version && steps.prep.outputs.disable-slack-notification == 'false' && success()
         uses: rtCamp/action-slack-notify@28e8b353eabda5998a2e1203aed33c5999944779
         env:
           SLACK_COLOR: ${{ job.status }} # It can turn the job status into a color. Success will be green.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ ARG DEBIAN=bullseye
 FROM python:$PYTHON-slim-$DEBIAN AS stage-0
 ARG PYTHON
 # install runtime first deps to speedup the dev deps and because layers will be reused on stage-1
-RUN apt-get -qy update
-RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
+RUN apt-get -o Acquire::Retries=3 -qy update
+RUN apt-get -o Acquire::Retries=3 -qy install libssl1.1 graphviz librocksdb6.11
 # dev deps for this build start here
-RUN apt-get -qy install libssl-dev libffi-dev build-essential zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev librocksdb-dev git pkg-config curl
+RUN apt-get -o Acquire::Retries=3 -qy install libssl-dev libffi-dev build-essential zlib1g-dev libbz2-dev libsnappy-dev liblz4-dev librocksdb-dev git pkg-config curl
 # Bullseye's apt cargo is too old for htr-rs (edition 2024 / resolver 3 require Rust 1.85+), so install via rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -38,8 +38,8 @@ RUN poetry run pip install --no-deps --force-reinstall ./hathorlib ./htr-rs/crat
 # lean and mean: this image should be about ~50MB, would be about ~470MB if using the whole stage-1
 FROM python:$PYTHON-slim-$DEBIAN
 ARG PYTHON
-RUN apt-get -qy update
-RUN apt-get -qy install libssl1.1 graphviz librocksdb6.11
+RUN apt-get -o Acquire::Retries=3 -qy update
+RUN apt-get -o Acquire::Retries=3 -qy install libssl1.1 graphviz librocksdb6.11
 COPY --from=stage-0 /app/.venv/lib/python${PYTHON}/site-packages/ /usr/local/lib/python${PYTHON}/site-packages/
 # XXX: copy optional BUILD_VERSION file using ...VERSIO[N] instead of ...VERSION* to ensure only one file will be copied
 # XXX: also copying the README.md because we need at least one existing file

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
-py_sources = hathor/ hathor_tests/ extras/custom_tests/
+py_sources = hathor/ hathor_tests/ extras/custom_tests/ extras/github/
 
 .PHONY: all
 all: check tests
@@ -73,11 +73,11 @@ tests-full:
 
 .PHONY: mypy
 mypy:
-	mypy -p hathor -p hathor_tests -p extras.custom_tests
+	mypy -p hathor -p hathor_tests -p extras.custom_tests -p extras.github
 
 .PHONY: dmypy
 dmypy:
-	dmypy run --timeout 86400 -- -p hathor -p hathor_tests -p extras.custom_tests
+	dmypy run --timeout 86400 -- -p hathor -p hathor_tests -p extras.custom_tests -p extras.github
 
 .PHONY: ruff
 ruff:

--- a/extras/github/docker.py
+++ b/extras/github/docker.py
@@ -1,22 +1,25 @@
 # SPDX-FileCopyrightText: Hathor Labs
 # SPDX-License-Identifier: Apache-2.0
 
-import re
+import datetime
 import os
-from typing import Dict
+import re
+from collections.abc import Mapping
 
-def print_output(output: Dict):
+
+def print_output(output: Mapping[str, str]) -> None:
     outputs = ['{}={}\n'.format(k, v) for k, v in output.items()]
     with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
         f.writelines(outputs)
 
-def prep_base_version(environ: Dict):
-    GITHUB_REF = environ.get('GITHUB_REF')
-    GITHUB_EVENT_NAME = environ.get('GITHUB_EVENT_NAME')
-    GITHUB_SHA = environ.get('GITHUB_SHA')
-    GITHUB_EVENT_DEFAULT_BRANCH = environ.get('GITHUB_EVENT_DEFAULT_BRANCH')
-    GITHUB_EVENT_NUMBER = environ.get('GITHUB_EVENT_NUMBER')
-    GITHUB_REPOSITORY = environ.get('GITHUB_REPOSITORY')
+
+def prep_base_version(environ: Mapping[str, str]) -> tuple[dict[str, str], str, bool, bool]:
+    GITHUB_REF = environ.get('GITHUB_REF', '')
+    GITHUB_EVENT_NAME = environ.get('GITHUB_EVENT_NAME', '')
+    GITHUB_SHA = environ.get('GITHUB_SHA', '')
+    GITHUB_EVENT_DEFAULT_BRANCH = environ.get('GITHUB_EVENT_DEFAULT_BRANCH', '')
+    GITHUB_EVENT_NUMBER = environ.get('GITHUB_EVENT_NUMBER', '')
+    GITHUB_REPOSITORY = environ.get('GITHUB_REPOSITORY', '')
 
     ref = GITHUB_REF
 
@@ -27,7 +30,7 @@ def prep_base_version(environ: Dict):
 
     overwrite_hathor_core_version = False
 
-    output = {}
+    output: dict[str, str] = {}
 
     if GITHUB_EVENT_NAME == 'schedule':
         commit_short_sha = GITHUB_SHA[:8]
@@ -35,9 +38,8 @@ def prep_base_version(environ: Dict):
         is_nightly = True
     elif ref.startswith('refs/tags/'):
         git_tag = ref[10:]
-        base_version = git_tag.split('-', 1)[0]
-
-        pre_release = (git_tag.split('-', 1)[1:] or [None])[0]
+        # `v0.53.0-rc.1` splits into `v0.53.0` and `rc.1`, `v0.53.0` leaves an empty pre-release
+        base_version, _, pre_release = git_tag.partition('-')
         overwrite_hathor_core_version = True
         # This will be used to check against the versions in our source files
         check_version = base_version[1:]
@@ -63,35 +65,34 @@ def prep_base_version(environ: Dict):
 
     overwrite_hathor_core_version = is_release or is_pre_release or is_nightly
     # We don't know for sure at this point in which cases we should enable Slack notification,
-    # but we know when we should disable it for sure
-    output['disable-slack-notification'] = not (is_release or is_pre_release)
+    # but we know when we should disable it for sure.
+    # NOTE: these are lowercase strings, not bools, because the workflow compares them against 'false'
+    output['disable-slack-notification'] = 'false' if (is_release or is_pre_release) else 'true'
 
     if GITHUB_REPOSITORY.lower() != 'hathornetwork/hathor-core':
-        output['disable-slack-notification'] = True
+        output['disable-slack-notification'] = 'true'
 
     return output, base_version, is_pre_release, overwrite_hathor_core_version
 
 
-def prep_tags(environ: Dict, base_version: str, is_pre_release: bool):
-    MATRIX_PYTHON_IMPL = environ.get('MATRIX_PYTHON_IMPL')
-    MATRIX_PYTHON_VERSION = environ.get('MATRIX_PYTHON_VERSION')
+def prep_tags(environ: Mapping[str, str], base_version: str, is_pre_release: bool) -> dict[str, str]:
+    MATRIX_PYTHON_VERSION = environ.get('MATRIX_PYTHON_VERSION', '')
 
-    SECRETS_DOCKERHUB_IMAGE = environ.get('SECRETS_DOCKERHUB_IMAGE')
-    SECRETS_GHCR_IMAGE = environ.get('SECRETS_GHCR_IMAGE')
+    SECRETS_DOCKERHUB_IMAGE = environ.get('SECRETS_DOCKERHUB_IMAGE', '')
+    SECRETS_GHCR_IMAGE = environ.get('SECRETS_GHCR_IMAGE', '')
 
-    GITHUB_EVENT_NAME = environ.get('GITHUB_EVENT_NAME')
-    GITHUB_SHA = environ.get('GITHUB_SHA')
+    GITHUB_EVENT_NAME = environ.get('GITHUB_EVENT_NAME', '')
+    GITHUB_SHA = environ.get('GITHUB_SHA', '')
 
-    import datetime
-    import re
-
-    output = {}
+    output: dict[str, str] = {}
 
     # Extract default python versions from the Dockerfiles
-    def extract_pyver(filename):
-        for line in open(filename).readlines():
-            if line.startswith('ARG PYTHON'):
-                return line.split('=')[1].strip()
+    def extract_pyver(filename: str) -> str:
+        with open(filename) as f:
+            for line in f:
+                if line.startswith('ARG PYTHON'):
+                    return line.split('=')[1].strip()
+        raise ValueError(f'Could not find an `ARG PYTHON` line in {filename}')
     dockerfile = 'Dockerfile'
     default_python = 'python' + extract_pyver(dockerfile)
     suffix = 'python' + MATRIX_PYTHON_VERSION
@@ -114,24 +115,29 @@ def prep_tags(environ: Dict, base_version: str, is_pre_release: bool):
         tags.add(minor + '-' + suffix)
         if suffix == default_python:
             tags.add('latest')
-    elif GITHUB_EVENT_NAME == 'push' and not is_pre_release:
+    elif GITHUB_EVENT_NAME == 'push' and not is_pre_release and suffix == default_python:
         tags.add('sha-' + GITHUB_SHA[:8])
 
     # Build the image list and set outputs
     output['version'] = version
+    # Never publish from a pull request. The docker workflow has no `pull_request` trigger today, but if one is ever
+    # added, pull requests from a branch of this repository would see the registry secrets and start publishing
+    # `pr-<number>` tags to the production registries
+    is_pull_request = GITHUB_EVENT_NAME in ('pull_request', 'pull_request_target')
     images = []
-    docker_image = SECRETS_DOCKERHUB_IMAGE
+    docker_image = '' if is_pull_request else SECRETS_DOCKERHUB_IMAGE
     if docker_image:
         images.append(docker_image)
         output['login-dockerhub'] = 'true'
     else:
         output['login-dockerhub'] = 'false'
-    ghcr_image = SECRETS_GHCR_IMAGE
+    ghcr_image = '' if is_pull_request else SECRETS_GHCR_IMAGE
     if ghcr_image:
         images.append(ghcr_image)
         output['login-ghcr'] = 'true'
     else:
         output['login-ghcr'] = 'false'
+    output['repositories'] = ','.join(images)
     if images and tags:
         output['tags'] = ','.join(f'{i}:{t}' for i in images for t in tags)
         output['push'] = 'true'
@@ -145,7 +151,7 @@ def prep_tags(environ: Dict, base_version: str, is_pre_release: bool):
     return output
 
 
-def overwrite_version(base_version: str):
+def overwrite_version(base_version: str) -> None:
     with open('BUILD_VERSION', 'w') as file:
         if base_version.startswith('v'):
             base_version = base_version[1:]

--- a/extras/github/test_docker.py
+++ b/extras/github/test_docker.py
@@ -23,7 +23,6 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
-            'MATRIX_PYTHON_IMPL': 'python',
             'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': '',
             'SECRETS_GHCR_IMAGE': '',
@@ -33,7 +32,7 @@ class DockerWorkflowTest(unittest.TestCase):
 
         self.assertTrue(overwrite_hathor_core_version)
         self.assertFalse(is_release_candidate)
-        self.assertTrue(output['disable-slack-notification'])
+        self.assertEqual(output['disable-slack-notification'], 'true')
         self.assertEqual(base_version, 'nightly-55629a7d')
 
         output = prep_tags(os.environ, base_version, is_release_candidate)
@@ -53,7 +52,6 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
-            'MATRIX_PYTHON_IMPL': 'python',
             'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
@@ -63,7 +61,7 @@ class DockerWorkflowTest(unittest.TestCase):
 
         self.assertTrue(overwrite_hathor_core_version)
         self.assertFalse(is_release_candidate)
-        self.assertTrue(output['disable-slack-notification'])
+        self.assertEqual(output['disable-slack-notification'], 'true')
         self.assertEqual(base_version, 'nightly-55629a7d')
 
         output = prep_tags(os.environ, base_version, is_release_candidate)
@@ -78,6 +76,102 @@ class DockerWorkflowTest(unittest.TestCase):
         self.assertEqual(output['push'], 'true')
         self.assertEqual(output['dockerfile'], 'Dockerfile')
 
+    def test_repository_outputs_and_tag_cartesian_product(self):
+        common_environ = {
+            'GITHUB_EVENT_NAME': 'push',
+            'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
+        }
+        cases = [
+            ('no registry', '', '', '', {'dont-push--local-only'}),
+            (
+                'Docker Hub only',
+                'mock_image',
+                '',
+                'mock_image',
+                {
+                    f'mock_image:dev-python{DEFAULT_PYTHON_VERSION}',
+                    'mock_image:dev',
+                    'mock_image:sha-55629a7d',
+                },
+            ),
+            (
+                'GHCR only',
+                '',
+                'ghcr.io/hathornetwork/hathor-core',
+                'ghcr.io/hathornetwork/hathor-core',
+                {
+                    f'ghcr.io/hathornetwork/hathor-core:dev-python{DEFAULT_PYTHON_VERSION}',
+                    'ghcr.io/hathornetwork/hathor-core:dev',
+                    'ghcr.io/hathornetwork/hathor-core:sha-55629a7d',
+                },
+            ),
+            (
+                'both registries',
+                'mock_image',
+                'ghcr.io/hathornetwork/hathor-core',
+                'mock_image,ghcr.io/hathornetwork/hathor-core',
+                {
+                    f'mock_image:dev-python{DEFAULT_PYTHON_VERSION}',
+                    'mock_image:dev',
+                    'mock_image:sha-55629a7d',
+                    f'ghcr.io/hathornetwork/hathor-core:dev-python{DEFAULT_PYTHON_VERSION}',
+                    'ghcr.io/hathornetwork/hathor-core:dev',
+                    'ghcr.io/hathornetwork/hathor-core:sha-55629a7d',
+                },
+            ),
+        ]
+
+        for name, dockerhub_image, ghcr_image, repositories, expected_tags in cases:
+            with self.subTest(name=name):
+                os.environ.update({
+                    **common_environ,
+                    'SECRETS_DOCKERHUB_IMAGE': dockerhub_image,
+                    'SECRETS_GHCR_IMAGE': ghcr_image,
+                })
+
+                output = prep_tags(os.environ, 'dev', is_pre_release=False)
+
+                self.assertEqual(output['repositories'], repositories)
+                self.assertEqual(set(output['tags'].split(',')), expected_tags)
+                self.assertEqual(output['push'], 'true' if repositories else 'false')
+
+    def test_non_default_python_does_not_publish_sha_tag(self):
+        os.environ.update({
+            'GITHUB_EVENT_NAME': 'push',
+            'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
+            'MATRIX_PYTHON_VERSION': NON_DEFAULT_PYTHON_VERSION,
+            'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
+            'SECRETS_GHCR_IMAGE': 'ghcr.io/hathornetwork/hathor-core',
+        })
+
+        output = prep_tags(os.environ, 'dev', is_pre_release=False)
+
+        self.assertEqual(
+            set(output['tags'].split(',')),
+            {
+                f'mock_image:dev-python{NON_DEFAULT_PYTHON_VERSION}',
+                f'ghcr.io/hathornetwork/hathor-core:dev-python{NON_DEFAULT_PYTHON_VERSION}',
+            },
+        )
+
+    def test_pull_request_never_publishes(self):
+        os.environ.update({
+            'GITHUB_EVENT_NAME': 'pull_request',
+            'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
+            'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
+            'SECRETS_GHCR_IMAGE': 'ghcr.io/hathornetwork/hathor-core',
+        })
+
+        output = prep_tags(os.environ, 'pr-1774', is_pre_release=False)
+
+        # both registry secrets are set, yet nothing must be published nor even logged into
+        self.assertEqual(output['repositories'], '')
+        self.assertEqual(output['tags'], 'dont-push--local-only')
+        self.assertEqual(output['push'], 'false')
+        self.assertEqual(output['login-dockerhub'], 'false')
+        self.assertEqual(output['login-ghcr'], 'false')
 
     def test_release_candidate_non_default_python(self):
         os.environ.update({
@@ -86,7 +180,6 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
-            'MATRIX_PYTHON_IMPL': 'python',
             'MATRIX_PYTHON_VERSION': NON_DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
@@ -96,7 +189,7 @@ class DockerWorkflowTest(unittest.TestCase):
 
         self.assertTrue(overwrite_hathor_core_version)
         self.assertTrue(is_release_candidate)
-        self.assertFalse(output['disable-slack-notification'])
+        self.assertEqual(output['disable-slack-notification'], 'false')
         self.assertEqual(base_version, 'v0.53.0-rc.1')
 
         output = prep_tags(os.environ, base_version, is_release_candidate)
@@ -117,7 +210,6 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
-            'MATRIX_PYTHON_IMPL': 'python',
             'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
@@ -127,7 +219,7 @@ class DockerWorkflowTest(unittest.TestCase):
 
         self.assertTrue(overwrite_hathor_core_version)
         self.assertTrue(is_release_candidate)
-        self.assertFalse(output['disable-slack-notification'])
+        self.assertEqual(output['disable-slack-notification'], 'false')
         self.assertEqual(base_version, 'v0.53.0-rc.1')
 
         output = prep_tags(os.environ, base_version, is_release_candidate)
@@ -151,7 +243,6 @@ class DockerWorkflowTest(unittest.TestCase):
             'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
             'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
             'GITHUB_EVENT_NUMBER': '',
-            'MATRIX_PYTHON_IMPL': 'python',
             'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
             'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
             'SECRETS_GHCR_IMAGE': '',
@@ -161,7 +252,7 @@ class DockerWorkflowTest(unittest.TestCase):
 
         self.assertTrue(overwrite_hathor_core_version)
         self.assertFalse(is_release_candidate)
-        self.assertFalse(output['disable-slack-notification'])
+        self.assertEqual(output['disable-slack-notification'], 'false')
         self.assertEqual(base_version, 'v0.53.0')
 
         output = prep_tags(os.environ, base_version, is_release_candidate)
@@ -177,3 +268,23 @@ class DockerWorkflowTest(unittest.TestCase):
         self.assertIn('mock_image:latest', output['tags'].split(','))
         self.assertEqual(output['push'], 'true')
         self.assertEqual(output['dockerfile'], 'Dockerfile')
+
+    def test_slack_notification_disabled_outside_main_repository(self):
+        os.environ.update({
+            'GITHUB_REPOSITORY': 'someone-else/hathor-core',
+            'GITHUB_REF': 'refs/tags/v0.53.0',
+            'GITHUB_EVENT_NAME': 'push',
+            'GITHUB_SHA': '55629a7d0ae267cdd27618f452e9f1ad6764fd43',
+            'GITHUB_EVENT_DEFAULT_BRANCH': 'master',
+            'GITHUB_EVENT_NUMBER': '',
+            'MATRIX_PYTHON_VERSION': DEFAULT_PYTHON_VERSION,
+            'SECRETS_DOCKERHUB_IMAGE': 'mock_image',
+            'SECRETS_GHCR_IMAGE': '',
+        })
+
+        output, base_version, is_release_candidate, _ = prep_base_version(os.environ)
+
+        self.assertFalse(is_release_candidate)
+        self.assertEqual(base_version, 'v0.53.0')
+        # a release would otherwise enable the notification, it must stay disabled outside the main repository
+        self.assertEqual(output['disable-slack-notification'], 'true')


### PR DESCRIPTION
### Motivation

The Docker workflow built `linux/amd64` and `linux/arm64` in a single job using QEMU to emulate arm64, which typically took ~24 minutes. GitHub now offers native arm64 runners, so each architecture can build on matching hardware in parallel, with the multi-platform manifest assembled afterwards from the per-architecture digests — bringing builds down to ~4 minutes ([example run](https://github.com/HathorNetwork/hathor-core/actions/runs/30666475095)).

The PR also fixes two small bugs: a condition referencing `steps.prep_base_version.outputs.*` never matched an existing step `id`, so the Slack notification never fired; and both Python versions published the same `sha-<short>` tag, overwriting each other.

### Acceptance Criteria

- Build `linux/amd64` on `ubuntu-24.04` and `linux/arm64` on `ubuntu-24.04-arm` natively and in parallel instead of emulating arm64 under QEMU, failing early on a mismatched runner.
- Push each architecture by digest and assemble the multi-platform manifest in a new `merge` job, validating the digests and inspecting the result.
- Build once, `quick_test` the loaded image, and only then push, so a broken build never gets a tag.
- Rename the build jobs to `buildx python-<version> <platform>` and add `merge python-<version>`: anything pinned to the old `buildx python-<version>` names needs updating.
- Drop the layer cache: it wasn't working and the upload/download was slowing down the build, the build has been fast anyway so we wouldn't benefit in fixing it.
- Run one build per ref and event with `cancel-in-progress: true`, as the other workflows do, so the newest push wins the shared tags and intermediate commits may not get a `sha-<short>` image.
- Fail `merge` explicitly when the build failed and there is nothing to publish, instead of reporting success.
- Never publish from a `pull_request` event, so adding that trigger later cannot push `pr-<number>` tags with the repository secrets.
- Restrict `GITHUB_TOKEN` to `contents: read` and `packages: write`.
- Fix the Slack notification, and publish `sha-<short>` only for the default Python version rather than letting both overwrite it.
- Expose a `repositories` output from `extras/github/docker.py`, with unit tests for it and the tag changes.
- Update pinned actions to current majors, drop `setup-qemu-action`, and keep the `env.ACT == ''` guards for `nektos/act`.
- Retry `apt-get` in the `Dockerfile`, and lint and type-check `extras/github/`.

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged


