### PR TITLE
fix(nano): validate ids at the API boundary in nano contract resources

### DIFF
--- a/hathor/nanocontracts/resources/builtin.py
+++ b/hathor/nanocontracts/resources/builtin.py
@@ -11,7 +11,7 @@ from hathor._openapi.register import register_resource
 from hathor.api_util import Resource, set_cors
 from hathor.manager import HathorManager
 from hathor.nanocontracts import Blueprint
-from hathor.util import collect_n
+from hathor.util import bytes_from_hex, collect_n
 from hathor.utils.api import ErrorResponse, QueryParams, Response
 
 
@@ -64,7 +64,15 @@ class BlueprintBuiltinResource(Resource):
 
         sorted_bps = SortedKeyList(filtered_bps, key=lambda bp_id_and_class: bp_id_and_class[0])
         reverse = bool(params.before)
-        start_key = bytes.fromhex(params.before or params.after or '') or None
+        start_key: bytes | None = None
+        if params.before or params.after:
+            start_key = bytes_from_hex(params.before or params.after or '') or None
+            if start_key is None:
+                request.setResponseCode(400)
+                error_response = ErrorResponse(
+                    success=False, error='Invalid before/after parameter: not a valid hex string.'
+                )
+                return error_response.json_dumpb()
         bp_iter: Iterator[tuple[bytes, type[Blueprint]]] = sorted_bps.irange_key(
             min_key=None if reverse else start_key,
             max_key=start_key if reverse else None,

--- a/hathor/nanocontracts/resources/nc_creation.py
+++ b/hathor/nanocontracts/resources/nc_creation.py
@@ -15,6 +15,7 @@ from hathor.nanocontracts.exception import NanoContractDoesNotExist
 from hathor.nanocontracts.resources.on_chain import SortOrder
 from hathor.nanocontracts.types import BlueprintId, VertexId
 from hathor.transaction import Transaction
+from hathor.transaction.base_transaction import TX_HASH_SIZE
 from hathor.transaction.storage.exceptions import TransactionDoesNotExist
 from hathor.util import bytes_from_hex, not_none
 from hathor.utils.api import ErrorResponse, QueryParams, Response
@@ -57,8 +58,9 @@ class NCCreationResource(Resource):
         if params.search:
             search = params.search.strip()
             maybe_bytes = bytes_from_hex(search)
-            if maybe_bytes is None:
-                # in this case we do have `search` but it's not a valid hex, so we return empty.
+            if maybe_bytes is None or len(maybe_bytes) != TX_HASH_SIZE:
+                # `search` is either a NC ID or a BP ID, so anything that isn't a valid hex of the
+                # right size can't match. It must not reach the indexes below, which assert on key size.
                 response = NCCreationResponse(
                     nc_creation_txs=[],
                     before=params.before,

--- a/hathor_tests/resources/nanocontracts/test_builtin.py
+++ b/hathor_tests/resources/nanocontracts/test_builtin.py
@@ -263,3 +263,28 @@ class BlueprintBuiltinResourceTest(_BaseResourceTest._ResourceTest):
             has_more=False,
             blueprints=[],
         )
+
+    async def test_non_hex_pagination(self) -> None:
+        # A non-hex `before`/`after` used to escape as an uncaught ValueError, returning HTTP 500.
+        for param in (b'before', b'after'):
+            response = await self.web.get('builtin', {
+                param: b'zz',
+            })
+            data = response.json_value()
+            assert response.responseCode == 400
+            assert data == dict(
+                success=False,
+                error='Invalid before/after parameter: not a valid hex string.',
+            )
+
+    async def test_whitespace_pagination(self) -> None:
+        # `bytes.fromhex` skips ASCII whitespace, so a blank-but-truthy value decodes to b''.
+        response = await self.web.get('builtin', {
+            b'after': b' ',
+        })
+        data = response.json_value()
+        assert response.responseCode == 400
+        assert data == dict(
+            success=False,
+            error='Invalid before/after parameter: not a valid hex string.',
+        )

--- a/hathor_tests/resources/nanocontracts/test_nc_creation.py
+++ b/hathor_tests/resources/nanocontracts/test_nc_creation.py
@@ -556,6 +556,41 @@ class NCCreationResourceTest(_BaseResourceTest._ResourceTest):
             nc_creation_txs=[],
         )
 
+    async def test_search_wrong_size(self) -> None:
+        # A valid hex of the wrong size is neither a NC ID nor a BP ID. It used to reach the
+        # blueprint-history index and trip its `len(key) == _KEY_SIZE` assert, returning HTTP 500.
+        self.prepare_ncs()
+        for search in (b'ab', b'ab' * 31, b'ab' * 33):
+            response = await self.web.get('creation', {
+                b'search': search,
+            })
+            data = response.json_value()
+            assert data == dict(
+                success=True,
+                count=10,
+                before=None,
+                after=None,
+                has_more=False,
+                nc_creation_txs=[],
+            )
+
+    async def test_search_wrong_size_asc(self) -> None:
+        # Same as above, but the ascending order takes a different branch (get_oldest).
+        self.prepare_ncs()
+        response = await self.web.get('creation', {
+            b'search': b'ab' * 31,
+            b'order': b'asc',
+        })
+        data = response.json_value()
+        assert data == dict(
+            success=True,
+            count=10,
+            before=None,
+            after=None,
+            has_more=False,
+            nc_creation_txs=[],
+        )
+
     async def test_non_hex_pagination(self) -> None:
         self.prepare_ncs()
         response = await self.web.get('creation', {


### PR DESCRIPTION
### Motivation

The public `/nano_contract/creation` endpoint lets arbitrary user input reach a RocksDB index invariant. Its `search` parameter is checked for hex validity but never for length, so a valid hex string of the wrong size is accepted as a `VertexId`. When it does not match an existing nano contract, `_get_nc_creation_item` returns `None` and the value falls through to be treated as a blueprint id, reaching `RocksDBBlueprintHistoryIndex` — whose `_KEY_SIZE` is 32 — and tripping `assert len(rocksdb_key) == self._KEY_SIZE` in `RocksDBTxGroupIndex._to_rocksdb_key`. The assert escapes as an uncaught `AssertionError`, turning a malformed request into an HTTP 500 plus a `critical` log line. This fired on a `testnet-india` fullnode running v0.71.0 (OpsGenie alert 53262):

```
File ".../hathor/nanocontracts/resources/nc_creation.py", line 134, in render_GET
    for nc_id in iter_nc_ids:
File ".../hathor/indexes/rocksdb_tx_group_index.py", line 155, in _get_sorted_from_key
    it.seek(self._to_rocksdb_key(key, tx_start))
File ".../hathor/indexes/rocksdb_tx_group_index.py", line 97, in _to_rocksdb_key
    assert len(rocksdb_key) == self._KEY_SIZE
AssertionError
```

Because `_get_sorted_from_key` is a generator, the failure surfaces at the iteration in `render_GET` rather than at the index call itself. Both sort orders are affected, since `get_newest` and `get_oldest` reach the same key serialization.

This is the same class of bug as #1758, which hardened the `/thin_wallet` endpoints and the websocket `subscribe_address` handler but did not cover `hathor/nanocontracts/resources/`. Auditing that package also found `/nano_contract/blueprint/builtin`, where `bytes.fromhex` on the `before`/`after` pagination parameters is not guarded, so a non-hex value escapes as an uncaught `ValueError` — also a 500. `/nano_contract/on_chain_blueprints` already carries the equivalent guard, so this PR reuses its error message and response shape. The remaining resources in the package (`blueprint`, `blueprint_source_code`, `nc_exec_logs`, `state`, `history`) were checked and already validate their inputs.

### Acceptance Criteria

- `/nano_contract/creation` returns its existing empty `success: true` response for a `search` whose decoded length is not `TX_HASH_SIZE`, instead of an HTTP 500
- `/nano_contract/blueprint/builtin` returns a `success: false` 400 for a `before`/`after` that is not a valid hex string, instead of an HTTP 500, matching `/nano_contract/on_chain_blueprints`
- Regression tests cover the wrong-size `search` in both sort orders, and the non-hex and whitespace-only pagination parameters
- Behavior change: `/nano_contract/blueprint/builtin` previously ignored a whitespace-only `before`/`after` and returned the unpaginated list, because `bytes.fromhex` skips ASCII whitespace and decodes it to `b''`; it now returns the invalid-parameter error

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
