### PR TITLE
fix(vertex_parser): raise StructError on input too short to hold a version

### DIFF
--- a/hathor/transaction/vertex_parser/_vertex_parser.py
+++ b/hathor/transaction/vertex_parser/_vertex_parser.py
@@ -52,9 +52,15 @@ class VertexParser:
         return supported_headers[header_id]
 
     def deserialize(self, data: bytes, storage: TransactionStorage | None = None) -> BaseTransaction:
-        """Creates the correct tx subclass from a sequence of bytes."""
+        """Creates the correct tx subclass from a sequence of bytes.
+
+        Raise `StructError` when `data` cannot be parsed into a vertex, including when it is too
+        short to hold the version field.
+        """
         # version field takes up the second byte only
         from hathor.transaction import TxVersion
+        if len(data) < 2:
+            raise StructError('Invalid bytes to create transaction subclass: too short.')
         version = data[1]
         try:
             tx_version = TxVersion(version)

--- a/hathor_tests/resources/transaction/test_pushtx.py
+++ b/hathor_tests/resources/transaction/test_pushtx.py
@@ -192,6 +192,15 @@ class BasePushTxTest(_BaseResourceTest._ResourceTest):
         data_error2 = response_error2.json_value()
         self.assertFalse(data_error2['success'])
 
+        # Valid hex but too short to hold a version byte
+        response_error3: Any = yield self.push_tx({'hex_tx': '00'})
+        data_error3 = response_error3.json_value()
+        self.assertFalse(data_error3['success'])
+
+        response_error4: Any = yield self.push_tx({'hex_tx': ''})
+        data_error4 = response_error4.json_value()
+        self.assertFalse(data_error4['success'])
+
     @inlineCallbacks
     def test_script_too_big(self) -> Generator:
         self.manager.wallet.unlock(b'MYPASS')

--- a/hathor_tests/tx/test_tx.py
+++ b/hathor_tests/tx/test_tx.py
@@ -1211,6 +1211,18 @@ class TransactionTest(unittest.TestCase):
         self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(output3_address_b58)), 1)
         self.assertEqual(len(self.tx_storage.indexes.addresses.get_from_address(new_address_b58)), 1)
 
+    def test_deserialize_too_short(self):
+        # `deserialize` reads the version from the second byte, so anything shorter than 2 bytes has
+        # no version to read. It must raise `StructError` like any other undecodable input, and not
+        # let a bare `IndexError` escape to the callers.
+        from struct import error as StructError
+
+        parser = self.manager.vertex_parser
+
+        for data in [b'', b'\x00']:
+            with self.assertRaises(StructError):
+                parser.deserialize(data)
+
     def test_sighash_cache(self):
         from unittest import mock
 

--- a/hathorlib/hathorlib/base_transaction.py
+++ b/hathorlib/hathorlib/base_transaction.py
@@ -774,8 +774,13 @@ def output_value_to_bytes(number: int) -> bytes:
 
 def tx_or_block_from_bytes(data: bytes) -> BaseTransaction:
     """ Creates the correct tx subclass from a sequence of bytes
+
+    Raise `StructError` when `data` cannot be parsed into a vertex, including when it is too short
+    to hold the version field.
     """
     # version field takes up the second byte only
+    if len(data) < 2:
+        raise StructError('Invalid bytes to create transaction subclass: too short.')
     version = data[1]
     try:
         tx_version = TxVersion(version)

--- a/hathorlib/tests/test_basic.py
+++ b/hathorlib/tests/test_basic.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from struct import error as StructError
 
 from hathorlib import Block, TokenCreationTransaction, Transaction
 from hathorlib.base_transaction import get_cls_from_tx_version, tx_or_block_from_bytes
@@ -147,6 +148,14 @@ class HathorCommonsTestCase(unittest.TestCase):
 
     def test_script_basics(self):
         create_output_script(decode_address('HVZjvL1FJ23kH3buGNuttVRsRKq66WHUVZ'))
+
+    def test_tx_or_block_from_bytes_too_short(self):
+        # The version is read from the second byte, so anything shorter than 2 bytes has no version
+        # to read. It must raise StructError like any other undecodable input, and not let a bare
+        # IndexError escape to the callers.
+        for data in [b'', b'\x00']:
+            with self.assertRaises(StructError):
+                tx_or_block_from_bytes(data)
 
     def test_standard_tx(self):
         data = bytes.fromhex('0001000102000001e0e88216036e4e52872ba60a96df7570c3e29cc30eda6dd92ea0fd'


### PR DESCRIPTION
### Motivation

`VertexParser.deserialize` reads the version field with `version = data[1]` before any length check, and that read sits *outside* the `try` block:

```python
def deserialize(self, data: bytes, storage: TransactionStorage | None = None) -> BaseTransaction:
    """Creates the correct tx subclass from a sequence of bytes."""
    from hathor.transaction import TxVersion
    version = data[1]        # <-- no length check, outside the try
    try:
        ...
    except (ValueError, SerializationError) as e:
        raise StructError('Invalid bytes to create transaction subclass.') from e
```

Any payload shorter than 2 bytes therefore escapes the function's own `StructError` contract as a bare `IndexError`. Callers that dutifully catch `struct.error` — the documented failure mode — miss it entirely.

On a public node this is reachable from arbitrary internet input. `bytes.fromhex('')` → `b''` and `bytes.fromhex('00')` → `b'\x00'` both succeed, so a `hex_tx` that is valid hex but under 2 bytes sails past the hex validation and trips the unguarded read. The result is an HTTP 500 and a `critical` traceback instead of the graceful `success: false` these endpoints are designed to return. This was observed on mainnet via `POST /v1a/push_tx`:

```
File ".../hathor/transaction/resources/push_tx.py", line 61, in handle_push_tx
    tx = self.manager.vertex_parser.deserialize(tx_bytes)
File ".../hathor/transaction/vertex_parser/_vertex_parser.py", line 58, in deserialize
    version = data[1]
              ~~~~^^^
IndexError: index out of range
```

**Why not another per-endpoint `except`.** #1770 / #1772 fixed exactly this bug for `/decode_tx` by adding `IndexError` to that single endpoint's handler. That closed one of ten call sites and left the shared parser unguarded, so the identical failure resurfaced on `/push_tx`. #1770 itself recommended the systemic route under *Suggested fix*:

> `vertex_parser.deserialize` should length-check and raise a typed decode error (e.g. `struct.error` / a domain error) on truncated input instead of a bare `IndexError`.

This PR takes that route. Because `StructError` **is** `struct.error` (`from struct import error as StructError`), guarding the length inside `deserialize` means every caller inherits the fix, and the two public endpoints that already catch `struct.error` are covered with no change of their own:

- `/push_tx` (`push_tx.py`) — `except struct.error` → now returns `success: false`
- `/thin_wallet/send_tokens` (`send_tokens.py`) — `except (ValueError, struct.error)` → now returns `param_invalid_hex`

`hathorlib.base_transaction.tx_or_block_from_bytes` carries an independent copy of the same unguarded read and gets the same guard, which also covers downstream consumers of the library.

This continues the input-hardening line of #1758 / #1760 (`/thin_wallet` RocksDB index asserts) and #1770 / #1772 (`/decode_tx`), and closes the class at the shared layer rather than one endpoint at a time.

### Acceptance Criteria

- Guard `VertexParser.deserialize` so `data` shorter than 2 bytes raises `StructError` instead of letting a bare `IndexError` escape, and document that contract in the docstring.
- Apply the same guard to `hathorlib.base_transaction.tx_or_block_from_bytes`, which contains an independent copy of the same unguarded read.
- Confirm `POST`/`GET /push_tx` returns `success: false` for `hex_tx` values of `""` and `"00"` rather than HTTP 500, with no change to `push_tx.py` itself.
- Add a parser-level regression test asserting `StructError` for `b''` and `b'\x00'`.
- Add `/push_tx` resource regression tests covering both short-input cases, alongside the existing invalid-parameter cases.
- Add the equivalent `hathorlib` regression test for `tx_or_block_from_bytes`.
- Leave behavior unchanged for all well-formed input and for every other `deserialize` call site (sync-v2, RocksDB storage, mining, `/decode_tx`).

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
